### PR TITLE
ext: Import Atmel SAM4E header files from ASF library

### DIFF
--- a/asf/sam/include/sam4e/README
+++ b/asf/sam/include/sam4e/README
@@ -1,0 +1,41 @@
+Atmel SAM4E
+###########
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAM4E Series Device Support (1.1.57)
+   http://packs.download.atmel.com/Atmel.SAM4E_DFP.1.1.57.atpack
+
+Status:
+   version 1.1.57
+
+Purpose:
+   Official package for SAM4E.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAM4E_DFP.1.1.57.atpack
+
+commit:
+   n/a
+
+Maintained-by:
+   External
+
+License:
+   SAM Software Package License
+
+License Link:
+   n/a
+
+Patch Lst:
+   * Add MPU peripheral in device file
+   * Fix CHIPID_EXID for SAM4E8C and SAM4E16C
+

--- a/asf/sam/include/sam4e/component-version.h
+++ b/asf/sam/include/sam4e/component-version.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+ *
+ * Copyright (C) 2016 Atmel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * * Neither the name of the copyright holders nor the names of
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ****************************************************************************/
+
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 1
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version, with leading zeros. The COMPONENT_VERSION
+// is at least 8 digits long.
+//
+#define COMPONENT_VERSION 00010001
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 57
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.1"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2016-09-15 20:37:05"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/asf/sam/include/sam4e/component/acc.h
+++ b/asf/sam/include/sam4e/component/acc.h
@@ -1,0 +1,124 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_ACC_COMPONENT_
+#define _SAM4E_ACC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Analog Comparator Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_ACC Analog Comparator Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Acc hardware registers */
+typedef struct {
+  WoReg ACC_CR;        /**< \brief (Acc Offset: 0x00) Control Register */
+  RwReg ACC_MR;        /**< \brief (Acc Offset: 0x04) Mode Register */
+  RoReg Reserved1[7];
+  WoReg ACC_IER;       /**< \brief (Acc Offset: 0x24) Interrupt Enable Register */
+  WoReg ACC_IDR;       /**< \brief (Acc Offset: 0x28) Interrupt Disable Register */
+  RoReg ACC_IMR;       /**< \brief (Acc Offset: 0x2C) Interrupt Mask Register */
+  RoReg ACC_ISR;       /**< \brief (Acc Offset: 0x30) Interrupt Status Register */
+  RoReg Reserved2[24];
+  RwReg ACC_ACR;       /**< \brief (Acc Offset: 0x94) Analog Control Register */
+  RoReg Reserved3[19];
+  RwReg ACC_WPMR;      /**< \brief (Acc Offset: 0xE4) Write Protect Mode Register */
+  RoReg ACC_WPSR;      /**< \brief (Acc Offset: 0xE8) Write Protect Status Register */
+} Acc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- ACC_CR : (ACC Offset: 0x00) Control Register -------- */
+#define ACC_CR_SWRST (0x1u << 0) /**< \brief (ACC_CR) SoftWare ReSeT */
+/* -------- ACC_MR : (ACC Offset: 0x04) Mode Register -------- */
+#define ACC_MR_SELMINUS_Pos 0
+#define ACC_MR_SELMINUS_Msk (0x7u << ACC_MR_SELMINUS_Pos) /**< \brief (ACC_MR) SELection for MINUS comparator input */
+#define   ACC_MR_SELMINUS_TS (0x0u << 0) /**< \brief (ACC_MR) SelectTS */
+#define   ACC_MR_SELMINUS_ADVREF (0x1u << 0) /**< \brief (ACC_MR) Select ADVREF */
+#define   ACC_MR_SELMINUS_DAC0 (0x2u << 0) /**< \brief (ACC_MR) Select DAC0 */
+#define   ACC_MR_SELMINUS_DAC1 (0x3u << 0) /**< \brief (ACC_MR) Select DAC1 */
+#define   ACC_MR_SELMINUS_AD0 (0x4u << 0) /**< \brief (ACC_MR) Select AD0 */
+#define   ACC_MR_SELMINUS_AD1 (0x5u << 0) /**< \brief (ACC_MR) Select AD1 */
+#define   ACC_MR_SELMINUS_AD2 (0x6u << 0) /**< \brief (ACC_MR) Select AD2 */
+#define   ACC_MR_SELMINUS_AD3 (0x7u << 0) /**< \brief (ACC_MR) Select AD3 */
+#define ACC_MR_SELPLUS_Pos 4
+#define ACC_MR_SELPLUS_Msk (0x7u << ACC_MR_SELPLUS_Pos) /**< \brief (ACC_MR) SELection for PLUS comparator input */
+#define   ACC_MR_SELPLUS_AD0 (0x0u << 4) /**< \brief (ACC_MR) Select AD0 */
+#define   ACC_MR_SELPLUS_AD1 (0x1u << 4) /**< \brief (ACC_MR) Select AD1 */
+#define   ACC_MR_SELPLUS_AD2 (0x2u << 4) /**< \brief (ACC_MR) Select AD2 */
+#define   ACC_MR_SELPLUS_AD3 (0x3u << 4) /**< \brief (ACC_MR) Select AD3 */
+#define   ACC_MR_SELPLUS_AD4 (0x4u << 4) /**< \brief (ACC_MR) Select AD4 */
+#define   ACC_MR_SELPLUS_AD5 (0x5u << 4) /**< \brief (ACC_MR) Select AD5 */
+#define   ACC_MR_SELPLUS_AD6 (0x6u << 4) /**< \brief (ACC_MR) Select AD6 */
+#define   ACC_MR_SELPLUS_AD7 (0x7u << 4) /**< \brief (ACC_MR) Select AD7 */
+#define ACC_MR_ACEN (0x1u << 8) /**< \brief (ACC_MR) Analog Comparator ENable */
+#define   ACC_MR_ACEN_DIS (0x0u << 8) /**< \brief (ACC_MR) Analog Comparator Disabled. */
+#define   ACC_MR_ACEN_EN (0x1u << 8) /**< \brief (ACC_MR) Analog Comparator Enabled. */
+#define ACC_MR_EDGETYP_Pos 9
+#define ACC_MR_EDGETYP_Msk (0x3u << ACC_MR_EDGETYP_Pos) /**< \brief (ACC_MR) EDGE TYPe */
+#define   ACC_MR_EDGETYP_RISING (0x0u << 9) /**< \brief (ACC_MR) only rising edge of comparator output */
+#define   ACC_MR_EDGETYP_FALLING (0x1u << 9) /**< \brief (ACC_MR) falling edge of comparator output */
+#define   ACC_MR_EDGETYP_ANY (0x2u << 9) /**< \brief (ACC_MR) any edge of comparator output */
+#define ACC_MR_INV (0x1u << 12) /**< \brief (ACC_MR) INVert comparator output */
+#define   ACC_MR_INV_DIS (0x0u << 12) /**< \brief (ACC_MR) Analog Comparator output is directly processed. */
+#define   ACC_MR_INV_EN (0x1u << 12) /**< \brief (ACC_MR) Analog Comparator output is inverted prior to being processed. */
+#define ACC_MR_SELFS (0x1u << 13) /**< \brief (ACC_MR) SELection of Fault Source */
+#define   ACC_MR_SELFS_CF (0x0u << 13) /**< \brief (ACC_MR) the CF flag is used to drive the FAULT output. */
+#define   ACC_MR_SELFS_OUTPUT (0x1u << 13) /**< \brief (ACC_MR) the output of the Analog Comparator flag is used to drive the FAULT output. */
+#define ACC_MR_FE (0x1u << 14) /**< \brief (ACC_MR) Fault Enable */
+#define   ACC_MR_FE_DIS (0x0u << 14) /**< \brief (ACC_MR) the FAULT output is tied to 0. */
+#define   ACC_MR_FE_EN (0x1u << 14) /**< \brief (ACC_MR) the FAULT output is driven by the signal defined by SELFS. */
+/* -------- ACC_IER : (ACC Offset: 0x24) Interrupt Enable Register -------- */
+#define ACC_IER_CE (0x1u << 0) /**< \brief (ACC_IER) Comparison Edge */
+/* -------- ACC_IDR : (ACC Offset: 0x28) Interrupt Disable Register -------- */
+#define ACC_IDR_CE (0x1u << 0) /**< \brief (ACC_IDR) Comparison Edge */
+/* -------- ACC_IMR : (ACC Offset: 0x2C) Interrupt Mask Register -------- */
+#define ACC_IMR_CE (0x1u << 0) /**< \brief (ACC_IMR) Comparison Edge */
+/* -------- ACC_ISR : (ACC Offset: 0x30) Interrupt Status Register -------- */
+#define ACC_ISR_CE (0x1u << 0) /**< \brief (ACC_ISR) Comparison Edge */
+#define ACC_ISR_SCO (0x1u << 1) /**< \brief (ACC_ISR) Synchronized Comparator Output */
+#define ACC_ISR_MASK (0x1u << 31) /**< \brief (ACC_ISR)  */
+/* -------- ACC_ACR : (ACC Offset: 0x94) Analog Control Register -------- */
+#define ACC_ACR_ISEL (0x1u << 0) /**< \brief (ACC_ACR) Current SELection */
+#define   ACC_ACR_ISEL_LOPW (0x0u << 0) /**< \brief (ACC_ACR) low power option. */
+#define   ACC_ACR_ISEL_HISP (0x1u << 0) /**< \brief (ACC_ACR) high speed option. */
+#define ACC_ACR_HYST_Pos 1
+#define ACC_ACR_HYST_Msk (0x3u << ACC_ACR_HYST_Pos) /**< \brief (ACC_ACR) HYSTeresis selection */
+#define ACC_ACR_HYST(value) ((ACC_ACR_HYST_Msk & ((value) << ACC_ACR_HYST_Pos)))
+/* -------- ACC_WPMR : (ACC Offset: 0xE4) Write Protect Mode Register -------- */
+#define ACC_WPMR_WPEN (0x1u << 0) /**< \brief (ACC_WPMR) Write Protect Enable */
+#define ACC_WPMR_WPKEY_Pos 8
+#define ACC_WPMR_WPKEY_Msk (0xffffffu << ACC_WPMR_WPKEY_Pos) /**< \brief (ACC_WPMR) Write Protect KEY */
+#define ACC_WPMR_WPKEY(value) ((ACC_WPMR_WPKEY_Msk & ((value) << ACC_WPMR_WPKEY_Pos)))
+/* -------- ACC_WPSR : (ACC Offset: 0xE8) Write Protect Status Register -------- */
+#define ACC_WPSR_WPROTERR (0x1u << 0) /**< \brief (ACC_WPSR) Write PROTection ERRor */
+
+/*@}*/
+
+
+#endif /* _SAM4E_ACC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/aes.h
+++ b/asf/sam/include/sam4e/component/aes.h
@@ -1,0 +1,149 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_AES_COMPONENT_
+#define _SAM4E_AES_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Advanced Encryption Standard */
+/* ============================================================================= */
+/** \addtogroup SAM4E_AES Advanced Encryption Standard */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Aes hardware registers */
+typedef struct {
+  WoReg AES_CR;        /**< \brief (Aes Offset: 0x00) Control Register */
+  RwReg AES_MR;        /**< \brief (Aes Offset: 0x04) Mode Register */
+  RoReg Reserved1[2];
+  WoReg AES_IER;       /**< \brief (Aes Offset: 0x10) Interrupt Enable Register */
+  WoReg AES_IDR;       /**< \brief (Aes Offset: 0x14) Interrupt Disable Register */
+  RoReg AES_IMR;       /**< \brief (Aes Offset: 0x18) Interrupt Mask Register */
+  RoReg AES_ISR;       /**< \brief (Aes Offset: 0x1C) Interrupt Status Register */
+  WoReg AES_KEYWR[8];  /**< \brief (Aes Offset: 0x20) Key Word Register */
+  WoReg AES_IDATAR[4]; /**< \brief (Aes Offset: 0x40) Input Data Register */
+  RoReg AES_ODATAR[4]; /**< \brief (Aes Offset: 0x50) Output Data Register */
+  WoReg AES_IVR[4];    /**< \brief (Aes Offset: 0x60) Initialization Vector Register */
+} Aes;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- AES_CR : (AES Offset: 0x00) Control Register -------- */
+#define AES_CR_START (0x1u << 0) /**< \brief (AES_CR) Start Processing */
+#define AES_CR_SWRST (0x1u << 8) /**< \brief (AES_CR) Software Reset */
+/* -------- AES_MR : (AES Offset: 0x04) Mode Register -------- */
+#define AES_MR_CIPHER (0x1u << 0) /**< \brief (AES_MR) Processing Mode */
+#define AES_MR_DUALBUFF (0x1u << 3) /**< \brief (AES_MR) Dual Input BUFFer */
+#define   AES_MR_DUALBUFF_INACTIVE (0x0u << 3) /**< \brief (AES_MR) AES_IDATARx cannot be written during processing of previous block. */
+#define   AES_MR_DUALBUFF_ACTIVE (0x1u << 3) /**< \brief (AES_MR) AES_IDATARx can be written during processing of previous block when SMOD = 0x2. It speeds up the overall runtime of large files. */
+#define AES_MR_PROCDLY_Pos 4
+#define AES_MR_PROCDLY_Msk (0xfu << AES_MR_PROCDLY_Pos) /**< \brief (AES_MR) Processing Delay */
+#define AES_MR_PROCDLY(value) ((AES_MR_PROCDLY_Msk & ((value) << AES_MR_PROCDLY_Pos)))
+#define AES_MR_SMOD_Pos 8
+#define AES_MR_SMOD_Msk (0x3u << AES_MR_SMOD_Pos) /**< \brief (AES_MR) Start Mode */
+#define   AES_MR_SMOD_MANUAL_START (0x0u << 8) /**< \brief (AES_MR) Manual Mode */
+#define   AES_MR_SMOD_AUTO_START (0x1u << 8) /**< \brief (AES_MR) Auto Mode */
+#define   AES_MR_SMOD_IDATAR0_START (0x2u << 8) /**< \brief (AES_MR) AES_IDATAR0 access only Auto Mode */
+#define AES_MR_KEYSIZE_Pos 10
+#define AES_MR_KEYSIZE_Msk (0x3u << AES_MR_KEYSIZE_Pos) /**< \brief (AES_MR) Key Size */
+#define   AES_MR_KEYSIZE_AES128 (0x0u << 10) /**< \brief (AES_MR) AES Key Size is 128 bits */
+#define   AES_MR_KEYSIZE_AES192 (0x1u << 10) /**< \brief (AES_MR) AES Key Size is 192 bits */
+#define   AES_MR_KEYSIZE_AES256 (0x2u << 10) /**< \brief (AES_MR) AES Key Size is 256 bits */
+#define AES_MR_OPMOD_Pos 12
+#define AES_MR_OPMOD_Msk (0x7u << AES_MR_OPMOD_Pos) /**< \brief (AES_MR) Operation Mode */
+#define   AES_MR_OPMOD_ECB (0x0u << 12) /**< \brief (AES_MR) ECB: Electronic Code Book mode */
+#define   AES_MR_OPMOD_CBC (0x1u << 12) /**< \brief (AES_MR) CBC: Cipher Block Chaining mode */
+#define   AES_MR_OPMOD_OFB (0x2u << 12) /**< \brief (AES_MR) OFB: Output Feedback mode */
+#define   AES_MR_OPMOD_CFB (0x3u << 12) /**< \brief (AES_MR) CFB: Cipher Feedback mode */
+#define   AES_MR_OPMOD_CTR (0x4u << 12) /**< \brief (AES_MR) CTR: Counter mode (16-bit internal counter) */
+#define AES_MR_LOD (0x1u << 15) /**< \brief (AES_MR) Last Output Data Mode */
+#define AES_MR_CFBS_Pos 16
+#define AES_MR_CFBS_Msk (0x7u << AES_MR_CFBS_Pos) /**< \brief (AES_MR) Cipher Feedback Data Size */
+#define   AES_MR_CFBS_SIZE_128BIT (0x0u << 16) /**< \brief (AES_MR) 128-bit */
+#define   AES_MR_CFBS_SIZE_64BIT (0x1u << 16) /**< \brief (AES_MR) 64-bit */
+#define   AES_MR_CFBS_SIZE_32BIT (0x2u << 16) /**< \brief (AES_MR) 32-bit */
+#define   AES_MR_CFBS_SIZE_16BIT (0x3u << 16) /**< \brief (AES_MR) 16-bit */
+#define   AES_MR_CFBS_SIZE_8BIT (0x4u << 16) /**< \brief (AES_MR) 8-bit */
+#define AES_MR_CKEY_Pos 20
+#define AES_MR_CKEY_Msk (0xfu << AES_MR_CKEY_Pos) /**< \brief (AES_MR) Key */
+#define AES_MR_CKEY(value) ((AES_MR_CKEY_Msk & ((value) << AES_MR_CKEY_Pos)))
+/* -------- AES_IER : (AES Offset: 0x10) Interrupt Enable Register -------- */
+#define AES_IER_DATRDY (0x1u << 0) /**< \brief (AES_IER) Data Ready Interrupt Enable */
+#define AES_IER_ENDRX (0x1u << 1) /**< \brief (AES_IER) End of Receive Buffer Interrupt Enable */
+#define AES_IER_ENDTX (0x1u << 2) /**< \brief (AES_IER) End of Transmit Buffer Interrupt Enable */
+#define AES_IER_RXBUFF (0x1u << 3) /**< \brief (AES_IER) Receive Buffer Full Interrupt Enable */
+#define AES_IER_TXBUFE (0x1u << 4) /**< \brief (AES_IER) Transmit Buffer Empty Interrupt Enable */
+#define AES_IER_URAD (0x1u << 8) /**< \brief (AES_IER) Unspecified Register Access Detection Interrupt Enable */
+/* -------- AES_IDR : (AES Offset: 0x14) Interrupt Disable Register -------- */
+#define AES_IDR_DATRDY (0x1u << 0) /**< \brief (AES_IDR) Data Ready Interrupt Disable */
+#define AES_IDR_ENDRX (0x1u << 1) /**< \brief (AES_IDR) End of Receive Buffer Interrupt Disable */
+#define AES_IDR_ENDTX (0x1u << 2) /**< \brief (AES_IDR) End of Transmit Buffer Interrupt Disable */
+#define AES_IDR_RXBUFF (0x1u << 3) /**< \brief (AES_IDR) Receive Buffer Full Interrupt Disable */
+#define AES_IDR_TXBUFE (0x1u << 4) /**< \brief (AES_IDR) Transmit Buffer Empty Interrupt Disable */
+#define AES_IDR_URAD (0x1u << 8) /**< \brief (AES_IDR) Unspecified Register Access Detection Interrupt Disable */
+/* -------- AES_IMR : (AES Offset: 0x18) Interrupt Mask Register -------- */
+#define AES_IMR_DATRDY (0x1u << 0) /**< \brief (AES_IMR) Data Ready Interrupt Mask */
+#define AES_IMR_ENDRX (0x1u << 1) /**< \brief (AES_IMR) End of Receive Buffer Interrupt Mask */
+#define AES_IMR_ENDTX (0x1u << 2) /**< \brief (AES_IMR) End of Transmit Buffer Interrupt Mask */
+#define AES_IMR_RXBUFF (0x1u << 3) /**< \brief (AES_IMR) Receive Buffer Full Interrupt Mask */
+#define AES_IMR_TXBUFE (0x1u << 4) /**< \brief (AES_IMR) Transmit Buffer Empty Interrupt Mask */
+#define AES_IMR_URAD (0x1u << 8) /**< \brief (AES_IMR) Unspecified Register Access Detection Interrupt Mask */
+/* -------- AES_ISR : (AES Offset: 0x1C) Interrupt Status Register -------- */
+#define AES_ISR_DATRDY (0x1u << 0) /**< \brief (AES_ISR) Data Ready */
+#define AES_ISR_ENDRX (0x1u << 1) /**< \brief (AES_ISR) End of RX Buffer */
+#define AES_ISR_ENDTX (0x1u << 2) /**< \brief (AES_ISR) End of TX Buffer */
+#define AES_ISR_RXBUFF (0x1u << 3) /**< \brief (AES_ISR) RX Buffer Full */
+#define AES_ISR_TXBUFE (0x1u << 4) /**< \brief (AES_ISR) TX Buffer Empty */
+#define AES_ISR_URAD (0x1u << 8) /**< \brief (AES_ISR) Unspecified Register Access Detection Status */
+#define AES_ISR_URAT_Pos 12
+#define AES_ISR_URAT_Msk (0xfu << AES_ISR_URAT_Pos) /**< \brief (AES_ISR) Unspecified Register Access: */
+#define   AES_ISR_URAT_IDR_WR_PROCESSING (0x0u << 12) /**< \brief (AES_ISR) Input Data Register written during the data processing when SMOD=0x2 mode. */
+#define   AES_ISR_URAT_ODR_RD_PROCESSING (0x1u << 12) /**< \brief (AES_ISR) Output Data Register read during the data processing. */
+#define   AES_ISR_URAT_MR_WR_PROCESSING (0x2u << 12) /**< \brief (AES_ISR) Mode Register written during the data processing. */
+#define   AES_ISR_URAT_ODR_RD_SUBKGEN (0x3u << 12) /**< \brief (AES_ISR) Output Data Register read during the sub-keys generation. */
+#define   AES_ISR_URAT_MR_WR_SUBKGEN (0x4u << 12) /**< \brief (AES_ISR) Mode Register written during the sub-keys generation. */
+#define   AES_ISR_URAT_WOR_RD_ACCESS (0x5u << 12) /**< \brief (AES_ISR) Write-only register read access. */
+/* -------- AES_KEYWR[8] : (AES Offset: 0x20) Key Word Register -------- */
+#define AES_KEYWR_KEYW_Pos 0
+#define AES_KEYWR_KEYW_Msk (0xffffffffu << AES_KEYWR_KEYW_Pos) /**< \brief (AES_KEYWR[8]) Key Word */
+#define AES_KEYWR_KEYW(value) ((AES_KEYWR_KEYW_Msk & ((value) << AES_KEYWR_KEYW_Pos)))
+/* -------- AES_IDATAR[4] : (AES Offset: 0x40) Input Data Register -------- */
+#define AES_IDATAR_IDATA_Pos 0
+#define AES_IDATAR_IDATA_Msk (0xffffffffu << AES_IDATAR_IDATA_Pos) /**< \brief (AES_IDATAR[4]) Input Data Word */
+#define AES_IDATAR_IDATA(value) ((AES_IDATAR_IDATA_Msk & ((value) << AES_IDATAR_IDATA_Pos)))
+/* -------- AES_ODATAR[4] : (AES Offset: 0x50) Output Data Register -------- */
+#define AES_ODATAR_ODATA_Pos 0
+#define AES_ODATAR_ODATA_Msk (0xffffffffu << AES_ODATAR_ODATA_Pos) /**< \brief (AES_ODATAR[4]) Output Data */
+/* -------- AES_IVR[4] : (AES Offset: 0x60) Initialization Vector Register -------- */
+#define AES_IVR_IV_Pos 0
+#define AES_IVR_IV_Msk (0xffffffffu << AES_IVR_IV_Pos) /**< \brief (AES_IVR[4]) Initialization Vector */
+#define AES_IVR_IV(value) ((AES_IVR_IV_Msk & ((value) << AES_IVR_IV_Pos)))
+
+/*@}*/
+
+
+#endif /* _SAM4E_AES_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/afec.h
+++ b/asf/sam/include/sam4e/component/afec.h
@@ -1,0 +1,625 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_AFEC_COMPONENT_
+#define _SAM4E_AFEC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Analog-Front-End Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_AFEC Analog-Front-End Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Afec hardware registers */
+typedef struct {
+  WoReg AFE_CR;        /**< \brief (Afec Offset: 0x00) Control Register */
+  RwReg AFE_MR;        /**< \brief (Afec Offset: 0x04) Mode Register */
+  RwReg AFE_EMR;       /**< \brief (Afec Offset: 0x08) Extended Mode Register */
+  RwReg AFE_SEQ1R;     /**< \brief (Afec Offset: 0x0C) Channel Sequence 1 Register */
+  RwReg AFE_SEQ2R;     /**< \brief (Afec Offset: 0x10) Channel Sequence 2 Register */
+  WoReg AFE_CHER;      /**< \brief (Afec Offset: 0x14) Channel Enable Register */
+  WoReg AFE_CHDR;      /**< \brief (Afec Offset: 0x18) Channel Disable Register */
+  RoReg AFE_CHSR;      /**< \brief (Afec Offset: 0x1C) Channel Status Register */
+  RoReg AFE_LCDR;      /**< \brief (Afec Offset: 0x20) Last Converted Data Register */
+  WoReg AFE_IER;       /**< \brief (Afec Offset: 0x24) Interrupt Enable Register */
+  WoReg AFE_IDR;       /**< \brief (Afec Offset: 0x28) Interrupt Disable Register */
+  RoReg AFE_IMR;       /**< \brief (Afec Offset: 0x2C) Interrupt Mask Register */
+  RoReg AFE_ISR;       /**< \brief (Afec Offset: 0x30) Interrupt Status Register */
+  RoReg Reserved1[6];
+  RoReg AFE_OVER;      /**< \brief (Afec Offset: 0x4C) Overrun Status Register */
+  RwReg AFE_CWR;       /**< \brief (Afec Offset: 0x50) Compare Window Register */
+  RwReg AFE_CGR;       /**< \brief (Afec Offset: 0x54) Channel Gain Register */
+  RoReg Reserved2[1];
+  RwReg AFE_CDOR;      /**< \brief (Afec Offset: 0x5C) Channel DC Offset Register */
+  RwReg AFE_DIFFR;     /**< \brief (Afec Offset: 0x60) Channel Differential Register */
+  RoReg AFE_CSELR;     /**< \brief (Afec Offset: 0x64) Channel Register Selection */
+  RoReg AFE_CDR;       /**< \brief (Afec Offset: 0x68) Channel Data Register */
+  RoReg AFE_COCR;      /**< \brief (Afec Offset: 0x6C) Channel Offset Compensation Register */
+  RwReg AFE_TEMPMR;    /**< \brief (Afec Offset: 0x70) Temperature Sensor Mode Register */
+  RwReg AFE_TEMPCWR;   /**< \brief (Afec Offset: 0x74) Temperature Compare Window Register */
+  RoReg Reserved3[7];
+  RwReg AFE_ACR;       /**< \brief (Afec Offset: 0x94) Analog Control Register */
+  RoReg Reserved4[19];
+  RwReg AFE_WPMR;      /**< \brief (Afec Offset: 0xE4) Write Protect Mode Register */
+  RoReg AFE_WPSR;      /**< \brief (Afec Offset: 0xE8) Write Protect Status Register */
+  RoReg Reserved5[5];
+  RwReg AFE_RPR;       /**< \brief (Afec Offset: 0x100) Receive Pointer Register */
+  RwReg AFE_RCR;       /**< \brief (Afec Offset: 0x104) Receive Counter Register */
+  RoReg Reserved6[2];
+  RwReg AFE_RNPR;      /**< \brief (Afec Offset: 0x110) Receive Next Pointer Register */
+  RwReg AFE_RNCR;      /**< \brief (Afec Offset: 0x114) Receive Next Counter Register */
+  RoReg Reserved7[2];
+  WoReg AFE_PTCR;      /**< \brief (Afec Offset: 0x120) Transfer Control Register */
+  RoReg AFE_PTSR;      /**< \brief (Afec Offset: 0x124) Transfer Status Register */
+} Afec;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- AFE_CR : (AFEC Offset: 0x00) Control Register -------- */
+#define AFE_CR_SWRST (0x1u << 0) /**< \brief (AFE_CR) Software Reset */
+#define AFE_CR_START (0x1u << 1) /**< \brief (AFE_CR) Start Conversion */
+#define AFE_CR_AUTOCAL (0x1u << 3) /**< \brief (AFE_CR) Automatic Calibration of AFE */
+/* -------- AFE_MR : (AFEC Offset: 0x04) Mode Register -------- */
+#define AFE_MR_TRGEN (0x1u << 0) /**< \brief (AFE_MR) Trigger Enable */
+#define   AFE_MR_TRGEN_DIS (0x0u << 0) /**< \brief (AFE_MR) Hardware triggers are disabled. Starting a conversion is only possible by software. */
+#define   AFE_MR_TRGEN_EN (0x1u << 0) /**< \brief (AFE_MR) Hardware trigger selected by TRGSEL field is enabled. */
+#define AFE_MR_TRGSEL_Pos 1
+#define AFE_MR_TRGSEL_Msk (0x7u << AFE_MR_TRGSEL_Pos) /**< \brief (AFE_MR) Trigger Selection */
+#define   AFE_MR_TRGSEL_AFE_TRIG0 (0x0u << 1) /**< \brief (AFE_MR) ADTRG pin */
+#define   AFE_MR_TRGSEL_AFE_TRIG1 (0x1u << 1) /**< \brief (AFE_MR) TIO Output of the Timer Counter Channel 0 */
+#define   AFE_MR_TRGSEL_AFE_TRIG2 (0x2u << 1) /**< \brief (AFE_MR) TIO Output of the Timer Counter Channel 1 */
+#define   AFE_MR_TRGSEL_AFE_TRIG3 (0x3u << 1) /**< \brief (AFE_MR) TIO Output of the Timer Counter Channel 2 */
+#define   AFE_MR_TRGSEL_AFE_TRIG4 (0x4u << 1) /**< \brief (AFE_MR) PWM Event Line 0 */
+#define   AFE_MR_TRGSEL_AFE_TRIG5 (0x5u << 1) /**< \brief (AFE_MR) PWM Event Line 1 */
+#define AFE_MR_SLEEP (0x1u << 5) /**< \brief (AFE_MR) Sleep Mode */
+#define   AFE_MR_SLEEP_NORMAL (0x0u << 5) /**< \brief (AFE_MR) Normal Mode: The AFE Core and reference voltage circuitry are kept ON between conversions */
+#define   AFE_MR_SLEEP_SLEEP (0x1u << 5) /**< \brief (AFE_MR) Sleep Mode: The AFE Core and reference voltage circuitry are OFF between conversions */
+#define AFE_MR_FWUP (0x1u << 6) /**< \brief (AFE_MR) Fast Wake Up */
+#define   AFE_MR_FWUP_OFF (0x0u << 6) /**< \brief (AFE_MR) Normal Sleep Mode: The sleep mode is defined by the SLEEP bit */
+#define   AFE_MR_FWUP_ON (0x1u << 6) /**< \brief (AFE_MR) Fast Wake Up Sleep Mode: The Voltage reference is ON between conversions and AFE Core is OFF */
+#define AFE_MR_FREERUN (0x1u << 7) /**< \brief (AFE_MR) Free Run Mode */
+#define   AFE_MR_FREERUN_OFF (0x0u << 7) /**< \brief (AFE_MR) Normal Mode */
+#define   AFE_MR_FREERUN_ON (0x1u << 7) /**< \brief (AFE_MR) Free Run Mode: Never wait for any trigger. */
+#define AFE_MR_PRESCAL_Pos 8
+#define AFE_MR_PRESCAL_Msk (0xffu << AFE_MR_PRESCAL_Pos) /**< \brief (AFE_MR) Prescaler Rate Selection */
+#define AFE_MR_PRESCAL(value) ((AFE_MR_PRESCAL_Msk & ((value) << AFE_MR_PRESCAL_Pos)))
+#define AFE_MR_STARTUP_Pos 16
+#define AFE_MR_STARTUP_Msk (0xfu << AFE_MR_STARTUP_Pos) /**< \brief (AFE_MR) Start Up Time */
+#define   AFE_MR_STARTUP_SUT0 (0x0u << 16) /**< \brief (AFE_MR) 0 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT8 (0x1u << 16) /**< \brief (AFE_MR) 8 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT16 (0x2u << 16) /**< \brief (AFE_MR) 16 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT24 (0x3u << 16) /**< \brief (AFE_MR) 24 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT64 (0x4u << 16) /**< \brief (AFE_MR) 64 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT80 (0x5u << 16) /**< \brief (AFE_MR) 80 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT96 (0x6u << 16) /**< \brief (AFE_MR) 96 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT112 (0x7u << 16) /**< \brief (AFE_MR) 112 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT512 (0x8u << 16) /**< \brief (AFE_MR) 512 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT576 (0x9u << 16) /**< \brief (AFE_MR) 576 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT640 (0xAu << 16) /**< \brief (AFE_MR) 640 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT704 (0xBu << 16) /**< \brief (AFE_MR) 704 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT768 (0xCu << 16) /**< \brief (AFE_MR) 768 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT832 (0xDu << 16) /**< \brief (AFE_MR) 832 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT896 (0xEu << 16) /**< \brief (AFE_MR) 896 periods of AFEClock */
+#define   AFE_MR_STARTUP_SUT960 (0xFu << 16) /**< \brief (AFE_MR) 960 periods of AFEClock */
+#define AFE_MR_SETTLING_Pos 20
+#define AFE_MR_SETTLING_Msk (0x3u << AFE_MR_SETTLING_Pos) /**< \brief (AFE_MR) Analog Settling Time */
+#define   AFE_MR_SETTLING_AST3 (0x0u << 20) /**< \brief (AFE_MR) 3 periods of AFEClock */
+#define   AFE_MR_SETTLING_AST5 (0x1u << 20) /**< \brief (AFE_MR) 5 periods of AFEClock */
+#define   AFE_MR_SETTLING_AST9 (0x2u << 20) /**< \brief (AFE_MR) 9 periods of AFEClock */
+#define   AFE_MR_SETTLING_AST17 (0x3u << 20) /**< \brief (AFE_MR) 17 periods of AFEClock */
+#define AFE_MR_ANACH (0x1u << 23) /**< \brief (AFE_MR) Analog Change */
+#define   AFE_MR_ANACH_NONE (0x0u << 23) /**< \brief (AFE_MR) No analog change on channel switching: DIFF0, GAIN0 and OFF0 are used for all channels */
+#define   AFE_MR_ANACH_ALLOWED (0x1u << 23) /**< \brief (AFE_MR) Allows different analog settings for each channel. See AFE_CGR and AFE_CDOR Registers */
+#define AFE_MR_TRACKTIM_Pos 24
+#define AFE_MR_TRACKTIM_Msk (0xfu << AFE_MR_TRACKTIM_Pos) /**< \brief (AFE_MR) Tracking Time */
+#define AFE_MR_TRACKTIM(value) ((AFE_MR_TRACKTIM_Msk & ((value) << AFE_MR_TRACKTIM_Pos)))
+#define AFE_MR_TRANSFER_Pos 28
+#define AFE_MR_TRANSFER_Msk (0x3u << AFE_MR_TRANSFER_Pos) /**< \brief (AFE_MR) Transfer Period */
+#define AFE_MR_TRANSFER(value) ((AFE_MR_TRANSFER_Msk & ((value) << AFE_MR_TRANSFER_Pos)))
+#define AFE_MR_USEQ (0x1u << 31) /**< \brief (AFE_MR) Use Sequence Enable */
+#define   AFE_MR_USEQ_NUM_ORDER (0x0u << 31) /**< \brief (AFE_MR) Normal Mode: The controller converts channels in a simple numeric order. */
+#define   AFE_MR_USEQ_REG_ORDER (0x1u << 31) /**< \brief (AFE_MR) User Sequence Mode: The sequence respects what is defined in AFE_SEQR1 and AFE_SEQR2 registers. */
+/* -------- AFE_EMR : (AFEC Offset: 0x08) Extended Mode Register -------- */
+#define AFE_EMR_CMPMODE_Pos 0
+#define AFE_EMR_CMPMODE_Msk (0x3u << AFE_EMR_CMPMODE_Pos) /**< \brief (AFE_EMR) Comparison Mode */
+#define   AFE_EMR_CMPMODE_LOW (0x0u << 0) /**< \brief (AFE_EMR) Generates an event when the converted data is lower than the low threshold of the window. */
+#define   AFE_EMR_CMPMODE_HIGH (0x1u << 0) /**< \brief (AFE_EMR) Generates an event when the converted data is higher than the high threshold of the window. */
+#define   AFE_EMR_CMPMODE_IN (0x2u << 0) /**< \brief (AFE_EMR) Generates an event when the converted data is in the comparison window. */
+#define   AFE_EMR_CMPMODE_OUT (0x3u << 0) /**< \brief (AFE_EMR) Generates an event when the converted data is out of the comparison window. */
+#define AFE_EMR_CMPSEL_Pos 3
+#define AFE_EMR_CMPSEL_Msk (0x1fu << AFE_EMR_CMPSEL_Pos) /**< \brief (AFE_EMR) Comparison Selected Channel */
+#define AFE_EMR_CMPSEL(value) ((AFE_EMR_CMPSEL_Msk & ((value) << AFE_EMR_CMPSEL_Pos)))
+#define AFE_EMR_CMPALL (0x1u << 9) /**< \brief (AFE_EMR) Compare All Channels */
+#define AFE_EMR_CMPFILTER_Pos 12
+#define AFE_EMR_CMPFILTER_Msk (0x3u << AFE_EMR_CMPFILTER_Pos) /**< \brief (AFE_EMR) Compare Event Filtering */
+#define AFE_EMR_CMPFILTER(value) ((AFE_EMR_CMPFILTER_Msk & ((value) << AFE_EMR_CMPFILTER_Pos)))
+#define AFE_EMR_RES_Pos 16
+#define AFE_EMR_RES_Msk (0x7u << AFE_EMR_RES_Pos) /**< \brief (AFE_EMR) Resolution */
+#define   AFE_EMR_RES_NO_AVERAGE (0x0u << 16) /**< \brief (AFE_EMR) 12-bit resolution, AFE sample rate is maximum (no averaging). */
+#define   AFE_EMR_RES_LOW_RES (0x1u << 16) /**< \brief (AFE_EMR) 10-bit resolution, AFE sample rate is maximum (no averaging). */
+#define   AFE_EMR_RES_OSR4 (0x2u << 16) /**< \brief (AFE_EMR) 13-bit resolution, AFE sample rate divided by 4 (averaging). */
+#define   AFE_EMR_RES_OSR16 (0x3u << 16) /**< \brief (AFE_EMR) 14-bit resolution, AFE sample rate divided by 16 (averaging). */
+#define   AFE_EMR_RES_OSR64 (0x4u << 16) /**< \brief (AFE_EMR) 15-bit resolution, AFE sample rate divided by 64 (averaging). */
+#define   AFE_EMR_RES_OSR256 (0x5u << 16) /**< \brief (AFE_EMR) 16-bit resolution, AFE sample rate divided by 256 (averaging). */
+#define AFE_EMR_TAG (0x1u << 24) /**< \brief (AFE_EMR) TAG of AFE_LDCR register */
+#define AFE_EMR_STM (0x1u << 25) /**< \brief (AFE_EMR) Single Trigger Mode */
+/* -------- AFE_SEQ1R : (AFEC Offset: 0x0C) Channel Sequence 1 Register -------- */
+#define AFE_SEQ1R_USCH0_Pos 0
+#define AFE_SEQ1R_USCH0_Msk (0xfu << AFE_SEQ1R_USCH0_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 0 */
+#define AFE_SEQ1R_USCH0(value) ((AFE_SEQ1R_USCH0_Msk & ((value) << AFE_SEQ1R_USCH0_Pos)))
+#define AFE_SEQ1R_USCH1_Pos 4
+#define AFE_SEQ1R_USCH1_Msk (0xfu << AFE_SEQ1R_USCH1_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 1 */
+#define AFE_SEQ1R_USCH1(value) ((AFE_SEQ1R_USCH1_Msk & ((value) << AFE_SEQ1R_USCH1_Pos)))
+#define AFE_SEQ1R_USCH2_Pos 8
+#define AFE_SEQ1R_USCH2_Msk (0xfu << AFE_SEQ1R_USCH2_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 2 */
+#define AFE_SEQ1R_USCH2(value) ((AFE_SEQ1R_USCH2_Msk & ((value) << AFE_SEQ1R_USCH2_Pos)))
+#define AFE_SEQ1R_USCH3_Pos 12
+#define AFE_SEQ1R_USCH3_Msk (0xfu << AFE_SEQ1R_USCH3_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 3 */
+#define AFE_SEQ1R_USCH3(value) ((AFE_SEQ1R_USCH3_Msk & ((value) << AFE_SEQ1R_USCH3_Pos)))
+#define AFE_SEQ1R_USCH4_Pos 16
+#define AFE_SEQ1R_USCH4_Msk (0xfu << AFE_SEQ1R_USCH4_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 4 */
+#define AFE_SEQ1R_USCH4(value) ((AFE_SEQ1R_USCH4_Msk & ((value) << AFE_SEQ1R_USCH4_Pos)))
+#define AFE_SEQ1R_USCH5_Pos 20
+#define AFE_SEQ1R_USCH5_Msk (0xfu << AFE_SEQ1R_USCH5_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 5 */
+#define AFE_SEQ1R_USCH5(value) ((AFE_SEQ1R_USCH5_Msk & ((value) << AFE_SEQ1R_USCH5_Pos)))
+#define AFE_SEQ1R_USCH6_Pos 24
+#define AFE_SEQ1R_USCH6_Msk (0xfu << AFE_SEQ1R_USCH6_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 6 */
+#define AFE_SEQ1R_USCH6(value) ((AFE_SEQ1R_USCH6_Msk & ((value) << AFE_SEQ1R_USCH6_Pos)))
+#define AFE_SEQ1R_USCH7_Pos 28
+#define AFE_SEQ1R_USCH7_Msk (0xfu << AFE_SEQ1R_USCH7_Pos) /**< \brief (AFE_SEQ1R) User Sequence Number 7 */
+#define AFE_SEQ1R_USCH7(value) ((AFE_SEQ1R_USCH7_Msk & ((value) << AFE_SEQ1R_USCH7_Pos)))
+/* -------- AFE_SEQ2R : (AFEC Offset: 0x10) Channel Sequence 2 Register -------- */
+#define AFE_SEQ2R_USCH8_Pos 0
+#define AFE_SEQ2R_USCH8_Msk (0xfu << AFE_SEQ2R_USCH8_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 8 */
+#define AFE_SEQ2R_USCH8(value) ((AFE_SEQ2R_USCH8_Msk & ((value) << AFE_SEQ2R_USCH8_Pos)))
+#define AFE_SEQ2R_USCH9_Pos 4
+#define AFE_SEQ2R_USCH9_Msk (0xfu << AFE_SEQ2R_USCH9_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 9 */
+#define AFE_SEQ2R_USCH9(value) ((AFE_SEQ2R_USCH9_Msk & ((value) << AFE_SEQ2R_USCH9_Pos)))
+#define AFE_SEQ2R_USCH10_Pos 8
+#define AFE_SEQ2R_USCH10_Msk (0xfu << AFE_SEQ2R_USCH10_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 10 */
+#define AFE_SEQ2R_USCH10(value) ((AFE_SEQ2R_USCH10_Msk & ((value) << AFE_SEQ2R_USCH10_Pos)))
+#define AFE_SEQ2R_USCH11_Pos 12
+#define AFE_SEQ2R_USCH11_Msk (0xfu << AFE_SEQ2R_USCH11_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 11 */
+#define AFE_SEQ2R_USCH11(value) ((AFE_SEQ2R_USCH11_Msk & ((value) << AFE_SEQ2R_USCH11_Pos)))
+#define AFE_SEQ2R_USCH12_Pos 16
+#define AFE_SEQ2R_USCH12_Msk (0xfu << AFE_SEQ2R_USCH12_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 12 */
+#define AFE_SEQ2R_USCH12(value) ((AFE_SEQ2R_USCH12_Msk & ((value) << AFE_SEQ2R_USCH12_Pos)))
+#define AFE_SEQ2R_USCH13_Pos 20
+#define AFE_SEQ2R_USCH13_Msk (0xfu << AFE_SEQ2R_USCH13_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 13 */
+#define AFE_SEQ2R_USCH13(value) ((AFE_SEQ2R_USCH13_Msk & ((value) << AFE_SEQ2R_USCH13_Pos)))
+#define AFE_SEQ2R_USCH14_Pos 24
+#define AFE_SEQ2R_USCH14_Msk (0xfu << AFE_SEQ2R_USCH14_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 14 */
+#define AFE_SEQ2R_USCH14(value) ((AFE_SEQ2R_USCH14_Msk & ((value) << AFE_SEQ2R_USCH14_Pos)))
+#define AFE_SEQ2R_USCH15_Pos 28
+#define AFE_SEQ2R_USCH15_Msk (0xfu << AFE_SEQ2R_USCH15_Pos) /**< \brief (AFE_SEQ2R) User Sequence Number 15 */
+#define AFE_SEQ2R_USCH15(value) ((AFE_SEQ2R_USCH15_Msk & ((value) << AFE_SEQ2R_USCH15_Pos)))
+/* -------- AFE_CHER : (AFEC Offset: 0x14) Channel Enable Register -------- */
+#define AFE_CHER_CH0 (0x1u << 0) /**< \brief (AFE_CHER) Channel 0 Enable */
+#define AFE_CHER_CH1 (0x1u << 1) /**< \brief (AFE_CHER) Channel 1 Enable */
+#define AFE_CHER_CH2 (0x1u << 2) /**< \brief (AFE_CHER) Channel 2 Enable */
+#define AFE_CHER_CH3 (0x1u << 3) /**< \brief (AFE_CHER) Channel 3 Enable */
+#define AFE_CHER_CH4 (0x1u << 4) /**< \brief (AFE_CHER) Channel 4 Enable */
+#define AFE_CHER_CH5 (0x1u << 5) /**< \brief (AFE_CHER) Channel 5 Enable */
+#define AFE_CHER_CH6 (0x1u << 6) /**< \brief (AFE_CHER) Channel 6 Enable */
+#define AFE_CHER_CH7 (0x1u << 7) /**< \brief (AFE_CHER) Channel 7 Enable */
+#define AFE_CHER_CH8 (0x1u << 8) /**< \brief (AFE_CHER) Channel 8 Enable */
+#define AFE_CHER_CH9 (0x1u << 9) /**< \brief (AFE_CHER) Channel 9 Enable */
+#define AFE_CHER_CH10 (0x1u << 10) /**< \brief (AFE_CHER) Channel 10 Enable */
+#define AFE_CHER_CH11 (0x1u << 11) /**< \brief (AFE_CHER) Channel 11 Enable */
+#define AFE_CHER_CH12 (0x1u << 12) /**< \brief (AFE_CHER) Channel 12 Enable */
+#define AFE_CHER_CH13 (0x1u << 13) /**< \brief (AFE_CHER) Channel 13 Enable */
+#define AFE_CHER_CH14 (0x1u << 14) /**< \brief (AFE_CHER) Channel 14 Enable */
+#define AFE_CHER_CH15 (0x1u << 15) /**< \brief (AFE_CHER) Channel 15 Enable */
+#define AFE_CHER_CH16 (0x1u << 16) /**< \brief (AFE_CHER) Channel 16 Enable */
+#define AFE_CHER_DIFF17 (0x1u << 17) /**< \brief (AFE_CHER)  */
+#define AFE_CHER_CH18 (0x1u << 18) /**< \brief (AFE_CHER) Channel 18 Enable */
+#define AFE_CHER_CH19 (0x1u << 19) /**< \brief (AFE_CHER) Channel 19 Enable */
+#define AFE_CHER_CH20 (0x1u << 20) /**< \brief (AFE_CHER) Channel 20 Enable */
+#define AFE_CHER_CH21 (0x1u << 21) /**< \brief (AFE_CHER) Channel 21 Enable */
+#define AFE_CHER_CH22 (0x1u << 22) /**< \brief (AFE_CHER) Channel 22 Enable */
+#define AFE_CHER_CH23 (0x1u << 23) /**< \brief (AFE_CHER) Channel 23 Enable */
+/* -------- AFE_CHDR : (AFEC Offset: 0x18) Channel Disable Register -------- */
+#define AFE_CHDR_CH0 (0x1u << 0) /**< \brief (AFE_CHDR) Channel 0 Disable */
+#define AFE_CHDR_CH1 (0x1u << 1) /**< \brief (AFE_CHDR) Channel 1 Disable */
+#define AFE_CHDR_CH2 (0x1u << 2) /**< \brief (AFE_CHDR) Channel 2 Disable */
+#define AFE_CHDR_CH3 (0x1u << 3) /**< \brief (AFE_CHDR) Channel 3 Disable */
+#define AFE_CHDR_CH4 (0x1u << 4) /**< \brief (AFE_CHDR) Channel 4 Disable */
+#define AFE_CHDR_CH5 (0x1u << 5) /**< \brief (AFE_CHDR) Channel 5 Disable */
+#define AFE_CHDR_CH6 (0x1u << 6) /**< \brief (AFE_CHDR) Channel 6 Disable */
+#define AFE_CHDR_CH7 (0x1u << 7) /**< \brief (AFE_CHDR) Channel 7 Disable */
+#define AFE_CHDR_CH8 (0x1u << 8) /**< \brief (AFE_CHDR) Channel 8 Disable */
+#define AFE_CHDR_CH9 (0x1u << 9) /**< \brief (AFE_CHDR) Channel 9 Disable */
+#define AFE_CHDR_CH10 (0x1u << 10) /**< \brief (AFE_CHDR) Channel 10 Disable */
+#define AFE_CHDR_CH11 (0x1u << 11) /**< \brief (AFE_CHDR) Channel 11 Disable */
+#define AFE_CHDR_CH12 (0x1u << 12) /**< \brief (AFE_CHDR) Channel 12 Disable */
+#define AFE_CHDR_CH13 (0x1u << 13) /**< \brief (AFE_CHDR) Channel 13 Disable */
+#define AFE_CHDR_CH14 (0x1u << 14) /**< \brief (AFE_CHDR) Channel 14 Disable */
+#define AFE_CHDR_CH15 (0x1u << 15) /**< \brief (AFE_CHDR) Channel 15 Disable */
+#define AFE_CHDR_CH16 (0x1u << 16) /**< \brief (AFE_CHDR) Channel 16 Disable */
+#define AFE_CHDR_DIFF17 (0x1u << 17) /**< \brief (AFE_CHDR)  */
+#define AFE_CHDR_CH18 (0x1u << 18) /**< \brief (AFE_CHDR) Channel 18 Disable */
+#define AFE_CHDR_CH19 (0x1u << 19) /**< \brief (AFE_CHDR) Channel 19 Disable */
+#define AFE_CHDR_CH20 (0x1u << 20) /**< \brief (AFE_CHDR) Channel 20 Disable */
+#define AFE_CHDR_CH21 (0x1u << 21) /**< \brief (AFE_CHDR) Channel 21 Disable */
+#define AFE_CHDR_CH22 (0x1u << 22) /**< \brief (AFE_CHDR) Channel 22 Disable */
+#define AFE_CHDR_CH23 (0x1u << 23) /**< \brief (AFE_CHDR) Channel 23 Disable */
+/* -------- AFE_CHSR : (AFEC Offset: 0x1C) Channel Status Register -------- */
+#define AFE_CHSR_CH0 (0x1u << 0) /**< \brief (AFE_CHSR) Channel 0 Status */
+#define AFE_CHSR_CH1 (0x1u << 1) /**< \brief (AFE_CHSR) Channel 1 Status */
+#define AFE_CHSR_CH2 (0x1u << 2) /**< \brief (AFE_CHSR) Channel 2 Status */
+#define AFE_CHSR_CH3 (0x1u << 3) /**< \brief (AFE_CHSR) Channel 3 Status */
+#define AFE_CHSR_CH4 (0x1u << 4) /**< \brief (AFE_CHSR) Channel 4 Status */
+#define AFE_CHSR_CH5 (0x1u << 5) /**< \brief (AFE_CHSR) Channel 5 Status */
+#define AFE_CHSR_CH6 (0x1u << 6) /**< \brief (AFE_CHSR) Channel 6 Status */
+#define AFE_CHSR_CH7 (0x1u << 7) /**< \brief (AFE_CHSR) Channel 7 Status */
+#define AFE_CHSR_CH8 (0x1u << 8) /**< \brief (AFE_CHSR) Channel 8 Status */
+#define AFE_CHSR_CH9 (0x1u << 9) /**< \brief (AFE_CHSR) Channel 9 Status */
+#define AFE_CHSR_CH10 (0x1u << 10) /**< \brief (AFE_CHSR) Channel 10 Status */
+#define AFE_CHSR_CH11 (0x1u << 11) /**< \brief (AFE_CHSR) Channel 11 Status */
+#define AFE_CHSR_CH12 (0x1u << 12) /**< \brief (AFE_CHSR) Channel 12 Status */
+#define AFE_CHSR_CH13 (0x1u << 13) /**< \brief (AFE_CHSR) Channel 13 Status */
+#define AFE_CHSR_CH14 (0x1u << 14) /**< \brief (AFE_CHSR) Channel 14 Status */
+#define AFE_CHSR_CH15 (0x1u << 15) /**< \brief (AFE_CHSR) Channel 15 Status */
+#define AFE_CHSR_CH16 (0x1u << 16) /**< \brief (AFE_CHSR) Channel 16 Status */
+#define AFE_CHSR_DIFF17 (0x1u << 17) /**< \brief (AFE_CHSR)  */
+#define AFE_CHSR_CH18 (0x1u << 18) /**< \brief (AFE_CHSR) Channel 18 Status */
+#define AFE_CHSR_CH19 (0x1u << 19) /**< \brief (AFE_CHSR) Channel 19 Status */
+#define AFE_CHSR_CH20 (0x1u << 20) /**< \brief (AFE_CHSR) Channel 20 Status */
+#define AFE_CHSR_CH21 (0x1u << 21) /**< \brief (AFE_CHSR) Channel 21 Status */
+#define AFE_CHSR_CH22 (0x1u << 22) /**< \brief (AFE_CHSR) Channel 22 Status */
+#define AFE_CHSR_CH23 (0x1u << 23) /**< \brief (AFE_CHSR) Channel 23 Status */
+/* -------- AFE_LCDR : (AFEC Offset: 0x20) Last Converted Data Register -------- */
+#define AFE_LCDR_LDATA_Pos 0
+#define AFE_LCDR_LDATA_Msk (0xffffu << AFE_LCDR_LDATA_Pos) /**< \brief (AFE_LCDR) Last Data Converted */
+#define AFE_LCDR_CHNB_Pos 24
+#define AFE_LCDR_CHNB_Msk (0xfu << AFE_LCDR_CHNB_Pos) /**< \brief (AFE_LCDR) Channel Number */
+/* -------- AFE_IER : (AFEC Offset: 0x24) Interrupt Enable Register -------- */
+#define AFE_IER_EOC0 (0x1u << 0) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 0 */
+#define AFE_IER_EOC1 (0x1u << 1) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 1 */
+#define AFE_IER_EOC2 (0x1u << 2) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 2 */
+#define AFE_IER_EOC3 (0x1u << 3) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 3 */
+#define AFE_IER_EOC4 (0x1u << 4) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 4 */
+#define AFE_IER_EOC5 (0x1u << 5) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 5 */
+#define AFE_IER_EOC6 (0x1u << 6) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 6 */
+#define AFE_IER_EOC7 (0x1u << 7) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 7 */
+#define AFE_IER_EOC8 (0x1u << 8) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 8 */
+#define AFE_IER_EOC9 (0x1u << 9) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 9 */
+#define AFE_IER_EOC10 (0x1u << 10) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 10 */
+#define AFE_IER_EOC11 (0x1u << 11) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 11 */
+#define AFE_IER_EOC12 (0x1u << 12) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 12 */
+#define AFE_IER_EOC13 (0x1u << 13) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 13 */
+#define AFE_IER_EOC14 (0x1u << 14) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 14 */
+#define AFE_IER_EOC15 (0x1u << 15) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 15 */
+#define AFE_IER_EOC16 (0x1u << 16) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 16 */
+#define AFE_IER_EOC17 (0x1u << 17) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 17 */
+#define AFE_IER_EOC18 (0x1u << 18) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 18 */
+#define AFE_IER_EOC19 (0x1u << 19) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 19 */
+#define AFE_IER_EOC20 (0x1u << 20) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 20 */
+#define AFE_IER_EOC21 (0x1u << 21) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 21 */
+#define AFE_IER_EOC22 (0x1u << 22) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 22 */
+#define AFE_IER_EOC23 (0x1u << 23) /**< \brief (AFE_IER) End of Conversion Interrupt Enable 23 */
+#define AFE_IER_DRDY (0x1u << 24) /**< \brief (AFE_IER) Data Ready Interrupt Enable */
+#define AFE_IER_GOVRE (0x1u << 25) /**< \brief (AFE_IER) General Overrun Error Interrupt Enable */
+#define AFE_IER_COMPE (0x1u << 26) /**< \brief (AFE_IER) Comparison Event Interrupt Enable+ */
+#define AFE_IER_ENDRX (0x1u << 27) /**< \brief (AFE_IER) End of Receive Buffer Interrupt Enable */
+#define AFE_IER_RXBUFF (0x1u << 28) /**< \brief (AFE_IER) Receive Buffer Full Interrupt Enable */
+#define AFE_IER_TEMPCHG (0x1u << 30) /**< \brief (AFE_IER) Temperature Change Interrupt Enable */
+#define AFE_IER_EOCAL (0x1u << 31) /**< \brief (AFE_IER) End of Calibration Sequence Interrupt Enable */
+/* -------- AFE_IDR : (AFEC Offset: 0x28) Interrupt Disable Register -------- */
+#define AFE_IDR_EOC0 (0x1u << 0) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 0 */
+#define AFE_IDR_EOC1 (0x1u << 1) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 1 */
+#define AFE_IDR_EOC2 (0x1u << 2) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 2 */
+#define AFE_IDR_EOC3 (0x1u << 3) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 3 */
+#define AFE_IDR_EOC4 (0x1u << 4) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 4 */
+#define AFE_IDR_EOC5 (0x1u << 5) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 5 */
+#define AFE_IDR_EOC6 (0x1u << 6) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 6 */
+#define AFE_IDR_EOC7 (0x1u << 7) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 7 */
+#define AFE_IDR_EOC8 (0x1u << 8) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 8 */
+#define AFE_IDR_EOC9 (0x1u << 9) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 9 */
+#define AFE_IDR_EOC10 (0x1u << 10) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 10 */
+#define AFE_IDR_EOC11 (0x1u << 11) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 11 */
+#define AFE_IDR_EOC12 (0x1u << 12) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 12 */
+#define AFE_IDR_EOC13 (0x1u << 13) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 13 */
+#define AFE_IDR_EOC14 (0x1u << 14) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 14 */
+#define AFE_IDR_EOC15 (0x1u << 15) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 15 */
+#define AFE_IDR_EOC16 (0x1u << 16) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 16 */
+#define AFE_IDR_EOC17 (0x1u << 17) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 17 */
+#define AFE_IDR_EOC18 (0x1u << 18) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 18 */
+#define AFE_IDR_EOC19 (0x1u << 19) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 19 */
+#define AFE_IDR_EOC20 (0x1u << 20) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 20 */
+#define AFE_IDR_EOC21 (0x1u << 21) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 21 */
+#define AFE_IDR_EOC22 (0x1u << 22) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 22 */
+#define AFE_IDR_EOC23 (0x1u << 23) /**< \brief (AFE_IDR) End of Conversion Interrupt Disable 23 */
+#define AFE_IDR_DRDY (0x1u << 24) /**< \brief (AFE_IDR) Data Ready Interrupt Disable */
+#define AFE_IDR_GOVRE (0x1u << 25) /**< \brief (AFE_IDR) General Overrun Error Interrupt Disable */
+#define AFE_IDR_COMPE (0x1u << 26) /**< \brief (AFE_IDR) Comparison Event Interrupt Disable */
+#define AFE_IDR_ENDRX (0x1u << 27) /**< \brief (AFE_IDR) End of Receive Buffer Interrupt Disable */
+#define AFE_IDR_RXBUFF (0x1u << 28) /**< \brief (AFE_IDR) Receive Buffer Full Interrupt Disable */
+#define AFE_IDR_TEMPCHG (0x1u << 30) /**< \brief (AFE_IDR) Temperature Change Interrupt Disable */
+#define AFE_IDR_EOCAL (0x1u << 31) /**< \brief (AFE_IDR) End of Calibration Sequence Interrupt Disable */
+/* -------- AFE_IMR : (AFEC Offset: 0x2C) Interrupt Mask Register -------- */
+#define AFE_IMR_EOC0 (0x1u << 0) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 0 */
+#define AFE_IMR_EOC1 (0x1u << 1) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 1 */
+#define AFE_IMR_EOC2 (0x1u << 2) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 2 */
+#define AFE_IMR_EOC3 (0x1u << 3) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 3 */
+#define AFE_IMR_EOC4 (0x1u << 4) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 4 */
+#define AFE_IMR_EOC5 (0x1u << 5) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 5 */
+#define AFE_IMR_EOC6 (0x1u << 6) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 6 */
+#define AFE_IMR_EOC7 (0x1u << 7) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 7 */
+#define AFE_IMR_EOC8 (0x1u << 8) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 8 */
+#define AFE_IMR_EOC9 (0x1u << 9) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 9 */
+#define AFE_IMR_EOC10 (0x1u << 10) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 10 */
+#define AFE_IMR_EOC11 (0x1u << 11) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 11 */
+#define AFE_IMR_EOC12 (0x1u << 12) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 12 */
+#define AFE_IMR_EOC13 (0x1u << 13) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 13 */
+#define AFE_IMR_EOC14 (0x1u << 14) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 14 */
+#define AFE_IMR_EOC15 (0x1u << 15) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 15 */
+#define AFE_IMR_EOC16 (0x1u << 16) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 16 */
+#define AFE_IMR_EOC17 (0x1u << 17) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 17 */
+#define AFE_IMR_EOC18 (0x1u << 18) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 18 */
+#define AFE_IMR_EOC19 (0x1u << 19) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 19 */
+#define AFE_IMR_EOC20 (0x1u << 20) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 20 */
+#define AFE_IMR_EOC21 (0x1u << 21) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 21 */
+#define AFE_IMR_EOC22 (0x1u << 22) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 22 */
+#define AFE_IMR_EOC23 (0x1u << 23) /**< \brief (AFE_IMR) End of Conversion Interrupt Mask 23 */
+#define AFE_IMR_DRDY (0x1u << 24) /**< \brief (AFE_IMR) Data Ready Interrupt Mask */
+#define AFE_IMR_GOVRE (0x1u << 25) /**< \brief (AFE_IMR) General Overrun Error Interrupt Mask */
+#define AFE_IMR_COMPE (0x1u << 26) /**< \brief (AFE_IMR) Comparison Event Interrupt Mask */
+#define AFE_IMR_ENDRX (0x1u << 27) /**< \brief (AFE_IMR) End of Receive Buffer Interrupt Mask */
+#define AFE_IMR_RXBUFF (0x1u << 28) /**< \brief (AFE_IMR) Receive Buffer Full Interrupt Mask */
+#define AFE_IMR_TEMPCHG (0x1u << 30) /**< \brief (AFE_IMR) Temperature Change Interrupt Mask */
+#define AFE_IMR_EOCAL (0x1u << 31) /**< \brief (AFE_IMR) End of Calibration Sequence Interrupt Mask */
+/* -------- AFE_ISR : (AFEC Offset: 0x30) Interrupt Status Register -------- */
+#define AFE_ISR_EOC0 (0x1u << 0) /**< \brief (AFE_ISR) End of Conversion 0 */
+#define AFE_ISR_EOC1 (0x1u << 1) /**< \brief (AFE_ISR) End of Conversion 1 */
+#define AFE_ISR_EOC2 (0x1u << 2) /**< \brief (AFE_ISR) End of Conversion 2 */
+#define AFE_ISR_EOC3 (0x1u << 3) /**< \brief (AFE_ISR) End of Conversion 3 */
+#define AFE_ISR_EOC4 (0x1u << 4) /**< \brief (AFE_ISR) End of Conversion 4 */
+#define AFE_ISR_EOC5 (0x1u << 5) /**< \brief (AFE_ISR) End of Conversion 5 */
+#define AFE_ISR_EOC6 (0x1u << 6) /**< \brief (AFE_ISR) End of Conversion 6 */
+#define AFE_ISR_EOC7 (0x1u << 7) /**< \brief (AFE_ISR) End of Conversion 7 */
+#define AFE_ISR_EOC8 (0x1u << 8) /**< \brief (AFE_ISR) End of Conversion 8 */
+#define AFE_ISR_EOC9 (0x1u << 9) /**< \brief (AFE_ISR) End of Conversion 9 */
+#define AFE_ISR_EOC10 (0x1u << 10) /**< \brief (AFE_ISR) End of Conversion 10 */
+#define AFE_ISR_EOC11 (0x1u << 11) /**< \brief (AFE_ISR) End of Conversion 11 */
+#define AFE_ISR_EOC12 (0x1u << 12) /**< \brief (AFE_ISR) End of Conversion 12 */
+#define AFE_ISR_EOC13 (0x1u << 13) /**< \brief (AFE_ISR) End of Conversion 13 */
+#define AFE_ISR_EOC14 (0x1u << 14) /**< \brief (AFE_ISR) End of Conversion 14 */
+#define AFE_ISR_EOC15 (0x1u << 15) /**< \brief (AFE_ISR) End of Conversion 15 */
+#define AFE_ISR_EOC16 (0x1u << 16) /**< \brief (AFE_ISR) End of Conversion 16 */
+#define AFE_ISR_EOC17 (0x1u << 17) /**< \brief (AFE_ISR) End of Conversion 17 */
+#define AFE_ISR_EOC18 (0x1u << 18) /**< \brief (AFE_ISR) End of Conversion 18 */
+#define AFE_ISR_EOC19 (0x1u << 19) /**< \brief (AFE_ISR) End of Conversion 19 */
+#define AFE_ISR_EOC20 (0x1u << 20) /**< \brief (AFE_ISR) End of Conversion 20 */
+#define AFE_ISR_EOC21 (0x1u << 21) /**< \brief (AFE_ISR) End of Conversion 21 */
+#define AFE_ISR_EOC22 (0x1u << 22) /**< \brief (AFE_ISR) End of Conversion 22 */
+#define AFE_ISR_EOC23 (0x1u << 23) /**< \brief (AFE_ISR) End of Conversion 23 */
+#define AFE_ISR_DRDY (0x1u << 24) /**< \brief (AFE_ISR) Data Ready */
+#define AFE_ISR_GOVRE (0x1u << 25) /**< \brief (AFE_ISR) General Overrun Error */
+#define AFE_ISR_COMPE (0x1u << 26) /**< \brief (AFE_ISR) Comparison Error */
+#define AFE_ISR_ENDRX (0x1u << 27) /**< \brief (AFE_ISR) End of RX Buffer */
+#define AFE_ISR_RXBUFF (0x1u << 28) /**< \brief (AFE_ISR) RX Buffer Full */
+#define AFE_ISR_TEMPCHG (0x1u << 30) /**< \brief (AFE_ISR) Temperature Change */
+#define AFE_ISR_EOCAL (0x1u << 31) /**< \brief (AFE_ISR) End of Calibration Sequence */
+/* -------- AFE_OVER : (AFEC Offset: 0x4C) Overrun Status Register -------- */
+#define AFE_OVER_OVRE0 (0x1u << 0) /**< \brief (AFE_OVER) Overrun Error 0 */
+#define AFE_OVER_OVRE1 (0x1u << 1) /**< \brief (AFE_OVER) Overrun Error 1 */
+#define AFE_OVER_OVRE2 (0x1u << 2) /**< \brief (AFE_OVER) Overrun Error 2 */
+#define AFE_OVER_OVRE3 (0x1u << 3) /**< \brief (AFE_OVER) Overrun Error 3 */
+#define AFE_OVER_OVRE4 (0x1u << 4) /**< \brief (AFE_OVER) Overrun Error 4 */
+#define AFE_OVER_OVRE5 (0x1u << 5) /**< \brief (AFE_OVER) Overrun Error 5 */
+#define AFE_OVER_OVRE6 (0x1u << 6) /**< \brief (AFE_OVER) Overrun Error 6 */
+#define AFE_OVER_OVRE7 (0x1u << 7) /**< \brief (AFE_OVER) Overrun Error 7 */
+#define AFE_OVER_OVRE8 (0x1u << 8) /**< \brief (AFE_OVER) Overrun Error 8 */
+#define AFE_OVER_OVRE9 (0x1u << 9) /**< \brief (AFE_OVER) Overrun Error 9 */
+#define AFE_OVER_OVRE10 (0x1u << 10) /**< \brief (AFE_OVER) Overrun Error 10 */
+#define AFE_OVER_OVRE11 (0x1u << 11) /**< \brief (AFE_OVER) Overrun Error 11 */
+#define AFE_OVER_OVRE12 (0x1u << 12) /**< \brief (AFE_OVER) Overrun Error 12 */
+#define AFE_OVER_OVRE13 (0x1u << 13) /**< \brief (AFE_OVER) Overrun Error 13 */
+#define AFE_OVER_OVRE14 (0x1u << 14) /**< \brief (AFE_OVER) Overrun Error 14 */
+#define AFE_OVER_OVRE15 (0x1u << 15) /**< \brief (AFE_OVER) Overrun Error 15 */
+#define AFE_OVER_OVRE16_Pos 16
+#define AFE_OVER_OVRE16_Msk (0x3u << AFE_OVER_OVRE16_Pos) /**< \brief (AFE_OVER) Overrun Error 16 */
+#define AFE_OVER_OVRE17 (0x1u << 18) /**< \brief (AFE_OVER) Overrun Error 17 */
+#define AFE_OVER_OVRE18 (0x1u << 19) /**< \brief (AFE_OVER) Overrun Error 18 */
+#define AFE_OVER_OVRE19 (0x1u << 20) /**< \brief (AFE_OVER) Overrun Error 19 */
+#define AFE_OVER_OVRE20 (0x1u << 21) /**< \brief (AFE_OVER) Overrun Error 20 */
+#define AFE_OVER_OVRE21 (0x1u << 22) /**< \brief (AFE_OVER) Overrun Error 21 */
+#define AFE_OVER_OVRE22 (0x1u << 23) /**< \brief (AFE_OVER) Overrun Error 22 */
+/* -------- AFE_CWR : (AFEC Offset: 0x50) Compare Window Register -------- */
+#define AFE_CWR_LOWTHRES_Pos 0
+#define AFE_CWR_LOWTHRES_Msk (0xfffu << AFE_CWR_LOWTHRES_Pos) /**< \brief (AFE_CWR) Low Threshold */
+#define AFE_CWR_LOWTHRES(value) ((AFE_CWR_LOWTHRES_Msk & ((value) << AFE_CWR_LOWTHRES_Pos)))
+#define AFE_CWR_HIGHTHRES_Pos 16
+#define AFE_CWR_HIGHTHRES_Msk (0xfffu << AFE_CWR_HIGHTHRES_Pos) /**< \brief (AFE_CWR) High Threshold */
+#define AFE_CWR_HIGHTHRES(value) ((AFE_CWR_HIGHTHRES_Msk & ((value) << AFE_CWR_HIGHTHRES_Pos)))
+/* -------- AFE_CGR : (AFEC Offset: 0x54) Channel Gain Register -------- */
+#define AFE_CGR_GAIN0_Pos 0
+#define AFE_CGR_GAIN0_Msk (0x3u << AFE_CGR_GAIN0_Pos) /**< \brief (AFE_CGR) Gain for channel 0 */
+#define AFE_CGR_GAIN0(value) ((AFE_CGR_GAIN0_Msk & ((value) << AFE_CGR_GAIN0_Pos)))
+#define AFE_CGR_GAIN1_Pos 2
+#define AFE_CGR_GAIN1_Msk (0x3u << AFE_CGR_GAIN1_Pos) /**< \brief (AFE_CGR) Gain for channel 1 */
+#define AFE_CGR_GAIN1(value) ((AFE_CGR_GAIN1_Msk & ((value) << AFE_CGR_GAIN1_Pos)))
+#define AFE_CGR_GAIN2_Pos 4
+#define AFE_CGR_GAIN2_Msk (0x3u << AFE_CGR_GAIN2_Pos) /**< \brief (AFE_CGR) Gain for channel 2 */
+#define AFE_CGR_GAIN2(value) ((AFE_CGR_GAIN2_Msk & ((value) << AFE_CGR_GAIN2_Pos)))
+#define AFE_CGR_GAIN3_Pos 6
+#define AFE_CGR_GAIN3_Msk (0x3u << AFE_CGR_GAIN3_Pos) /**< \brief (AFE_CGR) Gain for channel 3 */
+#define AFE_CGR_GAIN3(value) ((AFE_CGR_GAIN3_Msk & ((value) << AFE_CGR_GAIN3_Pos)))
+#define AFE_CGR_GAIN4_Pos 8
+#define AFE_CGR_GAIN4_Msk (0x3u << AFE_CGR_GAIN4_Pos) /**< \brief (AFE_CGR) Gain for channel 4 */
+#define AFE_CGR_GAIN4(value) ((AFE_CGR_GAIN4_Msk & ((value) << AFE_CGR_GAIN4_Pos)))
+#define AFE_CGR_GAIN5_Pos 10
+#define AFE_CGR_GAIN5_Msk (0x3u << AFE_CGR_GAIN5_Pos) /**< \brief (AFE_CGR) Gain for channel 5 */
+#define AFE_CGR_GAIN5(value) ((AFE_CGR_GAIN5_Msk & ((value) << AFE_CGR_GAIN5_Pos)))
+#define AFE_CGR_GAIN6_Pos 12
+#define AFE_CGR_GAIN6_Msk (0x3u << AFE_CGR_GAIN6_Pos) /**< \brief (AFE_CGR) Gain for channel 6 */
+#define AFE_CGR_GAIN6(value) ((AFE_CGR_GAIN6_Msk & ((value) << AFE_CGR_GAIN6_Pos)))
+#define AFE_CGR_GAIN7_Pos 14
+#define AFE_CGR_GAIN7_Msk (0x3u << AFE_CGR_GAIN7_Pos) /**< \brief (AFE_CGR) Gain for channel 7 */
+#define AFE_CGR_GAIN7(value) ((AFE_CGR_GAIN7_Msk & ((value) << AFE_CGR_GAIN7_Pos)))
+#define AFE_CGR_GAIN8_Pos 16
+#define AFE_CGR_GAIN8_Msk (0x3u << AFE_CGR_GAIN8_Pos) /**< \brief (AFE_CGR) Gain for channel 8 */
+#define AFE_CGR_GAIN8(value) ((AFE_CGR_GAIN8_Msk & ((value) << AFE_CGR_GAIN8_Pos)))
+#define AFE_CGR_GAIN9_Pos 18
+#define AFE_CGR_GAIN9_Msk (0x3u << AFE_CGR_GAIN9_Pos) /**< \brief (AFE_CGR) Gain for channel 9 */
+#define AFE_CGR_GAIN9(value) ((AFE_CGR_GAIN9_Msk & ((value) << AFE_CGR_GAIN9_Pos)))
+#define AFE_CGR_GAIN10_Pos 20
+#define AFE_CGR_GAIN10_Msk (0x3u << AFE_CGR_GAIN10_Pos) /**< \brief (AFE_CGR) Gain for channel 10 */
+#define AFE_CGR_GAIN10(value) ((AFE_CGR_GAIN10_Msk & ((value) << AFE_CGR_GAIN10_Pos)))
+#define AFE_CGR_GAIN11_Pos 22
+#define AFE_CGR_GAIN11_Msk (0x3u << AFE_CGR_GAIN11_Pos) /**< \brief (AFE_CGR) Gain for channel 11 */
+#define AFE_CGR_GAIN11(value) ((AFE_CGR_GAIN11_Msk & ((value) << AFE_CGR_GAIN11_Pos)))
+#define AFE_CGR_GAIN12_Pos 24
+#define AFE_CGR_GAIN12_Msk (0x3u << AFE_CGR_GAIN12_Pos) /**< \brief (AFE_CGR) Gain for channel 12 */
+#define AFE_CGR_GAIN12(value) ((AFE_CGR_GAIN12_Msk & ((value) << AFE_CGR_GAIN12_Pos)))
+#define AFE_CGR_GAIN13_Pos 26
+#define AFE_CGR_GAIN13_Msk (0x3u << AFE_CGR_GAIN13_Pos) /**< \brief (AFE_CGR) Gain for channel 13 */
+#define AFE_CGR_GAIN13(value) ((AFE_CGR_GAIN13_Msk & ((value) << AFE_CGR_GAIN13_Pos)))
+#define AFE_CGR_GAIN14_Pos 28
+#define AFE_CGR_GAIN14_Msk (0x3u << AFE_CGR_GAIN14_Pos) /**< \brief (AFE_CGR) Gain for channel 14 */
+#define AFE_CGR_GAIN14(value) ((AFE_CGR_GAIN14_Msk & ((value) << AFE_CGR_GAIN14_Pos)))
+#define AFE_CGR_GAIN15_Pos 30
+#define AFE_CGR_GAIN15_Msk (0x3u << AFE_CGR_GAIN15_Pos) /**< \brief (AFE_CGR) Gain for channel 15 */
+#define AFE_CGR_GAIN15(value) ((AFE_CGR_GAIN15_Msk & ((value) << AFE_CGR_GAIN15_Pos)))
+/* -------- AFE_CDOR : (AFEC Offset: 0x5C) Channel DC Offset Register -------- */
+#define AFE_CDOR_OFF0 (0x1u << 0) /**< \brief (AFE_CDOR) Offset for channel 0 */
+#define AFE_CDOR_OFF1 (0x1u << 1) /**< \brief (AFE_CDOR) Offset for channel 1 */
+#define AFE_CDOR_OFF2 (0x1u << 2) /**< \brief (AFE_CDOR) Offset for channel 2 */
+#define AFE_CDOR_OFF3 (0x1u << 3) /**< \brief (AFE_CDOR) Offset for channel 3 */
+#define AFE_CDOR_OFF4 (0x1u << 4) /**< \brief (AFE_CDOR) Offset for channel 4 */
+#define AFE_CDOR_OFF5 (0x1u << 5) /**< \brief (AFE_CDOR) Offset for channel 5 */
+#define AFE_CDOR_OFF6 (0x1u << 6) /**< \brief (AFE_CDOR) Offset for channel 6 */
+#define AFE_CDOR_OFF7 (0x1u << 7) /**< \brief (AFE_CDOR) Offset for channel 7 */
+#define AFE_CDOR_OFF8 (0x1u << 8) /**< \brief (AFE_CDOR) Offset for channel 8 */
+#define AFE_CDOR_OFF9 (0x1u << 9) /**< \brief (AFE_CDOR) Offset for channel 9 */
+#define AFE_CDOR_OFF10 (0x1u << 10) /**< \brief (AFE_CDOR) Offset for channel 10 */
+#define AFE_CDOR_OFF11 (0x1u << 11) /**< \brief (AFE_CDOR) Offset for channel 11 */
+#define AFE_CDOR_OFF12 (0x1u << 12) /**< \brief (AFE_CDOR) Offset for channel 12 */
+#define AFE_CDOR_OFF13 (0x1u << 13) /**< \brief (AFE_CDOR) Offset for channel 13 */
+#define AFE_CDOR_OFF14 (0x1u << 14) /**< \brief (AFE_CDOR) Offset for channel 14 */
+#define AFE_CDOR_OFF15 (0x1u << 15) /**< \brief (AFE_CDOR) Offset for channel 15 */
+#define AFE_CDOR_OVRE16 (0x1u << 16) /**< \brief (AFE_CDOR)  */
+#define AFE_CDOR_OVRE17 (0x1u << 17) /**< \brief (AFE_CDOR)  */
+#define AFE_CDOR_OFF18 (0x1u << 18) /**< \brief (AFE_CDOR) Offset for channel 18 */
+#define AFE_CDOR_OFF19 (0x1u << 19) /**< \brief (AFE_CDOR) Offset for channel 19 */
+#define AFE_CDOR_OFF20 (0x1u << 20) /**< \brief (AFE_CDOR) Offset for channel 20 */
+#define AFE_CDOR_OFF21 (0x1u << 21) /**< \brief (AFE_CDOR) Offset for channel 21 */
+#define AFE_CDOR_OFF22 (0x1u << 22) /**< \brief (AFE_CDOR) Offset for channel 22 */
+#define AFE_CDOR_OFF23 (0x1u << 23) /**< \brief (AFE_CDOR) Offset for channel 23 */
+/* -------- AFE_DIFFR : (AFEC Offset: 0x60) Channel Differential Register -------- */
+#define AFE_DIFFR_DIFF0 (0x1u << 0) /**< \brief (AFE_DIFFR) Differential inputs for channel 0 */
+#define AFE_DIFFR_DIFF1 (0x1u << 1) /**< \brief (AFE_DIFFR) Differential inputs for channel 1 */
+#define AFE_DIFFR_DIFF2 (0x1u << 2) /**< \brief (AFE_DIFFR) Differential inputs for channel 2 */
+#define AFE_DIFFR_DIFF3 (0x1u << 3) /**< \brief (AFE_DIFFR) Differential inputs for channel 3 */
+#define AFE_DIFFR_DIFF4 (0x1u << 4) /**< \brief (AFE_DIFFR) Differential inputs for channel 4 */
+#define AFE_DIFFR_DIFF5 (0x1u << 5) /**< \brief (AFE_DIFFR) Differential inputs for channel 5 */
+#define AFE_DIFFR_DIFF6 (0x1u << 6) /**< \brief (AFE_DIFFR) Differential inputs for channel 6 */
+#define AFE_DIFFR_DIFF7 (0x1u << 7) /**< \brief (AFE_DIFFR) Differential inputs for channel 7 */
+#define AFE_DIFFR_DIFF8 (0x1u << 8) /**< \brief (AFE_DIFFR) Differential inputs for channel 8 */
+#define AFE_DIFFR_DIFF9 (0x1u << 9) /**< \brief (AFE_DIFFR) Differential inputs for channel 9 */
+#define AFE_DIFFR_DIFF10 (0x1u << 10) /**< \brief (AFE_DIFFR) Differential inputs for channel 10 */
+#define AFE_DIFFR_DIFF11 (0x1u << 11) /**< \brief (AFE_DIFFR) Differential inputs for channel 11 */
+#define AFE_DIFFR_DIFF12 (0x1u << 12) /**< \brief (AFE_DIFFR) Differential inputs for channel 12 */
+#define AFE_DIFFR_DIFF13 (0x1u << 13) /**< \brief (AFE_DIFFR) Differential inputs for channel 13 */
+#define AFE_DIFFR_DIFF14 (0x1u << 14) /**< \brief (AFE_DIFFR) Differential inputs for channel 14 */
+#define AFE_DIFFR_DIFF15 (0x1u << 15) /**< \brief (AFE_DIFFR) Differential inputs for channel 15 */
+#define AFE_DIFFR_DIFF16 (0x1u << 16) /**< \brief (AFE_DIFFR) Differential inputs for channel 16 */
+#define AFE_DIFFR_DIFF17 (0x1u << 17) /**< \brief (AFE_DIFFR) Differential inputs for channel 17 */
+#define AFE_DIFFR_DIFF18 (0x1u << 18) /**< \brief (AFE_DIFFR) Differential inputs for channel 18 */
+#define AFE_DIFFR_DIFF19 (0x1u << 19) /**< \brief (AFE_DIFFR) Differential inputs for channel 19 */
+#define AFE_DIFFR_DIFF20 (0x1u << 20) /**< \brief (AFE_DIFFR) Differential inputs for channel 20 */
+#define AFE_DIFFR_DIFF21 (0x1u << 21) /**< \brief (AFE_DIFFR) Differential inputs for channel 21 */
+#define AFE_DIFFR_DIFF22 (0x1u << 22) /**< \brief (AFE_DIFFR) Differential inputs for channel 22 */
+#define AFE_DIFFR_DIFF23 (0x1u << 23) /**< \brief (AFE_DIFFR) Differential inputs for channel 23 */
+/* -------- AFE_CSELR : (AFEC Offset: 0x64) Channel Register Selection -------- */
+#define AFE_CSELR_CSEL_Pos 0
+#define AFE_CSELR_CSEL_Msk (0xfu << AFE_CSELR_CSEL_Pos) /**< \brief (AFE_CSELR) Channel Selection */
+/* -------- AFE_CDR : (AFEC Offset: 0x68) Channel Data Register -------- */
+#define AFE_CDR_DATA_Pos 0
+#define AFE_CDR_DATA_Msk (0xfffu << AFE_CDR_DATA_Pos) /**< \brief (AFE_CDR) Converted Data */
+/* -------- AFE_COCR : (AFEC Offset: 0x6C) Channel Offset Compensation Register -------- */
+#define AFE_COCR_AOFF_Pos 0
+#define AFE_COCR_AOFF_Msk (0xfffu << AFE_COCR_AOFF_Pos) /**< \brief (AFE_COCR) Analog Offset */
+/* -------- AFE_TEMPMR : (AFEC Offset: 0x70) Temperature Sensor Mode Register -------- */
+#define AFE_TEMPMR_RTCT (0x1u << 0) /**< \brief (AFE_TEMPMR) Temperature Sensor RTC Trigger mode */
+#define AFE_TEMPMR_TEMPCMPMOD_Pos 4
+#define AFE_TEMPMR_TEMPCMPMOD_Msk (0x3u << AFE_TEMPMR_TEMPCMPMOD_Pos) /**< \brief (AFE_TEMPMR) Temperature Comparison Mode */
+#define   AFE_TEMPMR_TEMPCMPMOD_LOW (0x0u << 4) /**< \brief (AFE_TEMPMR) Generates an event when the converted data is lower than the low threshold of the window. */
+#define   AFE_TEMPMR_TEMPCMPMOD_HIGH (0x1u << 4) /**< \brief (AFE_TEMPMR) Generates an event when the converted data is higher than the high threshold of the window. */
+#define   AFE_TEMPMR_TEMPCMPMOD_IN (0x2u << 4) /**< \brief (AFE_TEMPMR) Generates an event when the converted data is in the comparison window. */
+#define   AFE_TEMPMR_TEMPCMPMOD_OUT (0x3u << 4) /**< \brief (AFE_TEMPMR) Generates an event when the converted data is out of the comparison window. */
+/* -------- AFE_TEMPCWR : (AFEC Offset: 0x74) Temperature Compare Window Register -------- */
+#define AFE_TEMPCWR_TLOWTHRES_Pos 0
+#define AFE_TEMPCWR_TLOWTHRES_Msk (0xffffu << AFE_TEMPCWR_TLOWTHRES_Pos) /**< \brief (AFE_TEMPCWR) Temperature Low Threshold */
+#define AFE_TEMPCWR_TLOWTHRES(value) ((AFE_TEMPCWR_TLOWTHRES_Msk & ((value) << AFE_TEMPCWR_TLOWTHRES_Pos)))
+#define AFE_TEMPCWR_THIGHTHRES_Pos 16
+#define AFE_TEMPCWR_THIGHTHRES_Msk (0xffffu << AFE_TEMPCWR_THIGHTHRES_Pos) /**< \brief (AFE_TEMPCWR) Temperature High Threshold */
+#define AFE_TEMPCWR_THIGHTHRES(value) ((AFE_TEMPCWR_THIGHTHRES_Msk & ((value) << AFE_TEMPCWR_THIGHTHRES_Pos)))
+/* -------- AFE_ACR : (AFEC Offset: 0x94) Analog Control Register -------- */
+#define AFE_ACR_IBCTL_Pos 8
+#define AFE_ACR_IBCTL_Msk (0x3u << AFE_ACR_IBCTL_Pos) /**< \brief (AFE_ACR) AFE Bias Current Control */
+#define AFE_ACR_IBCTL(value) ((AFE_ACR_IBCTL_Msk & ((value) << AFE_ACR_IBCTL_Pos)))
+/* -------- AFE_WPMR : (AFEC Offset: 0xE4) Write Protect Mode Register -------- */
+#define AFE_WPMR_WPEN (0x1u << 0) /**< \brief (AFE_WPMR) Write Protect Enable */
+#define AFE_WPMR_WPKEY_Pos 8
+#define AFE_WPMR_WPKEY_Msk (0xffffffu << AFE_WPMR_WPKEY_Pos) /**< \brief (AFE_WPMR) Write Protect KEY */
+#define AFE_WPMR_WPKEY(value) ((AFE_WPMR_WPKEY_Msk & ((value) << AFE_WPMR_WPKEY_Pos)))
+/* -------- AFE_WPSR : (AFEC Offset: 0xE8) Write Protect Status Register -------- */
+#define AFE_WPSR_WPVS (0x1u << 0) /**< \brief (AFE_WPSR) Write Protect Violation Status */
+#define AFE_WPSR_WPVSRC_Pos 8
+#define AFE_WPSR_WPVSRC_Msk (0xffffu << AFE_WPSR_WPVSRC_Pos) /**< \brief (AFE_WPSR) Write Protect Violation Source */
+/* -------- AFE_RPR : (AFEC Offset: 0x100) Receive Pointer Register -------- */
+#define AFE_RPR_RXPTR_Pos 0
+#define AFE_RPR_RXPTR_Msk (0xffffffffu << AFE_RPR_RXPTR_Pos) /**< \brief (AFE_RPR) Receive Pointer Register */
+#define AFE_RPR_RXPTR(value) ((AFE_RPR_RXPTR_Msk & ((value) << AFE_RPR_RXPTR_Pos)))
+/* -------- AFE_RCR : (AFEC Offset: 0x104) Receive Counter Register -------- */
+#define AFE_RCR_RXCTR_Pos 0
+#define AFE_RCR_RXCTR_Msk (0xffffu << AFE_RCR_RXCTR_Pos) /**< \brief (AFE_RCR) Receive Counter Register */
+#define AFE_RCR_RXCTR(value) ((AFE_RCR_RXCTR_Msk & ((value) << AFE_RCR_RXCTR_Pos)))
+/* -------- AFE_RNPR : (AFEC Offset: 0x110) Receive Next Pointer Register -------- */
+#define AFE_RNPR_RXNPTR_Pos 0
+#define AFE_RNPR_RXNPTR_Msk (0xffffffffu << AFE_RNPR_RXNPTR_Pos) /**< \brief (AFE_RNPR) Receive Next Pointer */
+#define AFE_RNPR_RXNPTR(value) ((AFE_RNPR_RXNPTR_Msk & ((value) << AFE_RNPR_RXNPTR_Pos)))
+/* -------- AFE_RNCR : (AFEC Offset: 0x114) Receive Next Counter Register -------- */
+#define AFE_RNCR_RXNCTR_Pos 0
+#define AFE_RNCR_RXNCTR_Msk (0xffffu << AFE_RNCR_RXNCTR_Pos) /**< \brief (AFE_RNCR) Receive Next Counter */
+#define AFE_RNCR_RXNCTR(value) ((AFE_RNCR_RXNCTR_Msk & ((value) << AFE_RNCR_RXNCTR_Pos)))
+/* -------- AFE_PTCR : (AFEC Offset: 0x120) Transfer Control Register -------- */
+#define AFE_PTCR_RXTEN (0x1u << 0) /**< \brief (AFE_PTCR) Receiver Transfer Enable */
+#define AFE_PTCR_RXTDIS (0x1u << 1) /**< \brief (AFE_PTCR) Receiver Transfer Disable */
+#define AFE_PTCR_TXTEN (0x1u << 8) /**< \brief (AFE_PTCR) Transmitter Transfer Enable */
+#define AFE_PTCR_TXTDIS (0x1u << 9) /**< \brief (AFE_PTCR) Transmitter Transfer Disable */
+/* -------- AFE_PTSR : (AFEC Offset: 0x124) Transfer Status Register -------- */
+#define AFE_PTSR_RXTEN (0x1u << 0) /**< \brief (AFE_PTSR) Receiver Transfer Enable */
+#define AFE_PTSR_TXTEN (0x1u << 8) /**< \brief (AFE_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_AFEC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/can.h
+++ b/asf/sam/include/sam4e/component/can.h
@@ -1,0 +1,292 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CAN_COMPONENT_
+#define _SAM4E_CAN_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Controller Area Network */
+/* ============================================================================= */
+/** \addtogroup SAM4E_CAN Controller Area Network */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief CanMb hardware registers */
+typedef struct {
+  RwReg  CAN_MMR;       /**< \brief (CanMb Offset: 0x0) Mailbox Mode Register */
+  RwReg  CAN_MAM;       /**< \brief (CanMb Offset: 0x4) Mailbox Acceptance Mask Register */
+  RwReg  CAN_MID;       /**< \brief (CanMb Offset: 0x8) Mailbox ID Register */
+  RwReg  CAN_MFID;      /**< \brief (CanMb Offset: 0xC) Mailbox Family ID Register */
+  RwReg  CAN_MSR;       /**< \brief (CanMb Offset: 0x10) Mailbox Status Register */
+  RwReg  CAN_MDL;       /**< \brief (CanMb Offset: 0x14) Mailbox Data Low Register */
+  RwReg  CAN_MDH;       /**< \brief (CanMb Offset: 0x18) Mailbox Data High Register */
+  RwReg  CAN_MCR;       /**< \brief (CanMb Offset: 0x1C) Mailbox Control Register */
+} CanMb;
+/** \brief Can hardware registers */
+#define CANMB_NUMBER 8
+typedef struct {
+  RwReg  CAN_MR;        /**< \brief (Can Offset: 0x0000) Mode Register */
+  WoReg  CAN_IER;       /**< \brief (Can Offset: 0x0004) Interrupt Enable Register */
+  WoReg  CAN_IDR;       /**< \brief (Can Offset: 0x0008) Interrupt Disable Register */
+  RoReg  CAN_IMR;       /**< \brief (Can Offset: 0x000C) Interrupt Mask Register */
+  RoReg  CAN_SR;        /**< \brief (Can Offset: 0x0010) Status Register */
+  RwReg  CAN_BR;        /**< \brief (Can Offset: 0x0014) Baudrate Register */
+  RoReg  CAN_TIM;       /**< \brief (Can Offset: 0x0018) Timer Register */
+  RoReg  CAN_TIMESTP;   /**< \brief (Can Offset: 0x001C) Timestamp Register */
+  RoReg  CAN_ECR;       /**< \brief (Can Offset: 0x0020) Error Counter Register */
+  WoReg  CAN_TCR;       /**< \brief (Can Offset: 0x0024) Transfer Command Register */
+  WoReg  CAN_ACR;       /**< \brief (Can Offset: 0x0028) Abort Command Register */
+  RoReg  Reserved1[46];
+  RwReg  CAN_WPMR;      /**< \brief (Can Offset: 0x00E4) Write Protect Mode Register */
+  RoReg  CAN_WPSR;      /**< \brief (Can Offset: 0x00E8) Write Protect Status Register */
+  RoReg  Reserved2[69];
+  CanMb  CAN_MB[CANMB_NUMBER]; /**< \brief (Can Offset: 0x200) MB = 0 .. 7 */
+} Can;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- CAN_MR : (CAN Offset: 0x0000) Mode Register -------- */
+#define CAN_MR_CANEN (0x1u << 0) /**< \brief (CAN_MR) CAN Controller Enable */
+#define CAN_MR_LPM (0x1u << 1) /**< \brief (CAN_MR) Disable/Enable Low Power Mode */
+#define CAN_MR_ABM (0x1u << 2) /**< \brief (CAN_MR) Disable/Enable Autobaud/Listen mode */
+#define CAN_MR_OVL (0x1u << 3) /**< \brief (CAN_MR) Disable/Enable Overload Frame */
+#define CAN_MR_TEOF (0x1u << 4) /**< \brief (CAN_MR) Timestamp messages at each end of Frame */
+#define CAN_MR_TTM (0x1u << 5) /**< \brief (CAN_MR) Disable/Enable Time Triggered Mode */
+#define CAN_MR_TIMFRZ (0x1u << 6) /**< \brief (CAN_MR) Enable Timer Freeze */
+#define CAN_MR_DRPT (0x1u << 7) /**< \brief (CAN_MR) Disable Repeat */
+/* -------- CAN_IER : (CAN Offset: 0x0004) Interrupt Enable Register -------- */
+#define CAN_IER_MB0 (0x1u << 0) /**< \brief (CAN_IER) Mailbox 0 Interrupt Enable */
+#define CAN_IER_MB1 (0x1u << 1) /**< \brief (CAN_IER) Mailbox 1 Interrupt Enable */
+#define CAN_IER_MB2 (0x1u << 2) /**< \brief (CAN_IER) Mailbox 2 Interrupt Enable */
+#define CAN_IER_MB3 (0x1u << 3) /**< \brief (CAN_IER) Mailbox 3 Interrupt Enable */
+#define CAN_IER_MB4 (0x1u << 4) /**< \brief (CAN_IER) Mailbox 4 Interrupt Enable */
+#define CAN_IER_MB5 (0x1u << 5) /**< \brief (CAN_IER) Mailbox 5 Interrupt Enable */
+#define CAN_IER_MB6 (0x1u << 6) /**< \brief (CAN_IER) Mailbox 6 Interrupt Enable */
+#define CAN_IER_MB7 (0x1u << 7) /**< \brief (CAN_IER) Mailbox 7 Interrupt Enable */
+#define CAN_IER_ERRA (0x1u << 16) /**< \brief (CAN_IER) Error Active Mode Interrupt Enable */
+#define CAN_IER_WARN (0x1u << 17) /**< \brief (CAN_IER) Warning Limit Interrupt Enable */
+#define CAN_IER_ERRP (0x1u << 18) /**< \brief (CAN_IER) Error Passive Mode Interrupt Enable */
+#define CAN_IER_BOFF (0x1u << 19) /**< \brief (CAN_IER) Bus Off Mode Interrupt Enable */
+#define CAN_IER_SLEEP (0x1u << 20) /**< \brief (CAN_IER) Sleep Interrupt Enable */
+#define CAN_IER_WAKEUP (0x1u << 21) /**< \brief (CAN_IER) Wakeup Interrupt Enable */
+#define CAN_IER_TOVF (0x1u << 22) /**< \brief (CAN_IER) Timer Overflow Interrupt Enable */
+#define CAN_IER_TSTP (0x1u << 23) /**< \brief (CAN_IER) TimeStamp Interrupt Enable */
+#define CAN_IER_CERR (0x1u << 24) /**< \brief (CAN_IER) CRC Error Interrupt Enable */
+#define CAN_IER_SERR (0x1u << 25) /**< \brief (CAN_IER) Stuffing Error Interrupt Enable */
+#define CAN_IER_AERR (0x1u << 26) /**< \brief (CAN_IER) Acknowledgment Error Interrupt Enable */
+#define CAN_IER_FERR (0x1u << 27) /**< \brief (CAN_IER) Form Error Interrupt Enable */
+#define CAN_IER_BERR (0x1u << 28) /**< \brief (CAN_IER) Bit Error Interrupt Enable */
+/* -------- CAN_IDR : (CAN Offset: 0x0008) Interrupt Disable Register -------- */
+#define CAN_IDR_MB0 (0x1u << 0) /**< \brief (CAN_IDR) Mailbox 0 Interrupt Disable */
+#define CAN_IDR_MB1 (0x1u << 1) /**< \brief (CAN_IDR) Mailbox 1 Interrupt Disable */
+#define CAN_IDR_MB2 (0x1u << 2) /**< \brief (CAN_IDR) Mailbox 2 Interrupt Disable */
+#define CAN_IDR_MB3 (0x1u << 3) /**< \brief (CAN_IDR) Mailbox 3 Interrupt Disable */
+#define CAN_IDR_MB4 (0x1u << 4) /**< \brief (CAN_IDR) Mailbox 4 Interrupt Disable */
+#define CAN_IDR_MB5 (0x1u << 5) /**< \brief (CAN_IDR) Mailbox 5 Interrupt Disable */
+#define CAN_IDR_MB6 (0x1u << 6) /**< \brief (CAN_IDR) Mailbox 6 Interrupt Disable */
+#define CAN_IDR_MB7 (0x1u << 7) /**< \brief (CAN_IDR) Mailbox 7 Interrupt Disable */
+#define CAN_IDR_ERRA (0x1u << 16) /**< \brief (CAN_IDR) Error Active Mode Interrupt Disable */
+#define CAN_IDR_WARN (0x1u << 17) /**< \brief (CAN_IDR) Warning Limit Interrupt Disable */
+#define CAN_IDR_ERRP (0x1u << 18) /**< \brief (CAN_IDR) Error Passive Mode Interrupt Disable */
+#define CAN_IDR_BOFF (0x1u << 19) /**< \brief (CAN_IDR) Bus Off Mode Interrupt Disable */
+#define CAN_IDR_SLEEP (0x1u << 20) /**< \brief (CAN_IDR) Sleep Interrupt Disable */
+#define CAN_IDR_WAKEUP (0x1u << 21) /**< \brief (CAN_IDR) Wakeup Interrupt Disable */
+#define CAN_IDR_TOVF (0x1u << 22) /**< \brief (CAN_IDR) Timer Overflow Interrupt */
+#define CAN_IDR_TSTP (0x1u << 23) /**< \brief (CAN_IDR) TimeStamp Interrupt Disable */
+#define CAN_IDR_CERR (0x1u << 24) /**< \brief (CAN_IDR) CRC Error Interrupt Disable */
+#define CAN_IDR_SERR (0x1u << 25) /**< \brief (CAN_IDR) Stuffing Error Interrupt Disable */
+#define CAN_IDR_AERR (0x1u << 26) /**< \brief (CAN_IDR) Acknowledgment Error Interrupt Disable */
+#define CAN_IDR_FERR (0x1u << 27) /**< \brief (CAN_IDR) Form Error Interrupt Disable */
+#define CAN_IDR_BERR (0x1u << 28) /**< \brief (CAN_IDR) Bit Error Interrupt Disable */
+/* -------- CAN_IMR : (CAN Offset: 0x000C) Interrupt Mask Register -------- */
+#define CAN_IMR_MB0 (0x1u << 0) /**< \brief (CAN_IMR) Mailbox 0 Interrupt Mask */
+#define CAN_IMR_MB1 (0x1u << 1) /**< \brief (CAN_IMR) Mailbox 1 Interrupt Mask */
+#define CAN_IMR_MB2 (0x1u << 2) /**< \brief (CAN_IMR) Mailbox 2 Interrupt Mask */
+#define CAN_IMR_MB3 (0x1u << 3) /**< \brief (CAN_IMR) Mailbox 3 Interrupt Mask */
+#define CAN_IMR_MB4 (0x1u << 4) /**< \brief (CAN_IMR) Mailbox 4 Interrupt Mask */
+#define CAN_IMR_MB5 (0x1u << 5) /**< \brief (CAN_IMR) Mailbox 5 Interrupt Mask */
+#define CAN_IMR_MB6 (0x1u << 6) /**< \brief (CAN_IMR) Mailbox 6 Interrupt Mask */
+#define CAN_IMR_MB7 (0x1u << 7) /**< \brief (CAN_IMR) Mailbox 7 Interrupt Mask */
+#define CAN_IMR_ERRA (0x1u << 16) /**< \brief (CAN_IMR) Error Active Mode Interrupt Mask */
+#define CAN_IMR_WARN (0x1u << 17) /**< \brief (CAN_IMR) Warning Limit Interrupt Mask */
+#define CAN_IMR_ERRP (0x1u << 18) /**< \brief (CAN_IMR) Error Passive Mode Interrupt Mask */
+#define CAN_IMR_BOFF (0x1u << 19) /**< \brief (CAN_IMR) Bus Off Mode Interrupt Mask */
+#define CAN_IMR_SLEEP (0x1u << 20) /**< \brief (CAN_IMR) Sleep Interrupt Mask */
+#define CAN_IMR_WAKEUP (0x1u << 21) /**< \brief (CAN_IMR) Wakeup Interrupt Mask */
+#define CAN_IMR_TOVF (0x1u << 22) /**< \brief (CAN_IMR) Timer Overflow Interrupt Mask */
+#define CAN_IMR_TSTP (0x1u << 23) /**< \brief (CAN_IMR) Timestamp Interrupt Mask */
+#define CAN_IMR_CERR (0x1u << 24) /**< \brief (CAN_IMR) CRC Error Interrupt Mask */
+#define CAN_IMR_SERR (0x1u << 25) /**< \brief (CAN_IMR) Stuffing Error Interrupt Mask */
+#define CAN_IMR_AERR (0x1u << 26) /**< \brief (CAN_IMR) Acknowledgment Error Interrupt Mask */
+#define CAN_IMR_FERR (0x1u << 27) /**< \brief (CAN_IMR) Form Error Interrupt Mask */
+#define CAN_IMR_BERR (0x1u << 28) /**< \brief (CAN_IMR) Bit Error Interrupt Mask */
+/* -------- CAN_SR : (CAN Offset: 0x0010) Status Register -------- */
+#define CAN_SR_MB0 (0x1u << 0) /**< \brief (CAN_SR) Mailbox 0 Event */
+#define CAN_SR_MB1 (0x1u << 1) /**< \brief (CAN_SR) Mailbox 1 Event */
+#define CAN_SR_MB2 (0x1u << 2) /**< \brief (CAN_SR) Mailbox 2 Event */
+#define CAN_SR_MB3 (0x1u << 3) /**< \brief (CAN_SR) Mailbox 3 Event */
+#define CAN_SR_MB4 (0x1u << 4) /**< \brief (CAN_SR) Mailbox 4 Event */
+#define CAN_SR_MB5 (0x1u << 5) /**< \brief (CAN_SR) Mailbox 5 Event */
+#define CAN_SR_MB6 (0x1u << 6) /**< \brief (CAN_SR) Mailbox 6 Event */
+#define CAN_SR_MB7 (0x1u << 7) /**< \brief (CAN_SR) Mailbox 7 Event */
+#define CAN_SR_ERRA (0x1u << 16) /**< \brief (CAN_SR) Error Active Mode */
+#define CAN_SR_WARN (0x1u << 17) /**< \brief (CAN_SR) Warning Limit */
+#define CAN_SR_ERRP (0x1u << 18) /**< \brief (CAN_SR) Error Passive Mode */
+#define CAN_SR_BOFF (0x1u << 19) /**< \brief (CAN_SR) Bus Off Mode */
+#define CAN_SR_SLEEP (0x1u << 20) /**< \brief (CAN_SR) CAN controller in Low power Mode */
+#define CAN_SR_WAKEUP (0x1u << 21) /**< \brief (CAN_SR) CAN controller is not in Low power Mode */
+#define CAN_SR_TOVF (0x1u << 22) /**< \brief (CAN_SR) Timer Overflow */
+#define CAN_SR_TSTP (0x1u << 23) /**< \brief (CAN_SR)  */
+#define CAN_SR_CERR (0x1u << 24) /**< \brief (CAN_SR) Mailbox CRC Error */
+#define CAN_SR_SERR (0x1u << 25) /**< \brief (CAN_SR) Mailbox Stuffing Error */
+#define CAN_SR_AERR (0x1u << 26) /**< \brief (CAN_SR) Acknowledgment Error */
+#define CAN_SR_FERR (0x1u << 27) /**< \brief (CAN_SR) Form Error */
+#define CAN_SR_BERR (0x1u << 28) /**< \brief (CAN_SR) Bit Error */
+#define CAN_SR_RBSY (0x1u << 29) /**< \brief (CAN_SR) Receiver busy */
+#define CAN_SR_TBSY (0x1u << 30) /**< \brief (CAN_SR) Transmitter busy */
+#define CAN_SR_OVLSY (0x1u << 31) /**< \brief (CAN_SR) Overload busy */
+/* -------- CAN_BR : (CAN Offset: 0x0014) Baudrate Register -------- */
+#define CAN_BR_PHASE2_Pos 0
+#define CAN_BR_PHASE2_Msk (0x7u << CAN_BR_PHASE2_Pos) /**< \brief (CAN_BR) Phase 2 segment */
+#define CAN_BR_PHASE2(value) ((CAN_BR_PHASE2_Msk & ((value) << CAN_BR_PHASE2_Pos)))
+#define CAN_BR_PHASE1_Pos 4
+#define CAN_BR_PHASE1_Msk (0x7u << CAN_BR_PHASE1_Pos) /**< \brief (CAN_BR) Phase 1 segment */
+#define CAN_BR_PHASE1(value) ((CAN_BR_PHASE1_Msk & ((value) << CAN_BR_PHASE1_Pos)))
+#define CAN_BR_PROPAG_Pos 8
+#define CAN_BR_PROPAG_Msk (0x7u << CAN_BR_PROPAG_Pos) /**< \brief (CAN_BR) Programming time segment */
+#define CAN_BR_PROPAG(value) ((CAN_BR_PROPAG_Msk & ((value) << CAN_BR_PROPAG_Pos)))
+#define CAN_BR_SJW_Pos 12
+#define CAN_BR_SJW_Msk (0x3u << CAN_BR_SJW_Pos) /**< \brief (CAN_BR) Re-synchronization jump width */
+#define CAN_BR_SJW(value) ((CAN_BR_SJW_Msk & ((value) << CAN_BR_SJW_Pos)))
+#define CAN_BR_BRP_Pos 16
+#define CAN_BR_BRP_Msk (0x7fu << CAN_BR_BRP_Pos) /**< \brief (CAN_BR) Baudrate Prescaler. */
+#define CAN_BR_BRP(value) ((CAN_BR_BRP_Msk & ((value) << CAN_BR_BRP_Pos)))
+#define CAN_BR_SMP (0x1u << 24) /**< \brief (CAN_BR) Sampling Mode */
+#define   CAN_BR_SMP_ONCE (0x0u << 24) /**< \brief (CAN_BR) The incoming bit stream is sampled once at sample point. */
+#define   CAN_BR_SMP_THREE (0x1u << 24) /**< \brief (CAN_BR) The incoming bit stream is sampled three times with a period of a MCK clock period, centered on sample point. */
+/* -------- CAN_TIM : (CAN Offset: 0x0018) Timer Register -------- */
+#define CAN_TIM_TIMER_Pos 0
+#define CAN_TIM_TIMER_Msk (0xffffu << CAN_TIM_TIMER_Pos) /**< \brief (CAN_TIM) Timer */
+/* -------- CAN_TIMESTP : (CAN Offset: 0x001C) Timestamp Register -------- */
+#define CAN_TIMESTP_MTIMESTAMP_Pos 0
+#define CAN_TIMESTP_MTIMESTAMP_Msk (0xffffu << CAN_TIMESTP_MTIMESTAMP_Pos) /**< \brief (CAN_TIMESTP) Timestamp */
+/* -------- CAN_ECR : (CAN Offset: 0x0020) Error Counter Register -------- */
+#define CAN_ECR_REC_Pos 0
+#define CAN_ECR_REC_Msk (0xffu << CAN_ECR_REC_Pos) /**< \brief (CAN_ECR) Receive Error Counter */
+#define CAN_ECR_TEC_Pos 16
+#define CAN_ECR_TEC_Msk (0x1ffu << CAN_ECR_TEC_Pos) /**< \brief (CAN_ECR) Transmit Error Counter */
+/* -------- CAN_TCR : (CAN Offset: 0x0024) Transfer Command Register -------- */
+#define CAN_TCR_MB0 (0x1u << 0) /**< \brief (CAN_TCR) Transfer Request for Mailbox 0 */
+#define CAN_TCR_MB1 (0x1u << 1) /**< \brief (CAN_TCR) Transfer Request for Mailbox 1 */
+#define CAN_TCR_MB2 (0x1u << 2) /**< \brief (CAN_TCR) Transfer Request for Mailbox 2 */
+#define CAN_TCR_MB3 (0x1u << 3) /**< \brief (CAN_TCR) Transfer Request for Mailbox 3 */
+#define CAN_TCR_MB4 (0x1u << 4) /**< \brief (CAN_TCR) Transfer Request for Mailbox 4 */
+#define CAN_TCR_MB5 (0x1u << 5) /**< \brief (CAN_TCR) Transfer Request for Mailbox 5 */
+#define CAN_TCR_MB6 (0x1u << 6) /**< \brief (CAN_TCR) Transfer Request for Mailbox 6 */
+#define CAN_TCR_MB7 (0x1u << 7) /**< \brief (CAN_TCR) Transfer Request for Mailbox 7 */
+#define CAN_TCR_TIMRST (0x1u << 31) /**< \brief (CAN_TCR) Timer Reset */
+/* -------- CAN_ACR : (CAN Offset: 0x0028) Abort Command Register -------- */
+#define CAN_ACR_MB0 (0x1u << 0) /**< \brief (CAN_ACR) Abort Request for Mailbox 0 */
+#define CAN_ACR_MB1 (0x1u << 1) /**< \brief (CAN_ACR) Abort Request for Mailbox 1 */
+#define CAN_ACR_MB2 (0x1u << 2) /**< \brief (CAN_ACR) Abort Request for Mailbox 2 */
+#define CAN_ACR_MB3 (0x1u << 3) /**< \brief (CAN_ACR) Abort Request for Mailbox 3 */
+#define CAN_ACR_MB4 (0x1u << 4) /**< \brief (CAN_ACR) Abort Request for Mailbox 4 */
+#define CAN_ACR_MB5 (0x1u << 5) /**< \brief (CAN_ACR) Abort Request for Mailbox 5 */
+#define CAN_ACR_MB6 (0x1u << 6) /**< \brief (CAN_ACR) Abort Request for Mailbox 6 */
+#define CAN_ACR_MB7 (0x1u << 7) /**< \brief (CAN_ACR) Abort Request for Mailbox 7 */
+/* -------- CAN_WPMR : (CAN Offset: 0x00E4) Write Protect Mode Register -------- */
+#define CAN_WPMR_WPEN (0x1u << 0) /**< \brief (CAN_WPMR) Write Protection Enable */
+#define CAN_WPMR_WPKEY_Pos 8
+#define CAN_WPMR_WPKEY_Msk (0xffffffu << CAN_WPMR_WPKEY_Pos) /**< \brief (CAN_WPMR) SPI Write Protection Key Password */
+#define CAN_WPMR_WPKEY(value) ((CAN_WPMR_WPKEY_Msk & ((value) << CAN_WPMR_WPKEY_Pos)))
+/* -------- CAN_WPSR : (CAN Offset: 0x00E8) Write Protect Status Register -------- */
+#define CAN_WPSR_WPVS (0x1u << 0) /**< \brief (CAN_WPSR) Write Protection Violation Status */
+#define CAN_WPSR_WPVSRC_Pos 8
+#define CAN_WPSR_WPVSRC_Msk (0xffu << CAN_WPSR_WPVSRC_Pos) /**< \brief (CAN_WPSR) Write Protection Violation Source */
+/* -------- CAN_MMR : (CAN Offset: N/A) Mailbox Mode Register -------- */
+#define CAN_MMR_MTIMEMARK_Pos 0
+#define CAN_MMR_MTIMEMARK_Msk (0xffffu << CAN_MMR_MTIMEMARK_Pos) /**< \brief (CAN_MMR) Mailbox Timemark */
+#define CAN_MMR_MTIMEMARK(value) ((CAN_MMR_MTIMEMARK_Msk & ((value) << CAN_MMR_MTIMEMARK_Pos)))
+#define CAN_MMR_PRIOR_Pos 16
+#define CAN_MMR_PRIOR_Msk (0xfu << CAN_MMR_PRIOR_Pos) /**< \brief (CAN_MMR) Mailbox Priority */
+#define CAN_MMR_PRIOR(value) ((CAN_MMR_PRIOR_Msk & ((value) << CAN_MMR_PRIOR_Pos)))
+#define CAN_MMR_MOT_Pos 24
+#define CAN_MMR_MOT_Msk (0x7u << CAN_MMR_MOT_Pos) /**< \brief (CAN_MMR) Mailbox Object Type */
+#define   CAN_MMR_MOT_MB_DISABLED (0x0u << 24) /**< \brief (CAN_MMR) Mailbox is disabled. This prevents receiving or transmitting any messages with this mailbox. */
+#define   CAN_MMR_MOT_MB_RX (0x1u << 24) /**< \brief (CAN_MMR) Reception Mailbox. Mailbox is configured for reception. If a message is received while the mailbox data register is full, it is discarded. */
+#define   CAN_MMR_MOT_MB_RX_OVERWRITE (0x2u << 24) /**< \brief (CAN_MMR) Reception mailbox with overwrite. Mailbox is configured for reception. If a message is received while the mailbox is full, it overwrites the previous message. */
+#define   CAN_MMR_MOT_MB_TX (0x3u << 24) /**< \brief (CAN_MMR) Transmit mailbox. Mailbox is configured for transmission. */
+#define   CAN_MMR_MOT_MB_CONSUMER (0x4u << 24) /**< \brief (CAN_MMR) Consumer Mailbox. Mailbox is configured in reception but behaves as a Transmit Mailbox, i.e., it sends a remote frame and waits for an answer. */
+#define   CAN_MMR_MOT_MB_PRODUCER (0x5u << 24) /**< \brief (CAN_MMR) Producer Mailbox. Mailbox is configured in transmission but also behaves like a reception mailbox, i.e., it waits to receive a Remote Frame before sending its contents. */
+/* -------- CAN_MAM : (CAN Offset: N/A) Mailbox Acceptance Mask Register -------- */
+#define CAN_MAM_MIDvB_Pos 0
+#define CAN_MAM_MIDvB_Msk (0x3ffffu << CAN_MAM_MIDvB_Pos) /**< \brief (CAN_MAM) Complementary bits for identifier in extended frame mode */
+#define CAN_MAM_MIDvB(value) ((CAN_MAM_MIDvB_Msk & ((value) << CAN_MAM_MIDvB_Pos)))
+#define CAN_MAM_MIDvA_Pos 18
+#define CAN_MAM_MIDvA_Msk (0x7ffu << CAN_MAM_MIDvA_Pos) /**< \brief (CAN_MAM) Identifier for standard frame mode */
+#define CAN_MAM_MIDvA(value) ((CAN_MAM_MIDvA_Msk & ((value) << CAN_MAM_MIDvA_Pos)))
+#define CAN_MAM_MIDE (0x1u << 29) /**< \brief (CAN_MAM) Identifier Version */
+/* -------- CAN_MID : (CAN Offset: N/A) Mailbox ID Register -------- */
+#define CAN_MID_MIDvB_Pos 0
+#define CAN_MID_MIDvB_Msk (0x3ffffu << CAN_MID_MIDvB_Pos) /**< \brief (CAN_MID) Complementary bits for identifier in extended frame mode */
+#define CAN_MID_MIDvB(value) ((CAN_MID_MIDvB_Msk & ((value) << CAN_MID_MIDvB_Pos)))
+#define CAN_MID_MIDvA_Pos 18
+#define CAN_MID_MIDvA_Msk (0x7ffu << CAN_MID_MIDvA_Pos) /**< \brief (CAN_MID) Identifier for standard frame mode */
+#define CAN_MID_MIDvA(value) ((CAN_MID_MIDvA_Msk & ((value) << CAN_MID_MIDvA_Pos)))
+#define CAN_MID_MIDE (0x1u << 29) /**< \brief (CAN_MID) Identifier Version */
+/* -------- CAN_MFID : (CAN Offset: N/A) Mailbox Family ID Register -------- */
+#define CAN_MFID_MFID_Pos 0
+#define CAN_MFID_MFID_Msk (0x1fffffffu << CAN_MFID_MFID_Pos) /**< \brief (CAN_MFID) Family ID */
+/* -------- CAN_MSR : (CAN Offset: N/A) Mailbox Status Register -------- */
+#define CAN_MSR_MTIMESTAMP_Pos 0
+#define CAN_MSR_MTIMESTAMP_Msk (0xffffu << CAN_MSR_MTIMESTAMP_Pos) /**< \brief (CAN_MSR) Timer value */
+#define CAN_MSR_MDLC_Pos 16
+#define CAN_MSR_MDLC_Msk (0xfu << CAN_MSR_MDLC_Pos) /**< \brief (CAN_MSR) Mailbox Data Length Code */
+#define CAN_MSR_MRTR (0x1u << 20) /**< \brief (CAN_MSR) Mailbox Remote Transmission Request */
+#define CAN_MSR_MABT (0x1u << 22) /**< \brief (CAN_MSR) Mailbox Message Abort */
+#define CAN_MSR_MRDY (0x1u << 23) /**< \brief (CAN_MSR) Mailbox Ready */
+#define CAN_MSR_MMI (0x1u << 24) /**< \brief (CAN_MSR) Mailbox Message Ignored */
+/* -------- CAN_MDL : (CAN Offset: N/A) Mailbox Data Low Register -------- */
+#define CAN_MDL_MDL_Pos 0
+#define CAN_MDL_MDL_Msk (0xffffffffu << CAN_MDL_MDL_Pos) /**< \brief (CAN_MDL) Message Data Low Value */
+#define CAN_MDL_MDL(value) ((CAN_MDL_MDL_Msk & ((value) << CAN_MDL_MDL_Pos)))
+/* -------- CAN_MDH : (CAN Offset: N/A) Mailbox Data High Register -------- */
+#define CAN_MDH_MDH_Pos 0
+#define CAN_MDH_MDH_Msk (0xffffffffu << CAN_MDH_MDH_Pos) /**< \brief (CAN_MDH) Message Data High Value */
+#define CAN_MDH_MDH(value) ((CAN_MDH_MDH_Msk & ((value) << CAN_MDH_MDH_Pos)))
+/* -------- CAN_MCR : (CAN Offset: N/A) Mailbox Control Register -------- */
+#define CAN_MCR_MDLC_Pos 16
+#define CAN_MCR_MDLC_Msk (0xfu << CAN_MCR_MDLC_Pos) /**< \brief (CAN_MCR) Mailbox Data Length Code */
+#define CAN_MCR_MDLC(value) ((CAN_MCR_MDLC_Msk & ((value) << CAN_MCR_MDLC_Pos)))
+#define CAN_MCR_MRTR (0x1u << 20) /**< \brief (CAN_MCR) Mailbox Remote Transmission Request */
+#define CAN_MCR_MACR (0x1u << 22) /**< \brief (CAN_MCR) Abort Request for Mailbox x */
+#define CAN_MCR_MTCR (0x1u << 23) /**< \brief (CAN_MCR) Mailbox Transfer Command */
+
+/*@}*/
+
+
+#endif /* _SAM4E_CAN_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/chipid.h
+++ b/asf/sam/include/sam4e/component/chipid.h
@@ -1,0 +1,162 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CHIPID_COMPONENT_
+#define _SAM4E_CHIPID_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Chip Identifier */
+/* ============================================================================= */
+/** \addtogroup SAM4E_CHIPID Chip Identifier */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Chipid hardware registers */
+typedef struct {
+  RoReg CHIPID_CIDR; /**< \brief (Chipid Offset: 0x0) Chip ID Register */
+  RoReg CHIPID_EXID; /**< \brief (Chipid Offset: 0x4) Chip ID Extension Register */
+} Chipid;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- CHIPID_CIDR : (CHIPID Offset: 0x0) Chip ID Register -------- */
+#define CHIPID_CIDR_VERSION_Pos 0
+#define CHIPID_CIDR_VERSION_Msk (0x1fu << CHIPID_CIDR_VERSION_Pos) /**< \brief (CHIPID_CIDR) Version of the Device */
+#define CHIPID_CIDR_EPROC_Pos 5
+#define CHIPID_CIDR_EPROC_Msk (0x7u << CHIPID_CIDR_EPROC_Pos) /**< \brief (CHIPID_CIDR) Embedded Processor */
+#define   CHIPID_CIDR_EPROC_ARM946ES (0x1u << 5) /**< \brief (CHIPID_CIDR) ARM946ES */
+#define   CHIPID_CIDR_EPROC_ARM7TDMI (0x2u << 5) /**< \brief (CHIPID_CIDR) ARM7TDMI */
+#define   CHIPID_CIDR_EPROC_CM3 (0x3u << 5) /**< \brief (CHIPID_CIDR) Cortex-M3 */
+#define   CHIPID_CIDR_EPROC_ARM920T (0x4u << 5) /**< \brief (CHIPID_CIDR) ARM920T */
+#define   CHIPID_CIDR_EPROC_ARM926EJS (0x5u << 5) /**< \brief (CHIPID_CIDR) ARM926EJS */
+#define   CHIPID_CIDR_EPROC_CA5 (0x6u << 5) /**< \brief (CHIPID_CIDR) Cortex-A5 */
+#define   CHIPID_CIDR_EPROC_CM4 (0x7u << 5) /**< \brief (CHIPID_CIDR) Cortex-M4 */
+#define CHIPID_CIDR_NVPSIZ_Pos 8
+#define CHIPID_CIDR_NVPSIZ_Msk (0xfu << CHIPID_CIDR_NVPSIZ_Pos) /**< \brief (CHIPID_CIDR) Nonvolatile Program Memory Size */
+#define   CHIPID_CIDR_NVPSIZ_NONE (0x0u << 8) /**< \brief (CHIPID_CIDR) None */
+#define   CHIPID_CIDR_NVPSIZ_8K (0x1u << 8) /**< \brief (CHIPID_CIDR) 8 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_16K (0x2u << 8) /**< \brief (CHIPID_CIDR) 16 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_32K (0x3u << 8) /**< \brief (CHIPID_CIDR) 32 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_64K (0x5u << 8) /**< \brief (CHIPID_CIDR) 64 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_128K (0x7u << 8) /**< \brief (CHIPID_CIDR) 128 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_256K (0x9u << 8) /**< \brief (CHIPID_CIDR) 256 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_512K (0xAu << 8) /**< \brief (CHIPID_CIDR) 512 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_1024K (0xCu << 8) /**< \brief (CHIPID_CIDR) 1024 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ_2048K (0xEu << 8) /**< \brief (CHIPID_CIDR) 2048 Kbytes */
+#define CHIPID_CIDR_NVPSIZ2_Pos 12
+#define CHIPID_CIDR_NVPSIZ2_Msk (0xfu << CHIPID_CIDR_NVPSIZ2_Pos) /**< \brief (CHIPID_CIDR) Second Nonvolatile Program Memory Size */
+#define   CHIPID_CIDR_NVPSIZ2_NONE (0x0u << 12) /**< \brief (CHIPID_CIDR) None */
+#define   CHIPID_CIDR_NVPSIZ2_8K (0x1u << 12) /**< \brief (CHIPID_CIDR) 8 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_16K (0x2u << 12) /**< \brief (CHIPID_CIDR) 16 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_32K (0x3u << 12) /**< \brief (CHIPID_CIDR) 32 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_64K (0x5u << 12) /**< \brief (CHIPID_CIDR) 64 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_128K (0x7u << 12) /**< \brief (CHIPID_CIDR) 128 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_256K (0x9u << 12) /**< \brief (CHIPID_CIDR) 256 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_512K (0xAu << 12) /**< \brief (CHIPID_CIDR) 512 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_1024K (0xCu << 12) /**< \brief (CHIPID_CIDR) 1024 Kbytes */
+#define   CHIPID_CIDR_NVPSIZ2_2048K (0xEu << 12) /**< \brief (CHIPID_CIDR) 2048 Kbytes */
+#define CHIPID_CIDR_SRAMSIZ_Pos 16
+#define CHIPID_CIDR_SRAMSIZ_Msk (0xfu << CHIPID_CIDR_SRAMSIZ_Pos) /**< \brief (CHIPID_CIDR) Internal SRAM Size */
+#define   CHIPID_CIDR_SRAMSIZ_48K (0x0u << 16) /**< \brief (CHIPID_CIDR) 48 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_192K (0x1u << 16) /**< \brief (CHIPID_CIDR) 192 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_2K (0x2u << 16) /**< \brief (CHIPID_CIDR) 2 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_6K (0x3u << 16) /**< \brief (CHIPID_CIDR) 6 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_24K (0x4u << 16) /**< \brief (CHIPID_CIDR) 24 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_4K (0x5u << 16) /**< \brief (CHIPID_CIDR) 4 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_80K (0x6u << 16) /**< \brief (CHIPID_CIDR) 80 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_160K (0x7u << 16) /**< \brief (CHIPID_CIDR) 160 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_8K (0x8u << 16) /**< \brief (CHIPID_CIDR) 8 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_16K (0x9u << 16) /**< \brief (CHIPID_CIDR) 16 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_32K (0xAu << 16) /**< \brief (CHIPID_CIDR) 32 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_64K (0xBu << 16) /**< \brief (CHIPID_CIDR) 64 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_128K (0xCu << 16) /**< \brief (CHIPID_CIDR) 128 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_256K (0xDu << 16) /**< \brief (CHIPID_CIDR) 256 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_96K (0xEu << 16) /**< \brief (CHIPID_CIDR) 96 Kbytes */
+#define   CHIPID_CIDR_SRAMSIZ_512K (0xFu << 16) /**< \brief (CHIPID_CIDR) 512 Kbytes */
+#define CHIPID_CIDR_ARCH_Pos 20
+#define CHIPID_CIDR_ARCH_Msk (0xffu << CHIPID_CIDR_ARCH_Pos) /**< \brief (CHIPID_CIDR) Architecture Identifier */
+#define   CHIPID_CIDR_ARCH_AT91SAM9xx (0x19u << 20) /**< \brief (CHIPID_CIDR) AT91SAM9xx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM9XExx (0x29u << 20) /**< \brief (CHIPID_CIDR) AT91SAM9XExx Series */
+#define   CHIPID_CIDR_ARCH_AT91x34 (0x34u << 20) /**< \brief (CHIPID_CIDR) AT91x34 Series */
+#define   CHIPID_CIDR_ARCH_CAP7 (0x37u << 20) /**< \brief (CHIPID_CIDR) CAP7 Series */
+#define   CHIPID_CIDR_ARCH_CAP9 (0x39u << 20) /**< \brief (CHIPID_CIDR) CAP9 Series */
+#define   CHIPID_CIDR_ARCH_CAP11 (0x3Bu << 20) /**< \brief (CHIPID_CIDR) CAP11 Series */
+#define   CHIPID_CIDR_ARCH_SAM4E (0x3Cu << 20) /**< \brief (CHIPID_CIDR) SAM4E Series */
+#define   CHIPID_CIDR_ARCH_AT91x40 (0x40u << 20) /**< \brief (CHIPID_CIDR) AT91x40 Series */
+#define   CHIPID_CIDR_ARCH_AT91x42 (0x42u << 20) /**< \brief (CHIPID_CIDR) AT91x42 Series */
+#define   CHIPID_CIDR_ARCH_AT91x43 (0x43u << 20) /**< \brief (CHIPID_CIDR) AT91x43 Series (WLCSP package) */
+#define   CHIPID_CIDR_ARCH_AT91x55 (0x55u << 20) /**< \brief (CHIPID_CIDR) AT91x55 Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7Axx (0x60u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7Axx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7AQxx (0x61u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7AQxx Series */
+#define   CHIPID_CIDR_ARCH_AT91x63 (0x63u << 20) /**< \brief (CHIPID_CIDR) AT91x63 Series */
+#define   CHIPID_CIDR_ARCH_SAM4CxxC (0x64u << 20) /**< \brief (CHIPID_CIDR) SAM4CxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4CxxE (0x66u << 20) /**< \brief (CHIPID_CIDR) SAM4CxE Series (144-pin version) */
+#define   CHIPID_CIDR_ARCH_AT91SAM7Sxx (0x70u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7Sxx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7XCxx (0x71u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7XCxx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7SExx (0x72u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7SExx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7Lxx (0x73u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7Lxx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7Xxx (0x75u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7Xxx Series */
+#define   CHIPID_CIDR_ARCH_AT91SAM7SLxx (0x76u << 20) /**< \brief (CHIPID_CIDR) AT91SAM7SLxx Series */
+#define   CHIPID_CIDR_ARCH_SAM3UxC (0x80u << 20) /**< \brief (CHIPID_CIDR) SAM3UxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3UxE (0x81u << 20) /**< \brief (CHIPID_CIDR) SAM3UxE Series (144-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3AxC (0x83u << 20) /**< \brief (CHIPID_CIDR) SAM3AxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3XxC (0x84u << 20) /**< \brief (CHIPID_CIDR) SAM3XxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3XxE (0x85u << 20) /**< \brief (CHIPID_CIDR) SAM3XxE Series (144-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3XxG (0x86u << 20) /**< \brief (CHIPID_CIDR) SAM3XxG Series (208/217-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3SxA (0x88u << 20) /**< \brief (CHIPID_CIDR) SAM3SxASeries (48-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4SxA (0x88u << 20) /**< \brief (CHIPID_CIDR) SAM4SxA Series (48-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3SxB (0x89u << 20) /**< \brief (CHIPID_CIDR) SAM3SxB Series (64-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4SxB (0x89u << 20) /**< \brief (CHIPID_CIDR) SAM4SxB Series (64-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3SxC (0x8Au << 20) /**< \brief (CHIPID_CIDR) SAM3SxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4SxC (0x8Au << 20) /**< \brief (CHIPID_CIDR) SAM4SxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_AT91x92 (0x92u << 20) /**< \brief (CHIPID_CIDR) AT91x92 Series */
+#define   CHIPID_CIDR_ARCH_SAM3NxA (0x93u << 20) /**< \brief (CHIPID_CIDR) SAM3NxA Series (48-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3NxB (0x94u << 20) /**< \brief (CHIPID_CIDR) SAM3NxB Series (64-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3NxC (0x95u << 20) /**< \brief (CHIPID_CIDR) SAM3NxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3SDxB (0x99u << 20) /**< \brief (CHIPID_CIDR) SAM3SDxB Series (64-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM3SDxC (0x9Au << 20) /**< \brief (CHIPID_CIDR) SAM3SDxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM5A (0xA5u << 20) /**< \brief (CHIPID_CIDR) SAM5A */
+#define   CHIPID_CIDR_ARCH_SAM4LxA (0xB0u << 20) /**< \brief (CHIPID_CIDR) SAM4LxA Series (48-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4LxB (0xB1u << 20) /**< \brief (CHIPID_CIDR) SAM4LxB Series (64-pin version) */
+#define   CHIPID_CIDR_ARCH_SAM4LxC (0xB2u << 20) /**< \brief (CHIPID_CIDR) SAM4LxC Series (100-pin version) */
+#define   CHIPID_CIDR_ARCH_AT75Cxx (0xF0u << 20) /**< \brief (CHIPID_CIDR) AT75Cxx Series */
+#define CHIPID_CIDR_NVPTYP_Pos 28
+#define CHIPID_CIDR_NVPTYP_Msk (0x7u << CHIPID_CIDR_NVPTYP_Pos) /**< \brief (CHIPID_CIDR) Nonvolatile Program Memory Type */
+#define   CHIPID_CIDR_NVPTYP_ROM (0x0u << 28) /**< \brief (CHIPID_CIDR) ROM */
+#define   CHIPID_CIDR_NVPTYP_ROMLESS (0x1u << 28) /**< \brief (CHIPID_CIDR) ROMless or on-chip Flash */
+#define   CHIPID_CIDR_NVPTYP_FLASH (0x2u << 28) /**< \brief (CHIPID_CIDR) Embedded Flash Memory */
+#define   CHIPID_CIDR_NVPTYP_ROM_FLASH (0x3u << 28) /**< \brief (CHIPID_CIDR) ROM and Embedded Flash MemoryNVPSIZ is ROM size      NVPSIZ2 is Flash size */
+#define   CHIPID_CIDR_NVPTYP_SRAM (0x4u << 28) /**< \brief (CHIPID_CIDR) SRAM emulating ROM */
+#define CHIPID_CIDR_EXT (0x1u << 31) /**< \brief (CHIPID_CIDR) Extension Flag */
+/* -------- CHIPID_EXID : (CHIPID Offset: 0x4) Chip ID Extension Register -------- */
+#define CHIPID_EXID_EXID_Pos 0
+#define CHIPID_EXID_EXID_Msk (0xffffffffu << CHIPID_EXID_EXID_Pos) /**< \brief (CHIPID_EXID) Chip ID Extension */
+
+/*@}*/
+
+
+#endif /* _SAM4E_CHIPID_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/cmcc.h
+++ b/asf/sam/include/sam4e/component/cmcc.h
@@ -1,0 +1,115 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CMCC_COMPONENT_
+#define _SAM4E_CMCC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Cortex M Cache Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_CMCC Cortex M Cache Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Cmcc hardware registers */
+typedef struct {
+  RoReg CMCC_TYPE;    /**< \brief (Cmcc Offset: 0x00) Cache Type Register */
+  RwReg CMCC_CFG;     /**< \brief (Cmcc Offset: 0x04) Cache Configuration Register */
+  WoReg CMCC_CTRL;    /**< \brief (Cmcc Offset: 0x08) Cache Control Register */
+  RoReg CMCC_SR;      /**< \brief (Cmcc Offset: 0x0C) Cache Status Register */
+  RoReg Reserved1[4];
+  WoReg CMCC_MAINT0;  /**< \brief (Cmcc Offset: 0x20) Cache Maintenance Register 0 */
+  WoReg CMCC_MAINT1;  /**< \brief (Cmcc Offset: 0x24) Cache Maintenance Register 1 */
+  RwReg CMCC_MCFG;    /**< \brief (Cmcc Offset: 0x28) Cache Monitor Configuration Register */
+  RwReg CMCC_MEN;     /**< \brief (Cmcc Offset: 0x2C) Cache Monitor Enable Register */
+  WoReg CMCC_MCTRL;   /**< \brief (Cmcc Offset: 0x30) Cache Monitor Control Register */
+  RoReg CMCC_MSR;     /**< \brief (Cmcc Offset: 0x34) Cache Monitor Status Register */
+} Cmcc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- CMCC_TYPE : (CMCC Offset: 0x00) Cache Type Register -------- */
+#define CMCC_TYPE_AP (0x1u << 0) /**< \brief (CMCC_TYPE) Access Port Access Allowed */
+#define CMCC_TYPE_GCLK (0x1u << 1) /**< \brief (CMCC_TYPE) Dynamic Clock Gating Supported */
+#define CMCC_TYPE_RANDP (0x1u << 2) /**< \brief (CMCC_TYPE) Random Selection Policy Supported */
+#define CMCC_TYPE_LRUP (0x1u << 3) /**< \brief (CMCC_TYPE) Least Recently Used Policy Supported */
+#define CMCC_TYPE_RRP (0x1u << 4) /**< \brief (CMCC_TYPE) Random Selection Policy Supported */
+#define CMCC_TYPE_WAYNUM_Pos 5
+#define CMCC_TYPE_WAYNUM_Msk (0x3u << CMCC_TYPE_WAYNUM_Pos) /**< \brief (CMCC_TYPE) Number of Way */
+#define   CMCC_TYPE_WAYNUM_DMAPPED (0x0u << 5) /**< \brief (CMCC_TYPE) Direct Mapped Cache */
+#define   CMCC_TYPE_WAYNUM_ARCH2WAY (0x1u << 5) /**< \brief (CMCC_TYPE) 2-WAY set associative */
+#define   CMCC_TYPE_WAYNUM_ARCH4WAY (0x2u << 5) /**< \brief (CMCC_TYPE) 4-WAY set associative */
+#define   CMCC_TYPE_WAYNUM_ARCH8WAY (0x3u << 5) /**< \brief (CMCC_TYPE) 8-WAY set associative */
+#define CMCC_TYPE_LCKDOWN (0x1u << 7) /**< \brief (CMCC_TYPE) Lock Down Supported */
+#define CMCC_TYPE_CSIZE_Pos 8
+#define CMCC_TYPE_CSIZE_Msk (0x7u << CMCC_TYPE_CSIZE_Pos) /**< \brief (CMCC_TYPE) Cache Size */
+#define   CMCC_TYPE_CSIZE_CSIZE_1KB (0x0u << 8) /**< \brief (CMCC_TYPE) Cache Size 1 Kbytes */
+#define   CMCC_TYPE_CSIZE_CSIZE_2KB (0x1u << 8) /**< \brief (CMCC_TYPE) Cache Size 2 Kbytes */
+#define   CMCC_TYPE_CSIZE_CSIZE_4KB (0x2u << 8) /**< \brief (CMCC_TYPE) Cache Size 4 Kbytes */
+#define   CMCC_TYPE_CSIZE_CSIZE_8KB (0x3u << 8) /**< \brief (CMCC_TYPE) Cache Size 8 Kbytes */
+#define CMCC_TYPE_CLSIZE_Pos 11
+#define CMCC_TYPE_CLSIZE_Msk (0x7u << CMCC_TYPE_CLSIZE_Pos) /**< \brief (CMCC_TYPE) Cache Size */
+#define   CMCC_TYPE_CLSIZE_CLSIZE_1KB (0x0u << 11) /**< \brief (CMCC_TYPE) 4 bytes */
+#define   CMCC_TYPE_CLSIZE_CLSIZE_2KB (0x1u << 11) /**< \brief (CMCC_TYPE) 8 bytes */
+#define   CMCC_TYPE_CLSIZE_CLSIZE_4KB (0x2u << 11) /**< \brief (CMCC_TYPE) 16 bytes */
+#define   CMCC_TYPE_CLSIZE_CLSIZE_8KB (0x3u << 11) /**< \brief (CMCC_TYPE) 32 bytes */
+/* -------- CMCC_CFG : (CMCC Offset: 0x04) Cache Configuration Register -------- */
+#define CMCC_CFG_GCLKDIS (0x1u << 0) /**< \brief (CMCC_CFG) Disable Clock Gating */
+/* -------- CMCC_CTRL : (CMCC Offset: 0x08) Cache Control Register -------- */
+#define CMCC_CTRL_CEN (0x1u << 0) /**< \brief (CMCC_CTRL) Cache Controller Enable */
+/* -------- CMCC_SR : (CMCC Offset: 0x0C) Cache Status Register -------- */
+#define CMCC_SR_CSTS (0x1u << 0) /**< \brief (CMCC_SR) Cache Controller Status */
+/* -------- CMCC_MAINT0 : (CMCC Offset: 0x20) Cache Maintenance Register 0 -------- */
+#define CMCC_MAINT0_INVALL (0x1u << 0) /**< \brief (CMCC_MAINT0) Cache Controller Invalidate All */
+/* -------- CMCC_MAINT1 : (CMCC Offset: 0x24) Cache Maintenance Register 1 -------- */
+#define CMCC_MAINT1_INDEX_Pos 4
+#define CMCC_MAINT1_INDEX_Msk (0x1fu << CMCC_MAINT1_INDEX_Pos) /**< \brief (CMCC_MAINT1) Invalidate Index */
+#define CMCC_MAINT1_INDEX(value) ((CMCC_MAINT1_INDEX_Msk & ((value) << CMCC_MAINT1_INDEX_Pos)))
+#define CMCC_MAINT1_WAY_Pos 30
+#define CMCC_MAINT1_WAY_Msk (0x3u << CMCC_MAINT1_WAY_Pos) /**< \brief (CMCC_MAINT1) Invalidate Way */
+#define   CMCC_MAINT1_WAY_WAY0 (0x0u << 30) /**< \brief (CMCC_MAINT1) Way 0 is selection for index invalidation */
+#define   CMCC_MAINT1_WAY_WAY1 (0x1u << 30) /**< \brief (CMCC_MAINT1) Way 1 is selection for index invalidation */
+#define   CMCC_MAINT1_WAY_WAY2 (0x2u << 30) /**< \brief (CMCC_MAINT1) Way 2 is selection for index invalidation */
+#define   CMCC_MAINT1_WAY_WAY3 (0x3u << 30) /**< \brief (CMCC_MAINT1) Way 3 is selection for index invalidation */
+/* -------- CMCC_MCFG : (CMCC Offset: 0x28) Cache Monitor Configuration Register -------- */
+#define CMCC_MCFG_MODE_Pos 0
+#define CMCC_MCFG_MODE_Msk (0x3u << CMCC_MCFG_MODE_Pos) /**< \brief (CMCC_MCFG) Cache Controller Monitor Counter Mode */
+#define   CMCC_MCFG_MODE_CYCLE_COUNT (0x0u << 0) /**< \brief (CMCC_MCFG) Cycle counter */
+#define   CMCC_MCFG_MODE_IHIT_COUNT (0x1u << 0) /**< \brief (CMCC_MCFG) Instruction hit counter */
+#define   CMCC_MCFG_MODE_DHIT_COUNT (0x2u << 0) /**< \brief (CMCC_MCFG) Data hit counter */
+/* -------- CMCC_MEN : (CMCC Offset: 0x2C) Cache Monitor Enable Register -------- */
+#define CMCC_MEN_MENABLE (0x1u << 0) /**< \brief (CMCC_MEN) Cache Controller Monitor Enable */
+/* -------- CMCC_MCTRL : (CMCC Offset: 0x30) Cache Monitor Control Register -------- */
+#define CMCC_MCTRL_SWRST (0x1u << 0) /**< \brief (CMCC_MCTRL) Monitor */
+/* -------- CMCC_MSR : (CMCC Offset: 0x34) Cache Monitor Status Register -------- */
+#define CMCC_MSR_EVENT_CNT_Pos 0
+#define CMCC_MSR_EVENT_CNT_Msk (0xffffffffu << CMCC_MSR_EVENT_CNT_Pos) /**< \brief (CMCC_MSR) Monitor Event Counter */
+
+/*@}*/
+
+
+#endif /* _SAM4E_CMCC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/crccu.h
+++ b/asf/sam/include/sam4e/component/crccu.h
@@ -1,0 +1,107 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CRCCU_COMPONENT_
+#define _SAM4E_CRCCU_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Cyclic Redundancy Check Calculation Unit */
+/* ============================================================================= */
+/** \addtogroup SAM4E_CRCCU Cyclic Redundancy Check Calculation Unit */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Crccu hardware registers */
+typedef struct {
+  RwReg CRCCU_DSCR;    /**< \brief (Crccu Offset: 0x00000000) CRCCU Descriptor Base Register */
+  RoReg Reserved1[1];
+  WoReg CRCCU_DMA_EN;  /**< \brief (Crccu Offset: 0x00000008) CRCCU DMA Enable Register */
+  WoReg CRCCU_DMA_DIS; /**< \brief (Crccu Offset: 0x0000000C) CRCCU DMA Disable Register */
+  RoReg CRCCU_DMA_SR;  /**< \brief (Crccu Offset: 0x00000010) CRCCU DMA Status Register */
+  WoReg CRCCU_DMA_IER; /**< \brief (Crccu Offset: 0x00000014) CRCCU DMA Interrupt Enable Register */
+  WoReg CRCCU_DMA_IDR; /**< \brief (Crccu Offset: 0x00000018) CRCCU DMA Interrupt Disable Register */
+  RoReg CRCCU_DMA_IMR; /**< \brief (Crccu Offset: 0x0000001C) CRCCU DMA Interrupt Mask Register */
+  RoReg CRCCU_DMA_ISR; /**< \brief (Crccu Offset: 0x00000020) CRCCU DMA Interrupt Status Register */
+  RoReg Reserved2[4];
+  WoReg CRCCU_CR;      /**< \brief (Crccu Offset: 0x00000034) CRCCU Control Register */
+  RwReg CRCCU_MR;      /**< \brief (Crccu Offset: 0x00000038) CRCCU Mode Register */
+  RoReg CRCCU_SR;      /**< \brief (Crccu Offset: 0x0000003C) CRCCU Status Register */
+  WoReg CRCCU_IER;     /**< \brief (Crccu Offset: 0x00000040) CRCCU Interrupt Enable Register */
+  WoReg CRCCU_IDR;     /**< \brief (Crccu Offset: 0x00000044) CRCCU Interrupt Disable Register */
+  RoReg CRCCU_IMR;     /**< \brief (Crccu Offset: 0x00000048) CRCCU Interrupt Mask Register */
+  RoReg CRCCU_ISR;     /**< \brief (Crccu Offset: 0x0000004C) CRCCU Interrupt Status Register */
+} Crccu;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- CRCCU_DSCR : (CRCCU Offset: 0x00000000) CRCCU Descriptor Base Register -------- */
+#define CRCCU_DSCR_DSCR_Pos 9
+#define CRCCU_DSCR_DSCR_Msk (0x7fffffu << CRCCU_DSCR_DSCR_Pos) /**< \brief (CRCCU_DSCR) Descriptor Base Address */
+#define CRCCU_DSCR_DSCR(value) ((CRCCU_DSCR_DSCR_Msk & ((value) << CRCCU_DSCR_DSCR_Pos)))
+/* -------- CRCCU_DMA_EN : (CRCCU Offset: 0x00000008) CRCCU DMA Enable Register -------- */
+#define CRCCU_DMA_EN_DMAEN (0x1u << 0) /**< \brief (CRCCU_DMA_EN) DMA Enable Register */
+/* -------- CRCCU_DMA_DIS : (CRCCU Offset: 0x0000000C) CRCCU DMA Disable Register -------- */
+#define CRCCU_DMA_DIS_DMADIS (0x1u << 0) /**< \brief (CRCCU_DMA_DIS) DMA Disable Register */
+/* -------- CRCCU_DMA_SR : (CRCCU Offset: 0x00000010) CRCCU DMA Status Register -------- */
+#define CRCCU_DMA_SR_DMASR (0x1u << 0) /**< \brief (CRCCU_DMA_SR) DMA Status Register */
+/* -------- CRCCU_DMA_IER : (CRCCU Offset: 0x00000014) CRCCU DMA Interrupt Enable Register -------- */
+#define CRCCU_DMA_IER_DMAIER (0x1u << 0) /**< \brief (CRCCU_DMA_IER) Interrupt Enable register */
+/* -------- CRCCU_DMA_IDR : (CRCCU Offset: 0x00000018) CRCCU DMA Interrupt Disable Register -------- */
+#define CRCCU_DMA_IDR_DMAIDR (0x1u << 0) /**< \brief (CRCCU_DMA_IDR) Interrupt Disable register */
+/* -------- CRCCU_DMA_IMR : (CRCCU Offset: 0x0000001C) CRCCU DMA Interrupt Mask Register -------- */
+#define CRCCU_DMA_IMR_DMAIMR (0x1u << 0) /**< \brief (CRCCU_DMA_IMR) Interrupt Mask Register */
+/* -------- CRCCU_DMA_ISR : (CRCCU Offset: 0x00000020) CRCCU DMA Interrupt Status Register -------- */
+#define CRCCU_DMA_ISR_DMAISR (0x1u << 0) /**< \brief (CRCCU_DMA_ISR) Interrupt Status register */
+/* -------- CRCCU_CR : (CRCCU Offset: 0x00000034) CRCCU Control Register -------- */
+#define CRCCU_CR_RESET (0x1u << 0) /**< \brief (CRCCU_CR) CRC Computation Reset */
+/* -------- CRCCU_MR : (CRCCU Offset: 0x00000038) CRCCU Mode Register -------- */
+#define CRCCU_MR_ENABLE (0x1u << 0) /**< \brief (CRCCU_MR) CRC Enable */
+#define CRCCU_MR_COMPARE (0x1u << 1) /**< \brief (CRCCU_MR) CRC Compare */
+#define CRCCU_MR_PTYPE_Pos 2
+#define CRCCU_MR_PTYPE_Msk (0x3u << CRCCU_MR_PTYPE_Pos) /**< \brief (CRCCU_MR) Primitive Polynomial */
+#define   CRCCU_MR_PTYPE_CCITT8023 (0x0u << 2) /**< \brief (CRCCU_MR) Polynom 0x04C11DB7 */
+#define   CRCCU_MR_PTYPE_CASTAGNOLI (0x1u << 2) /**< \brief (CRCCU_MR) Polynom 0x1EDC6F41 */
+#define   CRCCU_MR_PTYPE_CCITT16 (0x2u << 2) /**< \brief (CRCCU_MR) Polynom 0x1021 */
+#define CRCCU_MR_DIVIDER_Pos 4
+#define CRCCU_MR_DIVIDER_Msk (0xfu << CRCCU_MR_DIVIDER_Pos) /**< \brief (CRCCU_MR) Request Divider */
+#define CRCCU_MR_DIVIDER(value) ((CRCCU_MR_DIVIDER_Msk & ((value) << CRCCU_MR_DIVIDER_Pos)))
+/* -------- CRCCU_SR : (CRCCU Offset: 0x0000003C) CRCCU Status Register -------- */
+#define CRCCU_SR_CRC_Pos 0
+#define CRCCU_SR_CRC_Msk (0xffffffffu << CRCCU_SR_CRC_Pos) /**< \brief (CRCCU_SR) Cyclic Redundancy Check Value */
+/* -------- CRCCU_IER : (CRCCU Offset: 0x00000040) CRCCU Interrupt Enable Register -------- */
+#define CRCCU_IER_ERRIER (0x1u << 0) /**< \brief (CRCCU_IER) CRC Error Interrupt Enable */
+/* -------- CRCCU_IDR : (CRCCU Offset: 0x00000044) CRCCU Interrupt Disable Register -------- */
+#define CRCCU_IDR_ERRIDR (0x1u << 0) /**< \brief (CRCCU_IDR) CRC Error Interrupt Disable */
+/* -------- CRCCU_IMR : (CRCCU Offset: 0x00000048) CRCCU Interrupt Mask Register -------- */
+#define CRCCU_IMR_ERRIMR (0x1u << 0) /**< \brief (CRCCU_IMR) CRC Error Interrupt Mask */
+/* -------- CRCCU_ISR : (CRCCU Offset: 0x0000004C) CRCCU Interrupt Status Register -------- */
+#define CRCCU_ISR_ERRISR (0x1u << 0) /**< \brief (CRCCU_ISR) CRC Error Interrupt Status */
+
+/*@}*/
+
+
+#endif /* _SAM4E_CRCCU_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/dacc.h
+++ b/asf/sam/include/sam4e/component/dacc.h
@@ -1,0 +1,213 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_DACC_COMPONENT_
+#define _SAM4E_DACC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Digital-to-Analog Converter Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_DACC Digital-to-Analog Converter Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Dacc hardware registers */
+typedef struct {
+  WoReg DACC_CR;       /**< \brief (Dacc Offset: 0x00) Control Register */
+  RwReg DACC_MR;       /**< \brief (Dacc Offset: 0x04) Mode Register */
+  RoReg Reserved1[2];
+  WoReg DACC_CHER;     /**< \brief (Dacc Offset: 0x10) Channel Enable Register */
+  WoReg DACC_CHDR;     /**< \brief (Dacc Offset: 0x14) Channel Disable Register */
+  RoReg DACC_CHSR;     /**< \brief (Dacc Offset: 0x18) Channel Status Register */
+  RoReg Reserved2[1];
+  WoReg DACC_CDR;      /**< \brief (Dacc Offset: 0x20) Conversion Data Register */
+  WoReg DACC_IER;      /**< \brief (Dacc Offset: 0x24) Interrupt Enable Register */
+  WoReg DACC_IDR;      /**< \brief (Dacc Offset: 0x28) Interrupt Disable Register */
+  RoReg DACC_IMR;      /**< \brief (Dacc Offset: 0x2C) Interrupt Mask Register */
+  RoReg DACC_ISR;      /**< \brief (Dacc Offset: 0x30) Interrupt Status Register */
+  RoReg Reserved3[24];
+  RwReg DACC_ACR;      /**< \brief (Dacc Offset: 0x94) Analog Current Register */
+  RoReg Reserved4[19];
+  RwReg DACC_WPMR;     /**< \brief (Dacc Offset: 0xE4) Write Protect Mode register */
+  RoReg DACC_WPSR;     /**< \brief (Dacc Offset: 0xE8) Write Protect Status register */
+  RoReg Reserved5[7];
+  RwReg DACC_TPR;      /**< \brief (Dacc Offset: 0x108) Transmit Pointer Register */
+  RwReg DACC_TCR;      /**< \brief (Dacc Offset: 0x10C) Transmit Counter Register */
+  RoReg Reserved6[2];
+  RwReg DACC_TNPR;     /**< \brief (Dacc Offset: 0x118) Transmit Next Pointer Register */
+  RwReg DACC_TNCR;     /**< \brief (Dacc Offset: 0x11C) Transmit Next Counter Register */
+  WoReg DACC_PTCR;     /**< \brief (Dacc Offset: 0x120) Transfer Control Register */
+  RoReg DACC_PTSR;     /**< \brief (Dacc Offset: 0x124) Transfer Status Register */
+} Dacc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- DACC_CR : (DACC Offset: 0x00) Control Register -------- */
+#define DACC_CR_SWRST (0x1u << 0) /**< \brief (DACC_CR) Software Reset */
+/* -------- DACC_MR : (DACC Offset: 0x04) Mode Register -------- */
+#define DACC_MR_TRGEN (0x1u << 0) /**< \brief (DACC_MR) Trigger Enable */
+#define   DACC_MR_TRGEN_DIS (0x0u << 0) /**< \brief (DACC_MR) External trigger mode disabled. DACC in free running mode. */
+#define   DACC_MR_TRGEN_EN (0x1u << 0) /**< \brief (DACC_MR) External trigger mode enabled. */
+#define DACC_MR_TRGSEL_Pos 1
+#define DACC_MR_TRGSEL_Msk (0x7u << DACC_MR_TRGSEL_Pos) /**< \brief (DACC_MR) Trigger Selection */
+#define DACC_MR_TRGSEL(value) ((DACC_MR_TRGSEL_Msk & ((value) << DACC_MR_TRGSEL_Pos)))
+#define DACC_MR_WORD (0x1u << 4) /**< \brief (DACC_MR) Word Transfer */
+#define   DACC_MR_WORD_HALF (0x0u << 4) /**< \brief (DACC_MR) Half-Word transfer */
+#define   DACC_MR_WORD_WORD (0x1u << 4) /**< \brief (DACC_MR) Word Transfer */
+#define DACC_MR_SLEEP (0x1u << 5) /**< \brief (DACC_MR) Sleep Mode */
+#define DACC_MR_FASTWKUP (0x1u << 6) /**< \brief (DACC_MR) Fast Wake up Mode */
+#define DACC_MR_REFRESH_Pos 8
+#define DACC_MR_REFRESH_Msk (0xffu << DACC_MR_REFRESH_Pos) /**< \brief (DACC_MR) Refresh Period */
+#define DACC_MR_REFRESH(value) ((DACC_MR_REFRESH_Msk & ((value) << DACC_MR_REFRESH_Pos)))
+#define DACC_MR_USER_SEL_Pos 16
+#define DACC_MR_USER_SEL_Msk (0x3u << DACC_MR_USER_SEL_Pos) /**< \brief (DACC_MR) User Channel Selection */
+#define   DACC_MR_USER_SEL_CHANNEL0 (0x0u << 16) /**< \brief (DACC_MR) Channel 0 */
+#define   DACC_MR_USER_SEL_CHANNEL1 (0x1u << 16) /**< \brief (DACC_MR) Channel 1 */
+#define DACC_MR_TAG (0x1u << 20) /**< \brief (DACC_MR) Tag Selection Mode */
+#define   DACC_MR_TAG_DIS (0x0u << 20) /**< \brief (DACC_MR) Tag selection mode disabled. Using USER_SEL to select the channel for the conversion. */
+#define   DACC_MR_TAG_EN (0x1u << 20) /**< \brief (DACC_MR) Tag selection mode enabled */
+#define DACC_MR_MAXS (0x1u << 21) /**< \brief (DACC_MR) Max Speed Mode */
+#define   DACC_MR_MAXS_NORMAL (0x0u << 21) /**< \brief (DACC_MR) Normal Mode */
+#define   DACC_MR_MAXS_MAXIMUM (0x1u << 21) /**< \brief (DACC_MR) Max Speed Mode enabled */
+#define DACC_MR_CLKDIV (0x1u << 22) /**< \brief (DACC_MR) Clock Divider */
+#define   DACC_MR_CLKDIV_DIV_2 (0x0u << 22) /**< \brief (DACC_MR) The DAC clock is MCK divided by 2 */
+#define   DACC_MR_CLKDIV_DIV_4 (0x1u << 22) /**< \brief (DACC_MR) The DAC clock is MCK divided by 4 (to be used when MCK frequency is above 100MHz) */
+#define DACC_MR_STARTUP_Pos 24
+#define DACC_MR_STARTUP_Msk (0x3fu << DACC_MR_STARTUP_Pos) /**< \brief (DACC_MR) Startup Time Selection */
+#define   DACC_MR_STARTUP_0 (0x0u << 24) /**< \brief (DACC_MR) 0 periods of DACClock */
+#define   DACC_MR_STARTUP_8 (0x1u << 24) /**< \brief (DACC_MR) 8 periods of DACClock */
+#define   DACC_MR_STARTUP_16 (0x2u << 24) /**< \brief (DACC_MR) 16 periods of DACClock */
+#define   DACC_MR_STARTUP_24 (0x3u << 24) /**< \brief (DACC_MR) 24 periods of DACClock */
+#define   DACC_MR_STARTUP_64 (0x4u << 24) /**< \brief (DACC_MR) 64 periods of DACClock */
+#define   DACC_MR_STARTUP_80 (0x5u << 24) /**< \brief (DACC_MR) 80 periods of DACClock */
+#define   DACC_MR_STARTUP_96 (0x6u << 24) /**< \brief (DACC_MR) 96 periods of DACClock */
+#define   DACC_MR_STARTUP_112 (0x7u << 24) /**< \brief (DACC_MR) 112 periods of DACClock */
+#define   DACC_MR_STARTUP_512 (0x8u << 24) /**< \brief (DACC_MR) 512 periods of DACClock */
+#define   DACC_MR_STARTUP_576 (0x9u << 24) /**< \brief (DACC_MR) 576 periods of DACClock */
+#define   DACC_MR_STARTUP_640 (0xAu << 24) /**< \brief (DACC_MR) 640 periods of DACClock */
+#define   DACC_MR_STARTUP_704 (0xBu << 24) /**< \brief (DACC_MR) 704 periods of DACClock */
+#define   DACC_MR_STARTUP_768 (0xCu << 24) /**< \brief (DACC_MR) 768 periods of DACClock */
+#define   DACC_MR_STARTUP_832 (0xDu << 24) /**< \brief (DACC_MR) 832 periods of DACClock */
+#define   DACC_MR_STARTUP_896 (0xEu << 24) /**< \brief (DACC_MR) 896 periods of DACClock */
+#define   DACC_MR_STARTUP_960 (0xFu << 24) /**< \brief (DACC_MR) 960 periods of DACClock */
+#define   DACC_MR_STARTUP_1024 (0x10u << 24) /**< \brief (DACC_MR) 1024 periods of DACClock */
+#define   DACC_MR_STARTUP_1088 (0x11u << 24) /**< \brief (DACC_MR) 1088 periods of DACClock */
+#define   DACC_MR_STARTUP_1152 (0x12u << 24) /**< \brief (DACC_MR) 1152 periods of DACClock */
+#define   DACC_MR_STARTUP_1216 (0x13u << 24) /**< \brief (DACC_MR) 1216 periods of DACClock */
+#define   DACC_MR_STARTUP_1280 (0x14u << 24) /**< \brief (DACC_MR) 1280 periods of DACClock */
+#define   DACC_MR_STARTUP_1344 (0x15u << 24) /**< \brief (DACC_MR) 1344 periods of DACClock */
+#define   DACC_MR_STARTUP_1408 (0x16u << 24) /**< \brief (DACC_MR) 1408 periods of DACClock */
+#define   DACC_MR_STARTUP_1472 (0x17u << 24) /**< \brief (DACC_MR) 1472 periods of DACClock */
+#define   DACC_MR_STARTUP_1536 (0x18u << 24) /**< \brief (DACC_MR) 1536 periods of DACClock */
+#define   DACC_MR_STARTUP_1600 (0x19u << 24) /**< \brief (DACC_MR) 1600 periods of DACClock */
+#define   DACC_MR_STARTUP_1664 (0x1Au << 24) /**< \brief (DACC_MR) 1664 periods of DACClock */
+#define   DACC_MR_STARTUP_1728 (0x1Bu << 24) /**< \brief (DACC_MR) 1728 periods of DACClock */
+#define   DACC_MR_STARTUP_1792 (0x1Cu << 24) /**< \brief (DACC_MR) 1792 periods of DACClock */
+#define   DACC_MR_STARTUP_1856 (0x1Du << 24) /**< \brief (DACC_MR) 1856 periods of DACClock */
+#define   DACC_MR_STARTUP_1920 (0x1Eu << 24) /**< \brief (DACC_MR) 1920 periods of DACClock */
+#define   DACC_MR_STARTUP_1984 (0x1Fu << 24) /**< \brief (DACC_MR) 1984 periods of DACClock */
+/* -------- DACC_CHER : (DACC Offset: 0x10) Channel Enable Register -------- */
+#define DACC_CHER_CH0 (0x1u << 0) /**< \brief (DACC_CHER) Channel 0 Enable */
+#define DACC_CHER_CH1 (0x1u << 1) /**< \brief (DACC_CHER) Channel 1 Enable */
+/* -------- DACC_CHDR : (DACC Offset: 0x14) Channel Disable Register -------- */
+#define DACC_CHDR_CH0 (0x1u << 0) /**< \brief (DACC_CHDR) Channel 0 Disable */
+#define DACC_CHDR_CH1 (0x1u << 1) /**< \brief (DACC_CHDR) Channel 1 Disable */
+/* -------- DACC_CHSR : (DACC Offset: 0x18) Channel Status Register -------- */
+#define DACC_CHSR_CH0 (0x1u << 0) /**< \brief (DACC_CHSR) Channel 0 Status */
+#define DACC_CHSR_CH1 (0x1u << 1) /**< \brief (DACC_CHSR) Channel 1 Status */
+/* -------- DACC_CDR : (DACC Offset: 0x20) Conversion Data Register -------- */
+#define DACC_CDR_DATA_Pos 0
+#define DACC_CDR_DATA_Msk (0xffffffffu << DACC_CDR_DATA_Pos) /**< \brief (DACC_CDR) Data to Convert */
+#define DACC_CDR_DATA(value) ((DACC_CDR_DATA_Msk & ((value) << DACC_CDR_DATA_Pos)))
+/* -------- DACC_IER : (DACC Offset: 0x24) Interrupt Enable Register -------- */
+#define DACC_IER_TXRDY (0x1u << 0) /**< \brief (DACC_IER) Transmit Ready Interrupt Enable */
+#define DACC_IER_EOC (0x1u << 1) /**< \brief (DACC_IER) End of Conversion Interrupt Enable */
+#define DACC_IER_ENDTX (0x1u << 2) /**< \brief (DACC_IER) End of Transmit Buffer Interrupt Enable */
+#define DACC_IER_TXBUFE (0x1u << 3) /**< \brief (DACC_IER) Transmit Buffer Empty Interrupt Enable */
+/* -------- DACC_IDR : (DACC Offset: 0x28) Interrupt Disable Register -------- */
+#define DACC_IDR_TXRDY (0x1u << 0) /**< \brief (DACC_IDR) Transmit Ready Interrupt Disable. */
+#define DACC_IDR_EOC (0x1u << 1) /**< \brief (DACC_IDR) End of Conversion Interrupt Disable */
+#define DACC_IDR_ENDTX (0x1u << 2) /**< \brief (DACC_IDR) End of Transmit Buffer Interrupt Disable */
+#define DACC_IDR_TXBUFE (0x1u << 3) /**< \brief (DACC_IDR) Transmit Buffer Empty Interrupt Disable */
+/* -------- DACC_IMR : (DACC Offset: 0x2C) Interrupt Mask Register -------- */
+#define DACC_IMR_TXRDY (0x1u << 0) /**< \brief (DACC_IMR) Transmit Ready Interrupt Mask */
+#define DACC_IMR_EOC (0x1u << 1) /**< \brief (DACC_IMR) End of Conversion Interrupt Mask */
+#define DACC_IMR_ENDTX (0x1u << 2) /**< \brief (DACC_IMR) End of Transmit Buffer Interrupt Mask */
+#define DACC_IMR_TXBUFE (0x1u << 3) /**< \brief (DACC_IMR) Transmit Buffer Empty Interrupt Mask */
+/* -------- DACC_ISR : (DACC Offset: 0x30) Interrupt Status Register -------- */
+#define DACC_ISR_TXRDY (0x1u << 0) /**< \brief (DACC_ISR) Transmit Ready Interrupt Flag */
+#define DACC_ISR_EOC (0x1u << 1) /**< \brief (DACC_ISR) End of Conversion Interrupt Flag */
+#define DACC_ISR_ENDTX (0x1u << 2) /**< \brief (DACC_ISR) End of DMA Interrupt Flag */
+#define DACC_ISR_TXBUFE (0x1u << 3) /**< \brief (DACC_ISR) Transmit Buffer Empty */
+/* -------- DACC_ACR : (DACC Offset: 0x94) Analog Current Register -------- */
+#define DACC_ACR_IBCTLCH0_Pos 0
+#define DACC_ACR_IBCTLCH0_Msk (0x3u << DACC_ACR_IBCTLCH0_Pos) /**< \brief (DACC_ACR) Analog Output Current Control */
+#define DACC_ACR_IBCTLCH0(value) ((DACC_ACR_IBCTLCH0_Msk & ((value) << DACC_ACR_IBCTLCH0_Pos)))
+#define DACC_ACR_IBCTLCH1_Pos 2
+#define DACC_ACR_IBCTLCH1_Msk (0x3u << DACC_ACR_IBCTLCH1_Pos) /**< \brief (DACC_ACR) Analog Output Current Control */
+#define DACC_ACR_IBCTLCH1(value) ((DACC_ACR_IBCTLCH1_Msk & ((value) << DACC_ACR_IBCTLCH1_Pos)))
+#define DACC_ACR_IBCTLDACCORE_Pos 8
+#define DACC_ACR_IBCTLDACCORE_Msk (0x3u << DACC_ACR_IBCTLDACCORE_Pos) /**< \brief (DACC_ACR) Bias Current Control for DAC Core */
+#define DACC_ACR_IBCTLDACCORE(value) ((DACC_ACR_IBCTLDACCORE_Msk & ((value) << DACC_ACR_IBCTLDACCORE_Pos)))
+/* -------- DACC_WPMR : (DACC Offset: 0xE4) Write Protect Mode register -------- */
+#define DACC_WPMR_WPEN (0x1u << 0) /**< \brief (DACC_WPMR) Write Protect Enable */
+#define DACC_WPMR_WPKEY_Pos 8
+#define DACC_WPMR_WPKEY_Msk (0xffffffu << DACC_WPMR_WPKEY_Pos) /**< \brief (DACC_WPMR) Write Protect KEY */
+#define DACC_WPMR_WPKEY(value) ((DACC_WPMR_WPKEY_Msk & ((value) << DACC_WPMR_WPKEY_Pos)))
+/* -------- DACC_WPSR : (DACC Offset: 0xE8) Write Protect Status register -------- */
+#define DACC_WPSR_WPROTERR (0x1u << 0) /**< \brief (DACC_WPSR) Write protection error */
+#define DACC_WPSR_WPROTADDR_Pos 8
+#define DACC_WPSR_WPROTADDR_Msk (0xffu << DACC_WPSR_WPROTADDR_Pos) /**< \brief (DACC_WPSR) Write protection error address */
+/* -------- DACC_TPR : (DACC Offset: 0x108) Transmit Pointer Register -------- */
+#define DACC_TPR_TXPTR_Pos 0
+#define DACC_TPR_TXPTR_Msk (0xffffffffu << DACC_TPR_TXPTR_Pos) /**< \brief (DACC_TPR) Transmit Counter Register */
+#define DACC_TPR_TXPTR(value) ((DACC_TPR_TXPTR_Msk & ((value) << DACC_TPR_TXPTR_Pos)))
+/* -------- DACC_TCR : (DACC Offset: 0x10C) Transmit Counter Register -------- */
+#define DACC_TCR_TXCTR_Pos 0
+#define DACC_TCR_TXCTR_Msk (0xffffu << DACC_TCR_TXCTR_Pos) /**< \brief (DACC_TCR) Transmit Counter Register */
+#define DACC_TCR_TXCTR(value) ((DACC_TCR_TXCTR_Msk & ((value) << DACC_TCR_TXCTR_Pos)))
+/* -------- DACC_TNPR : (DACC Offset: 0x118) Transmit Next Pointer Register -------- */
+#define DACC_TNPR_TXNPTR_Pos 0
+#define DACC_TNPR_TXNPTR_Msk (0xffffffffu << DACC_TNPR_TXNPTR_Pos) /**< \brief (DACC_TNPR) Transmit Next Pointer */
+#define DACC_TNPR_TXNPTR(value) ((DACC_TNPR_TXNPTR_Msk & ((value) << DACC_TNPR_TXNPTR_Pos)))
+/* -------- DACC_TNCR : (DACC Offset: 0x11C) Transmit Next Counter Register -------- */
+#define DACC_TNCR_TXNCTR_Pos 0
+#define DACC_TNCR_TXNCTR_Msk (0xffffu << DACC_TNCR_TXNCTR_Pos) /**< \brief (DACC_TNCR) Transmit Counter Next */
+#define DACC_TNCR_TXNCTR(value) ((DACC_TNCR_TXNCTR_Msk & ((value) << DACC_TNCR_TXNCTR_Pos)))
+/* -------- DACC_PTCR : (DACC Offset: 0x120) Transfer Control Register -------- */
+#define DACC_PTCR_RXTEN (0x1u << 0) /**< \brief (DACC_PTCR) Receiver Transfer Enable */
+#define DACC_PTCR_RXTDIS (0x1u << 1) /**< \brief (DACC_PTCR) Receiver Transfer Disable */
+#define DACC_PTCR_TXTEN (0x1u << 8) /**< \brief (DACC_PTCR) Transmitter Transfer Enable */
+#define DACC_PTCR_TXTDIS (0x1u << 9) /**< \brief (DACC_PTCR) Transmitter Transfer Disable */
+/* -------- DACC_PTSR : (DACC Offset: 0x124) Transfer Status Register -------- */
+#define DACC_PTSR_RXTEN (0x1u << 0) /**< \brief (DACC_PTSR) Receiver Transfer Enable */
+#define DACC_PTSR_TXTEN (0x1u << 8) /**< \brief (DACC_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_DACC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/dmac.h
+++ b/asf/sam/include/sam4e/component/dmac.h
@@ -1,0 +1,293 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_DMAC_COMPONENT_
+#define _SAM4E_DMAC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR DMA Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_DMAC DMA Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief DmacCh_num hardware registers */
+typedef struct {
+  RwReg       DMAC_SADDR;     /**< \brief (DmacCh_num Offset: 0x0) DMAC Channel Source Address Register */
+  RwReg       DMAC_DADDR;     /**< \brief (DmacCh_num Offset: 0x4) DMAC Channel Destination Address Register */
+  RwReg       DMAC_DSCR;      /**< \brief (DmacCh_num Offset: 0x8) DMAC Channel Descriptor Address Register */
+  RwReg       DMAC_CTRLA;     /**< \brief (DmacCh_num Offset: 0xC) DMAC Channel Control A Register */
+  RwReg       DMAC_CTRLB;     /**< \brief (DmacCh_num Offset: 0x10) DMAC Channel Control B Register */
+  RwReg       DMAC_CFG;       /**< \brief (DmacCh_num Offset: 0x14) DMAC Channel Configuration Register */
+  RoReg       Reserved1[4];
+} DmacCh_num;
+/** \brief Dmac hardware registers */
+#define DMACCH_NUM_NUMBER 4
+typedef struct {
+  RwReg       DMAC_GCFG;      /**< \brief (Dmac Offset: 0x000) DMAC Global Configuration Register */
+  RwReg       DMAC_EN;        /**< \brief (Dmac Offset: 0x004) DMAC Enable Register */
+  RwReg       DMAC_SREQ;      /**< \brief (Dmac Offset: 0x008) DMAC Software Single Request Register */
+  RwReg       DMAC_CREQ;      /**< \brief (Dmac Offset: 0x00C) DMAC Software Chunk Transfer Request Register */
+  RwReg       DMAC_LAST;      /**< \brief (Dmac Offset: 0x010) DMAC Software Last Transfer Flag Register */
+  RoReg       Reserved1[1];
+  WoReg       DMAC_EBCIER;    /**< \brief (Dmac Offset: 0x018) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Enable register. */
+  WoReg       DMAC_EBCIDR;    /**< \brief (Dmac Offset: 0x01C) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Disable register. */
+  RoReg       DMAC_EBCIMR;    /**< \brief (Dmac Offset: 0x020) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Mask Register. */
+  RoReg       DMAC_EBCISR;    /**< \brief (Dmac Offset: 0x024) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Status Register. */
+  WoReg       DMAC_CHER;      /**< \brief (Dmac Offset: 0x028) DMAC Channel Handler Enable Register */
+  WoReg       DMAC_CHDR;      /**< \brief (Dmac Offset: 0x02C) DMAC Channel Handler Disable Register */
+  RoReg       DMAC_CHSR;      /**< \brief (Dmac Offset: 0x030) DMAC Channel Handler Status Register */
+  RoReg       Reserved2[2];
+  DmacCh_num  DMAC_CH_NUM[DMACCH_NUM_NUMBER]; /**< \brief (Dmac Offset: 0x3C) ch_num = 0 .. 3 */
+  RoReg       Reserved3[66];
+  RwReg       DMAC_WPMR;      /**< \brief (Dmac Offset: 0x1E4) DMAC Write Protect Mode Register */
+  RoReg       DMAC_WPSR;      /**< \brief (Dmac Offset: 0x1E8) DMAC Write Protect Status Register */
+} Dmac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- DMAC_GCFG : (DMAC Offset: 0x000) DMAC Global Configuration Register -------- */
+#define DMAC_GCFG_ARB_CFG (0x1u << 4) /**< \brief (DMAC_GCFG) Arbiter Configuration */
+#define   DMAC_GCFG_ARB_CFG_FIXED (0x0u << 4) /**< \brief (DMAC_GCFG) Fixed priority arbiter. */
+#define   DMAC_GCFG_ARB_CFG_ROUND_ROBIN (0x1u << 4) /**< \brief (DMAC_GCFG) Modified round robin arbiter. */
+/* -------- DMAC_EN : (DMAC Offset: 0x004) DMAC Enable Register -------- */
+#define DMAC_EN_ENABLE (0x1u << 0) /**< \brief (DMAC_EN) General Enable of DMA */
+/* -------- DMAC_SREQ : (DMAC Offset: 0x008) DMAC Software Single Request Register -------- */
+#define DMAC_SREQ_SSREQ0 (0x1u << 0) /**< \brief (DMAC_SREQ) Source Request */
+#define DMAC_SREQ_DSREQ0 (0x1u << 1) /**< \brief (DMAC_SREQ) Destination Request */
+#define DMAC_SREQ_SSREQ1 (0x1u << 2) /**< \brief (DMAC_SREQ) Source Request */
+#define DMAC_SREQ_DSREQ1 (0x1u << 3) /**< \brief (DMAC_SREQ) Destination Request */
+#define DMAC_SREQ_SSREQ2 (0x1u << 4) /**< \brief (DMAC_SREQ) Source Request */
+#define DMAC_SREQ_DSREQ2 (0x1u << 5) /**< \brief (DMAC_SREQ) Destination Request */
+#define DMAC_SREQ_SSREQ3 (0x1u << 6) /**< \brief (DMAC_SREQ) Source Request */
+#define DMAC_SREQ_DSREQ3 (0x1u << 7) /**< \brief (DMAC_SREQ) Destination Request */
+/* -------- DMAC_CREQ : (DMAC Offset: 0x00C) DMAC Software Chunk Transfer Request Register -------- */
+#define DMAC_CREQ_SCREQ0 (0x1u << 0) /**< \brief (DMAC_CREQ) Source Chunk Request */
+#define DMAC_CREQ_DCREQ0 (0x1u << 1) /**< \brief (DMAC_CREQ) Destination Chunk Request */
+#define DMAC_CREQ_SCREQ1 (0x1u << 2) /**< \brief (DMAC_CREQ) Source Chunk Request */
+#define DMAC_CREQ_DCREQ1 (0x1u << 3) /**< \brief (DMAC_CREQ) Destination Chunk Request */
+#define DMAC_CREQ_SCREQ2 (0x1u << 4) /**< \brief (DMAC_CREQ) Source Chunk Request */
+#define DMAC_CREQ_DCREQ2 (0x1u << 5) /**< \brief (DMAC_CREQ) Destination Chunk Request */
+#define DMAC_CREQ_SCREQ3 (0x1u << 6) /**< \brief (DMAC_CREQ) Source Chunk Request */
+#define DMAC_CREQ_DCREQ3 (0x1u << 7) /**< \brief (DMAC_CREQ) Destination Chunk Request */
+/* -------- DMAC_LAST : (DMAC Offset: 0x010) DMAC Software Last Transfer Flag Register -------- */
+#define DMAC_LAST_SLAST0 (0x1u << 0) /**< \brief (DMAC_LAST) Source Last */
+#define DMAC_LAST_DLAST0 (0x1u << 1) /**< \brief (DMAC_LAST) Destination Last */
+#define DMAC_LAST_SLAST1 (0x1u << 2) /**< \brief (DMAC_LAST) Source Last */
+#define DMAC_LAST_DLAST1 (0x1u << 3) /**< \brief (DMAC_LAST) Destination Last */
+#define DMAC_LAST_SLAST2 (0x1u << 4) /**< \brief (DMAC_LAST) Source Last */
+#define DMAC_LAST_DLAST2 (0x1u << 5) /**< \brief (DMAC_LAST) Destination Last */
+#define DMAC_LAST_SLAST3 (0x1u << 6) /**< \brief (DMAC_LAST) Source Last */
+#define DMAC_LAST_DLAST3 (0x1u << 7) /**< \brief (DMAC_LAST) Destination Last */
+/* -------- DMAC_EBCIER : (DMAC Offset: 0x018) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Enable register. -------- */
+#define DMAC_EBCIER_BTC0 (0x1u << 0) /**< \brief (DMAC_EBCIER) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_BTC1 (0x1u << 1) /**< \brief (DMAC_EBCIER) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_BTC2 (0x1u << 2) /**< \brief (DMAC_EBCIER) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_BTC3 (0x1u << 3) /**< \brief (DMAC_EBCIER) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_CBTC0 (0x1u << 8) /**< \brief (DMAC_EBCIER) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_CBTC1 (0x1u << 9) /**< \brief (DMAC_EBCIER) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_CBTC2 (0x1u << 10) /**< \brief (DMAC_EBCIER) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_CBTC3 (0x1u << 11) /**< \brief (DMAC_EBCIER) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIER_ERR0 (0x1u << 16) /**< \brief (DMAC_EBCIER) Access Error [3:0] */
+#define DMAC_EBCIER_ERR1 (0x1u << 17) /**< \brief (DMAC_EBCIER) Access Error [3:0] */
+#define DMAC_EBCIER_ERR2 (0x1u << 18) /**< \brief (DMAC_EBCIER) Access Error [3:0] */
+#define DMAC_EBCIER_ERR3 (0x1u << 19) /**< \brief (DMAC_EBCIER) Access Error [3:0] */
+/* -------- DMAC_EBCIDR : (DMAC Offset: 0x01C) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Disable register. -------- */
+#define DMAC_EBCIDR_BTC0 (0x1u << 0) /**< \brief (DMAC_EBCIDR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_BTC1 (0x1u << 1) /**< \brief (DMAC_EBCIDR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_BTC2 (0x1u << 2) /**< \brief (DMAC_EBCIDR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_BTC3 (0x1u << 3) /**< \brief (DMAC_EBCIDR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_CBTC0 (0x1u << 8) /**< \brief (DMAC_EBCIDR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_CBTC1 (0x1u << 9) /**< \brief (DMAC_EBCIDR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_CBTC2 (0x1u << 10) /**< \brief (DMAC_EBCIDR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_CBTC3 (0x1u << 11) /**< \brief (DMAC_EBCIDR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIDR_ERR0 (0x1u << 16) /**< \brief (DMAC_EBCIDR) Access Error [3:0] */
+#define DMAC_EBCIDR_ERR1 (0x1u << 17) /**< \brief (DMAC_EBCIDR) Access Error [3:0] */
+#define DMAC_EBCIDR_ERR2 (0x1u << 18) /**< \brief (DMAC_EBCIDR) Access Error [3:0] */
+#define DMAC_EBCIDR_ERR3 (0x1u << 19) /**< \brief (DMAC_EBCIDR) Access Error [3:0] */
+/* -------- DMAC_EBCIMR : (DMAC Offset: 0x020) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Mask Register. -------- */
+#define DMAC_EBCIMR_BTC0 (0x1u << 0) /**< \brief (DMAC_EBCIMR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_BTC1 (0x1u << 1) /**< \brief (DMAC_EBCIMR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_BTC2 (0x1u << 2) /**< \brief (DMAC_EBCIMR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_BTC3 (0x1u << 3) /**< \brief (DMAC_EBCIMR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_CBTC0 (0x1u << 8) /**< \brief (DMAC_EBCIMR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_CBTC1 (0x1u << 9) /**< \brief (DMAC_EBCIMR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_CBTC2 (0x1u << 10) /**< \brief (DMAC_EBCIMR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_CBTC3 (0x1u << 11) /**< \brief (DMAC_EBCIMR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCIMR_ERR0 (0x1u << 16) /**< \brief (DMAC_EBCIMR) Access Error [3:0] */
+#define DMAC_EBCIMR_ERR1 (0x1u << 17) /**< \brief (DMAC_EBCIMR) Access Error [3:0] */
+#define DMAC_EBCIMR_ERR2 (0x1u << 18) /**< \brief (DMAC_EBCIMR) Access Error [3:0] */
+#define DMAC_EBCIMR_ERR3 (0x1u << 19) /**< \brief (DMAC_EBCIMR) Access Error [3:0] */
+/* -------- DMAC_EBCISR : (DMAC Offset: 0x024) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Status Register. -------- */
+#define DMAC_EBCISR_BTC0 (0x1u << 0) /**< \brief (DMAC_EBCISR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_BTC1 (0x1u << 1) /**< \brief (DMAC_EBCISR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_BTC2 (0x1u << 2) /**< \brief (DMAC_EBCISR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_BTC3 (0x1u << 3) /**< \brief (DMAC_EBCISR) Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_CBTC0 (0x1u << 8) /**< \brief (DMAC_EBCISR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_CBTC1 (0x1u << 9) /**< \brief (DMAC_EBCISR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_CBTC2 (0x1u << 10) /**< \brief (DMAC_EBCISR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_CBTC3 (0x1u << 11) /**< \brief (DMAC_EBCISR) Chained Buffer Transfer Completed [3:0] */
+#define DMAC_EBCISR_ERR0 (0x1u << 16) /**< \brief (DMAC_EBCISR) Access Error [3:0] */
+#define DMAC_EBCISR_ERR1 (0x1u << 17) /**< \brief (DMAC_EBCISR) Access Error [3:0] */
+#define DMAC_EBCISR_ERR2 (0x1u << 18) /**< \brief (DMAC_EBCISR) Access Error [3:0] */
+#define DMAC_EBCISR_ERR3 (0x1u << 19) /**< \brief (DMAC_EBCISR) Access Error [3:0] */
+/* -------- DMAC_CHER : (DMAC Offset: 0x028) DMAC Channel Handler Enable Register -------- */
+#define DMAC_CHER_ENA0 (0x1u << 0) /**< \brief (DMAC_CHER) Enable [3:0] */
+#define DMAC_CHER_ENA1 (0x1u << 1) /**< \brief (DMAC_CHER) Enable [3:0] */
+#define DMAC_CHER_ENA2 (0x1u << 2) /**< \brief (DMAC_CHER) Enable [3:0] */
+#define DMAC_CHER_ENA3 (0x1u << 3) /**< \brief (DMAC_CHER) Enable [3:0] */
+#define DMAC_CHER_SUSP0 (0x1u << 8) /**< \brief (DMAC_CHER) Suspend [3:0] */
+#define DMAC_CHER_SUSP1 (0x1u << 9) /**< \brief (DMAC_CHER) Suspend [3:0] */
+#define DMAC_CHER_SUSP2 (0x1u << 10) /**< \brief (DMAC_CHER) Suspend [3:0] */
+#define DMAC_CHER_SUSP3 (0x1u << 11) /**< \brief (DMAC_CHER) Suspend [3:0] */
+#define DMAC_CHER_KEEP0 (0x1u << 24) /**< \brief (DMAC_CHER) Keep on [3:0] */
+#define DMAC_CHER_KEEP1 (0x1u << 25) /**< \brief (DMAC_CHER) Keep on [3:0] */
+#define DMAC_CHER_KEEP2 (0x1u << 26) /**< \brief (DMAC_CHER) Keep on [3:0] */
+#define DMAC_CHER_KEEP3 (0x1u << 27) /**< \brief (DMAC_CHER) Keep on [3:0] */
+/* -------- DMAC_CHDR : (DMAC Offset: 0x02C) DMAC Channel Handler Disable Register -------- */
+#define DMAC_CHDR_DIS0 (0x1u << 0) /**< \brief (DMAC_CHDR) Disable [3:0] */
+#define DMAC_CHDR_DIS1 (0x1u << 1) /**< \brief (DMAC_CHDR) Disable [3:0] */
+#define DMAC_CHDR_DIS2 (0x1u << 2) /**< \brief (DMAC_CHDR) Disable [3:0] */
+#define DMAC_CHDR_DIS3 (0x1u << 3) /**< \brief (DMAC_CHDR) Disable [3:0] */
+#define DMAC_CHDR_RES0 (0x1u << 8) /**< \brief (DMAC_CHDR) Resume [3:0] */
+#define DMAC_CHDR_RES1 (0x1u << 9) /**< \brief (DMAC_CHDR) Resume [3:0] */
+#define DMAC_CHDR_RES2 (0x1u << 10) /**< \brief (DMAC_CHDR) Resume [3:0] */
+#define DMAC_CHDR_RES3 (0x1u << 11) /**< \brief (DMAC_CHDR) Resume [3:0] */
+/* -------- DMAC_CHSR : (DMAC Offset: 0x030) DMAC Channel Handler Status Register -------- */
+#define DMAC_CHSR_ENA0 (0x1u << 0) /**< \brief (DMAC_CHSR) Enable [3:0] */
+#define DMAC_CHSR_ENA1 (0x1u << 1) /**< \brief (DMAC_CHSR) Enable [3:0] */
+#define DMAC_CHSR_ENA2 (0x1u << 2) /**< \brief (DMAC_CHSR) Enable [3:0] */
+#define DMAC_CHSR_ENA3 (0x1u << 3) /**< \brief (DMAC_CHSR) Enable [3:0] */
+#define DMAC_CHSR_SUSP0 (0x1u << 8) /**< \brief (DMAC_CHSR) Suspend [3:0] */
+#define DMAC_CHSR_SUSP1 (0x1u << 9) /**< \brief (DMAC_CHSR) Suspend [3:0] */
+#define DMAC_CHSR_SUSP2 (0x1u << 10) /**< \brief (DMAC_CHSR) Suspend [3:0] */
+#define DMAC_CHSR_SUSP3 (0x1u << 11) /**< \brief (DMAC_CHSR) Suspend [3:0] */
+#define DMAC_CHSR_EMPT0 (0x1u << 16) /**< \brief (DMAC_CHSR) Empty [3:0] */
+#define DMAC_CHSR_EMPT1 (0x1u << 17) /**< \brief (DMAC_CHSR) Empty [3:0] */
+#define DMAC_CHSR_EMPT2 (0x1u << 18) /**< \brief (DMAC_CHSR) Empty [3:0] */
+#define DMAC_CHSR_EMPT3 (0x1u << 19) /**< \brief (DMAC_CHSR) Empty [3:0] */
+#define DMAC_CHSR_STAL0 (0x1u << 24) /**< \brief (DMAC_CHSR) Stalled [3:0] */
+#define DMAC_CHSR_STAL1 (0x1u << 25) /**< \brief (DMAC_CHSR) Stalled [3:0] */
+#define DMAC_CHSR_STAL2 (0x1u << 26) /**< \brief (DMAC_CHSR) Stalled [3:0] */
+#define DMAC_CHSR_STAL3 (0x1u << 27) /**< \brief (DMAC_CHSR) Stalled [3:0] */
+/* -------- DMAC_SADDR : (DMAC Offset: N/A) DMAC Channel Source Address Register -------- */
+#define DMAC_SADDR_SADDR_Pos 0
+#define DMAC_SADDR_SADDR_Msk (0xffffffffu << DMAC_SADDR_SADDR_Pos) /**< \brief (DMAC_SADDR) Channel x Source Address */
+#define DMAC_SADDR_SADDR(value) ((DMAC_SADDR_SADDR_Msk & ((value) << DMAC_SADDR_SADDR_Pos)))
+/* -------- DMAC_DADDR : (DMAC Offset: N/A) DMAC Channel Destination Address Register -------- */
+#define DMAC_DADDR_DADDR_Pos 0
+#define DMAC_DADDR_DADDR_Msk (0xffffffffu << DMAC_DADDR_DADDR_Pos) /**< \brief (DMAC_DADDR) Channel x Destination Address */
+#define DMAC_DADDR_DADDR(value) ((DMAC_DADDR_DADDR_Msk & ((value) << DMAC_DADDR_DADDR_Pos)))
+/* -------- DMAC_DSCR : (DMAC Offset: N/A) DMAC Channel Descriptor Address Register -------- */
+#define DMAC_DSCR_DSCR_Pos 2
+#define DMAC_DSCR_DSCR_Msk (0x3fffffffu << DMAC_DSCR_DSCR_Pos) /**< \brief (DMAC_DSCR) Buffer Transfer Descriptor Address */
+#define DMAC_DSCR_DSCR(value) ((DMAC_DSCR_DSCR_Msk & ((value) << DMAC_DSCR_DSCR_Pos)))
+/* -------- DMAC_CTRLA : (DMAC Offset: N/A) DMAC Channel Control A Register -------- */
+#define DMAC_CTRLA_BTSIZE_Pos 0
+#define DMAC_CTRLA_BTSIZE_Msk (0xffffu << DMAC_CTRLA_BTSIZE_Pos) /**< \brief (DMAC_CTRLA) Buffer Transfer Size */
+#define DMAC_CTRLA_BTSIZE(value) ((DMAC_CTRLA_BTSIZE_Msk & ((value) << DMAC_CTRLA_BTSIZE_Pos)))
+#define DMAC_CTRLA_SRC_WIDTH_Pos 24
+#define DMAC_CTRLA_SRC_WIDTH_Msk (0x3u << DMAC_CTRLA_SRC_WIDTH_Pos) /**< \brief (DMAC_CTRLA) Transfer Width for the Source */
+#define   DMAC_CTRLA_SRC_WIDTH_BYTE (0x0u << 24) /**< \brief (DMAC_CTRLA) the transfer size is set to 8-bit width */
+#define   DMAC_CTRLA_SRC_WIDTH_HALF_WORD (0x1u << 24) /**< \brief (DMAC_CTRLA) the transfer size is set to 16-bit width */
+#define   DMAC_CTRLA_SRC_WIDTH_WORD (0x2u << 24) /**< \brief (DMAC_CTRLA) the transfer size is set to 32-bit width */
+#define DMAC_CTRLA_DST_WIDTH_Pos 28
+#define DMAC_CTRLA_DST_WIDTH_Msk (0x3u << DMAC_CTRLA_DST_WIDTH_Pos) /**< \brief (DMAC_CTRLA) Transfer Width for the Destination */
+#define   DMAC_CTRLA_DST_WIDTH_BYTE (0x0u << 28) /**< \brief (DMAC_CTRLA) the transfer size is set to 8-bit width */
+#define   DMAC_CTRLA_DST_WIDTH_HALF_WORD (0x1u << 28) /**< \brief (DMAC_CTRLA) the transfer size is set to 16-bit width */
+#define   DMAC_CTRLA_DST_WIDTH_WORD (0x2u << 28) /**< \brief (DMAC_CTRLA) the transfer size is set to 32-bit width */
+#define DMAC_CTRLA_DONE (0x1u << 31) /**< \brief (DMAC_CTRLA) Current Descriptor Stop Command and Transfer Completed Memory Indicator */
+/* -------- DMAC_CTRLB : (DMAC Offset: N/A) DMAC Channel Control B Register -------- */
+#define DMAC_CTRLB_SRC_DSCR (0x1u << 16) /**< \brief (DMAC_CTRLB) Source Address Descriptor */
+#define   DMAC_CTRLB_SRC_DSCR_FETCH_FROM_MEM (0x0u << 16) /**< \brief (DMAC_CTRLB) Source address is updated when the descriptor is fetched from the memory. */
+#define   DMAC_CTRLB_SRC_DSCR_FETCH_DISABLE (0x1u << 16) /**< \brief (DMAC_CTRLB) Buffer Descriptor Fetch operation is disabled for the source. */
+#define DMAC_CTRLB_DST_DSCR (0x1u << 20) /**< \brief (DMAC_CTRLB) Destination Address Descriptor */
+#define   DMAC_CTRLB_DST_DSCR_FETCH_FROM_MEM (0x0u << 20) /**< \brief (DMAC_CTRLB) Destination address is updated when the descriptor is fetched from the memory. */
+#define   DMAC_CTRLB_DST_DSCR_FETCH_DISABLE (0x1u << 20) /**< \brief (DMAC_CTRLB) Buffer Descriptor Fetch operation is disabled for the destination. */
+#define DMAC_CTRLB_FC_Pos 21
+#define DMAC_CTRLB_FC_Msk (0x3u << DMAC_CTRLB_FC_Pos) /**< \brief (DMAC_CTRLB) Flow Control */
+#define   DMAC_CTRLB_FC_MEM2MEM_DMA_FC (0x0u << 21) /**< \brief (DMAC_CTRLB) Memory-to-Memory Transfer DMAC is flow controller */
+#define   DMAC_CTRLB_FC_MEM2PER_DMA_FC (0x1u << 21) /**< \brief (DMAC_CTRLB) Memory-to-Peripheral Transfer DMAC is flow controller */
+#define   DMAC_CTRLB_FC_PER2MEM_DMA_FC (0x2u << 21) /**< \brief (DMAC_CTRLB) Peripheral-to-Memory Transfer DMAC is flow controller */
+#define   DMAC_CTRLB_FC_PER2PER_DMA_FC (0x3u << 21) /**< \brief (DMAC_CTRLB) Peripheral-to-Peripheral Transfer DMAC is flow controller */
+#define DMAC_CTRLB_SRC_INCR_Pos 24
+#define DMAC_CTRLB_SRC_INCR_Msk (0x3u << DMAC_CTRLB_SRC_INCR_Pos) /**< \brief (DMAC_CTRLB) Incrementing, Decrementing or Fixed Address for the Source */
+#define   DMAC_CTRLB_SRC_INCR_INCREMENTING (0x0u << 24) /**< \brief (DMAC_CTRLB) The source address is incremented */
+#define   DMAC_CTRLB_SRC_INCR_DECREMENTING (0x1u << 24) /**< \brief (DMAC_CTRLB) The source address is decremented */
+#define   DMAC_CTRLB_SRC_INCR_FIXED (0x2u << 24) /**< \brief (DMAC_CTRLB) The source address remains unchanged */
+#define DMAC_CTRLB_DST_INCR_Pos 28
+#define DMAC_CTRLB_DST_INCR_Msk (0x3u << DMAC_CTRLB_DST_INCR_Pos) /**< \brief (DMAC_CTRLB) Incrementing, Decrementing or Fixed Address for the Destination */
+#define   DMAC_CTRLB_DST_INCR_INCREMENTING (0x0u << 28) /**< \brief (DMAC_CTRLB) The destination address is incremented */
+#define   DMAC_CTRLB_DST_INCR_DECREMENTING (0x1u << 28) /**< \brief (DMAC_CTRLB) The destination address is decremented */
+#define   DMAC_CTRLB_DST_INCR_FIXED (0x2u << 28) /**< \brief (DMAC_CTRLB) The destination address remains unchanged */
+#define DMAC_CTRLB_IEN (0x1u << 30) /**< \brief (DMAC_CTRLB) Interrupt Enable Not */
+/* -------- DMAC_CFG : (DMAC Offset: N/A) DMAC Channel Configuration Register -------- */
+#define DMAC_CFG_SRC_PER_Pos 0
+#define DMAC_CFG_SRC_PER_Msk (0xfu << DMAC_CFG_SRC_PER_Pos) /**< \brief (DMAC_CFG) Source with Peripheral identifier */
+#define DMAC_CFG_SRC_PER(value) ((DMAC_CFG_SRC_PER_Msk & ((value) << DMAC_CFG_SRC_PER_Pos)))
+#define DMAC_CFG_DST_PER_Pos 4
+#define DMAC_CFG_DST_PER_Msk (0xfu << DMAC_CFG_DST_PER_Pos) /**< \brief (DMAC_CFG) Destination with Peripheral identifier */
+#define DMAC_CFG_DST_PER(value) ((DMAC_CFG_DST_PER_Msk & ((value) << DMAC_CFG_DST_PER_Pos)))
+#define DMAC_CFG_SRC_H2SEL (0x1u << 9) /**< \brief (DMAC_CFG) Software or Hardware Selection for the Source */
+#define   DMAC_CFG_SRC_H2SEL_SW (0x0u << 9) /**< \brief (DMAC_CFG) Software handshaking interface is used to trigger a transfer request. */
+#define   DMAC_CFG_SRC_H2SEL_HW (0x1u << 9) /**< \brief (DMAC_CFG) Hardware handshaking interface is used to trigger a transfer request. */
+#define DMAC_CFG_DST_H2SEL (0x1u << 13) /**< \brief (DMAC_CFG) Software or Hardware Selection for the Destination */
+#define   DMAC_CFG_DST_H2SEL_SW (0x0u << 13) /**< \brief (DMAC_CFG) Software handshaking interface is used to trigger a transfer request. */
+#define   DMAC_CFG_DST_H2SEL_HW (0x1u << 13) /**< \brief (DMAC_CFG) Hardware handshaking interface is used to trigger a transfer request. */
+#define DMAC_CFG_SOD (0x1u << 16) /**< \brief (DMAC_CFG) Stop On Done */
+#define   DMAC_CFG_SOD_DISABLE (0x0u << 16) /**< \brief (DMAC_CFG) STOP ON DONE disabled, the descriptor fetch operation ignores DONE Field of CTRLA register. */
+#define   DMAC_CFG_SOD_ENABLE (0x1u << 16) /**< \brief (DMAC_CFG) STOP ON DONE activated, the DMAC module is automatically disabled if DONE FIELD is set to 1. */
+#define DMAC_CFG_LOCK_IF (0x1u << 20) /**< \brief (DMAC_CFG) Interface Lock */
+#define   DMAC_CFG_LOCK_IF_DISABLE (0x0u << 20) /**< \brief (DMAC_CFG) Interface Lock capability is disabled */
+#define   DMAC_CFG_LOCK_IF_ENABLE (0x1u << 20) /**< \brief (DMAC_CFG) Interface Lock capability is enabled */
+#define DMAC_CFG_LOCK_B (0x1u << 21) /**< \brief (DMAC_CFG) Bus Lock */
+#define   DMAC_CFG_LOCK_B_DISABLE (0x0u << 21) /**< \brief (DMAC_CFG) AHB Bus Locking capability is disabled. */
+#define DMAC_CFG_LOCK_IF_L (0x1u << 22) /**< \brief (DMAC_CFG) Master Interface Arbiter Lock */
+#define   DMAC_CFG_LOCK_IF_L_CHUNK (0x0u << 22) /**< \brief (DMAC_CFG) The Master Interface Arbiter is locked by the channel x for a chunk transfer. */
+#define   DMAC_CFG_LOCK_IF_L_BUFFER (0x1u << 22) /**< \brief (DMAC_CFG) The Master Interface Arbiter is locked by the channel x for a buffer transfer. */
+#define DMAC_CFG_AHB_PROT_Pos 24
+#define DMAC_CFG_AHB_PROT_Msk (0x7u << DMAC_CFG_AHB_PROT_Pos) /**< \brief (DMAC_CFG) AHB Protection */
+#define DMAC_CFG_AHB_PROT(value) ((DMAC_CFG_AHB_PROT_Msk & ((value) << DMAC_CFG_AHB_PROT_Pos)))
+#define DMAC_CFG_FIFOCFG_Pos 28
+#define DMAC_CFG_FIFOCFG_Msk (0x3u << DMAC_CFG_FIFOCFG_Pos) /**< \brief (DMAC_CFG) FIFO Configuration */
+#define   DMAC_CFG_FIFOCFG_ALAP_CFG (0x0u << 28) /**< \brief (DMAC_CFG) The largest defined length AHB burst is performed on the destination AHB interface. */
+#define   DMAC_CFG_FIFOCFG_HALF_CFG (0x1u << 28) /**< \brief (DMAC_CFG) When half FIFO size is available/filled, a source/destination request is serviced. */
+#define   DMAC_CFG_FIFOCFG_ASAP_CFG (0x2u << 28) /**< \brief (DMAC_CFG) When there is enough space/data available to perform a single AHB access, then the request is serviced. */
+/* -------- DMAC_WPMR : (DMAC Offset: 0x1E4) DMAC Write Protect Mode Register -------- */
+#define DMAC_WPMR_WPEN (0x1u << 0) /**< \brief (DMAC_WPMR) Write Protect Enable */
+#define DMAC_WPMR_WPKEY_Pos 8
+#define DMAC_WPMR_WPKEY_Msk (0xffffffu << DMAC_WPMR_WPKEY_Pos) /**< \brief (DMAC_WPMR) Write Protect KEY */
+#define DMAC_WPMR_WPKEY(value) ((DMAC_WPMR_WPKEY_Msk & ((value) << DMAC_WPMR_WPKEY_Pos)))
+/* -------- DMAC_WPSR : (DMAC Offset: 0x1E8) DMAC Write Protect Status Register -------- */
+#define DMAC_WPSR_WPVS (0x1u << 0) /**< \brief (DMAC_WPSR) Write Protect Violation Status */
+#define DMAC_WPSR_WPVSRC_Pos 8
+#define DMAC_WPSR_WPVSRC_Msk (0xffffu << DMAC_WPSR_WPVSRC_Pos) /**< \brief (DMAC_WPSR) Write Protect Violation Source */
+
+/*@}*/
+
+
+#endif /* _SAM4E_DMAC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/efc.h
+++ b/asf/sam/include/sam4e/component/efc.h
@@ -1,0 +1,98 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_EFC_COMPONENT_
+#define _SAM4E_EFC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Embedded Flash Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_EFC Embedded Flash Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Efc hardware registers */
+typedef struct {
+  RwReg EEFC_FMR; /**< \brief (Efc Offset: 0x00) EEFC Flash Mode Register */
+  WoReg EEFC_FCR; /**< \brief (Efc Offset: 0x04) EEFC Flash Command Register */
+  RoReg EEFC_FSR; /**< \brief (Efc Offset: 0x08) EEFC Flash Status Register */
+  RoReg EEFC_FRR; /**< \brief (Efc Offset: 0x0C) EEFC Flash Result Register */
+} Efc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- EEFC_FMR : (EFC Offset: 0x00) EEFC Flash Mode Register -------- */
+#define EEFC_FMR_FRDY (0x1u << 0) /**< \brief (EEFC_FMR) Ready Interrupt Enable */
+#define EEFC_FMR_FWS_Pos 8
+#define EEFC_FMR_FWS_Msk (0xfu << EEFC_FMR_FWS_Pos) /**< \brief (EEFC_FMR) Flash Wait State */
+#define EEFC_FMR_FWS(value) ((EEFC_FMR_FWS_Msk & ((value) << EEFC_FMR_FWS_Pos)))
+#define EEFC_FMR_SCOD (0x1u << 16) /**< \brief (EEFC_FMR) Sequential Code Optimization Disable */
+#define EEFC_FMR_FAM (0x1u << 24) /**< \brief (EEFC_FMR) Flash Access Mode */
+#define EEFC_FMR_CLOE (0x1u << 26) /**< \brief (EEFC_FMR) Code Loops Optimization Enable */
+/* -------- EEFC_FCR : (EFC Offset: 0x04) EEFC Flash Command Register -------- */
+#define EEFC_FCR_FCMD_Pos 0
+#define EEFC_FCR_FCMD_Msk (0xffu << EEFC_FCR_FCMD_Pos) /**< \brief (EEFC_FCR) Flash Command */
+#define   EEFC_FCR_FCMD_GETD (0x0u << 0) /**< \brief (EEFC_FCR) Get Flash Descriptor */
+#define   EEFC_FCR_FCMD_WP (0x1u << 0) /**< \brief (EEFC_FCR) Write page */
+#define   EEFC_FCR_FCMD_WPL (0x2u << 0) /**< \brief (EEFC_FCR) Write page and lock */
+#define   EEFC_FCR_FCMD_EWP (0x3u << 0) /**< \brief (EEFC_FCR) Erase page and write page */
+#define   EEFC_FCR_FCMD_EWPL (0x4u << 0) /**< \brief (EEFC_FCR) Erase page and write page then lock */
+#define   EEFC_FCR_FCMD_EA (0x5u << 0) /**< \brief (EEFC_FCR) Erase all */
+#define   EEFC_FCR_FCMD_EPA (0x7u << 0) /**< \brief (EEFC_FCR) Erase Pages */
+#define   EEFC_FCR_FCMD_SLB (0x8u << 0) /**< \brief (EEFC_FCR) Set Lock Bit */
+#define   EEFC_FCR_FCMD_CLB (0x9u << 0) /**< \brief (EEFC_FCR) Clear Lock Bit */
+#define   EEFC_FCR_FCMD_GLB (0xAu << 0) /**< \brief (EEFC_FCR) Get Lock Bit */
+#define   EEFC_FCR_FCMD_SGPB (0xBu << 0) /**< \brief (EEFC_FCR) Set GPNVM Bit */
+#define   EEFC_FCR_FCMD_CGPB (0xCu << 0) /**< \brief (EEFC_FCR) Clear GPNVM Bit */
+#define   EEFC_FCR_FCMD_GGPB (0xDu << 0) /**< \brief (EEFC_FCR) Get GPNVM Bit */
+#define   EEFC_FCR_FCMD_STUI (0xEu << 0) /**< \brief (EEFC_FCR) Start Read Unique Identifier */
+#define   EEFC_FCR_FCMD_SPUI (0xFu << 0) /**< \brief (EEFC_FCR) Stop Read Unique Identifier */
+#define   EEFC_FCR_FCMD_GCALB (0x10u << 0) /**< \brief (EEFC_FCR) Get CALIB Bit */
+#define   EEFC_FCR_FCMD_ES (0x11u << 0) /**< \brief (EEFC_FCR) Erase Sector */
+#define   EEFC_FCR_FCMD_WUS (0x12u << 0) /**< \brief (EEFC_FCR) Write User Signature */
+#define   EEFC_FCR_FCMD_EUS (0x13u << 0) /**< \brief (EEFC_FCR) Erase User Signature */
+#define   EEFC_FCR_FCMD_STUS (0x14u << 0) /**< \brief (EEFC_FCR) Start Read User Signature */
+#define   EEFC_FCR_FCMD_SPUS (0x15u << 0) /**< \brief (EEFC_FCR) Stop Read User Signature */
+#define EEFC_FCR_FARG_Pos 8
+#define EEFC_FCR_FARG_Msk (0xffffu << EEFC_FCR_FARG_Pos) /**< \brief (EEFC_FCR) Flash Command Argument */
+#define EEFC_FCR_FARG(value) ((EEFC_FCR_FARG_Msk & ((value) << EEFC_FCR_FARG_Pos)))
+#define EEFC_FCR_FKEY_Pos 24
+#define EEFC_FCR_FKEY_Msk (0xffu << EEFC_FCR_FKEY_Pos) /**< \brief (EEFC_FCR) Flash Writing Protection Key */
+#define   EEFC_FCR_FKEY_PASSWD (0x5Au << 24) /**< \brief (EEFC_FCR) The 0x5A value enables the command defined by the bits of the register. If the field is written with a different value, the write is not performed and no action is started. */
+/* -------- EEFC_FSR : (EFC Offset: 0x08) EEFC Flash Status Register -------- */
+#define EEFC_FSR_FRDY (0x1u << 0) /**< \brief (EEFC_FSR) Flash Ready Status */
+#define EEFC_FSR_FCMDE (0x1u << 1) /**< \brief (EEFC_FSR) Flash Command Error Status */
+#define EEFC_FSR_FLOCKE (0x1u << 2) /**< \brief (EEFC_FSR) Flash Lock Error Status */
+#define EEFC_FSR_FLERR (0x1u << 3) /**< \brief (EEFC_FSR) Flash Error Status */
+/* -------- EEFC_FRR : (EFC Offset: 0x0C) EEFC Flash Result Register -------- */
+#define EEFC_FRR_FVALUE_Pos 0
+#define EEFC_FRR_FVALUE_Msk (0xffffffffu << EEFC_FRR_FVALUE_Pos) /**< \brief (EEFC_FRR) Flash Result Value */
+
+/*@}*/
+
+
+#endif /* _SAM4E_EFC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/gmac.h
+++ b/asf/sam/include/sam4e/component/gmac.h
@@ -1,0 +1,618 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_GMAC_COMPONENT_
+#define _SAM4E_GMAC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Gigabit Ethernet MAC */
+/* ============================================================================= */
+/** \addtogroup SAM4E_GMAC Gigabit Ethernet MAC */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief GmacSa hardware registers */
+typedef struct {
+  RwReg   GMAC_SAB;       /**< \brief (GmacSa Offset: 0x0) Specific Address 1 Bottom [31:0] Register */
+  RwReg   GMAC_SAT;       /**< \brief (GmacSa Offset: 0x4) Specific Address 1 Top [47:32] Register */
+} GmacSa;
+/** \brief Gmac hardware registers */
+#define GMACSA_NUMBER 4
+typedef struct {
+  RwReg   GMAC_NCR;       /**< \brief (Gmac Offset: 0x000) Network Control Register */
+  RwReg   GMAC_NCFGR;     /**< \brief (Gmac Offset: 0x004) Network Configuration Register */
+  RoReg   GMAC_NSR;       /**< \brief (Gmac Offset: 0x008) Network Status Register */
+  RwReg   GMAC_UR;        /**< \brief (Gmac Offset: 0x00C) User Register */
+  RwReg   GMAC_DCFGR;     /**< \brief (Gmac Offset: 0x010) DMA Configuration Register */
+  RwReg   GMAC_TSR;       /**< \brief (Gmac Offset: 0x014) Transmit Status Register */
+  RwReg   GMAC_RBQB;      /**< \brief (Gmac Offset: 0x018) Receive Buffer Queue Base Address */
+  RwReg   GMAC_TBQB;      /**< \brief (Gmac Offset: 0x01C) Transmit Buffer Queue Base Address */
+  RwReg   GMAC_RSR;       /**< \brief (Gmac Offset: 0x020) Receive Status Register */
+  RoReg   GMAC_ISR;       /**< \brief (Gmac Offset: 0x024) Interrupt Status Register */
+  WoReg   GMAC_IER;       /**< \brief (Gmac Offset: 0x028) Interrupt Enable Register */
+  WoReg   GMAC_IDR;       /**< \brief (Gmac Offset: 0x02C) Interrupt Disable Register */
+  RoReg   GMAC_IMR;       /**< \brief (Gmac Offset: 0x030) Interrupt Mask Register */
+  RwReg   GMAC_MAN;       /**< \brief (Gmac Offset: 0x034) PHY Maintenance Register */
+  RoReg   GMAC_RPQ;       /**< \brief (Gmac Offset: 0x038) Received Pause Quantum Register */
+  RwReg   GMAC_TPQ;       /**< \brief (Gmac Offset: 0x03C) Transmit Pause Quantum Register */
+  RoReg   Reserved1[16];
+  RwReg   GMAC_HRB;       /**< \brief (Gmac Offset: 0x080) Hash Register Bottom [31:0] */
+  RwReg   GMAC_HRT;       /**< \brief (Gmac Offset: 0x084) Hash Register Top [63:32] */
+  GmacSa  GMAC_SA[GMACSA_NUMBER]; /**< \brief (Gmac Offset: 0x088) 1 .. 4 */
+  RwReg   GMAC_TIDM[4];   /**< \brief (Gmac Offset: 0x0A8) Type ID Match 1 Register */
+  RoReg   Reserved2[1];
+  RwReg   GMAC_IPGS;      /**< \brief (Gmac Offset: 0x0BC) IPG Stretch Register */
+  RwReg   GMAC_SVLAN;     /**< \brief (Gmac Offset: 0x0C0) Stacked VLAN Register */
+  RwReg   GMAC_TPFCP;     /**< \brief (Gmac Offset: 0x0C4) Transmit PFC Pause Register */
+  RwReg   GMAC_SAMB1;     /**< \brief (Gmac Offset: 0x0C8) Specific Address 1 Mask Bottom [31:0] Register */
+  RwReg   GMAC_SAMT1;     /**< \brief (Gmac Offset: 0x0CC) Specific Address 1 Mask Top [47:32] Register */
+  RoReg   Reserved3[12];
+  RoReg   GMAC_OTLO;      /**< \brief (Gmac Offset: 0x100) Octets Transmitted [31:0] Register */
+  RoReg   GMAC_OTHI;      /**< \brief (Gmac Offset: 0x104) Octets Transmitted [47:32] Register */
+  RoReg   GMAC_FT;        /**< \brief (Gmac Offset: 0x108) Frames Transmitted Register */
+  RoReg   GMAC_BCFT;      /**< \brief (Gmac Offset: 0x10C) Broadcast Frames Transmitted Register */
+  RoReg   GMAC_MFT;       /**< \brief (Gmac Offset: 0x110) Multicast Frames Transmitted Register */
+  RoReg   GMAC_PFT;       /**< \brief (Gmac Offset: 0x114) Pause Frames Transmitted Register */
+  RoReg   GMAC_BFT64;     /**< \brief (Gmac Offset: 0x118) 64 Byte Frames Transmitted Register */
+  RoReg   GMAC_TBFT127;   /**< \brief (Gmac Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register */
+  RoReg   GMAC_TBFT255;   /**< \brief (Gmac Offset: 0x120) 128 to 255 Byte Frames Transmitted Register */
+  RoReg   GMAC_TBFT511;   /**< \brief (Gmac Offset: 0x124) 256 to 511 Byte Frames Transmitted Register */
+  RoReg   GMAC_TBFT1023;  /**< \brief (Gmac Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register */
+  RoReg   GMAC_TBFT1518;  /**< \brief (Gmac Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register */
+  RoReg   GMAC_GTBFT1518; /**< \brief (Gmac Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register */
+  RoReg   GMAC_TUR;       /**< \brief (Gmac Offset: 0x134) Transmit Under Runs Register */
+  RoReg   GMAC_SCF;       /**< \brief (Gmac Offset: 0x138) Single Collision Frames Register */
+  RoReg   GMAC_MCF;       /**< \brief (Gmac Offset: 0x13C) Multiple Collision Frames Register */
+  RoReg   GMAC_EC;        /**< \brief (Gmac Offset: 0x140) Excessive Collisions Register */
+  RoReg   GMAC_LC;        /**< \brief (Gmac Offset: 0x144) Late Collisions Register */
+  RoReg   GMAC_DTF;       /**< \brief (Gmac Offset: 0x148) Deferred Transmission Frames Register */
+  RoReg   GMAC_CSE;       /**< \brief (Gmac Offset: 0x14C) Carrier Sense Errors Register */
+  RoReg   GMAC_ORLO;      /**< \brief (Gmac Offset: 0x150) Octets Received [31:0] Received */
+  RoReg   GMAC_ORHI;      /**< \brief (Gmac Offset: 0x154) Octets Received [47:32] Received */
+  RoReg   GMAC_FR;        /**< \brief (Gmac Offset: 0x158) Frames Received Register */
+  RoReg   GMAC_BCFR;      /**< \brief (Gmac Offset: 0x15C) Broadcast Frames Received Register */
+  RoReg   GMAC_MFR;       /**< \brief (Gmac Offset: 0x160) Multicast Frames Received Register */
+  RoReg   GMAC_PFR;       /**< \brief (Gmac Offset: 0x164) Pause Frames Received Register */
+  RoReg   GMAC_BFR64;     /**< \brief (Gmac Offset: 0x168) 64 Byte Frames Received Register */
+  RoReg   GMAC_TBFR127;   /**< \brief (Gmac Offset: 0x16C) 65 to 127 Byte Frames Received Register */
+  RoReg   GMAC_TBFR255;   /**< \brief (Gmac Offset: 0x170) 128 to 255 Byte Frames Received Register */
+  RoReg   GMAC_TBFR511;   /**< \brief (Gmac Offset: 0x174) 256 to 511Byte Frames Received Register */
+  RoReg   GMAC_TBFR1023;  /**< \brief (Gmac Offset: 0x178) 512 to 1023 Byte Frames Received Register */
+  RoReg   GMAC_TBFR1518;  /**< \brief (Gmac Offset: 0x17C) 1024 to 1518 Byte Frames Received Register */
+  RoReg   GMAC_TMXBFR;    /**< \brief (Gmac Offset: 0x180) 1519 to Maximum Byte Frames Received Register */
+  RoReg   GMAC_UFR;       /**< \brief (Gmac Offset: 0x184) Undersize Frames Received Register */
+  RoReg   GMAC_OFR;       /**< \brief (Gmac Offset: 0x188) Oversize Frames Received Register */
+  RoReg   GMAC_JR;        /**< \brief (Gmac Offset: 0x18C) Jabbers Received Register */
+  RoReg   GMAC_FCSE;      /**< \brief (Gmac Offset: 0x190) Frame Check Sequence Errors Register */
+  RoReg   GMAC_LFFE;      /**< \brief (Gmac Offset: 0x194) Length Field Frame Errors Register */
+  RoReg   GMAC_RSE;       /**< \brief (Gmac Offset: 0x198) Receive Symbol Errors Register */
+  RoReg   GMAC_AE;        /**< \brief (Gmac Offset: 0x19C) Alignment Errors Register */
+  RoReg   GMAC_RRE;       /**< \brief (Gmac Offset: 0x1A0) Receive Resource Errors Register */
+  RoReg   GMAC_ROE;       /**< \brief (Gmac Offset: 0x1A4) Receive Overrun Register */
+  RoReg   GMAC_IHCE;      /**< \brief (Gmac Offset: 0x1A8) IP Header Checksum Errors Register */
+  RoReg   GMAC_TCE;       /**< \brief (Gmac Offset: 0x1AC) TCP Checksum Errors Register */
+  RoReg   GMAC_UCE;       /**< \brief (Gmac Offset: 0x1B0) UDP Checksum Errors Register */
+  RoReg   Reserved4[5];
+  RwReg   GMAC_TSSS;      /**< \brief (Gmac Offset: 0x1C8) 1588 Timer Sync Strobe Seconds Register */
+  RwReg   GMAC_TSSN;      /**< \brief (Gmac Offset: 0x1CC) 1588 Timer Sync Strobe Nanoseconds Register */
+  RwReg   GMAC_TS;        /**< \brief (Gmac Offset: 0x1D0) 1588 Timer Seconds Register */
+  RwReg   GMAC_TN;        /**< \brief (Gmac Offset: 0x1D4) 1588 Timer Nanoseconds Register */
+  WoReg   GMAC_TA;        /**< \brief (Gmac Offset: 0x1D8) 1588 Timer Adjust Register */
+  RwReg   GMAC_TI;        /**< \brief (Gmac Offset: 0x1DC) 1588 Timer Increment Register */
+  RoReg   GMAC_EFTS;      /**< \brief (Gmac Offset: 0x1E0) PTP Event Frame Transmitted Seconds */
+  RoReg   GMAC_EFTN;      /**< \brief (Gmac Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds */
+  RoReg   GMAC_EFRS;      /**< \brief (Gmac Offset: 0x1E8) PTP Event Frame Received Seconds */
+  RoReg   GMAC_EFRN;      /**< \brief (Gmac Offset: 0x1EC) PTP Event Frame Received Nanoseconds */
+  RoReg   GMAC_PEFTS;     /**< \brief (Gmac Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds */
+  RoReg   GMAC_PEFTN;     /**< \brief (Gmac Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds */
+  RoReg   GMAC_PEFRS;     /**< \brief (Gmac Offset: 0x1F8) PTP Peer Event Frame Received Seconds */
+  RoReg   GMAC_PEFRN;     /**< \brief (Gmac Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds */
+} Gmac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- GMAC_NCR : (GMAC Offset: 0x000) Network Control Register -------- */
+#define GMAC_NCR_LB (0x1u << 0) /**< \brief (GMAC_NCR) Loop Back */
+#define GMAC_NCR_LBL (0x1u << 1) /**< \brief (GMAC_NCR) Loop Back Local */
+#define GMAC_NCR_RXEN (0x1u << 2) /**< \brief (GMAC_NCR) Receive Enable */
+#define GMAC_NCR_TXEN (0x1u << 3) /**< \brief (GMAC_NCR) Transmit Enable */
+#define GMAC_NCR_MPE (0x1u << 4) /**< \brief (GMAC_NCR) Management Port Enable */
+#define GMAC_NCR_CLRSTAT (0x1u << 5) /**< \brief (GMAC_NCR) Clear Statistics Registers */
+#define GMAC_NCR_INCSTAT (0x1u << 6) /**< \brief (GMAC_NCR) Increment Statistics Registers */
+#define GMAC_NCR_WESTAT (0x1u << 7) /**< \brief (GMAC_NCR) Write Enable for Statistics Registers */
+#define GMAC_NCR_BP (0x1u << 8) /**< \brief (GMAC_NCR) Back pressure */
+#define GMAC_NCR_TSTART (0x1u << 9) /**< \brief (GMAC_NCR) Start Transmission */
+#define GMAC_NCR_THALT (0x1u << 10) /**< \brief (GMAC_NCR) Transmit Halt */
+#define GMAC_NCR_TXPF (0x1u << 11) /**< \brief (GMAC_NCR) Transmit Pause Frame */
+#define GMAC_NCR_TXZQPF (0x1u << 12) /**< \brief (GMAC_NCR) Transmit Zero Quantum Pause Frame */
+#define GMAC_NCR_RDS (0x1u << 14) /**< \brief (GMAC_NCR) Read Snapshot */
+#define GMAC_NCR_SRTSM (0x1u << 15) /**< \brief (GMAC_NCR) Store Receive Time Stamp to Memory */
+#define GMAC_NCR_ENPBPR (0x1u << 16) /**< \brief (GMAC_NCR) Enable PFC Priority-based Pause Reception */
+#define GMAC_NCR_TXPBPF (0x1u << 17) /**< \brief (GMAC_NCR) Transmit PFC Priority-based Pause Frame */
+#define GMAC_NCR_FNP (0x1u << 18) /**< \brief (GMAC_NCR) Flush Next Packet */
+/* -------- GMAC_NCFGR : (GMAC Offset: 0x004) Network Configuration Register -------- */
+#define GMAC_NCFGR_SPD (0x1u << 0) /**< \brief (GMAC_NCFGR) Speed */
+#define GMAC_NCFGR_FD (0x1u << 1) /**< \brief (GMAC_NCFGR) Full Duplex */
+#define GMAC_NCFGR_DNVLAN (0x1u << 2) /**< \brief (GMAC_NCFGR) Discard Non-VLAN FRAMES */
+#define GMAC_NCFGR_JFRAME (0x1u << 3) /**< \brief (GMAC_NCFGR) Jumbo Frame Size */
+#define GMAC_NCFGR_CAF (0x1u << 4) /**< \brief (GMAC_NCFGR) Copy All Frames */
+#define GMAC_NCFGR_NBC (0x1u << 5) /**< \brief (GMAC_NCFGR) No Broadcast */
+#define GMAC_NCFGR_MTIHEN (0x1u << 6) /**< \brief (GMAC_NCFGR) Multicast Hash Enable */
+#define GMAC_NCFGR_UNIHEN (0x1u << 7) /**< \brief (GMAC_NCFGR) Unicast Hash Enable */
+#define GMAC_NCFGR_MAXFS (0x1u << 8) /**< \brief (GMAC_NCFGR) 1536 Maximum Frame Size */
+#define GMAC_NCFGR_RTY (0x1u << 12) /**< \brief (GMAC_NCFGR) Retry Test */
+#define GMAC_NCFGR_PEN (0x1u << 13) /**< \brief (GMAC_NCFGR) Pause Enable */
+#define GMAC_NCFGR_RXBUFO_Pos 14
+#define GMAC_NCFGR_RXBUFO_Msk (0x3u << GMAC_NCFGR_RXBUFO_Pos) /**< \brief (GMAC_NCFGR) Receive Buffer Offset */
+#define GMAC_NCFGR_RXBUFO(value) ((GMAC_NCFGR_RXBUFO_Msk & ((value) << GMAC_NCFGR_RXBUFO_Pos)))
+#define GMAC_NCFGR_LFERD (0x1u << 16) /**< \brief (GMAC_NCFGR) Length Field Error Frame Discard */
+#define GMAC_NCFGR_RFCS (0x1u << 17) /**< \brief (GMAC_NCFGR) Remove FCS */
+#define GMAC_NCFGR_CLK_Pos 18
+#define GMAC_NCFGR_CLK_Msk (0x7u << GMAC_NCFGR_CLK_Pos) /**< \brief (GMAC_NCFGR) MDC CLock Division */
+#define   GMAC_NCFGR_CLK_MCK_8 (0x0u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 8 (MCK up to 20 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_16 (0x1u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 16 (MCK up to 40 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_32 (0x2u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 32 (MCK up to 80 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_48 (0x3u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 48 (MCK up to 120MHz) */
+#define   GMAC_NCFGR_CLK_MCK_64 (0x4u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 64 (MCK up to 160 MHz) */
+#define   GMAC_NCFGR_CLK_MCK_96 (0x5u << 18) /**< \brief (GMAC_NCFGR) MCK divided by 96 (MCK up to 240 MHz) */
+#define GMAC_NCFGR_DBW_Pos 21
+#define GMAC_NCFGR_DBW_Msk (0x3u << GMAC_NCFGR_DBW_Pos) /**< \brief (GMAC_NCFGR) Data Bus Width */
+#define GMAC_NCFGR_DBW(value) ((GMAC_NCFGR_DBW_Msk & ((value) << GMAC_NCFGR_DBW_Pos)))
+#define GMAC_NCFGR_DCPF (0x1u << 23) /**< \brief (GMAC_NCFGR) Disable Copy of Pause Frames */
+#define GMAC_NCFGR_RXCOEN (0x1u << 24) /**< \brief (GMAC_NCFGR) Receive Checksum Offload Enable */
+#define GMAC_NCFGR_EFRHD (0x1u << 25) /**< \brief (GMAC_NCFGR) Enable Frames Received in Half Duplex */
+#define GMAC_NCFGR_IRXFCS (0x1u << 26) /**< \brief (GMAC_NCFGR) Ignore RX FCS */
+#define GMAC_NCFGR_IPGSEN (0x1u << 28) /**< \brief (GMAC_NCFGR) IP Stretch Enable */
+#define GMAC_NCFGR_RXBP (0x1u << 29) /**< \brief (GMAC_NCFGR) Receive Bad Preamble */
+#define GMAC_NCFGR_IRXER (0x1u << 30) /**< \brief (GMAC_NCFGR) Ignore IPG GRXER */
+/* -------- GMAC_NSR : (GMAC Offset: 0x008) Network Status Register -------- */
+#define GMAC_NSR_MDIO (0x1u << 1) /**< \brief (GMAC_NSR) MDIO Input Status */
+#define GMAC_NSR_IDLE (0x1u << 2) /**< \brief (GMAC_NSR) PHY Management Logic Idle */
+/* -------- GMAC_UR : (GMAC Offset: 0x00C) User Register -------- */
+#define GMAC_UR_RMIIMII (0x1u << 0) /**< \brief (GMAC_UR)  */
+#define GMAC_UR_HDFC (0x1u << 6) /**< \brief (GMAC_UR) Half Duplex Flow Control */
+#define GMAC_UR_BPDG (0x1u << 7) /**< \brief (GMAC_UR) BPDG Bypass Deglitchers */
+/* -------- GMAC_DCFGR : (GMAC Offset: 0x010) DMA Configuration Register -------- */
+#define GMAC_DCFGR_FBLDO_Pos 0
+#define GMAC_DCFGR_FBLDO_Msk (0x1fu << GMAC_DCFGR_FBLDO_Pos) /**< \brief (GMAC_DCFGR) Fixed Burst Length for DMA Data Operations: */
+#define   GMAC_DCFGR_FBLDO_SINGLE (0x1u << 0) /**< \brief (GMAC_DCFGR) 00001: Always use SINGLE AHB bursts */
+#define   GMAC_DCFGR_FBLDO_INCR4 (0x4u << 0) /**< \brief (GMAC_DCFGR) 001xx: Attempt to use INCR4 AHB bursts (Default) */
+#define   GMAC_DCFGR_FBLDO_INCR8 (0x8u << 0) /**< \brief (GMAC_DCFGR) 01xxx: Attempt to use INCR8 AHB bursts */
+#define   GMAC_DCFGR_FBLDO_INCR16 (0x10u << 0) /**< \brief (GMAC_DCFGR) 1xxxx: Attempt to use INCR16 AHB bursts */
+#define GMAC_DCFGR_ESMA (0x1u << 6) /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Management Descriptor Accesses */
+#define GMAC_DCFGR_ESPA (0x1u << 7) /**< \brief (GMAC_DCFGR) Endian Swap Mode Enable for Packet Data Accesses */
+#define GMAC_DCFGR_TXCOEN (0x1u << 11) /**< \brief (GMAC_DCFGR) Transmitter Checksum Generation Offload Enable */
+#define GMAC_DCFGR_DRBS_Pos 16
+#define GMAC_DCFGR_DRBS_Msk (0xffu << GMAC_DCFGR_DRBS_Pos) /**< \brief (GMAC_DCFGR) DMA Receive Buffer Size */
+#define GMAC_DCFGR_DRBS(value) ((GMAC_DCFGR_DRBS_Msk & ((value) << GMAC_DCFGR_DRBS_Pos)))
+/* -------- GMAC_TSR : (GMAC Offset: 0x014) Transmit Status Register -------- */
+#define GMAC_TSR_UBR (0x1u << 0) /**< \brief (GMAC_TSR) Used Bit Read */
+#define GMAC_TSR_COL (0x1u << 1) /**< \brief (GMAC_TSR) Collision Occurred */
+#define GMAC_TSR_RLE (0x1u << 2) /**< \brief (GMAC_TSR) Retry Limit Exceeded */
+#define GMAC_TSR_TXGO (0x1u << 3) /**< \brief (GMAC_TSR) Transmit Go */
+#define GMAC_TSR_TFC (0x1u << 4) /**< \brief (GMAC_TSR) Transmit Frame Corruption due to AHB error */
+#define GMAC_TSR_TXCOMP (0x1u << 5) /**< \brief (GMAC_TSR) Transmit Complete */
+#define GMAC_TSR_UND (0x1u << 6) /**< \brief (GMAC_TSR) Transmit Under Run */
+#define GMAC_TSR_HRESP (0x1u << 8) /**< \brief (GMAC_TSR) HRESP Not OK */
+/* -------- GMAC_RBQB : (GMAC Offset: 0x018) Receive Buffer Queue Base Address -------- */
+#define GMAC_RBQB_ADDR_Pos 2
+#define GMAC_RBQB_ADDR_Msk (0x3fffffffu << GMAC_RBQB_ADDR_Pos) /**< \brief (GMAC_RBQB) Receive buffer queue base address */
+#define GMAC_RBQB_ADDR(value) ((GMAC_RBQB_ADDR_Msk & ((value) << GMAC_RBQB_ADDR_Pos)))
+/* -------- GMAC_TBQB : (GMAC Offset: 0x01C) Transmit Buffer Queue Base Address -------- */
+#define GMAC_TBQB_ADDR_Pos 2
+#define GMAC_TBQB_ADDR_Msk (0x3fffffffu << GMAC_TBQB_ADDR_Pos) /**< \brief (GMAC_TBQB) Transmit Buffer Queue Base Address */
+#define GMAC_TBQB_ADDR(value) ((GMAC_TBQB_ADDR_Msk & ((value) << GMAC_TBQB_ADDR_Pos)))
+/* -------- GMAC_RSR : (GMAC Offset: 0x020) Receive Status Register -------- */
+#define GMAC_RSR_BNA (0x1u << 0) /**< \brief (GMAC_RSR) Buffer Not Available */
+#define GMAC_RSR_REC (0x1u << 1) /**< \brief (GMAC_RSR) Frame Received */
+#define GMAC_RSR_RXOVR (0x1u << 2) /**< \brief (GMAC_RSR) Receive Overrun */
+#define GMAC_RSR_HNO (0x1u << 3) /**< \brief (GMAC_RSR) HRESP Not OK */
+/* -------- GMAC_ISR : (GMAC Offset: 0x024) Interrupt Status Register -------- */
+#define GMAC_ISR_MFS (0x1u << 0) /**< \brief (GMAC_ISR) Management Frame Sent */
+#define GMAC_ISR_RCOMP (0x1u << 1) /**< \brief (GMAC_ISR) Receive Complete */
+#define GMAC_ISR_RXUBR (0x1u << 2) /**< \brief (GMAC_ISR) RX Used Bit Read */
+#define GMAC_ISR_TXUBR (0x1u << 3) /**< \brief (GMAC_ISR) TX Used Bit Read */
+#define GMAC_ISR_TUR (0x1u << 4) /**< \brief (GMAC_ISR) Transmit Under Run */
+#define GMAC_ISR_RLEX (0x1u << 5) /**< \brief (GMAC_ISR) Retry Limit Exceeded */
+#define GMAC_ISR_TFC (0x1u << 6) /**< \brief (GMAC_ISR) Transmit Frame Corruption due to AHB error */
+#define GMAC_ISR_TCOMP (0x1u << 7) /**< \brief (GMAC_ISR) Transmit Complete */
+#define GMAC_ISR_ROVR (0x1u << 10) /**< \brief (GMAC_ISR) Receive Overrun */
+#define GMAC_ISR_HRESP (0x1u << 11) /**< \brief (GMAC_ISR) HRESP Not OK */
+#define GMAC_ISR_PFNZ (0x1u << 12) /**< \brief (GMAC_ISR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_ISR_PTZ (0x1u << 13) /**< \brief (GMAC_ISR) Pause Time Zero */
+#define GMAC_ISR_PFTR (0x1u << 14) /**< \brief (GMAC_ISR) Pause Frame Transmitted */
+#define GMAC_ISR_DRQFR (0x1u << 18) /**< \brief (GMAC_ISR) PTP Delay Request Frame Received */
+#define GMAC_ISR_SFR (0x1u << 19) /**< \brief (GMAC_ISR) PTP Sync Frame Received */
+#define GMAC_ISR_DRQFT (0x1u << 20) /**< \brief (GMAC_ISR) PTP Delay Request Frame Transmitted */
+#define GMAC_ISR_SFT (0x1u << 21) /**< \brief (GMAC_ISR) PTP Sync Frame Transmitted */
+#define GMAC_ISR_PDRQFR (0x1u << 22) /**< \brief (GMAC_ISR) PDelay Request Frame Received */
+#define GMAC_ISR_PDRSFR (0x1u << 23) /**< \brief (GMAC_ISR) PDelay Response Frame Received */
+#define GMAC_ISR_PDRQFT (0x1u << 24) /**< \brief (GMAC_ISR) PDelay Request Frame Transmitted */
+#define GMAC_ISR_PDRSFT (0x1u << 25) /**< \brief (GMAC_ISR) PDelay Response Frame Transmitted */
+#define GMAC_ISR_SRI (0x1u << 26) /**< \brief (GMAC_ISR) TSU Seconds Register Increment */
+#define GMAC_ISR_WOL (0x1u << 28) /**< \brief (GMAC_ISR) Wake On LAN */
+/* -------- GMAC_IER : (GMAC Offset: 0x028) Interrupt Enable Register -------- */
+#define GMAC_IER_MFS (0x1u << 0) /**< \brief (GMAC_IER) Management Frame Sent */
+#define GMAC_IER_RCOMP (0x1u << 1) /**< \brief (GMAC_IER) Receive Complete */
+#define GMAC_IER_RXUBR (0x1u << 2) /**< \brief (GMAC_IER) RX Used Bit Read */
+#define GMAC_IER_TXUBR (0x1u << 3) /**< \brief (GMAC_IER) TX Used Bit Read */
+#define GMAC_IER_TUR (0x1u << 4) /**< \brief (GMAC_IER) Transmit Under Run */
+#define GMAC_IER_RLEX (0x1u << 5) /**< \brief (GMAC_IER) Retry Limit Exceeded or Late Collision */
+#define GMAC_IER_TFC (0x1u << 6) /**< \brief (GMAC_IER) Transmit Frame Corruption due to AHB error */
+#define GMAC_IER_TCOMP (0x1u << 7) /**< \brief (GMAC_IER) Transmit Complete */
+#define GMAC_IER_ROVR (0x1u << 10) /**< \brief (GMAC_IER) Receive Overrun */
+#define GMAC_IER_HRESP (0x1u << 11) /**< \brief (GMAC_IER) HRESP Not OK */
+#define GMAC_IER_PFNZ (0x1u << 12) /**< \brief (GMAC_IER) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IER_PTZ (0x1u << 13) /**< \brief (GMAC_IER) Pause Time Zero */
+#define GMAC_IER_PFTR (0x1u << 14) /**< \brief (GMAC_IER) Pause Frame Transmitted */
+#define GMAC_IER_EXINT (0x1u << 15) /**< \brief (GMAC_IER) External Interrupt */
+#define GMAC_IER_DRQFR (0x1u << 18) /**< \brief (GMAC_IER) PTP Delay Request Frame Received */
+#define GMAC_IER_SFR (0x1u << 19) /**< \brief (GMAC_IER) PTP Sync Frame Received */
+#define GMAC_IER_DRQFT (0x1u << 20) /**< \brief (GMAC_IER) PTP Delay Request Frame Transmitted */
+#define GMAC_IER_SFT (0x1u << 21) /**< \brief (GMAC_IER) PTP Sync Frame Transmitted */
+#define GMAC_IER_PDRQFR (0x1u << 22) /**< \brief (GMAC_IER) PDelay Request Frame Received */
+#define GMAC_IER_PDRSFR (0x1u << 23) /**< \brief (GMAC_IER) PDelay Response Frame Received */
+#define GMAC_IER_PDRQFT (0x1u << 24) /**< \brief (GMAC_IER) PDelay Request Frame Transmitted */
+#define GMAC_IER_PDRSFT (0x1u << 25) /**< \brief (GMAC_IER) PDelay Response Frame Transmitted */
+#define GMAC_IER_SRI (0x1u << 26) /**< \brief (GMAC_IER) TSU Seconds Register Increment */
+#define GMAC_IER_WOL (0x1u << 28) /**< \brief (GMAC_IER) Wake On LAN */
+/* -------- GMAC_IDR : (GMAC Offset: 0x02C) Interrupt Disable Register -------- */
+#define GMAC_IDR_MFS (0x1u << 0) /**< \brief (GMAC_IDR) Management Frame Sent */
+#define GMAC_IDR_RCOMP (0x1u << 1) /**< \brief (GMAC_IDR) Receive Complete */
+#define GMAC_IDR_RXUBR (0x1u << 2) /**< \brief (GMAC_IDR) RX Used Bit Read */
+#define GMAC_IDR_TXUBR (0x1u << 3) /**< \brief (GMAC_IDR) TX Used Bit Read */
+#define GMAC_IDR_TUR (0x1u << 4) /**< \brief (GMAC_IDR) Transmit Under Run */
+#define GMAC_IDR_RLEX (0x1u << 5) /**< \brief (GMAC_IDR) Retry Limit Exceeded or Late Collision */
+#define GMAC_IDR_TFC (0x1u << 6) /**< \brief (GMAC_IDR) Transmit Frame Corruption due to AHB error */
+#define GMAC_IDR_TCOMP (0x1u << 7) /**< \brief (GMAC_IDR) Transmit Complete */
+#define GMAC_IDR_ROVR (0x1u << 10) /**< \brief (GMAC_IDR) Receive Overrun */
+#define GMAC_IDR_HRESP (0x1u << 11) /**< \brief (GMAC_IDR) HRESP Not OK */
+#define GMAC_IDR_PFNZ (0x1u << 12) /**< \brief (GMAC_IDR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IDR_PTZ (0x1u << 13) /**< \brief (GMAC_IDR) Pause Time Zero */
+#define GMAC_IDR_PFTR (0x1u << 14) /**< \brief (GMAC_IDR) Pause Frame Transmitted */
+#define GMAC_IDR_EXINT (0x1u << 15) /**< \brief (GMAC_IDR) External Interrupt */
+#define GMAC_IDR_DRQFR (0x1u << 18) /**< \brief (GMAC_IDR) PTP Delay Request Frame Received */
+#define GMAC_IDR_SFR (0x1u << 19) /**< \brief (GMAC_IDR) PTP Sync Frame Received */
+#define GMAC_IDR_DRQFT (0x1u << 20) /**< \brief (GMAC_IDR) PTP Delay Request Frame Transmitted */
+#define GMAC_IDR_SFT (0x1u << 21) /**< \brief (GMAC_IDR) PTP Sync Frame Transmitted */
+#define GMAC_IDR_PDRQFR (0x1u << 22) /**< \brief (GMAC_IDR) PDelay Request Frame Received */
+#define GMAC_IDR_PDRSFR (0x1u << 23) /**< \brief (GMAC_IDR) PDelay Response Frame Received */
+#define GMAC_IDR_PDRQFT (0x1u << 24) /**< \brief (GMAC_IDR) PDelay Request Frame Transmitted */
+#define GMAC_IDR_PDRSFT (0x1u << 25) /**< \brief (GMAC_IDR) PDelay Response Frame Transmitted */
+#define GMAC_IDR_SRI (0x1u << 26) /**< \brief (GMAC_IDR) TSU Seconds Register Increment */
+#define GMAC_IDR_WOL (0x1u << 28) /**< \brief (GMAC_IDR) Wake On LAN */
+/* -------- GMAC_IMR : (GMAC Offset: 0x030) Interrupt Mask Register -------- */
+#define GMAC_IMR_MFS (0x1u << 0) /**< \brief (GMAC_IMR) Management Frame Sent */
+#define GMAC_IMR_RCOMP (0x1u << 1) /**< \brief (GMAC_IMR) Receive Complete */
+#define GMAC_IMR_RXUBR (0x1u << 2) /**< \brief (GMAC_IMR) RX Used Bit Read */
+#define GMAC_IMR_TXUBR (0x1u << 3) /**< \brief (GMAC_IMR) TX Used Bit Read */
+#define GMAC_IMR_TUR (0x1u << 4) /**< \brief (GMAC_IMR) Transmit Under Run */
+#define GMAC_IMR_RLEX (0x1u << 5) /**< \brief (GMAC_IMR) Retry Limit Exceeded */
+#define GMAC_IMR_TFC (0x1u << 6) /**< \brief (GMAC_IMR) Transmit Frame Corruption due to AHB error */
+#define GMAC_IMR_TCOMP (0x1u << 7) /**< \brief (GMAC_IMR) Transmit Complete */
+#define GMAC_IMR_ROVR (0x1u << 10) /**< \brief (GMAC_IMR) Receive Overrun */
+#define GMAC_IMR_HRESP (0x1u << 11) /**< \brief (GMAC_IMR) HRESP Not OK */
+#define GMAC_IMR_PFNZ (0x1u << 12) /**< \brief (GMAC_IMR) Pause Frame with Non-zero Pause Quantum Received */
+#define GMAC_IMR_PTZ (0x1u << 13) /**< \brief (GMAC_IMR) Pause Time Zero */
+#define GMAC_IMR_PFTR (0x1u << 14) /**< \brief (GMAC_IMR) Pause Frame Transmitted */
+#define GMAC_IMR_EXINT (0x1u << 15) /**< \brief (GMAC_IMR) External Interrupt */
+#define GMAC_IMR_DRQFR (0x1u << 18) /**< \brief (GMAC_IMR) PTP Delay Request Frame Received */
+#define GMAC_IMR_SFR (0x1u << 19) /**< \brief (GMAC_IMR) PTP Sync Frame Received */
+#define GMAC_IMR_DRQFT (0x1u << 20) /**< \brief (GMAC_IMR) PTP Delay Request Frame Transmitted */
+#define GMAC_IMR_SFT (0x1u << 21) /**< \brief (GMAC_IMR) PTP Sync Frame Transmitted */
+#define GMAC_IMR_PDRQFR (0x1u << 22) /**< \brief (GMAC_IMR) PDelay Request Frame Received */
+#define GMAC_IMR_PDRSFR (0x1u << 23) /**< \brief (GMAC_IMR) PDelay Response Frame Received */
+#define GMAC_IMR_PDRQFT (0x1u << 24) /**< \brief (GMAC_IMR) PDelay Request Frame Transmitted */
+#define GMAC_IMR_PDRSFT (0x1u << 25) /**< \brief (GMAC_IMR) PDelay Response Frame Transmitted */
+/* -------- GMAC_MAN : (GMAC Offset: 0x034) PHY Maintenance Register -------- */
+#define GMAC_MAN_DATA_Pos 0
+#define GMAC_MAN_DATA_Msk (0xffffu << GMAC_MAN_DATA_Pos) /**< \brief (GMAC_MAN) PHY Data */
+#define GMAC_MAN_DATA(value) ((GMAC_MAN_DATA_Msk & ((value) << GMAC_MAN_DATA_Pos)))
+#define GMAC_MAN_WTN_Pos 16
+#define GMAC_MAN_WTN_Msk (0x3u << GMAC_MAN_WTN_Pos) /**< \brief (GMAC_MAN) Write Ten */
+#define GMAC_MAN_WTN(value) ((GMAC_MAN_WTN_Msk & ((value) << GMAC_MAN_WTN_Pos)))
+#define GMAC_MAN_REGA_Pos 18
+#define GMAC_MAN_REGA_Msk (0x1fu << GMAC_MAN_REGA_Pos) /**< \brief (GMAC_MAN) Register Address */
+#define GMAC_MAN_REGA(value) ((GMAC_MAN_REGA_Msk & ((value) << GMAC_MAN_REGA_Pos)))
+#define GMAC_MAN_PHYA_Pos 23
+#define GMAC_MAN_PHYA_Msk (0x1fu << GMAC_MAN_PHYA_Pos) /**< \brief (GMAC_MAN) PHY Address */
+#define GMAC_MAN_PHYA(value) ((GMAC_MAN_PHYA_Msk & ((value) << GMAC_MAN_PHYA_Pos)))
+#define GMAC_MAN_OP_Pos 28
+#define GMAC_MAN_OP_Msk (0x3u << GMAC_MAN_OP_Pos) /**< \brief (GMAC_MAN) Operation */
+#define GMAC_MAN_OP(value) ((GMAC_MAN_OP_Msk & ((value) << GMAC_MAN_OP_Pos)))
+#define GMAC_MAN_CLTTO (0x1u << 30) /**< \brief (GMAC_MAN) Clause 22 Operation */
+#define GMAC_MAN_WZO (0x1u << 31) /**< \brief (GMAC_MAN) Write ZERO */
+/* -------- GMAC_RPQ : (GMAC Offset: 0x038) Received Pause Quantum Register -------- */
+#define GMAC_RPQ_RPQ_Pos 0
+#define GMAC_RPQ_RPQ_Msk (0xffffu << GMAC_RPQ_RPQ_Pos) /**< \brief (GMAC_RPQ) Received Pause Quantum */
+/* -------- GMAC_TPQ : (GMAC Offset: 0x03C) Transmit Pause Quantum Register -------- */
+#define GMAC_TPQ_TPQ_Pos 0
+#define GMAC_TPQ_TPQ_Msk (0xffffu << GMAC_TPQ_TPQ_Pos) /**< \brief (GMAC_TPQ) Transmit Pause Quantum */
+#define GMAC_TPQ_TPQ(value) ((GMAC_TPQ_TPQ_Msk & ((value) << GMAC_TPQ_TPQ_Pos)))
+/* -------- GMAC_HRB : (GMAC Offset: 0x080) Hash Register Bottom [31:0] -------- */
+#define GMAC_HRB_ADDR_Pos 0
+#define GMAC_HRB_ADDR_Msk (0xffffffffu << GMAC_HRB_ADDR_Pos) /**< \brief (GMAC_HRB) Hash Address */
+#define GMAC_HRB_ADDR(value) ((GMAC_HRB_ADDR_Msk & ((value) << GMAC_HRB_ADDR_Pos)))
+/* -------- GMAC_HRT : (GMAC Offset: 0x084) Hash Register Top [63:32] -------- */
+#define GMAC_HRT_ADDR_Pos 0
+#define GMAC_HRT_ADDR_Msk (0xffffffffu << GMAC_HRT_ADDR_Pos) /**< \brief (GMAC_HRT) Hash Address */
+#define GMAC_HRT_ADDR(value) ((GMAC_HRT_ADDR_Msk & ((value) << GMAC_HRT_ADDR_Pos)))
+/* -------- GMAC_SAB1 : (GMAC Offset: 0x088) Specific Address 1 Bottom [31:0] Register -------- */
+#define GMAC_SAB1_ADDR_Pos 0
+#define GMAC_SAB1_ADDR_Msk (0xffffffffu << GMAC_SAB1_ADDR_Pos) /**< \brief (GMAC_SAB1) Specific Address 1 */
+#define GMAC_SAB1_ADDR(value) ((GMAC_SAB1_ADDR_Msk & ((value) << GMAC_SAB1_ADDR_Pos)))
+/* -------- GMAC_SAT1 : (GMAC Offset: 0x08C) Specific Address 1 Top [47:32] Register -------- */
+#define GMAC_SAT1_ADDR_Pos 0
+#define GMAC_SAT1_ADDR_Msk (0xffffu << GMAC_SAT1_ADDR_Pos) /**< \brief (GMAC_SAT1) Specific Address 1 */
+#define GMAC_SAT1_ADDR(value) ((GMAC_SAT1_ADDR_Msk & ((value) << GMAC_SAT1_ADDR_Pos)))
+/* -------- GMAC_SAB2 : (GMAC Offset: 0x090) Specific Address 2 Bottom [31:0] Register -------- */
+#define GMAC_SAB2_ADDR_Pos 0
+#define GMAC_SAB2_ADDR_Msk (0xffffffffu << GMAC_SAB2_ADDR_Pos) /**< \brief (GMAC_SAB2) Specific Address 2 */
+#define GMAC_SAB2_ADDR(value) ((GMAC_SAB2_ADDR_Msk & ((value) << GMAC_SAB2_ADDR_Pos)))
+/* -------- GMAC_SAT2 : (GMAC Offset: 0x094) Specific Address 2 Top [47:32] Register -------- */
+#define GMAC_SAT2_ADDR_Pos 0
+#define GMAC_SAT2_ADDR_Msk (0xffffu << GMAC_SAT2_ADDR_Pos) /**< \brief (GMAC_SAT2) Specific Address 2 */
+#define GMAC_SAT2_ADDR(value) ((GMAC_SAT2_ADDR_Msk & ((value) << GMAC_SAT2_ADDR_Pos)))
+/* -------- GMAC_SAB3 : (GMAC Offset: 0x098) Specific Address 3 Bottom [31:0] Register -------- */
+#define GMAC_SAB3_ADDR_Pos 0
+#define GMAC_SAB3_ADDR_Msk (0xffffffffu << GMAC_SAB3_ADDR_Pos) /**< \brief (GMAC_SAB3) Specific Address 3 */
+#define GMAC_SAB3_ADDR(value) ((GMAC_SAB3_ADDR_Msk & ((value) << GMAC_SAB3_ADDR_Pos)))
+/* -------- GMAC_SAT3 : (GMAC Offset: 0x09C) Specific Address 3 Top [47:32] Register -------- */
+#define GMAC_SAT3_ADDR_Pos 0
+#define GMAC_SAT3_ADDR_Msk (0xffffu << GMAC_SAT3_ADDR_Pos) /**< \brief (GMAC_SAT3) Specific Address 3 */
+#define GMAC_SAT3_ADDR(value) ((GMAC_SAT3_ADDR_Msk & ((value) << GMAC_SAT3_ADDR_Pos)))
+/* -------- GMAC_SAB4 : (GMAC Offset: 0x0A0) Specific Address 4 Bottom [31:0] Register -------- */
+#define GMAC_SAB4_ADDR_Pos 0
+#define GMAC_SAB4_ADDR_Msk (0xffffffffu << GMAC_SAB4_ADDR_Pos) /**< \brief (GMAC_SAB4) Specific Address 4 */
+#define GMAC_SAB4_ADDR(value) ((GMAC_SAB4_ADDR_Msk & ((value) << GMAC_SAB4_ADDR_Pos)))
+/* -------- GMAC_SAT4 : (GMAC Offset: 0x0A4) Specific Address 4 Top [47:32] Register -------- */
+#define GMAC_SAT4_ADDR_Pos 0
+#define GMAC_SAT4_ADDR_Msk (0xffffu << GMAC_SAT4_ADDR_Pos) /**< \brief (GMAC_SAT4) Specific Address 4 */
+#define GMAC_SAT4_ADDR(value) ((GMAC_SAT4_ADDR_Msk & ((value) << GMAC_SAT4_ADDR_Pos)))
+/* -------- GMAC_TIDM[4] : (GMAC Offset: 0x0A8) Type ID Match 1 Register -------- */
+#define GMAC_TIDM_TID_Pos 0
+#define GMAC_TIDM_TID_Msk (0xffffu << GMAC_TIDM_TID_Pos) /**< \brief (GMAC_TIDM[4]) Type ID Match 1 */
+#define GMAC_TIDM_TID(value) ((GMAC_TIDM_TID_Msk & ((value) << GMAC_TIDM_TID_Pos)))
+/* -------- GMAC_IPGS : (GMAC Offset: 0x0BC) IPG Stretch Register -------- */
+#define GMAC_IPGS_FL_Pos 0
+#define GMAC_IPGS_FL_Msk (0xffffu << GMAC_IPGS_FL_Pos) /**< \brief (GMAC_IPGS) Frame Length */
+#define GMAC_IPGS_FL(value) ((GMAC_IPGS_FL_Msk & ((value) << GMAC_IPGS_FL_Pos)))
+/* -------- GMAC_SVLAN : (GMAC Offset: 0x0C0) Stacked VLAN Register -------- */
+#define GMAC_SVLAN_VLAN_TYPE_Pos 0
+#define GMAC_SVLAN_VLAN_TYPE_Msk (0xffffu << GMAC_SVLAN_VLAN_TYPE_Pos) /**< \brief (GMAC_SVLAN) User Defined VLAN_TYPE Field */
+#define GMAC_SVLAN_VLAN_TYPE(value) ((GMAC_SVLAN_VLAN_TYPE_Msk & ((value) << GMAC_SVLAN_VLAN_TYPE_Pos)))
+#define GMAC_SVLAN_ESVLAN (0x1u << 31) /**< \brief (GMAC_SVLAN) Enable Stacked VLAN Processing Mode */
+/* -------- GMAC_TPFCP : (GMAC Offset: 0x0C4) Transmit PFC Pause Register -------- */
+#define GMAC_TPFCP_PEV_Pos 0
+#define GMAC_TPFCP_PEV_Msk (0xffu << GMAC_TPFCP_PEV_Pos) /**< \brief (GMAC_TPFCP) Priority Enable Vector */
+#define GMAC_TPFCP_PEV(value) ((GMAC_TPFCP_PEV_Msk & ((value) << GMAC_TPFCP_PEV_Pos)))
+#define GMAC_TPFCP_PQ_Pos 8
+#define GMAC_TPFCP_PQ_Msk (0xffu << GMAC_TPFCP_PQ_Pos) /**< \brief (GMAC_TPFCP) Pause Quantum */
+#define GMAC_TPFCP_PQ(value) ((GMAC_TPFCP_PQ_Msk & ((value) << GMAC_TPFCP_PQ_Pos)))
+/* -------- GMAC_SAMB1 : (GMAC Offset: 0x0C8) Specific Address 1 Mask Bottom [31:0] Register -------- */
+#define GMAC_SAMB1_ADDR_Pos 0
+#define GMAC_SAMB1_ADDR_Msk (0xffffffffu << GMAC_SAMB1_ADDR_Pos) /**< \brief (GMAC_SAMB1) Specific Address 1 Mask */
+#define GMAC_SAMB1_ADDR(value) ((GMAC_SAMB1_ADDR_Msk & ((value) << GMAC_SAMB1_ADDR_Pos)))
+/* -------- GMAC_SAMT1 : (GMAC Offset: 0x0CC) Specific Address 1 Mask Top [47:32] Register -------- */
+#define GMAC_SAMT1_ADDR_Pos 0
+#define GMAC_SAMT1_ADDR_Msk (0xffffu << GMAC_SAMT1_ADDR_Pos) /**< \brief (GMAC_SAMT1) Specific Address 1 Mask */
+#define GMAC_SAMT1_ADDR(value) ((GMAC_SAMT1_ADDR_Msk & ((value) << GMAC_SAMT1_ADDR_Pos)))
+/* -------- GMAC_OTLO : (GMAC Offset: 0x100) Octets Transmitted [31:0] Register -------- */
+#define GMAC_OTLO_TXO_Pos 0
+#define GMAC_OTLO_TXO_Msk (0xffffffffu << GMAC_OTLO_TXO_Pos) /**< \brief (GMAC_OTLO) Transmitted Octets */
+/* -------- GMAC_OTHI : (GMAC Offset: 0x104) Octets Transmitted [47:32] Register -------- */
+#define GMAC_OTHI_TXO_Pos 0
+#define GMAC_OTHI_TXO_Msk (0xffffu << GMAC_OTHI_TXO_Pos) /**< \brief (GMAC_OTHI) Transmitted Octets */
+/* -------- GMAC_FT : (GMAC Offset: 0x108) Frames Transmitted Register -------- */
+#define GMAC_FT_FTX_Pos 0
+#define GMAC_FT_FTX_Msk (0xffffffffu << GMAC_FT_FTX_Pos) /**< \brief (GMAC_FT) Frames Transmitted without Error */
+/* -------- GMAC_BCFT : (GMAC Offset: 0x10C) Broadcast Frames Transmitted Register -------- */
+#define GMAC_BCFT_BFTX_Pos 0
+#define GMAC_BCFT_BFTX_Msk (0xffffffffu << GMAC_BCFT_BFTX_Pos) /**< \brief (GMAC_BCFT) Broadcast Frames Transmitted without Error */
+/* -------- GMAC_MFT : (GMAC Offset: 0x110) Multicast Frames Transmitted Register -------- */
+#define GMAC_MFT_MFTX_Pos 0
+#define GMAC_MFT_MFTX_Msk (0xffffffffu << GMAC_MFT_MFTX_Pos) /**< \brief (GMAC_MFT) Multicast Frames Transmitted without Error */
+/* -------- GMAC_PFT : (GMAC Offset: 0x114) Pause Frames Transmitted Register -------- */
+#define GMAC_PFT_PFTX_Pos 0
+#define GMAC_PFT_PFTX_Msk (0xffffu << GMAC_PFT_PFTX_Pos) /**< \brief (GMAC_PFT) Pause Frames Transmitted Register */
+/* -------- GMAC_BFT64 : (GMAC Offset: 0x118) 64 Byte Frames Transmitted Register -------- */
+#define GMAC_BFT64_NFTX_Pos 0
+#define GMAC_BFT64_NFTX_Msk (0xffffffffu << GMAC_BFT64_NFTX_Pos) /**< \brief (GMAC_BFT64) 64 Byte Frames Transmitted without Error */
+/* -------- GMAC_TBFT127 : (GMAC Offset: 0x11C) 65 to 127 Byte Frames Transmitted Register -------- */
+#define GMAC_TBFT127_NFTX_Pos 0
+#define GMAC_TBFT127_NFTX_Msk (0xffffffffu << GMAC_TBFT127_NFTX_Pos) /**< \brief (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted without Error */
+/* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) 128 to 255 Byte Frames Transmitted Register -------- */
+#define GMAC_TBFT255_NFTX_Pos 0
+#define GMAC_TBFT255_NFTX_Msk (0xffffffffu << GMAC_TBFT255_NFTX_Pos) /**< \brief (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted without Error */
+/* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) 256 to 511 Byte Frames Transmitted Register -------- */
+#define GMAC_TBFT511_NFTX_Pos 0
+#define GMAC_TBFT511_NFTX_Msk (0xffffffffu << GMAC_TBFT511_NFTX_Pos) /**< \brief (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted without Error */
+/* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) 512 to 1023 Byte Frames Transmitted Register -------- */
+#define GMAC_TBFT1023_NFTX_Pos 0
+#define GMAC_TBFT1023_NFTX_Msk (0xffffffffu << GMAC_TBFT1023_NFTX_Pos) /**< \brief (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted without Error */
+/* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12C) 1024 to 1518 Byte Frames Transmitted Register -------- */
+#define GMAC_TBFT1518_NFTX_Pos 0
+#define GMAC_TBFT1518_NFTX_Msk (0xffffffffu << GMAC_TBFT1518_NFTX_Pos) /**< \brief (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted without Error */
+/* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) Greater Than 1518 Byte Frames Transmitted Register -------- */
+#define GMAC_GTBFT1518_NFTX_Pos 0
+#define GMAC_GTBFT1518_NFTX_Msk (0xffffffffu << GMAC_GTBFT1518_NFTX_Pos) /**< \brief (GMAC_GTBFT1518) Greater than 1518 Byte Frames Transmitted without Error */
+/* -------- GMAC_TUR : (GMAC Offset: 0x134) Transmit Under Runs Register -------- */
+#define GMAC_TUR_TXUNR_Pos 0
+#define GMAC_TUR_TXUNR_Msk (0x3ffu << GMAC_TUR_TXUNR_Pos) /**< \brief (GMAC_TUR) Transmit Under Runs */
+/* -------- GMAC_SCF : (GMAC Offset: 0x138) Single Collision Frames Register -------- */
+#define GMAC_SCF_SCOL_Pos 0
+#define GMAC_SCF_SCOL_Msk (0x3ffffu << GMAC_SCF_SCOL_Pos) /**< \brief (GMAC_SCF) Single Collision */
+/* -------- GMAC_MCF : (GMAC Offset: 0x13C) Multiple Collision Frames Register -------- */
+#define GMAC_MCF_MCOL_Pos 0
+#define GMAC_MCF_MCOL_Msk (0x3ffffu << GMAC_MCF_MCOL_Pos) /**< \brief (GMAC_MCF) Multiple Collision */
+/* -------- GMAC_EC : (GMAC Offset: 0x140) Excessive Collisions Register -------- */
+#define GMAC_EC_XCOL_Pos 0
+#define GMAC_EC_XCOL_Msk (0x3ffu << GMAC_EC_XCOL_Pos) /**< \brief (GMAC_EC) Excessive Collisions */
+/* -------- GMAC_LC : (GMAC Offset: 0x144) Late Collisions Register -------- */
+#define GMAC_LC_LCOL_Pos 0
+#define GMAC_LC_LCOL_Msk (0x3ffu << GMAC_LC_LCOL_Pos) /**< \brief (GMAC_LC) Late Collisions */
+/* -------- GMAC_DTF : (GMAC Offset: 0x148) Deferred Transmission Frames Register -------- */
+#define GMAC_DTF_DEFT_Pos 0
+#define GMAC_DTF_DEFT_Msk (0x3ffffu << GMAC_DTF_DEFT_Pos) /**< \brief (GMAC_DTF) Deferred Transmission */
+/* -------- GMAC_CSE : (GMAC Offset: 0x14C) Carrier Sense Errors Register -------- */
+#define GMAC_CSE_CSR_Pos 0
+#define GMAC_CSE_CSR_Msk (0x3ffu << GMAC_CSE_CSR_Pos) /**< \brief (GMAC_CSE) Carrier Sense Error */
+/* -------- GMAC_ORLO : (GMAC Offset: 0x150) Octets Received [31:0] Received -------- */
+#define GMAC_ORLO_RXO_Pos 0
+#define GMAC_ORLO_RXO_Msk (0xffffffffu << GMAC_ORLO_RXO_Pos) /**< \brief (GMAC_ORLO) Received Octets */
+/* -------- GMAC_ORHI : (GMAC Offset: 0x154) Octets Received [47:32] Received -------- */
+#define GMAC_ORHI_RXO_Pos 0
+#define GMAC_ORHI_RXO_Msk (0xffffu << GMAC_ORHI_RXO_Pos) /**< \brief (GMAC_ORHI) Received Octets */
+/* -------- GMAC_FR : (GMAC Offset: 0x158) Frames Received Register -------- */
+#define GMAC_FR_FRX_Pos 0
+#define GMAC_FR_FRX_Msk (0xffffffffu << GMAC_FR_FRX_Pos) /**< \brief (GMAC_FR) Frames Received without Error */
+/* -------- GMAC_BCFR : (GMAC Offset: 0x15C) Broadcast Frames Received Register -------- */
+#define GMAC_BCFR_BFRX_Pos 0
+#define GMAC_BCFR_BFRX_Msk (0xffffffffu << GMAC_BCFR_BFRX_Pos) /**< \brief (GMAC_BCFR) Broadcast Frames Received without Error */
+/* -------- GMAC_MFR : (GMAC Offset: 0x160) Multicast Frames Received Register -------- */
+#define GMAC_MFR_MFRX_Pos 0
+#define GMAC_MFR_MFRX_Msk (0xffffffffu << GMAC_MFR_MFRX_Pos) /**< \brief (GMAC_MFR) Multicast Frames Received without Error */
+/* -------- GMAC_PFR : (GMAC Offset: 0x164) Pause Frames Received Register -------- */
+#define GMAC_PFR_PFRX_Pos 0
+#define GMAC_PFR_PFRX_Msk (0xffffu << GMAC_PFR_PFRX_Pos) /**< \brief (GMAC_PFR) Pause Frames Received Register */
+/* -------- GMAC_BFR64 : (GMAC Offset: 0x168) 64 Byte Frames Received Register -------- */
+#define GMAC_BFR64_NFRX_Pos 0
+#define GMAC_BFR64_NFRX_Msk (0xffffffffu << GMAC_BFR64_NFRX_Pos) /**< \brief (GMAC_BFR64) 64 Byte Frames Received without Error */
+/* -------- GMAC_TBFR127 : (GMAC Offset: 0x16C) 65 to 127 Byte Frames Received Register -------- */
+#define GMAC_TBFR127_NFRX_Pos 0
+#define GMAC_TBFR127_NFRX_Msk (0xffffffffu << GMAC_TBFR127_NFRX_Pos) /**< \brief (GMAC_TBFR127) 65 to 127 Byte Frames Received without Error */
+/* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) 128 to 255 Byte Frames Received Register -------- */
+#define GMAC_TBFR255_NFRX_Pos 0
+#define GMAC_TBFR255_NFRX_Msk (0xffffffffu << GMAC_TBFR255_NFRX_Pos) /**< \brief (GMAC_TBFR255) 128 to 255 Byte Frames Received without Error */
+/* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) 256 to 511Byte Frames Received Register -------- */
+#define GMAC_TBFR511_NFRX_Pos 0
+#define GMAC_TBFR511_NFRX_Msk (0xffffffffu << GMAC_TBFR511_NFRX_Pos) /**< \brief (GMAC_TBFR511) 256 to 511 Byte Frames Received without Error */
+/* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) 512 to 1023 Byte Frames Received Register -------- */
+#define GMAC_TBFR1023_NFRX_Pos 0
+#define GMAC_TBFR1023_NFRX_Msk (0xffffffffu << GMAC_TBFR1023_NFRX_Pos) /**< \brief (GMAC_TBFR1023) 512 to 1023 Byte Frames Received without Error */
+/* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17C) 1024 to 1518 Byte Frames Received Register -------- */
+#define GMAC_TBFR1518_NFRX_Pos 0
+#define GMAC_TBFR1518_NFRX_Msk (0xffffffffu << GMAC_TBFR1518_NFRX_Pos) /**< \brief (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received without Error */
+/* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) 1519 to Maximum Byte Frames Received Register -------- */
+#define GMAC_TMXBFR_NFRX_Pos 0
+#define GMAC_TMXBFR_NFRX_Msk (0xffffffffu << GMAC_TMXBFR_NFRX_Pos) /**< \brief (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received without Error */
+/* -------- GMAC_UFR : (GMAC Offset: 0x184) Undersize Frames Received Register -------- */
+#define GMAC_UFR_UFRX_Pos 0
+#define GMAC_UFR_UFRX_Msk (0x3ffu << GMAC_UFR_UFRX_Pos) /**< \brief (GMAC_UFR) Undersize Frames Received */
+/* -------- GMAC_OFR : (GMAC Offset: 0x188) Oversize Frames Received Register -------- */
+#define GMAC_OFR_OFRX_Pos 0
+#define GMAC_OFR_OFRX_Msk (0x3ffu << GMAC_OFR_OFRX_Pos) /**< \brief (GMAC_OFR) Oversized Frames Received */
+/* -------- GMAC_JR : (GMAC Offset: 0x18C) Jabbers Received Register -------- */
+#define GMAC_JR_JRX_Pos 0
+#define GMAC_JR_JRX_Msk (0x3ffu << GMAC_JR_JRX_Pos) /**< \brief (GMAC_JR) Jabbers Received */
+/* -------- GMAC_FCSE : (GMAC Offset: 0x190) Frame Check Sequence Errors Register -------- */
+#define GMAC_FCSE_FCKR_Pos 0
+#define GMAC_FCSE_FCKR_Msk (0x3ffu << GMAC_FCSE_FCKR_Pos) /**< \brief (GMAC_FCSE) Frame Check Sequence Errors */
+/* -------- GMAC_LFFE : (GMAC Offset: 0x194) Length Field Frame Errors Register -------- */
+#define GMAC_LFFE_LFER_Pos 0
+#define GMAC_LFFE_LFER_Msk (0x3ffu << GMAC_LFFE_LFER_Pos) /**< \brief (GMAC_LFFE) Length Field Frame Errors */
+/* -------- GMAC_RSE : (GMAC Offset: 0x198) Receive Symbol Errors Register -------- */
+#define GMAC_RSE_RXSE_Pos 0
+#define GMAC_RSE_RXSE_Msk (0x3ffu << GMAC_RSE_RXSE_Pos) /**< \brief (GMAC_RSE) Receive Symbol Errors */
+/* -------- GMAC_AE : (GMAC Offset: 0x19C) Alignment Errors Register -------- */
+#define GMAC_AE_AER_Pos 0
+#define GMAC_AE_AER_Msk (0x3ffu << GMAC_AE_AER_Pos) /**< \brief (GMAC_AE) Alignment Errors */
+/* -------- GMAC_RRE : (GMAC Offset: 0x1A0) Receive Resource Errors Register -------- */
+#define GMAC_RRE_RXRER_Pos 0
+#define GMAC_RRE_RXRER_Msk (0x3ffffu << GMAC_RRE_RXRER_Pos) /**< \brief (GMAC_RRE) Receive Resource Errors */
+/* -------- GMAC_ROE : (GMAC Offset: 0x1A4) Receive Overrun Register -------- */
+#define GMAC_ROE_RXOVR_Pos 0
+#define GMAC_ROE_RXOVR_Msk (0x3ffu << GMAC_ROE_RXOVR_Pos) /**< \brief (GMAC_ROE) Receive Overruns */
+/* -------- GMAC_IHCE : (GMAC Offset: 0x1A8) IP Header Checksum Errors Register -------- */
+#define GMAC_IHCE_HCKER_Pos 0
+#define GMAC_IHCE_HCKER_Msk (0xffu << GMAC_IHCE_HCKER_Pos) /**< \brief (GMAC_IHCE) IP Header Checksum Errors */
+/* -------- GMAC_TCE : (GMAC Offset: 0x1AC) TCP Checksum Errors Register -------- */
+#define GMAC_TCE_TCKER_Pos 0
+#define GMAC_TCE_TCKER_Msk (0xffu << GMAC_TCE_TCKER_Pos) /**< \brief (GMAC_TCE) TCP Checksum Errors */
+/* -------- GMAC_UCE : (GMAC Offset: 0x1B0) UDP Checksum Errors Register -------- */
+#define GMAC_UCE_UCKER_Pos 0
+#define GMAC_UCE_UCKER_Msk (0xffu << GMAC_UCE_UCKER_Pos) /**< \brief (GMAC_UCE) UDP Checksum Errors */
+/* -------- GMAC_TSSS : (GMAC Offset: 0x1C8) 1588 Timer Sync Strobe Seconds Register -------- */
+#define GMAC_TSSS_VTS_Pos 0
+#define GMAC_TSSS_VTS_Msk (0xffffffffu << GMAC_TSSS_VTS_Pos) /**< \brief (GMAC_TSSS) Value of Timer Seconds Register Capture */
+#define GMAC_TSSS_VTS(value) ((GMAC_TSSS_VTS_Msk & ((value) << GMAC_TSSS_VTS_Pos)))
+/* -------- GMAC_TSSN : (GMAC Offset: 0x1CC) 1588 Timer Sync Strobe Nanoseconds Register -------- */
+#define GMAC_TSSN_VTN_Pos 0
+#define GMAC_TSSN_VTN_Msk (0x3fffffffu << GMAC_TSSN_VTN_Pos) /**< \brief (GMAC_TSSN) Value Timer Nanoseconds Register Capture */
+#define GMAC_TSSN_VTN(value) ((GMAC_TSSN_VTN_Msk & ((value) << GMAC_TSSN_VTN_Pos)))
+/* -------- GMAC_TS : (GMAC Offset: 0x1D0) 1588 Timer Seconds Register -------- */
+#define GMAC_TS_TCS_Pos 0
+#define GMAC_TS_TCS_Msk (0xffffffffu << GMAC_TS_TCS_Pos) /**< \brief (GMAC_TS) Timer Count in Seconds */
+#define GMAC_TS_TCS(value) ((GMAC_TS_TCS_Msk & ((value) << GMAC_TS_TCS_Pos)))
+/* -------- GMAC_TN : (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register -------- */
+#define GMAC_TN_TNS_Pos 0
+#define GMAC_TN_TNS_Msk (0x3fffffffu << GMAC_TN_TNS_Pos) /**< \brief (GMAC_TN) Timer Count in Nanoseconds */
+#define GMAC_TN_TNS(value) ((GMAC_TN_TNS_Msk & ((value) << GMAC_TN_TNS_Pos)))
+/* -------- GMAC_TA : (GMAC Offset: 0x1D8) 1588 Timer Adjust Register -------- */
+#define GMAC_TA_ITDT_Pos 0
+#define GMAC_TA_ITDT_Msk (0x3fffffffu << GMAC_TA_ITDT_Pos) /**< \brief (GMAC_TA) Increment/Decrement */
+#define GMAC_TA_ITDT(value) ((GMAC_TA_ITDT_Msk & ((value) << GMAC_TA_ITDT_Pos)))
+#define GMAC_TA_ADJ (0x1u << 31) /**< \brief (GMAC_TA) Adjust 1588 Timer */
+/* -------- GMAC_TI : (GMAC Offset: 0x1DC) 1588 Timer Increment Register -------- */
+#define GMAC_TI_CNS_Pos 0
+#define GMAC_TI_CNS_Msk (0xffu << GMAC_TI_CNS_Pos) /**< \brief (GMAC_TI) Count Nanoseconds */
+#define GMAC_TI_CNS(value) ((GMAC_TI_CNS_Msk & ((value) << GMAC_TI_CNS_Pos)))
+#define GMAC_TI_ACNS_Pos 8
+#define GMAC_TI_ACNS_Msk (0xffu << GMAC_TI_ACNS_Pos) /**< \brief (GMAC_TI) Alternative Count Nanoseconds */
+#define GMAC_TI_ACNS(value) ((GMAC_TI_ACNS_Msk & ((value) << GMAC_TI_ACNS_Pos)))
+#define GMAC_TI_NIT_Pos 16
+#define GMAC_TI_NIT_Msk (0xffu << GMAC_TI_NIT_Pos) /**< \brief (GMAC_TI) Number of Increments */
+#define GMAC_TI_NIT(value) ((GMAC_TI_NIT_Msk & ((value) << GMAC_TI_NIT_Pos)))
+/* -------- GMAC_EFTS : (GMAC Offset: 0x1E0) PTP Event Frame Transmitted Seconds -------- */
+#define GMAC_EFTS_RUD_Pos 0
+#define GMAC_EFTS_RUD_Msk (0xffffffffu << GMAC_EFTS_RUD_Pos) /**< \brief (GMAC_EFTS) Register Update */
+/* -------- GMAC_EFTN : (GMAC Offset: 0x1E4) PTP Event Frame Transmitted Nanoseconds -------- */
+#define GMAC_EFTN_RUD_Pos 0
+#define GMAC_EFTN_RUD_Msk (0x3fffffffu << GMAC_EFTN_RUD_Pos) /**< \brief (GMAC_EFTN) Register Update */
+/* -------- GMAC_EFRS : (GMAC Offset: 0x1E8) PTP Event Frame Received Seconds -------- */
+#define GMAC_EFRS_RUD_Pos 0
+#define GMAC_EFRS_RUD_Msk (0xffffffffu << GMAC_EFRS_RUD_Pos) /**< \brief (GMAC_EFRS) Register Update */
+/* -------- GMAC_EFRN : (GMAC Offset: 0x1EC) PTP Event Frame Received Nanoseconds -------- */
+#define GMAC_EFRN_RUD_Pos 0
+#define GMAC_EFRN_RUD_Msk (0x3fffffffu << GMAC_EFRN_RUD_Pos) /**< \brief (GMAC_EFRN) Register Update */
+/* -------- GMAC_PEFTS : (GMAC Offset: 0x1F0) PTP Peer Event Frame Transmitted Seconds -------- */
+#define GMAC_PEFTS_RUD_Pos 0
+#define GMAC_PEFTS_RUD_Msk (0xffffffffu << GMAC_PEFTS_RUD_Pos) /**< \brief (GMAC_PEFTS) Register Update */
+/* -------- GMAC_PEFTN : (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds -------- */
+#define GMAC_PEFTN_RUD_Pos 0
+#define GMAC_PEFTN_RUD_Msk (0x3fffffffu << GMAC_PEFTN_RUD_Pos) /**< \brief (GMAC_PEFTN) Register Update */
+/* -------- GMAC_PEFRS : (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds -------- */
+#define GMAC_PEFRS_RUD_Pos 0
+#define GMAC_PEFRS_RUD_Msk (0xffffffffu << GMAC_PEFRS_RUD_Pos) /**< \brief (GMAC_PEFRS) Register Update */
+/* -------- GMAC_PEFRN : (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds -------- */
+#define GMAC_PEFRN_RUD_Pos 0
+#define GMAC_PEFRN_RUD_Msk (0x3fffffffu << GMAC_PEFRN_RUD_Pos) /**< \brief (GMAC_PEFRN) Register Update */
+
+/*@}*/
+
+
+#endif /* _SAM4E_GMAC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/gmac.h
+++ b/asf/sam/include/sam4e/component/gmac.h
@@ -193,7 +193,7 @@ typedef struct {
 #define GMAC_NSR_MDIO (0x1u << 1) /**< \brief (GMAC_NSR) MDIO Input Status */
 #define GMAC_NSR_IDLE (0x1u << 2) /**< \brief (GMAC_NSR) PHY Management Logic Idle */
 /* -------- GMAC_UR : (GMAC Offset: 0x00C) User Register -------- */
-#define GMAC_UR_RMIIMII (0x1u << 0) /**< \brief (GMAC_UR)  */
+#define GMAC_UR_RMII (0x1u << 0) /**< \brief (GMAC_UR)  */
 #define GMAC_UR_HDFC (0x1u << 6) /**< \brief (GMAC_UR) Half Duplex Flow Control */
 #define GMAC_UR_BPDG (0x1u << 7) /**< \brief (GMAC_UR) BPDG Bypass Deglitchers */
 /* -------- GMAC_DCFGR : (GMAC Offset: 0x010) DMA Configuration Register -------- */

--- a/asf/sam/include/sam4e/component/gpbr.h
+++ b/asf/sam/include/sam4e/component/gpbr.h
@@ -1,0 +1,53 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_GPBR_COMPONENT_
+#define _SAM4E_GPBR_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR General Purpose Backup Register */
+/* ============================================================================= */
+/** \addtogroup SAM4E_GPBR General Purpose Backup Register */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Gpbr hardware registers */
+typedef struct {
+  RwReg SYS_GPBR[20]; /**< \brief (Gpbr Offset: 0x0) General Purpose Backup Register */
+} Gpbr;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- SYS_GPBR[20] : (GPBR Offset: 0x0) General Purpose Backup Register -------- */
+#define SYS_GPBR_GPBR_VALUE_Pos 0
+#define SYS_GPBR_GPBR_VALUE_Msk (0xffffffffu << SYS_GPBR_GPBR_VALUE_Pos) /**< \brief (SYS_GPBR[20]) Value of GPBR x */
+#define SYS_GPBR_GPBR_VALUE(value) ((SYS_GPBR_GPBR_VALUE_Msk & ((value) << SYS_GPBR_GPBR_VALUE_Pos)))
+
+/*@}*/
+
+
+#endif /* _SAM4E_GPBR_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/hsmci.h
+++ b/asf/sam/include/sam4e/component/hsmci.h
@@ -1,0 +1,383 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_HSMCI_COMPONENT_
+#define _SAM4E_HSMCI_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR High Speed MultiMedia Card Interface */
+/* ============================================================================= */
+/** \addtogroup SAM4E_HSMCI High Speed MultiMedia Card Interface */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Hsmci hardware registers */
+typedef struct {
+  WoReg HSMCI_CR;        /**< \brief (Hsmci Offset: 0x00) Control Register */
+  RwReg HSMCI_MR;        /**< \brief (Hsmci Offset: 0x04) Mode Register */
+  RwReg HSMCI_DTOR;      /**< \brief (Hsmci Offset: 0x08) Data Timeout Register */
+  RwReg HSMCI_SDCR;      /**< \brief (Hsmci Offset: 0x0C) SD/SDIO Card Register */
+  RwReg HSMCI_ARGR;      /**< \brief (Hsmci Offset: 0x10) Argument Register */
+  WoReg HSMCI_CMDR;      /**< \brief (Hsmci Offset: 0x14) Command Register */
+  RwReg HSMCI_BLKR;      /**< \brief (Hsmci Offset: 0x18) Block Register */
+  RwReg HSMCI_CSTOR;     /**< \brief (Hsmci Offset: 0x1C) Completion Signal Timeout Register */
+  RoReg HSMCI_RSPR[4];   /**< \brief (Hsmci Offset: 0x20) Response Register */
+  RoReg HSMCI_RDR;       /**< \brief (Hsmci Offset: 0x30) Receive Data Register */
+  WoReg HSMCI_TDR;       /**< \brief (Hsmci Offset: 0x34) Transmit Data Register */
+  RoReg Reserved1[2];
+  RoReg HSMCI_SR;        /**< \brief (Hsmci Offset: 0x40) Status Register */
+  WoReg HSMCI_IER;       /**< \brief (Hsmci Offset: 0x44) Interrupt Enable Register */
+  WoReg HSMCI_IDR;       /**< \brief (Hsmci Offset: 0x48) Interrupt Disable Register */
+  RoReg HSMCI_IMR;       /**< \brief (Hsmci Offset: 0x4C) Interrupt Mask Register */
+  RoReg Reserved2[1];
+  RwReg HSMCI_CFG;       /**< \brief (Hsmci Offset: 0x54) Configuration Register */
+  RoReg Reserved3[35];
+  RwReg HSMCI_WPMR;      /**< \brief (Hsmci Offset: 0xE4) Write Protection Mode Register */
+  RoReg HSMCI_WPSR;      /**< \brief (Hsmci Offset: 0xE8) Write Protection Status Register */
+  RoReg Reserved4[5];
+  RwReg HSMCI_RPR;       /**< \brief (Hsmci Offset: 0x100) Receive Pointer Register */
+  RwReg HSMCI_RCR;       /**< \brief (Hsmci Offset: 0x104) Receive Counter Register */
+  RwReg HSMCI_TPR;       /**< \brief (Hsmci Offset: 0x108) Transmit Pointer Register */
+  RwReg HSMCI_TCR;       /**< \brief (Hsmci Offset: 0x10C) Transmit Counter Register */
+  RwReg HSMCI_RNPR;      /**< \brief (Hsmci Offset: 0x110) Receive Next Pointer Register */
+  RwReg HSMCI_RNCR;      /**< \brief (Hsmci Offset: 0x114) Receive Next Counter Register */
+  RwReg HSMCI_TNPR;      /**< \brief (Hsmci Offset: 0x118) Transmit Next Pointer Register */
+  RwReg HSMCI_TNCR;      /**< \brief (Hsmci Offset: 0x11C) Transmit Next Counter Register */
+  WoReg HSMCI_PTCR;      /**< \brief (Hsmci Offset: 0x120) Transfer Control Register */
+  RoReg HSMCI_PTSR;      /**< \brief (Hsmci Offset: 0x124) Transfer Status Register */
+  RoReg Reserved5[54];
+  RwReg HSMCI_FIFO[256]; /**< \brief (Hsmci Offset: 0x200) FIFO Memory Aperture0 */
+} Hsmci;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- HSMCI_CR : (HSMCI Offset: 0x00) Control Register -------- */
+#define HSMCI_CR_MCIEN (0x1u << 0) /**< \brief (HSMCI_CR) Multi-Media Interface Enable */
+#define HSMCI_CR_MCIDIS (0x1u << 1) /**< \brief (HSMCI_CR) Multi-Media Interface Disable */
+#define HSMCI_CR_PWSEN (0x1u << 2) /**< \brief (HSMCI_CR) Power Save Mode Enable */
+#define HSMCI_CR_PWSDIS (0x1u << 3) /**< \brief (HSMCI_CR) Power Save Mode Disable */
+#define HSMCI_CR_SWRST (0x1u << 7) /**< \brief (HSMCI_CR) Software Reset */
+/* -------- HSMCI_MR : (HSMCI Offset: 0x04) Mode Register -------- */
+#define HSMCI_MR_CLKDIV_Pos 0
+#define HSMCI_MR_CLKDIV_Msk (0xffu << HSMCI_MR_CLKDIV_Pos) /**< \brief (HSMCI_MR) Clock Divider */
+#define HSMCI_MR_CLKDIV(value) ((HSMCI_MR_CLKDIV_Msk & ((value) << HSMCI_MR_CLKDIV_Pos)))
+#define HSMCI_MR_PWSDIV_Pos 8
+#define HSMCI_MR_PWSDIV_Msk (0x7u << HSMCI_MR_PWSDIV_Pos) /**< \brief (HSMCI_MR) Power Saving Divider */
+#define HSMCI_MR_PWSDIV(value) ((HSMCI_MR_PWSDIV_Msk & ((value) << HSMCI_MR_PWSDIV_Pos)))
+#define HSMCI_MR_RDPROOF (0x1u << 11) /**< \brief (HSMCI_MR) Read Proof Enable */
+#define HSMCI_MR_WRPROOF (0x1u << 12) /**< \brief (HSMCI_MR) Write Proof Enable */
+#define HSMCI_MR_FBYTE (0x1u << 13) /**< \brief (HSMCI_MR) Force Byte Transfer */
+#define HSMCI_MR_PADV (0x1u << 14) /**< \brief (HSMCI_MR) Padding Value */
+#define HSMCI_MR_PDCMODE (0x1u << 15) /**< \brief (HSMCI_MR) PDC-oriented Mode */
+#define HSMCI_MR_CLKODD (0x1u << 16) /**< \brief (HSMCI_MR) Clock divider is odd */
+/* -------- HSMCI_DTOR : (HSMCI Offset: 0x08) Data Timeout Register -------- */
+#define HSMCI_DTOR_DTOCYC_Pos 0
+#define HSMCI_DTOR_DTOCYC_Msk (0xfu << HSMCI_DTOR_DTOCYC_Pos) /**< \brief (HSMCI_DTOR) Data Timeout Cycle Number */
+#define HSMCI_DTOR_DTOCYC(value) ((HSMCI_DTOR_DTOCYC_Msk & ((value) << HSMCI_DTOR_DTOCYC_Pos)))
+#define HSMCI_DTOR_DTOMUL_Pos 4
+#define HSMCI_DTOR_DTOMUL_Msk (0x7u << HSMCI_DTOR_DTOMUL_Pos) /**< \brief (HSMCI_DTOR) Data Timeout Multiplier */
+#define   HSMCI_DTOR_DTOMUL_1 (0x0u << 4) /**< \brief (HSMCI_DTOR) DTOCYC */
+#define   HSMCI_DTOR_DTOMUL_16 (0x1u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 16 */
+#define   HSMCI_DTOR_DTOMUL_128 (0x2u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 128 */
+#define   HSMCI_DTOR_DTOMUL_256 (0x3u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 256 */
+#define   HSMCI_DTOR_DTOMUL_1024 (0x4u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 1024 */
+#define   HSMCI_DTOR_DTOMUL_4096 (0x5u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 4096 */
+#define   HSMCI_DTOR_DTOMUL_65536 (0x6u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 65536 */
+#define   HSMCI_DTOR_DTOMUL_1048576 (0x7u << 4) /**< \brief (HSMCI_DTOR) DTOCYC x 1048576 */
+/* -------- HSMCI_SDCR : (HSMCI Offset: 0x0C) SD/SDIO Card Register -------- */
+#define HSMCI_SDCR_SDCSEL_Pos 0
+#define HSMCI_SDCR_SDCSEL_Msk (0x3u << HSMCI_SDCR_SDCSEL_Pos) /**< \brief (HSMCI_SDCR) SDCard/SDIO Slot */
+#define   HSMCI_SDCR_SDCSEL_SLOTA (0x0u << 0) /**< \brief (HSMCI_SDCR) Slot A is selected. */
+#define   HSMCI_SDCR_SDCSEL_SLOTB (0x1u << 0) /**< \brief (HSMCI_SDCR) - */
+#define   HSMCI_SDCR_SDCSEL_SLOTC (0x2u << 0) /**< \brief (HSMCI_SDCR) - */
+#define   HSMCI_SDCR_SDCSEL_SLOTD (0x3u << 0) /**< \brief (HSMCI_SDCR) - */
+#define HSMCI_SDCR_SDCBUS_Pos 6
+#define HSMCI_SDCR_SDCBUS_Msk (0x3u << HSMCI_SDCR_SDCBUS_Pos) /**< \brief (HSMCI_SDCR) SDCard/SDIO Bus Width */
+#define   HSMCI_SDCR_SDCBUS_1 (0x0u << 6) /**< \brief (HSMCI_SDCR) 1 bit */
+#define   HSMCI_SDCR_SDCBUS_4 (0x2u << 6) /**< \brief (HSMCI_SDCR) 4 bit */
+#define   HSMCI_SDCR_SDCBUS_8 (0x3u << 6) /**< \brief (HSMCI_SDCR) 8 bit */
+/* -------- HSMCI_ARGR : (HSMCI Offset: 0x10) Argument Register -------- */
+#define HSMCI_ARGR_ARG_Pos 0
+#define HSMCI_ARGR_ARG_Msk (0xffffffffu << HSMCI_ARGR_ARG_Pos) /**< \brief (HSMCI_ARGR) Command Argument */
+#define HSMCI_ARGR_ARG(value) ((HSMCI_ARGR_ARG_Msk & ((value) << HSMCI_ARGR_ARG_Pos)))
+/* -------- HSMCI_CMDR : (HSMCI Offset: 0x14) Command Register -------- */
+#define HSMCI_CMDR_CMDNB_Pos 0
+#define HSMCI_CMDR_CMDNB_Msk (0x3fu << HSMCI_CMDR_CMDNB_Pos) /**< \brief (HSMCI_CMDR) Command Number */
+#define HSMCI_CMDR_CMDNB(value) ((HSMCI_CMDR_CMDNB_Msk & ((value) << HSMCI_CMDR_CMDNB_Pos)))
+#define HSMCI_CMDR_RSPTYP_Pos 6
+#define HSMCI_CMDR_RSPTYP_Msk (0x3u << HSMCI_CMDR_RSPTYP_Pos) /**< \brief (HSMCI_CMDR) Response Type */
+#define   HSMCI_CMDR_RSPTYP_NORESP (0x0u << 6) /**< \brief (HSMCI_CMDR) No response. */
+#define   HSMCI_CMDR_RSPTYP_48_BIT (0x1u << 6) /**< \brief (HSMCI_CMDR) 48-bit response. */
+#define   HSMCI_CMDR_RSPTYP_136_BIT (0x2u << 6) /**< \brief (HSMCI_CMDR) 136-bit response. */
+#define   HSMCI_CMDR_RSPTYP_R1B (0x3u << 6) /**< \brief (HSMCI_CMDR) R1b response type */
+#define HSMCI_CMDR_SPCMD_Pos 8
+#define HSMCI_CMDR_SPCMD_Msk (0x7u << HSMCI_CMDR_SPCMD_Pos) /**< \brief (HSMCI_CMDR) Special Command */
+#define   HSMCI_CMDR_SPCMD_STD (0x0u << 8) /**< \brief (HSMCI_CMDR) Not a special CMD. */
+#define   HSMCI_CMDR_SPCMD_INIT (0x1u << 8) /**< \brief (HSMCI_CMDR) Initialization CMD: 74 clock cycles for initialization sequence. */
+#define   HSMCI_CMDR_SPCMD_SYNC (0x2u << 8) /**< \brief (HSMCI_CMDR) Synchronized CMD: Wait for the end of the current data block transfer before sending the pending command. */
+#define   HSMCI_CMDR_SPCMD_CE_ATA (0x3u << 8) /**< \brief (HSMCI_CMDR) CE-ATA Completion Signal disable Command. The host cancels the ability for the device to return a command completion signal on the command line. */
+#define   HSMCI_CMDR_SPCMD_IT_CMD (0x4u << 8) /**< \brief (HSMCI_CMDR) Interrupt command: Corresponds to the Interrupt Mode (CMD40). */
+#define   HSMCI_CMDR_SPCMD_IT_RESP (0x5u << 8) /**< \brief (HSMCI_CMDR) Interrupt response: Corresponds to the Interrupt Mode (CMD40). */
+#define   HSMCI_CMDR_SPCMD_BOR (0x6u << 8) /**< \brief (HSMCI_CMDR) Boot Operation Request. Start a boot operation mode, the host processor can read boot data from the MMC device directly. */
+#define   HSMCI_CMDR_SPCMD_EBO (0x7u << 8) /**< \brief (HSMCI_CMDR) End Boot Operation. This command allows the host processor to terminate the boot operation mode. */
+#define HSMCI_CMDR_OPDCMD (0x1u << 11) /**< \brief (HSMCI_CMDR) Open Drain Command */
+#define   HSMCI_CMDR_OPDCMD_PUSHPULL (0x0u << 11) /**< \brief (HSMCI_CMDR) Push pull command. */
+#define   HSMCI_CMDR_OPDCMD_OPENDRAIN (0x1u << 11) /**< \brief (HSMCI_CMDR) Open drain command. */
+#define HSMCI_CMDR_MAXLAT (0x1u << 12) /**< \brief (HSMCI_CMDR) Max Latency for Command to Response */
+#define   HSMCI_CMDR_MAXLAT_5 (0x0u << 12) /**< \brief (HSMCI_CMDR) 5-cycle max latency. */
+#define   HSMCI_CMDR_MAXLAT_64 (0x1u << 12) /**< \brief (HSMCI_CMDR) 64-cycle max latency. */
+#define HSMCI_CMDR_TRCMD_Pos 16
+#define HSMCI_CMDR_TRCMD_Msk (0x3u << HSMCI_CMDR_TRCMD_Pos) /**< \brief (HSMCI_CMDR) Transfer Command */
+#define   HSMCI_CMDR_TRCMD_NO_DATA (0x0u << 16) /**< \brief (HSMCI_CMDR) No data transfer */
+#define   HSMCI_CMDR_TRCMD_START_DATA (0x1u << 16) /**< \brief (HSMCI_CMDR) Start data transfer */
+#define   HSMCI_CMDR_TRCMD_STOP_DATA (0x2u << 16) /**< \brief (HSMCI_CMDR) Stop data transfer */
+#define HSMCI_CMDR_TRDIR (0x1u << 18) /**< \brief (HSMCI_CMDR) Transfer Direction */
+#define   HSMCI_CMDR_TRDIR_WRITE (0x0u << 18) /**< \brief (HSMCI_CMDR) Write. */
+#define   HSMCI_CMDR_TRDIR_READ (0x1u << 18) /**< \brief (HSMCI_CMDR) Read. */
+#define HSMCI_CMDR_TRTYP_Pos 19
+#define HSMCI_CMDR_TRTYP_Msk (0x7u << HSMCI_CMDR_TRTYP_Pos) /**< \brief (HSMCI_CMDR) Transfer Type */
+#define   HSMCI_CMDR_TRTYP_SINGLE (0x0u << 19) /**< \brief (HSMCI_CMDR) MMC/SD Card Single Block */
+#define   HSMCI_CMDR_TRTYP_MULTIPLE (0x1u << 19) /**< \brief (HSMCI_CMDR) MMC/SD Card Multiple Block */
+#define   HSMCI_CMDR_TRTYP_STREAM (0x2u << 19) /**< \brief (HSMCI_CMDR) MMC Stream */
+#define   HSMCI_CMDR_TRTYP_BYTE (0x4u << 19) /**< \brief (HSMCI_CMDR) SDIO Byte */
+#define   HSMCI_CMDR_TRTYP_BLOCK (0x5u << 19) /**< \brief (HSMCI_CMDR) SDIO Block */
+#define HSMCI_CMDR_IOSPCMD_Pos 24
+#define HSMCI_CMDR_IOSPCMD_Msk (0x3u << HSMCI_CMDR_IOSPCMD_Pos) /**< \brief (HSMCI_CMDR) SDIO Special Command */
+#define   HSMCI_CMDR_IOSPCMD_STD (0x0u << 24) /**< \brief (HSMCI_CMDR) Not an SDIO Special Command */
+#define   HSMCI_CMDR_IOSPCMD_SUSPEND (0x1u << 24) /**< \brief (HSMCI_CMDR) SDIO Suspend Command */
+#define   HSMCI_CMDR_IOSPCMD_RESUME (0x2u << 24) /**< \brief (HSMCI_CMDR) SDIO Resume Command */
+#define HSMCI_CMDR_ATACS (0x1u << 26) /**< \brief (HSMCI_CMDR) ATA with Command Completion Signal */
+#define   HSMCI_CMDR_ATACS_NORMAL (0x0u << 26) /**< \brief (HSMCI_CMDR) Normal operation mode. */
+#define   HSMCI_CMDR_ATACS_COMPLETION (0x1u << 26) /**< \brief (HSMCI_CMDR) This bit indicates that a completion signal is expected within a programmed amount of time (HSMCI_CSTOR). */
+#define HSMCI_CMDR_BOOT_ACK (0x1u << 27) /**< \brief (HSMCI_CMDR) Boot Operation Acknowledge. */
+/* -------- HSMCI_BLKR : (HSMCI Offset: 0x18) Block Register -------- */
+#define HSMCI_BLKR_BCNT_Pos 0
+#define HSMCI_BLKR_BCNT_Msk (0xffffu << HSMCI_BLKR_BCNT_Pos) /**< \brief (HSMCI_BLKR) MMC/SDIO Block Count - SDIO Byte Count */
+#define HSMCI_BLKR_BCNT(value) ((HSMCI_BLKR_BCNT_Msk & ((value) << HSMCI_BLKR_BCNT_Pos)))
+#define HSMCI_BLKR_BLKLEN_Pos 16
+#define HSMCI_BLKR_BLKLEN_Msk (0xffffu << HSMCI_BLKR_BLKLEN_Pos) /**< \brief (HSMCI_BLKR) Data Block Length */
+#define HSMCI_BLKR_BLKLEN(value) ((HSMCI_BLKR_BLKLEN_Msk & ((value) << HSMCI_BLKR_BLKLEN_Pos)))
+/* -------- HSMCI_CSTOR : (HSMCI Offset: 0x1C) Completion Signal Timeout Register -------- */
+#define HSMCI_CSTOR_CSTOCYC_Pos 0
+#define HSMCI_CSTOR_CSTOCYC_Msk (0xfu << HSMCI_CSTOR_CSTOCYC_Pos) /**< \brief (HSMCI_CSTOR) Completion Signal Timeout Cycle Number */
+#define HSMCI_CSTOR_CSTOCYC(value) ((HSMCI_CSTOR_CSTOCYC_Msk & ((value) << HSMCI_CSTOR_CSTOCYC_Pos)))
+#define HSMCI_CSTOR_CSTOMUL_Pos 4
+#define HSMCI_CSTOR_CSTOMUL_Msk (0x7u << HSMCI_CSTOR_CSTOMUL_Pos) /**< \brief (HSMCI_CSTOR) Completion Signal Timeout Multiplier */
+#define   HSMCI_CSTOR_CSTOMUL_1 (0x0u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 1 */
+#define   HSMCI_CSTOR_CSTOMUL_16 (0x1u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 16 */
+#define   HSMCI_CSTOR_CSTOMUL_128 (0x2u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 128 */
+#define   HSMCI_CSTOR_CSTOMUL_256 (0x3u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 256 */
+#define   HSMCI_CSTOR_CSTOMUL_1024 (0x4u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 1024 */
+#define   HSMCI_CSTOR_CSTOMUL_4096 (0x5u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 4096 */
+#define   HSMCI_CSTOR_CSTOMUL_65536 (0x6u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 65536 */
+#define   HSMCI_CSTOR_CSTOMUL_1048576 (0x7u << 4) /**< \brief (HSMCI_CSTOR) CSTOCYC x 1048576 */
+/* -------- HSMCI_RSPR[4] : (HSMCI Offset: 0x20) Response Register -------- */
+#define HSMCI_RSPR_RSP_Pos 0
+#define HSMCI_RSPR_RSP_Msk (0xffffffffu << HSMCI_RSPR_RSP_Pos) /**< \brief (HSMCI_RSPR[4]) Response */
+/* -------- HSMCI_RDR : (HSMCI Offset: 0x30) Receive Data Register -------- */
+#define HSMCI_RDR_DATA_Pos 0
+#define HSMCI_RDR_DATA_Msk (0xffffffffu << HSMCI_RDR_DATA_Pos) /**< \brief (HSMCI_RDR) Data to Read */
+/* -------- HSMCI_TDR : (HSMCI Offset: 0x34) Transmit Data Register -------- */
+#define HSMCI_TDR_DATA_Pos 0
+#define HSMCI_TDR_DATA_Msk (0xffffffffu << HSMCI_TDR_DATA_Pos) /**< \brief (HSMCI_TDR) Data to Write */
+#define HSMCI_TDR_DATA(value) ((HSMCI_TDR_DATA_Msk & ((value) << HSMCI_TDR_DATA_Pos)))
+/* -------- HSMCI_SR : (HSMCI Offset: 0x40) Status Register -------- */
+#define HSMCI_SR_CMDRDY (0x1u << 0) /**< \brief (HSMCI_SR) Command Ready */
+#define HSMCI_SR_RXRDY (0x1u << 1) /**< \brief (HSMCI_SR) Receiver Ready */
+#define HSMCI_SR_TXRDY (0x1u << 2) /**< \brief (HSMCI_SR) Transmit Ready */
+#define HSMCI_SR_BLKE (0x1u << 3) /**< \brief (HSMCI_SR) Data Block Ended */
+#define HSMCI_SR_DTIP (0x1u << 4) /**< \brief (HSMCI_SR) Data Transfer in Progress */
+#define HSMCI_SR_NOTBUSY (0x1u << 5) /**< \brief (HSMCI_SR) HSMCI Not Busy */
+#define HSMCI_SR_ENDRX (0x1u << 6) /**< \brief (HSMCI_SR) End of RX Buffer */
+#define HSMCI_SR_ENDTX (0x1u << 7) /**< \brief (HSMCI_SR) End of TX Buffer */
+#define HSMCI_SR_SDIOIRQA (0x1u << 8) /**< \brief (HSMCI_SR) SDIO Interrupt for Slot A */
+#define HSMCI_SR_SDIOWAIT (0x1u << 12) /**< \brief (HSMCI_SR) SDIO Read Wait Operation Status */
+#define HSMCI_SR_CSRCV (0x1u << 13) /**< \brief (HSMCI_SR) CE-ATA Completion Signal Received */
+#define HSMCI_SR_RXBUFF (0x1u << 14) /**< \brief (HSMCI_SR) RX Buffer Full */
+#define HSMCI_SR_TXBUFE (0x1u << 15) /**< \brief (HSMCI_SR) TX Buffer Empty */
+#define HSMCI_SR_RINDE (0x1u << 16) /**< \brief (HSMCI_SR) Response Index Error */
+#define HSMCI_SR_RDIRE (0x1u << 17) /**< \brief (HSMCI_SR) Response Direction Error */
+#define HSMCI_SR_RCRCE (0x1u << 18) /**< \brief (HSMCI_SR) Response CRC Error */
+#define HSMCI_SR_RENDE (0x1u << 19) /**< \brief (HSMCI_SR) Response End Bit Error */
+#define HSMCI_SR_RTOE (0x1u << 20) /**< \brief (HSMCI_SR) Response Time-out Error */
+#define HSMCI_SR_DCRCE (0x1u << 21) /**< \brief (HSMCI_SR) Data CRC Error */
+#define HSMCI_SR_DTOE (0x1u << 22) /**< \brief (HSMCI_SR) Data Time-out Error */
+#define HSMCI_SR_CSTOE (0x1u << 23) /**< \brief (HSMCI_SR) Completion Signal Time-out Error */
+#define HSMCI_SR_FIFOEMPTY (0x1u << 26) /**< \brief (HSMCI_SR) FIFO empty flag */
+#define HSMCI_SR_XFRDONE (0x1u << 27) /**< \brief (HSMCI_SR) Transfer Done flag */
+#define HSMCI_SR_ACKRCV (0x1u << 28) /**< \brief (HSMCI_SR) Boot Operation Acknowledge Received */
+#define HSMCI_SR_ACKRCVE (0x1u << 29) /**< \brief (HSMCI_SR) Boot Operation Acknowledge Error */
+#define HSMCI_SR_OVRE (0x1u << 30) /**< \brief (HSMCI_SR) Overrun */
+#define HSMCI_SR_UNRE (0x1u << 31) /**< \brief (HSMCI_SR) Underrun */
+/* -------- HSMCI_IER : (HSMCI Offset: 0x44) Interrupt Enable Register -------- */
+#define HSMCI_IER_CMDRDY (0x1u << 0) /**< \brief (HSMCI_IER) Command Ready Interrupt Enable */
+#define HSMCI_IER_RXRDY (0x1u << 1) /**< \brief (HSMCI_IER) Receiver Ready Interrupt Enable */
+#define HSMCI_IER_TXRDY (0x1u << 2) /**< \brief (HSMCI_IER) Transmit Ready Interrupt Enable */
+#define HSMCI_IER_BLKE (0x1u << 3) /**< \brief (HSMCI_IER) Data Block Ended Interrupt Enable */
+#define HSMCI_IER_DTIP (0x1u << 4) /**< \brief (HSMCI_IER) Data Transfer in Progress Interrupt Enable */
+#define HSMCI_IER_NOTBUSY (0x1u << 5) /**< \brief (HSMCI_IER) Data Not Busy Interrupt Enable */
+#define HSMCI_IER_ENDRX (0x1u << 6) /**< \brief (HSMCI_IER) End of Receive Buffer Interrupt Enable */
+#define HSMCI_IER_ENDTX (0x1u << 7) /**< \brief (HSMCI_IER) End of Transmit Buffer Interrupt Enable */
+#define HSMCI_IER_SDIOIRQA (0x1u << 8) /**< \brief (HSMCI_IER) SDIO Interrupt for Slot A Interrupt Enable */
+#define HSMCI_IER_SDIOWAIT (0x1u << 12) /**< \brief (HSMCI_IER) SDIO Read Wait Operation Status Interrupt Enable */
+#define HSMCI_IER_CSRCV (0x1u << 13) /**< \brief (HSMCI_IER) Completion Signal Received Interrupt Enable */
+#define HSMCI_IER_RXBUFF (0x1u << 14) /**< \brief (HSMCI_IER) Receive Buffer Full Interrupt Enable */
+#define HSMCI_IER_TXBUFE (0x1u << 15) /**< \brief (HSMCI_IER) Transmit Buffer Empty Interrupt Enable */
+#define HSMCI_IER_RINDE (0x1u << 16) /**< \brief (HSMCI_IER) Response Index Error Interrupt Enable */
+#define HSMCI_IER_RDIRE (0x1u << 17) /**< \brief (HSMCI_IER) Response Direction Error Interrupt Enable */
+#define HSMCI_IER_RCRCE (0x1u << 18) /**< \brief (HSMCI_IER) Response CRC Error Interrupt Enable */
+#define HSMCI_IER_RENDE (0x1u << 19) /**< \brief (HSMCI_IER) Response End Bit Error Interrupt Enable */
+#define HSMCI_IER_RTOE (0x1u << 20) /**< \brief (HSMCI_IER) Response Time-out Error Interrupt Enable */
+#define HSMCI_IER_DCRCE (0x1u << 21) /**< \brief (HSMCI_IER) Data CRC Error Interrupt Enable */
+#define HSMCI_IER_DTOE (0x1u << 22) /**< \brief (HSMCI_IER) Data Time-out Error Interrupt Enable */
+#define HSMCI_IER_CSTOE (0x1u << 23) /**< \brief (HSMCI_IER) Completion Signal Timeout Error Interrupt Enable */
+#define HSMCI_IER_FIFOEMPTY (0x1u << 26) /**< \brief (HSMCI_IER) FIFO empty Interrupt enable */
+#define HSMCI_IER_XFRDONE (0x1u << 27) /**< \brief (HSMCI_IER) Transfer Done Interrupt enable */
+#define HSMCI_IER_ACKRCV (0x1u << 28) /**< \brief (HSMCI_IER) Boot Acknowledge Interrupt Enable */
+#define HSMCI_IER_ACKRCVE (0x1u << 29) /**< \brief (HSMCI_IER) Boot Acknowledge Error Interrupt Enable */
+#define HSMCI_IER_OVRE (0x1u << 30) /**< \brief (HSMCI_IER) Overrun Interrupt Enable */
+#define HSMCI_IER_UNRE (0x1u << 31) /**< \brief (HSMCI_IER) Underrun Interrupt Enable */
+/* -------- HSMCI_IDR : (HSMCI Offset: 0x48) Interrupt Disable Register -------- */
+#define HSMCI_IDR_CMDRDY (0x1u << 0) /**< \brief (HSMCI_IDR) Command Ready Interrupt Disable */
+#define HSMCI_IDR_RXRDY (0x1u << 1) /**< \brief (HSMCI_IDR) Receiver Ready Interrupt Disable */
+#define HSMCI_IDR_TXRDY (0x1u << 2) /**< \brief (HSMCI_IDR) Transmit Ready Interrupt Disable */
+#define HSMCI_IDR_BLKE (0x1u << 3) /**< \brief (HSMCI_IDR) Data Block Ended Interrupt Disable */
+#define HSMCI_IDR_DTIP (0x1u << 4) /**< \brief (HSMCI_IDR) Data Transfer in Progress Interrupt Disable */
+#define HSMCI_IDR_NOTBUSY (0x1u << 5) /**< \brief (HSMCI_IDR) Data Not Busy Interrupt Disable */
+#define HSMCI_IDR_ENDRX (0x1u << 6) /**< \brief (HSMCI_IDR) End of Receive Buffer Interrupt Disable */
+#define HSMCI_IDR_ENDTX (0x1u << 7) /**< \brief (HSMCI_IDR) End of Transmit Buffer Interrupt Disable */
+#define HSMCI_IDR_SDIOIRQA (0x1u << 8) /**< \brief (HSMCI_IDR) SDIO Interrupt for Slot A Interrupt Disable */
+#define HSMCI_IDR_SDIOWAIT (0x1u << 12) /**< \brief (HSMCI_IDR) SDIO Read Wait Operation Status Interrupt Disable */
+#define HSMCI_IDR_CSRCV (0x1u << 13) /**< \brief (HSMCI_IDR) Completion Signal received interrupt Disable */
+#define HSMCI_IDR_RXBUFF (0x1u << 14) /**< \brief (HSMCI_IDR) Receive Buffer Full Interrupt Disable */
+#define HSMCI_IDR_TXBUFE (0x1u << 15) /**< \brief (HSMCI_IDR) Transmit Buffer Empty Interrupt Disable */
+#define HSMCI_IDR_RINDE (0x1u << 16) /**< \brief (HSMCI_IDR) Response Index Error Interrupt Disable */
+#define HSMCI_IDR_RDIRE (0x1u << 17) /**< \brief (HSMCI_IDR) Response Direction Error Interrupt Disable */
+#define HSMCI_IDR_RCRCE (0x1u << 18) /**< \brief (HSMCI_IDR) Response CRC Error Interrupt Disable */
+#define HSMCI_IDR_RENDE (0x1u << 19) /**< \brief (HSMCI_IDR) Response End Bit Error Interrupt Disable */
+#define HSMCI_IDR_RTOE (0x1u << 20) /**< \brief (HSMCI_IDR) Response Time-out Error Interrupt Disable */
+#define HSMCI_IDR_DCRCE (0x1u << 21) /**< \brief (HSMCI_IDR) Data CRC Error Interrupt Disable */
+#define HSMCI_IDR_DTOE (0x1u << 22) /**< \brief (HSMCI_IDR) Data Time-out Error Interrupt Disable */
+#define HSMCI_IDR_CSTOE (0x1u << 23) /**< \brief (HSMCI_IDR) Completion Signal Time out Error Interrupt Disable */
+#define HSMCI_IDR_FIFOEMPTY (0x1u << 26) /**< \brief (HSMCI_IDR) FIFO empty Interrupt Disable */
+#define HSMCI_IDR_XFRDONE (0x1u << 27) /**< \brief (HSMCI_IDR) Transfer Done Interrupt Disable */
+#define HSMCI_IDR_ACKRCV (0x1u << 28) /**< \brief (HSMCI_IDR) Boot Acknowledge Interrupt Disable */
+#define HSMCI_IDR_ACKRCVE (0x1u << 29) /**< \brief (HSMCI_IDR) Boot Acknowledge Error Interrupt Disable */
+#define HSMCI_IDR_OVRE (0x1u << 30) /**< \brief (HSMCI_IDR) Overrun Interrupt Disable */
+#define HSMCI_IDR_UNRE (0x1u << 31) /**< \brief (HSMCI_IDR) Underrun Interrupt Disable */
+/* -------- HSMCI_IMR : (HSMCI Offset: 0x4C) Interrupt Mask Register -------- */
+#define HSMCI_IMR_CMDRDY (0x1u << 0) /**< \brief (HSMCI_IMR) Command Ready Interrupt Mask */
+#define HSMCI_IMR_RXRDY (0x1u << 1) /**< \brief (HSMCI_IMR) Receiver Ready Interrupt Mask */
+#define HSMCI_IMR_TXRDY (0x1u << 2) /**< \brief (HSMCI_IMR) Transmit Ready Interrupt Mask */
+#define HSMCI_IMR_BLKE (0x1u << 3) /**< \brief (HSMCI_IMR) Data Block Ended Interrupt Mask */
+#define HSMCI_IMR_DTIP (0x1u << 4) /**< \brief (HSMCI_IMR) Data Transfer in Progress Interrupt Mask */
+#define HSMCI_IMR_NOTBUSY (0x1u << 5) /**< \brief (HSMCI_IMR) Data Not Busy Interrupt Mask */
+#define HSMCI_IMR_ENDRX (0x1u << 6) /**< \brief (HSMCI_IMR) End of Receive Buffer Interrupt Mask */
+#define HSMCI_IMR_ENDTX (0x1u << 7) /**< \brief (HSMCI_IMR) End of Transmit Buffer Interrupt Mask */
+#define HSMCI_IMR_SDIOIRQA (0x1u << 8) /**< \brief (HSMCI_IMR) SDIO Interrupt for Slot A Interrupt Mask */
+#define HSMCI_IMR_SDIOWAIT (0x1u << 12) /**< \brief (HSMCI_IMR) SDIO Read Wait Operation Status Interrupt Mask */
+#define HSMCI_IMR_CSRCV (0x1u << 13) /**< \brief (HSMCI_IMR) Completion Signal Received Interrupt Mask */
+#define HSMCI_IMR_RXBUFF (0x1u << 14) /**< \brief (HSMCI_IMR) Receive Buffer Full Interrupt Mask */
+#define HSMCI_IMR_TXBUFE (0x1u << 15) /**< \brief (HSMCI_IMR) Transmit Buffer Empty Interrupt Mask */
+#define HSMCI_IMR_RINDE (0x1u << 16) /**< \brief (HSMCI_IMR) Response Index Error Interrupt Mask */
+#define HSMCI_IMR_RDIRE (0x1u << 17) /**< \brief (HSMCI_IMR) Response Direction Error Interrupt Mask */
+#define HSMCI_IMR_RCRCE (0x1u << 18) /**< \brief (HSMCI_IMR) Response CRC Error Interrupt Mask */
+#define HSMCI_IMR_RENDE (0x1u << 19) /**< \brief (HSMCI_IMR) Response End Bit Error Interrupt Mask */
+#define HSMCI_IMR_RTOE (0x1u << 20) /**< \brief (HSMCI_IMR) Response Time-out Error Interrupt Mask */
+#define HSMCI_IMR_DCRCE (0x1u << 21) /**< \brief (HSMCI_IMR) Data CRC Error Interrupt Mask */
+#define HSMCI_IMR_DTOE (0x1u << 22) /**< \brief (HSMCI_IMR) Data Time-out Error Interrupt Mask */
+#define HSMCI_IMR_CSTOE (0x1u << 23) /**< \brief (HSMCI_IMR) Completion Signal Time-out Error Interrupt Mask */
+#define HSMCI_IMR_FIFOEMPTY (0x1u << 26) /**< \brief (HSMCI_IMR) FIFO Empty Interrupt Mask */
+#define HSMCI_IMR_XFRDONE (0x1u << 27) /**< \brief (HSMCI_IMR) Transfer Done Interrupt Mask */
+#define HSMCI_IMR_ACKRCV (0x1u << 28) /**< \brief (HSMCI_IMR) Boot Operation Acknowledge Received Interrupt Mask */
+#define HSMCI_IMR_ACKRCVE (0x1u << 29) /**< \brief (HSMCI_IMR) Boot Operation Acknowledge Error Interrupt Mask */
+#define HSMCI_IMR_OVRE (0x1u << 30) /**< \brief (HSMCI_IMR) Overrun Interrupt Mask */
+#define HSMCI_IMR_UNRE (0x1u << 31) /**< \brief (HSMCI_IMR) Underrun Interrupt Mask */
+/* -------- HSMCI_CFG : (HSMCI Offset: 0x54) Configuration Register -------- */
+#define HSMCI_CFG_FIFOMODE (0x1u << 0) /**< \brief (HSMCI_CFG) HSMCI Internal FIFO control mode */
+#define HSMCI_CFG_FERRCTRL (0x1u << 4) /**< \brief (HSMCI_CFG) Flow Error flag reset control mode */
+#define HSMCI_CFG_HSMODE (0x1u << 8) /**< \brief (HSMCI_CFG) High Speed Mode */
+#define HSMCI_CFG_LSYNC (0x1u << 12) /**< \brief (HSMCI_CFG) Synchronize on the last block */
+/* -------- HSMCI_WPMR : (HSMCI Offset: 0xE4) Write Protection Mode Register -------- */
+#define HSMCI_WPMR_WP_EN (0x1u << 0) /**< \brief (HSMCI_WPMR) Write Protection Enable */
+#define HSMCI_WPMR_WP_KEY_Pos 8
+#define HSMCI_WPMR_WP_KEY_Msk (0xffffffu << HSMCI_WPMR_WP_KEY_Pos) /**< \brief (HSMCI_WPMR) Write Protection Key password */
+#define HSMCI_WPMR_WP_KEY(value) ((HSMCI_WPMR_WP_KEY_Msk & ((value) << HSMCI_WPMR_WP_KEY_Pos)))
+/* -------- HSMCI_WPSR : (HSMCI Offset: 0xE8) Write Protection Status Register -------- */
+#define HSMCI_WPSR_WP_VS_Pos 0
+#define HSMCI_WPSR_WP_VS_Msk (0xfu << HSMCI_WPSR_WP_VS_Pos) /**< \brief (HSMCI_WPSR) Write Protection Violation Status */
+#define   HSMCI_WPSR_WP_VS_NONE (0x0u << 0) /**< \brief (HSMCI_WPSR) No Write Protection Violation occurred since the last read of this register (WP_SR) */
+#define   HSMCI_WPSR_WP_VS_WRITE (0x1u << 0) /**< \brief (HSMCI_WPSR) Write Protection detected unauthorized attempt to write a control register had occurred (since the last read.) */
+#define   HSMCI_WPSR_WP_VS_RESET (0x2u << 0) /**< \brief (HSMCI_WPSR) Software reset had been performed while Write Protection was enabled (since the last read). */
+#define   HSMCI_WPSR_WP_VS_BOTH (0x3u << 0) /**< \brief (HSMCI_WPSR) Both Write Protection violation and software reset with Write Protection enabled have occurred since the last read. */
+#define HSMCI_WPSR_WP_VSRC_Pos 8
+#define HSMCI_WPSR_WP_VSRC_Msk (0xffffu << HSMCI_WPSR_WP_VSRC_Pos) /**< \brief (HSMCI_WPSR) Write Protection Violation SouRCe */
+/* -------- HSMCI_RPR : (HSMCI Offset: 0x100) Receive Pointer Register -------- */
+#define HSMCI_RPR_RXPTR_Pos 0
+#define HSMCI_RPR_RXPTR_Msk (0xffffffffu << HSMCI_RPR_RXPTR_Pos) /**< \brief (HSMCI_RPR) Receive Pointer Register */
+#define HSMCI_RPR_RXPTR(value) ((HSMCI_RPR_RXPTR_Msk & ((value) << HSMCI_RPR_RXPTR_Pos)))
+/* -------- HSMCI_RCR : (HSMCI Offset: 0x104) Receive Counter Register -------- */
+#define HSMCI_RCR_RXCTR_Pos 0
+#define HSMCI_RCR_RXCTR_Msk (0xffffu << HSMCI_RCR_RXCTR_Pos) /**< \brief (HSMCI_RCR) Receive Counter Register */
+#define HSMCI_RCR_RXCTR(value) ((HSMCI_RCR_RXCTR_Msk & ((value) << HSMCI_RCR_RXCTR_Pos)))
+/* -------- HSMCI_TPR : (HSMCI Offset: 0x108) Transmit Pointer Register -------- */
+#define HSMCI_TPR_TXPTR_Pos 0
+#define HSMCI_TPR_TXPTR_Msk (0xffffffffu << HSMCI_TPR_TXPTR_Pos) /**< \brief (HSMCI_TPR) Transmit Counter Register */
+#define HSMCI_TPR_TXPTR(value) ((HSMCI_TPR_TXPTR_Msk & ((value) << HSMCI_TPR_TXPTR_Pos)))
+/* -------- HSMCI_TCR : (HSMCI Offset: 0x10C) Transmit Counter Register -------- */
+#define HSMCI_TCR_TXCTR_Pos 0
+#define HSMCI_TCR_TXCTR_Msk (0xffffu << HSMCI_TCR_TXCTR_Pos) /**< \brief (HSMCI_TCR) Transmit Counter Register */
+#define HSMCI_TCR_TXCTR(value) ((HSMCI_TCR_TXCTR_Msk & ((value) << HSMCI_TCR_TXCTR_Pos)))
+/* -------- HSMCI_RNPR : (HSMCI Offset: 0x110) Receive Next Pointer Register -------- */
+#define HSMCI_RNPR_RXNPTR_Pos 0
+#define HSMCI_RNPR_RXNPTR_Msk (0xffffffffu << HSMCI_RNPR_RXNPTR_Pos) /**< \brief (HSMCI_RNPR) Receive Next Pointer */
+#define HSMCI_RNPR_RXNPTR(value) ((HSMCI_RNPR_RXNPTR_Msk & ((value) << HSMCI_RNPR_RXNPTR_Pos)))
+/* -------- HSMCI_RNCR : (HSMCI Offset: 0x114) Receive Next Counter Register -------- */
+#define HSMCI_RNCR_RXNCTR_Pos 0
+#define HSMCI_RNCR_RXNCTR_Msk (0xffffu << HSMCI_RNCR_RXNCTR_Pos) /**< \brief (HSMCI_RNCR) Receive Next Counter */
+#define HSMCI_RNCR_RXNCTR(value) ((HSMCI_RNCR_RXNCTR_Msk & ((value) << HSMCI_RNCR_RXNCTR_Pos)))
+/* -------- HSMCI_TNPR : (HSMCI Offset: 0x118) Transmit Next Pointer Register -------- */
+#define HSMCI_TNPR_TXNPTR_Pos 0
+#define HSMCI_TNPR_TXNPTR_Msk (0xffffffffu << HSMCI_TNPR_TXNPTR_Pos) /**< \brief (HSMCI_TNPR) Transmit Next Pointer */
+#define HSMCI_TNPR_TXNPTR(value) ((HSMCI_TNPR_TXNPTR_Msk & ((value) << HSMCI_TNPR_TXNPTR_Pos)))
+/* -------- HSMCI_TNCR : (HSMCI Offset: 0x11C) Transmit Next Counter Register -------- */
+#define HSMCI_TNCR_TXNCTR_Pos 0
+#define HSMCI_TNCR_TXNCTR_Msk (0xffffu << HSMCI_TNCR_TXNCTR_Pos) /**< \brief (HSMCI_TNCR) Transmit Counter Next */
+#define HSMCI_TNCR_TXNCTR(value) ((HSMCI_TNCR_TXNCTR_Msk & ((value) << HSMCI_TNCR_TXNCTR_Pos)))
+/* -------- HSMCI_PTCR : (HSMCI Offset: 0x120) Transfer Control Register -------- */
+#define HSMCI_PTCR_RXTEN (0x1u << 0) /**< \brief (HSMCI_PTCR) Receiver Transfer Enable */
+#define HSMCI_PTCR_RXTDIS (0x1u << 1) /**< \brief (HSMCI_PTCR) Receiver Transfer Disable */
+#define HSMCI_PTCR_TXTEN (0x1u << 8) /**< \brief (HSMCI_PTCR) Transmitter Transfer Enable */
+#define HSMCI_PTCR_TXTDIS (0x1u << 9) /**< \brief (HSMCI_PTCR) Transmitter Transfer Disable */
+/* -------- HSMCI_PTSR : (HSMCI Offset: 0x124) Transfer Status Register -------- */
+#define HSMCI_PTSR_RXTEN (0x1u << 0) /**< \brief (HSMCI_PTSR) Receiver Transfer Enable */
+#define HSMCI_PTSR_TXTEN (0x1u << 8) /**< \brief (HSMCI_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_HSMCI_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/matrix.h
+++ b/asf/sam/include/sam4e/component/matrix.h
@@ -1,0 +1,182 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_MATRIX_COMPONENT_
+#define _SAM4E_MATRIX_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR AHB Bus Matrix */
+/* ============================================================================= */
+/** \addtogroup SAM4E_MATRIX AHB Bus Matrix */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Matrix hardware registers */
+typedef struct {
+  RwReg MATRIX_MCFG[16]; /**< \brief (Matrix Offset: 0x0000) Master Configuration Register */
+  RwReg MATRIX_SCFG[16]; /**< \brief (Matrix Offset: 0x0040) Slave Configuration Register */
+  RwReg MATRIX_PRAS0;    /**< \brief (Matrix Offset: 0x0080) Priority Register A for Slave 0 */
+  RwReg MATRIX_PRBS0;    /**< \brief (Matrix Offset: 0x0084) Priority Register B for Slave 0 */
+  RwReg MATRIX_PRAS1;    /**< \brief (Matrix Offset: 0x0088) Priority Register A for Slave 1 */
+  RwReg MATRIX_PRBS1;    /**< \brief (Matrix Offset: 0x008C) Priority Register B for Slave 1 */
+  RwReg MATRIX_PRAS2;    /**< \brief (Matrix Offset: 0x0090) Priority Register A for Slave 2 */
+  RwReg MATRIX_PRBS2;    /**< \brief (Matrix Offset: 0x0094) Priority Register B for Slave 2 */
+  RwReg MATRIX_PRAS3;    /**< \brief (Matrix Offset: 0x0098) Priority Register A for Slave 3 */
+  RwReg MATRIX_PRBS3;    /**< \brief (Matrix Offset: 0x009C) Priority Register B for Slave 3 */
+  RwReg MATRIX_PRAS4;    /**< \brief (Matrix Offset: 0x00A0) Priority Register A for Slave 4 */
+  RwReg MATRIX_PRBS4;    /**< \brief (Matrix Offset: 0x00A4) Priority Register B for Slave 4 */
+  RwReg MATRIX_PRAS5;    /**< \brief (Matrix Offset: 0x00A8) Priority Register A for Slave 5 */
+  RwReg MATRIX_PRBS5;    /**< \brief (Matrix Offset: 0x00AC) Priority Register B for Slave 5 */
+  RwReg MATRIX_PRAS6;    /**< \brief (Matrix Offset: 0x00B0) Priority Register A for Slave 6 */
+  RwReg MATRIX_PRBS6;    /**< \brief (Matrix Offset: 0x00B4) Priority Register B for Slave 6 */
+  RwReg MATRIX_PRAS7;    /**< \brief (Matrix Offset: 0x00B8) Priority Register A for Slave 7 */
+  RwReg MATRIX_PRBS7;    /**< \brief (Matrix Offset: 0x00BC) Priority Register B for Slave 7 */
+  RwReg MATRIX_PRAS8;    /**< \brief (Matrix Offset: 0x00C0) Priority Register A for Slave 8 */
+  RwReg MATRIX_PRBS8;    /**< \brief (Matrix Offset: 0x00C4) Priority Register B for Slave 8 */
+  RwReg MATRIX_PRAS9;    /**< \brief (Matrix Offset: 0x00C8) Priority Register A for Slave 9 */
+  RwReg MATRIX_PRBS9;    /**< \brief (Matrix Offset: 0x00CC) Priority Register B for Slave 9 */
+  RwReg MATRIX_PRAS10;   /**< \brief (Matrix Offset: 0x00D0) Priority Register A for Slave 10 */
+  RwReg MATRIX_PRBS10;   /**< \brief (Matrix Offset: 0x00D4) Priority Register B for Slave 10 */
+  RwReg MATRIX_PRAS11;   /**< \brief (Matrix Offset: 0x00D8) Priority Register A for Slave 11 */
+  RwReg MATRIX_PRBS11;   /**< \brief (Matrix Offset: 0x00DC) Priority Register B for Slave 11 */
+  RwReg MATRIX_PRAS12;   /**< \brief (Matrix Offset: 0x00E0) Priority Register A for Slave 12 */
+  RwReg MATRIX_PRBS12;   /**< \brief (Matrix Offset: 0x00E4) Priority Register B for Slave 12 */
+  RwReg MATRIX_PRAS13;   /**< \brief (Matrix Offset: 0x00E8) Priority Register A for Slave 13 */
+  RwReg MATRIX_PRBS13;   /**< \brief (Matrix Offset: 0x00EC) Priority Register B for Slave 13 */
+  RwReg MATRIX_PRAS14;   /**< \brief (Matrix Offset: 0x00F0) Priority Register A for Slave 14 */
+  RwReg MATRIX_PRBS14;   /**< \brief (Matrix Offset: 0x00F4) Priority Register B for Slave 14 */
+  RwReg MATRIX_PRAS15;   /**< \brief (Matrix Offset: 0x00F8) Priority Register A for Slave 15 */
+  RwReg MATRIX_PRBS15;   /**< \brief (Matrix Offset: 0x00FC) Priority Register B for Slave 15 */
+  RwReg MATRIX_MRCR;     /**< \brief (Matrix Offset: 0x0100) Master Remap Control Register */
+  RoReg Reserved1[3];
+  RwReg MATRIX_SFR[16];  /**< \brief (Matrix Offset: 0x0110) Special Function Register */
+  RoReg Reserved2[37];
+  RwReg MATRIX_WPMR;     /**< \brief (Matrix Offset: 0x01E4) Write Protect Mode Register */
+  RoReg MATRIX_WPSR;     /**< \brief (Matrix Offset: 0x01E8) Write Protect Status Register */
+} Matrix;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- MATRIX_MCFG[16] : (MATRIX Offset: 0x0000) Master Configuration Register -------- */
+#define MATRIX_MCFG_ULBT_Pos 0
+#define MATRIX_MCFG_ULBT_Msk (0x7u << MATRIX_MCFG_ULBT_Pos) /**< \brief (MATRIX_MCFG[16]) Undefined Length Burst Type */
+#define MATRIX_MCFG_ULBT(value) ((MATRIX_MCFG_ULBT_Msk & ((value) << MATRIX_MCFG_ULBT_Pos)))
+/* -------- MATRIX_SCFG[16] : (MATRIX Offset: 0x0040) Slave Configuration Register -------- */
+#define MATRIX_SCFG_SLOT_CYCLE_Pos 0
+#define MATRIX_SCFG_SLOT_CYCLE_Msk (0x1ffu << MATRIX_SCFG_SLOT_CYCLE_Pos) /**< \brief (MATRIX_SCFG[16]) Maximum Bus Grant Duration for Masters */
+#define MATRIX_SCFG_SLOT_CYCLE(value) ((MATRIX_SCFG_SLOT_CYCLE_Msk & ((value) << MATRIX_SCFG_SLOT_CYCLE_Pos)))
+#define MATRIX_SCFG_DEFMSTR_TYPE_Pos 16
+#define MATRIX_SCFG_DEFMSTR_TYPE_Msk (0x3u << MATRIX_SCFG_DEFMSTR_TYPE_Pos) /**< \brief (MATRIX_SCFG[16]) Default Master Type */
+#define MATRIX_SCFG_DEFMSTR_TYPE(value) ((MATRIX_SCFG_DEFMSTR_TYPE_Msk & ((value) << MATRIX_SCFG_DEFMSTR_TYPE_Pos)))
+#define MATRIX_SCFG_FIXED_DEFMSTR_Pos 18
+#define MATRIX_SCFG_FIXED_DEFMSTR_Msk (0xfu << MATRIX_SCFG_FIXED_DEFMSTR_Pos) /**< \brief (MATRIX_SCFG[16]) Fixed Default Master */
+#define MATRIX_SCFG_FIXED_DEFMSTR(value) ((MATRIX_SCFG_FIXED_DEFMSTR_Msk & ((value) << MATRIX_SCFG_FIXED_DEFMSTR_Pos)))
+/* -------- MATRIX_PRAS : (MATRIX Offset: N/A) Priority Register A for Slave 0 -------- */
+#define MATRIX_PRAS_M0PR_Pos 0
+#define MATRIX_PRAS_M0PR_Msk (0x3u << MATRIX_PRAS_M0PR_Pos) /**< \brief (MATRIX_PRAS) Master 0 Priority */
+#define MATRIX_PRAS_M0PR(value) ((MATRIX_PRAS_M0PR_Msk & ((value) << MATRIX_PRAS_M0PR_Pos)))
+#define MATRIX_PRAS_M1PR_Pos 4
+#define MATRIX_PRAS_M1PR_Msk (0x3u << MATRIX_PRAS_M1PR_Pos) /**< \brief (MATRIX_PRAS) Master 1 Priority */
+#define MATRIX_PRAS_M1PR(value) ((MATRIX_PRAS_M1PR_Msk & ((value) << MATRIX_PRAS_M1PR_Pos)))
+#define MATRIX_PRAS_M2PR_Pos 8
+#define MATRIX_PRAS_M2PR_Msk (0x3u << MATRIX_PRAS_M2PR_Pos) /**< \brief (MATRIX_PRAS) Master 2 Priority */
+#define MATRIX_PRAS_M2PR(value) ((MATRIX_PRAS_M2PR_Msk & ((value) << MATRIX_PRAS_M2PR_Pos)))
+#define MATRIX_PRAS_M3PR_Pos 12
+#define MATRIX_PRAS_M3PR_Msk (0x3u << MATRIX_PRAS_M3PR_Pos) /**< \brief (MATRIX_PRAS) Master 3 Priority */
+#define MATRIX_PRAS_M3PR(value) ((MATRIX_PRAS_M3PR_Msk & ((value) << MATRIX_PRAS_M3PR_Pos)))
+#define MATRIX_PRAS_M4PR_Pos 16
+#define MATRIX_PRAS_M4PR_Msk (0x3u << MATRIX_PRAS_M4PR_Pos) /**< \brief (MATRIX_PRAS) Master 4 Priority */
+#define MATRIX_PRAS_M4PR(value) ((MATRIX_PRAS_M4PR_Msk & ((value) << MATRIX_PRAS_M4PR_Pos)))
+#define MATRIX_PRAS_M5PR_Pos 20
+#define MATRIX_PRAS_M5PR_Msk (0x3u << MATRIX_PRAS_M5PR_Pos) /**< \brief (MATRIX_PRAS) Master 5 Priority */
+#define MATRIX_PRAS_M5PR(value) ((MATRIX_PRAS_M5PR_Msk & ((value) << MATRIX_PRAS_M5PR_Pos)))
+#define MATRIX_PRAS_M6PR_Pos 24
+#define MATRIX_PRAS_M6PR_Msk (0x3u << MATRIX_PRAS_M6PR_Pos) /**< \brief (MATRIX_PRAS) Master 6 Priority */
+#define MATRIX_PRAS_M6PR(value) ((MATRIX_PRAS_M6PR_Msk & ((value) << MATRIX_PRAS_M6PR_Pos)))
+#define MATRIX_PRAS_M7PR_Pos 28
+#define MATRIX_PRAS_M7PR_Msk (0x3u << MATRIX_PRAS_M7PR_Pos) /**< \brief (MATRIX_PRAS) Master 7 Priority */
+#define MATRIX_PRAS_M7PR(value) ((MATRIX_PRAS_M7PR_Msk & ((value) << MATRIX_PRAS_M7PR_Pos)))
+/* -------- MATRIX_PRBS : (MATRIX Offset: N/A) Priority Register B for Slave 0 -------- */
+#define MATRIX_PRBS_M8PR_Pos 0
+#define MATRIX_PRBS_M8PR_Msk (0x3u << MATRIX_PRBS_M8PR_Pos) /**< \brief (MATRIX_PRBS) Master 8 Priority */
+#define MATRIX_PRBS_M8PR(value) ((MATRIX_PRBS_M8PR_Msk & ((value) << MATRIX_PRBS_M8PR_Pos)))
+#define MATRIX_PRBS_M9PR_Pos 4
+#define MATRIX_PRBS_M9PR_Msk (0x3u << MATRIX_PRBS_M9PR_Pos) /**< \brief (MATRIX_PRBS) Master 9 Priority */
+#define MATRIX_PRBS_M9PR(value) ((MATRIX_PRBS_M9PR_Msk & ((value) << MATRIX_PRBS_M9PR_Pos)))
+#define MATRIX_PRBS_M10PR_Pos 8
+#define MATRIX_PRBS_M10PR_Msk (0x3u << MATRIX_PRBS_M10PR_Pos) /**< \brief (MATRIX_PRBS) Master 10 Priority */
+#define MATRIX_PRBS_M10PR(value) ((MATRIX_PRBS_M10PR_Msk & ((value) << MATRIX_PRBS_M10PR_Pos)))
+#define MATRIX_PRBS_M11PR_Pos 12
+#define MATRIX_PRBS_M11PR_Msk (0x3u << MATRIX_PRBS_M11PR_Pos) /**< \brief (MATRIX_PRBS) Master 11 Priority */
+#define MATRIX_PRBS_M11PR(value) ((MATRIX_PRBS_M11PR_Msk & ((value) << MATRIX_PRBS_M11PR_Pos)))
+#define MATRIX_PRBS_M12PR_Pos 16
+#define MATRIX_PRBS_M12PR_Msk (0x3u << MATRIX_PRBS_M12PR_Pos) /**< \brief (MATRIX_PRBS) Master 12 Priority */
+#define MATRIX_PRBS_M12PR(value) ((MATRIX_PRBS_M12PR_Msk & ((value) << MATRIX_PRBS_M12PR_Pos)))
+#define MATRIX_PRBS_M13PR_Pos 20
+#define MATRIX_PRBS_M13PR_Msk (0x3u << MATRIX_PRBS_M13PR_Pos) /**< \brief (MATRIX_PRBS) Master 13 Priority */
+#define MATRIX_PRBS_M13PR(value) ((MATRIX_PRBS_M13PR_Msk & ((value) << MATRIX_PRBS_M13PR_Pos)))
+#define MATRIX_PRBS_M14PR_Pos 24
+#define MATRIX_PRBS_M14PR_Msk (0x3u << MATRIX_PRBS_M14PR_Pos) /**< \brief (MATRIX_PRBS) Master 14 Priority */
+#define MATRIX_PRBS_M14PR(value) ((MATRIX_PRBS_M14PR_Msk & ((value) << MATRIX_PRBS_M14PR_Pos)))
+#define MATRIX_PRBS_M15PR_Pos 28
+#define MATRIX_PRBS_M15PR_Msk (0x3u << MATRIX_PRBS_M15PR_Pos) /**< \brief (MATRIX_PRBS) Master 15 Priority */
+#define MATRIX_PRBS_M15PR(value) ((MATRIX_PRBS_M15PR_Msk & ((value) << MATRIX_PRBS_M15PR_Pos)))
+/* -------- MATRIX_MRCR : (MATRIX Offset: 0x0100) Master Remap Control Register -------- */
+#define MATRIX_MRCR_RCB0 (0x1u << 0) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB1 (0x1u << 1) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB2 (0x1u << 2) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB3 (0x1u << 3) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB4 (0x1u << 4) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB5 (0x1u << 5) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB6 (0x1u << 6) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB7 (0x1u << 7) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB8 (0x1u << 8) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB9 (0x1u << 9) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB10 (0x1u << 10) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB11 (0x1u << 11) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB12 (0x1u << 12) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB13 (0x1u << 13) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB14 (0x1u << 14) /**< \brief (MATRIX_MRCR)  */
+#define MATRIX_MRCR_RCB15 (0x1u << 15) /**< \brief (MATRIX_MRCR)  */
+/* -------- MATRIX_SFR[16] : (MATRIX Offset: 0x0110) Special Function Register -------- */
+#define MATRIX_SFR_SFR_Pos 0
+#define MATRIX_SFR_SFR_Msk (0xffffffffu << MATRIX_SFR_SFR_Pos) /**< \brief (MATRIX_SFR[16]) Special Function Register Fields */
+#define MATRIX_SFR_SFR(value) ((MATRIX_SFR_SFR_Msk & ((value) << MATRIX_SFR_SFR_Pos)))
+/* -------- MATRIX_WPMR : (MATRIX Offset: 0x01E4) Write Protect Mode Register -------- */
+#define MATRIX_WPMR_WPEN (0x1u << 0) /**< \brief (MATRIX_WPMR) Write Protect Enable */
+#define MATRIX_WPMR_WPKEY_Pos 8
+#define MATRIX_WPMR_WPKEY_Msk (0xffffffu << MATRIX_WPMR_WPKEY_Pos) /**< \brief (MATRIX_WPMR) Write Protect KEY (Write-only) */
+#define MATRIX_WPMR_WPKEY(value) ((MATRIX_WPMR_WPKEY_Msk & ((value) << MATRIX_WPMR_WPKEY_Pos)))
+/* -------- MATRIX_WPSR : (MATRIX Offset: 0x01E8) Write Protect Status Register -------- */
+#define MATRIX_WPSR_WPVS (0x1u << 0) /**< \brief (MATRIX_WPSR) Write Protect Violation Status */
+#define MATRIX_WPSR_WPVSRC_Pos 8
+#define MATRIX_WPSR_WPVSRC_Msk (0xffffu << MATRIX_WPSR_WPVSRC_Pos) /**< \brief (MATRIX_WPSR) Write Protect Violation Source */
+
+/*@}*/
+
+
+#endif /* _SAM4E_MATRIX_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/pdc.h
+++ b/asf/sam/include/sam4e/component/pdc.h
@@ -1,0 +1,98 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PDC_COMPONENT_
+#define _SAM4E_PDC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Peripheral DMA Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_PDC Peripheral DMA Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Pdc hardware registers */
+typedef struct {
+  RwReg PERIPH_RPR;  /**< \brief (Pdc Offset: 0x00) Receive Pointer Register */
+  RwReg PERIPH_RCR;  /**< \brief (Pdc Offset: 0x04) Receive Counter Register */
+  RwReg PERIPH_TPR;  /**< \brief (Pdc Offset: 0x08) Transmit Pointer Register */
+  RwReg PERIPH_TCR;  /**< \brief (Pdc Offset: 0x0C) Transmit Counter Register */
+  RwReg PERIPH_RNPR; /**< \brief (Pdc Offset: 0x10) Receive Next Pointer Register */
+  RwReg PERIPH_RNCR; /**< \brief (Pdc Offset: 0x14) Receive Next Counter Register */
+  RwReg PERIPH_TNPR; /**< \brief (Pdc Offset: 0x18) Transmit Next Pointer Register */
+  RwReg PERIPH_TNCR; /**< \brief (Pdc Offset: 0x1C) Transmit Next Counter Register */
+  WoReg PERIPH_PTCR; /**< \brief (Pdc Offset: 0x20) Transfer Control Register */
+  RoReg PERIPH_PTSR; /**< \brief (Pdc Offset: 0x24) Transfer Status Register */
+} Pdc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- PERIPH_RPR : (PDC Offset: 0x00) Receive Pointer Register -------- */
+#define PERIPH_RPR_RXPTR_Pos 0
+#define PERIPH_RPR_RXPTR_Msk (0xffffffffu << PERIPH_RPR_RXPTR_Pos) /**< \brief (PERIPH_RPR) Receive Pointer Register */
+#define PERIPH_RPR_RXPTR(value) ((PERIPH_RPR_RXPTR_Msk & ((value) << PERIPH_RPR_RXPTR_Pos)))
+/* -------- PERIPH_RCR : (PDC Offset: 0x04) Receive Counter Register -------- */
+#define PERIPH_RCR_RXCTR_Pos 0
+#define PERIPH_RCR_RXCTR_Msk (0xffffu << PERIPH_RCR_RXCTR_Pos) /**< \brief (PERIPH_RCR) Receive Counter Register */
+#define PERIPH_RCR_RXCTR(value) ((PERIPH_RCR_RXCTR_Msk & ((value) << PERIPH_RCR_RXCTR_Pos)))
+/* -------- PERIPH_TPR : (PDC Offset: 0x08) Transmit Pointer Register -------- */
+#define PERIPH_TPR_TXPTR_Pos 0
+#define PERIPH_TPR_TXPTR_Msk (0xffffffffu << PERIPH_TPR_TXPTR_Pos) /**< \brief (PERIPH_TPR) Transmit Counter Register */
+#define PERIPH_TPR_TXPTR(value) ((PERIPH_TPR_TXPTR_Msk & ((value) << PERIPH_TPR_TXPTR_Pos)))
+/* -------- PERIPH_TCR : (PDC Offset: 0x0C) Transmit Counter Register -------- */
+#define PERIPH_TCR_TXCTR_Pos 0
+#define PERIPH_TCR_TXCTR_Msk (0xffffu << PERIPH_TCR_TXCTR_Pos) /**< \brief (PERIPH_TCR) Transmit Counter Register */
+#define PERIPH_TCR_TXCTR(value) ((PERIPH_TCR_TXCTR_Msk & ((value) << PERIPH_TCR_TXCTR_Pos)))
+/* -------- PERIPH_RNPR : (PDC Offset: 0x10) Receive Next Pointer Register -------- */
+#define PERIPH_RNPR_RXNPTR_Pos 0
+#define PERIPH_RNPR_RXNPTR_Msk (0xffffffffu << PERIPH_RNPR_RXNPTR_Pos) /**< \brief (PERIPH_RNPR) Receive Next Pointer */
+#define PERIPH_RNPR_RXNPTR(value) ((PERIPH_RNPR_RXNPTR_Msk & ((value) << PERIPH_RNPR_RXNPTR_Pos)))
+/* -------- PERIPH_RNCR : (PDC Offset: 0x14) Receive Next Counter Register -------- */
+#define PERIPH_RNCR_RXNCTR_Pos 0
+#define PERIPH_RNCR_RXNCTR_Msk (0xffffu << PERIPH_RNCR_RXNCTR_Pos) /**< \brief (PERIPH_RNCR) Receive Next Counter */
+#define PERIPH_RNCR_RXNCTR(value) ((PERIPH_RNCR_RXNCTR_Msk & ((value) << PERIPH_RNCR_RXNCTR_Pos)))
+/* -------- PERIPH_TNPR : (PDC Offset: 0x18) Transmit Next Pointer Register -------- */
+#define PERIPH_TNPR_TXNPTR_Pos 0
+#define PERIPH_TNPR_TXNPTR_Msk (0xffffffffu << PERIPH_TNPR_TXNPTR_Pos) /**< \brief (PERIPH_TNPR) Transmit Next Pointer */
+#define PERIPH_TNPR_TXNPTR(value) ((PERIPH_TNPR_TXNPTR_Msk & ((value) << PERIPH_TNPR_TXNPTR_Pos)))
+/* -------- PERIPH_TNCR : (PDC Offset: 0x1C) Transmit Next Counter Register -------- */
+#define PERIPH_TNCR_TXNCTR_Pos 0
+#define PERIPH_TNCR_TXNCTR_Msk (0xffffu << PERIPH_TNCR_TXNCTR_Pos) /**< \brief (PERIPH_TNCR) Transmit Counter Next */
+#define PERIPH_TNCR_TXNCTR(value) ((PERIPH_TNCR_TXNCTR_Msk & ((value) << PERIPH_TNCR_TXNCTR_Pos)))
+/* -------- PERIPH_PTCR : (PDC Offset: 0x20) Transfer Control Register -------- */
+#define PERIPH_PTCR_RXTEN (0x1u << 0) /**< \brief (PERIPH_PTCR) Receiver Transfer Enable */
+#define PERIPH_PTCR_RXTDIS (0x1u << 1) /**< \brief (PERIPH_PTCR) Receiver Transfer Disable */
+#define PERIPH_PTCR_TXTEN (0x1u << 8) /**< \brief (PERIPH_PTCR) Transmitter Transfer Enable */
+#define PERIPH_PTCR_TXTDIS (0x1u << 9) /**< \brief (PERIPH_PTCR) Transmitter Transfer Disable */
+/* -------- PERIPH_PTSR : (PDC Offset: 0x24) Transfer Status Register -------- */
+#define PERIPH_PTSR_RXTEN (0x1u << 0) /**< \brief (PERIPH_PTSR) Receiver Transfer Enable */
+#define PERIPH_PTSR_TXTEN (0x1u << 8) /**< \brief (PERIPH_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_PDC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/pio.h
+++ b/asf/sam/include/sam4e/component/pio.h
@@ -1,0 +1,1671 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIO_COMPONENT_
+#define _SAM4E_PIO_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Parallel Input/Output Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_PIO Parallel Input/Output Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Pio hardware registers */
+typedef struct {
+  WoReg PIO_PER;        /**< \brief (Pio Offset: 0x0000) PIO Enable Register */
+  WoReg PIO_PDR;        /**< \brief (Pio Offset: 0x0004) PIO Disable Register */
+  RoReg PIO_PSR;        /**< \brief (Pio Offset: 0x0008) PIO Status Register */
+  RoReg Reserved1[1];
+  WoReg PIO_OER;        /**< \brief (Pio Offset: 0x0010) Output Enable Register */
+  WoReg PIO_ODR;        /**< \brief (Pio Offset: 0x0014) Output Disable Register */
+  RoReg PIO_OSR;        /**< \brief (Pio Offset: 0x0018) Output Status Register */
+  RoReg Reserved2[1];
+  WoReg PIO_IFER;       /**< \brief (Pio Offset: 0x0020) Glitch Input Filter Enable Register */
+  WoReg PIO_IFDR;       /**< \brief (Pio Offset: 0x0024) Glitch Input Filter Disable Register */
+  RoReg PIO_IFSR;       /**< \brief (Pio Offset: 0x0028) Glitch Input Filter Status Register */
+  RoReg Reserved3[1];
+  WoReg PIO_SODR;       /**< \brief (Pio Offset: 0x0030) Set Output Data Register */
+  WoReg PIO_CODR;       /**< \brief (Pio Offset: 0x0034) Clear Output Data Register */
+  RwReg PIO_ODSR;       /**< \brief (Pio Offset: 0x0038) Output Data Status Register */
+  RoReg PIO_PDSR;       /**< \brief (Pio Offset: 0x003C) Pin Data Status Register */
+  WoReg PIO_IER;        /**< \brief (Pio Offset: 0x0040) Interrupt Enable Register */
+  WoReg PIO_IDR;        /**< \brief (Pio Offset: 0x0044) Interrupt Disable Register */
+  RoReg PIO_IMR;        /**< \brief (Pio Offset: 0x0048) Interrupt Mask Register */
+  RoReg PIO_ISR;        /**< \brief (Pio Offset: 0x004C) Interrupt Status Register */
+  WoReg PIO_MDER;       /**< \brief (Pio Offset: 0x0050) Multi-driver Enable Register */
+  WoReg PIO_MDDR;       /**< \brief (Pio Offset: 0x0054) Multi-driver Disable Register */
+  RoReg PIO_MDSR;       /**< \brief (Pio Offset: 0x0058) Multi-driver Status Register */
+  RoReg Reserved4[1];
+  WoReg PIO_PUDR;       /**< \brief (Pio Offset: 0x0060) Pull-up Disable Register */
+  WoReg PIO_PUER;       /**< \brief (Pio Offset: 0x0064) Pull-up Enable Register */
+  RoReg PIO_PUSR;       /**< \brief (Pio Offset: 0x0068) Pad Pull-up Status Register */
+  RoReg Reserved5[1];
+  RwReg PIO_ABCDSR[2];  /**< \brief (Pio Offset: 0x0070) Peripheral Select Register */
+  RoReg Reserved6[2];
+  WoReg PIO_IFSCDR;     /**< \brief (Pio Offset: 0x0080) Input Filter Slow Clock Disable Register */
+  WoReg PIO_IFSCER;     /**< \brief (Pio Offset: 0x0084) Input Filter Slow Clock Enable Register */
+  RoReg PIO_IFSCSR;     /**< \brief (Pio Offset: 0x0088) Input Filter Slow Clock Status Register */
+  RwReg PIO_SCDR;       /**< \brief (Pio Offset: 0x008C) Slow Clock Divider Debouncing Register */
+  WoReg PIO_PPDDR;      /**< \brief (Pio Offset: 0x0090) Pad Pull-down Disable Register */
+  WoReg PIO_PPDER;      /**< \brief (Pio Offset: 0x0094) Pad Pull-down Enable Register */
+  RoReg PIO_PPDSR;      /**< \brief (Pio Offset: 0x0098) Pad Pull-down Status Register */
+  RoReg Reserved7[1];
+  WoReg PIO_OWER;       /**< \brief (Pio Offset: 0x00A0) Output Write Enable */
+  WoReg PIO_OWDR;       /**< \brief (Pio Offset: 0x00A4) Output Write Disable */
+  RoReg PIO_OWSR;       /**< \brief (Pio Offset: 0x00A8) Output Write Status Register */
+  RoReg Reserved8[1];
+  WoReg PIO_AIMER;      /**< \brief (Pio Offset: 0x00B0) Additional Interrupt Modes Enable Register */
+  WoReg PIO_AIMDR;      /**< \brief (Pio Offset: 0x00B4) Additional Interrupt Modes Disables Register */
+  RoReg PIO_AIMMR;      /**< \brief (Pio Offset: 0x00B8) Additional Interrupt Modes Mask Register */
+  RoReg Reserved9[1];
+  WoReg PIO_ESR;        /**< \brief (Pio Offset: 0x00C0) Edge Select Register */
+  WoReg PIO_LSR;        /**< \brief (Pio Offset: 0x00C4) Level Select Register */
+  RoReg PIO_ELSR;       /**< \brief (Pio Offset: 0x00C8) Edge/Level Status Register */
+  RoReg Reserved10[1];
+  WoReg PIO_FELLSR;     /**< \brief (Pio Offset: 0x00D0) Falling Edge/Low Level Select Register */
+  WoReg PIO_REHLSR;     /**< \brief (Pio Offset: 0x00D4) Rising Edge/ High Level Select Register */
+  RoReg PIO_FRLHSR;     /**< \brief (Pio Offset: 0x00D8) Fall/Rise - Low/High Status Register */
+  RoReg Reserved11[1];
+  RoReg PIO_LOCKSR;     /**< \brief (Pio Offset: 0x00E0) Lock Status */
+  RwReg PIO_WPMR;       /**< \brief (Pio Offset: 0x00E4) Write Protect Mode Register */
+  RoReg PIO_WPSR;       /**< \brief (Pio Offset: 0x00E8) Write Protect Status Register */
+  RoReg Reserved12[5];
+  RwReg PIO_SCHMITT;    /**< \brief (Pio Offset: 0x0100) Schmitt Trigger Register */
+  RoReg Reserved13[3];
+  RwReg PIO_DELAYR;     /**< \brief (Pio Offset: 0x0110) IO Delay Register */
+  RoReg Reserved14[15];
+  RwReg PIO_PCMR;       /**< \brief (Pio Offset: 0x150) Parallel Capture Mode Register */
+  WoReg PIO_PCIER;      /**< \brief (Pio Offset: 0x154) Parallel Capture Interrupt Enable Register */
+  WoReg PIO_PCIDR;      /**< \brief (Pio Offset: 0x158) Parallel Capture Interrupt Disable Register */
+  RoReg PIO_PCIMR;      /**< \brief (Pio Offset: 0x15C) Parallel Capture Interrupt Mask Register */
+  RoReg PIO_PCISR;      /**< \brief (Pio Offset: 0x160) Parallel Capture Interrupt Status Register */
+  RoReg PIO_PCRHR;      /**< \brief (Pio Offset: 0x164) Parallel Capture Reception Holding Register */
+  RwReg PIO_RPR;        /**< \brief (Pio Offset: 0x168) Receive Pointer Register */
+  RwReg PIO_RCR;        /**< \brief (Pio Offset: 0x16C) Receive Counter Register */
+  RoReg Reserved15[2];
+  RwReg PIO_RNPR;       /**< \brief (Pio Offset: 0x178) Receive Next Pointer Register */
+  RwReg PIO_RNCR;       /**< \brief (Pio Offset: 0x17C) Receive Next Counter Register */
+  RoReg Reserved16[2];
+  WoReg PIO_PTCR;       /**< \brief (Pio Offset: 0x188) Transfer Control Register */
+  RoReg PIO_PTSR;       /**< \brief (Pio Offset: 0x18C) Transfer Status Register */
+} Pio;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- PIO_PER : (PIO Offset: 0x0000) PIO Enable Register -------- */
+#define PIO_PER_P0 (0x1u << 0) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P1 (0x1u << 1) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P2 (0x1u << 2) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P3 (0x1u << 3) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P4 (0x1u << 4) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P5 (0x1u << 5) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P6 (0x1u << 6) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P7 (0x1u << 7) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P8 (0x1u << 8) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P9 (0x1u << 9) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P10 (0x1u << 10) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P11 (0x1u << 11) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P12 (0x1u << 12) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P13 (0x1u << 13) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P14 (0x1u << 14) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P15 (0x1u << 15) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P16 (0x1u << 16) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P17 (0x1u << 17) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P18 (0x1u << 18) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P19 (0x1u << 19) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P20 (0x1u << 20) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P21 (0x1u << 21) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P22 (0x1u << 22) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P23 (0x1u << 23) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P24 (0x1u << 24) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P25 (0x1u << 25) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P26 (0x1u << 26) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P27 (0x1u << 27) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P28 (0x1u << 28) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P29 (0x1u << 29) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P30 (0x1u << 30) /**< \brief (PIO_PER) PIO Enable */
+#define PIO_PER_P31 (0x1u << 31) /**< \brief (PIO_PER) PIO Enable */
+/* -------- PIO_PDR : (PIO Offset: 0x0004) PIO Disable Register -------- */
+#define PIO_PDR_P0 (0x1u << 0) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P1 (0x1u << 1) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P2 (0x1u << 2) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P3 (0x1u << 3) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P4 (0x1u << 4) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P5 (0x1u << 5) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P6 (0x1u << 6) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P7 (0x1u << 7) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P8 (0x1u << 8) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P9 (0x1u << 9) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P10 (0x1u << 10) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P11 (0x1u << 11) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P12 (0x1u << 12) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P13 (0x1u << 13) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P14 (0x1u << 14) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P15 (0x1u << 15) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P16 (0x1u << 16) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P17 (0x1u << 17) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P18 (0x1u << 18) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P19 (0x1u << 19) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P20 (0x1u << 20) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P21 (0x1u << 21) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P22 (0x1u << 22) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P23 (0x1u << 23) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P24 (0x1u << 24) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P25 (0x1u << 25) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P26 (0x1u << 26) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P27 (0x1u << 27) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P28 (0x1u << 28) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P29 (0x1u << 29) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P30 (0x1u << 30) /**< \brief (PIO_PDR) PIO Disable */
+#define PIO_PDR_P31 (0x1u << 31) /**< \brief (PIO_PDR) PIO Disable */
+/* -------- PIO_PSR : (PIO Offset: 0x0008) PIO Status Register -------- */
+#define PIO_PSR_P0 (0x1u << 0) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P1 (0x1u << 1) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P2 (0x1u << 2) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P3 (0x1u << 3) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P4 (0x1u << 4) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P5 (0x1u << 5) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P6 (0x1u << 6) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P7 (0x1u << 7) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P8 (0x1u << 8) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P9 (0x1u << 9) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P10 (0x1u << 10) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P11 (0x1u << 11) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P12 (0x1u << 12) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P13 (0x1u << 13) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P14 (0x1u << 14) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P15 (0x1u << 15) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P16 (0x1u << 16) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P17 (0x1u << 17) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P18 (0x1u << 18) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P19 (0x1u << 19) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P20 (0x1u << 20) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P21 (0x1u << 21) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P22 (0x1u << 22) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P23 (0x1u << 23) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P24 (0x1u << 24) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P25 (0x1u << 25) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P26 (0x1u << 26) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P27 (0x1u << 27) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P28 (0x1u << 28) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P29 (0x1u << 29) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P30 (0x1u << 30) /**< \brief (PIO_PSR) PIO Status */
+#define PIO_PSR_P31 (0x1u << 31) /**< \brief (PIO_PSR) PIO Status */
+/* -------- PIO_OER : (PIO Offset: 0x0010) Output Enable Register -------- */
+#define PIO_OER_P0 (0x1u << 0) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P1 (0x1u << 1) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P2 (0x1u << 2) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P3 (0x1u << 3) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P4 (0x1u << 4) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P5 (0x1u << 5) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P6 (0x1u << 6) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P7 (0x1u << 7) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P8 (0x1u << 8) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P9 (0x1u << 9) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P10 (0x1u << 10) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P11 (0x1u << 11) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P12 (0x1u << 12) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P13 (0x1u << 13) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P14 (0x1u << 14) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P15 (0x1u << 15) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P16 (0x1u << 16) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P17 (0x1u << 17) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P18 (0x1u << 18) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P19 (0x1u << 19) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P20 (0x1u << 20) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P21 (0x1u << 21) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P22 (0x1u << 22) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P23 (0x1u << 23) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P24 (0x1u << 24) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P25 (0x1u << 25) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P26 (0x1u << 26) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P27 (0x1u << 27) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P28 (0x1u << 28) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P29 (0x1u << 29) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P30 (0x1u << 30) /**< \brief (PIO_OER) Output Enable */
+#define PIO_OER_P31 (0x1u << 31) /**< \brief (PIO_OER) Output Enable */
+/* -------- PIO_ODR : (PIO Offset: 0x0014) Output Disable Register -------- */
+#define PIO_ODR_P0 (0x1u << 0) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P1 (0x1u << 1) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P2 (0x1u << 2) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P3 (0x1u << 3) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P4 (0x1u << 4) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P5 (0x1u << 5) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P6 (0x1u << 6) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P7 (0x1u << 7) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P8 (0x1u << 8) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P9 (0x1u << 9) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P10 (0x1u << 10) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P11 (0x1u << 11) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P12 (0x1u << 12) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P13 (0x1u << 13) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P14 (0x1u << 14) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P15 (0x1u << 15) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P16 (0x1u << 16) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P17 (0x1u << 17) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P18 (0x1u << 18) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P19 (0x1u << 19) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P20 (0x1u << 20) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P21 (0x1u << 21) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P22 (0x1u << 22) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P23 (0x1u << 23) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P24 (0x1u << 24) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P25 (0x1u << 25) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P26 (0x1u << 26) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P27 (0x1u << 27) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P28 (0x1u << 28) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P29 (0x1u << 29) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P30 (0x1u << 30) /**< \brief (PIO_ODR) Output Disable */
+#define PIO_ODR_P31 (0x1u << 31) /**< \brief (PIO_ODR) Output Disable */
+/* -------- PIO_OSR : (PIO Offset: 0x0018) Output Status Register -------- */
+#define PIO_OSR_P0 (0x1u << 0) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P1 (0x1u << 1) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P2 (0x1u << 2) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P3 (0x1u << 3) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P4 (0x1u << 4) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P5 (0x1u << 5) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P6 (0x1u << 6) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P7 (0x1u << 7) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P8 (0x1u << 8) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P9 (0x1u << 9) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P10 (0x1u << 10) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P11 (0x1u << 11) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P12 (0x1u << 12) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P13 (0x1u << 13) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P14 (0x1u << 14) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P15 (0x1u << 15) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P16 (0x1u << 16) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P17 (0x1u << 17) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P18 (0x1u << 18) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P19 (0x1u << 19) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P20 (0x1u << 20) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P21 (0x1u << 21) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P22 (0x1u << 22) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P23 (0x1u << 23) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P24 (0x1u << 24) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P25 (0x1u << 25) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P26 (0x1u << 26) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P27 (0x1u << 27) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P28 (0x1u << 28) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P29 (0x1u << 29) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P30 (0x1u << 30) /**< \brief (PIO_OSR) Output Status */
+#define PIO_OSR_P31 (0x1u << 31) /**< \brief (PIO_OSR) Output Status */
+/* -------- PIO_IFER : (PIO Offset: 0x0020) Glitch Input Filter Enable Register -------- */
+#define PIO_IFER_P0 (0x1u << 0) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P1 (0x1u << 1) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P2 (0x1u << 2) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P3 (0x1u << 3) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P4 (0x1u << 4) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P5 (0x1u << 5) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P6 (0x1u << 6) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P7 (0x1u << 7) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P8 (0x1u << 8) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P9 (0x1u << 9) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P10 (0x1u << 10) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P11 (0x1u << 11) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P12 (0x1u << 12) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P13 (0x1u << 13) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P14 (0x1u << 14) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P15 (0x1u << 15) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P16 (0x1u << 16) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P17 (0x1u << 17) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P18 (0x1u << 18) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P19 (0x1u << 19) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P20 (0x1u << 20) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P21 (0x1u << 21) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P22 (0x1u << 22) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P23 (0x1u << 23) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P24 (0x1u << 24) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P25 (0x1u << 25) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P26 (0x1u << 26) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P27 (0x1u << 27) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P28 (0x1u << 28) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P29 (0x1u << 29) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P30 (0x1u << 30) /**< \brief (PIO_IFER) Input Filter Enable */
+#define PIO_IFER_P31 (0x1u << 31) /**< \brief (PIO_IFER) Input Filter Enable */
+/* -------- PIO_IFDR : (PIO Offset: 0x0024) Glitch Input Filter Disable Register -------- */
+#define PIO_IFDR_P0 (0x1u << 0) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P1 (0x1u << 1) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P2 (0x1u << 2) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P3 (0x1u << 3) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P4 (0x1u << 4) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P5 (0x1u << 5) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P6 (0x1u << 6) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P7 (0x1u << 7) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P8 (0x1u << 8) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P9 (0x1u << 9) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P10 (0x1u << 10) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P11 (0x1u << 11) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P12 (0x1u << 12) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P13 (0x1u << 13) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P14 (0x1u << 14) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P15 (0x1u << 15) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P16 (0x1u << 16) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P17 (0x1u << 17) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P18 (0x1u << 18) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P19 (0x1u << 19) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P20 (0x1u << 20) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P21 (0x1u << 21) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P22 (0x1u << 22) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P23 (0x1u << 23) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P24 (0x1u << 24) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P25 (0x1u << 25) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P26 (0x1u << 26) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P27 (0x1u << 27) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P28 (0x1u << 28) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P29 (0x1u << 29) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P30 (0x1u << 30) /**< \brief (PIO_IFDR) Input Filter Disable */
+#define PIO_IFDR_P31 (0x1u << 31) /**< \brief (PIO_IFDR) Input Filter Disable */
+/* -------- PIO_IFSR : (PIO Offset: 0x0028) Glitch Input Filter Status Register -------- */
+#define PIO_IFSR_P0 (0x1u << 0) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P1 (0x1u << 1) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P2 (0x1u << 2) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P3 (0x1u << 3) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P4 (0x1u << 4) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P5 (0x1u << 5) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P6 (0x1u << 6) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P7 (0x1u << 7) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P8 (0x1u << 8) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P9 (0x1u << 9) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P10 (0x1u << 10) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P11 (0x1u << 11) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P12 (0x1u << 12) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P13 (0x1u << 13) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P14 (0x1u << 14) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P15 (0x1u << 15) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P16 (0x1u << 16) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P17 (0x1u << 17) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P18 (0x1u << 18) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P19 (0x1u << 19) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P20 (0x1u << 20) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P21 (0x1u << 21) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P22 (0x1u << 22) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P23 (0x1u << 23) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P24 (0x1u << 24) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P25 (0x1u << 25) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P26 (0x1u << 26) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P27 (0x1u << 27) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P28 (0x1u << 28) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P29 (0x1u << 29) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P30 (0x1u << 30) /**< \brief (PIO_IFSR) Input Filer Status */
+#define PIO_IFSR_P31 (0x1u << 31) /**< \brief (PIO_IFSR) Input Filer Status */
+/* -------- PIO_SODR : (PIO Offset: 0x0030) Set Output Data Register -------- */
+#define PIO_SODR_P0 (0x1u << 0) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P1 (0x1u << 1) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P2 (0x1u << 2) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P3 (0x1u << 3) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P4 (0x1u << 4) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P5 (0x1u << 5) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P6 (0x1u << 6) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P7 (0x1u << 7) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P8 (0x1u << 8) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P9 (0x1u << 9) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P10 (0x1u << 10) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P11 (0x1u << 11) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P12 (0x1u << 12) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P13 (0x1u << 13) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P14 (0x1u << 14) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P15 (0x1u << 15) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P16 (0x1u << 16) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P17 (0x1u << 17) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P18 (0x1u << 18) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P19 (0x1u << 19) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P20 (0x1u << 20) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P21 (0x1u << 21) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P22 (0x1u << 22) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P23 (0x1u << 23) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P24 (0x1u << 24) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P25 (0x1u << 25) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P26 (0x1u << 26) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P27 (0x1u << 27) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P28 (0x1u << 28) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P29 (0x1u << 29) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P30 (0x1u << 30) /**< \brief (PIO_SODR) Set Output Data */
+#define PIO_SODR_P31 (0x1u << 31) /**< \brief (PIO_SODR) Set Output Data */
+/* -------- PIO_CODR : (PIO Offset: 0x0034) Clear Output Data Register -------- */
+#define PIO_CODR_P0 (0x1u << 0) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P1 (0x1u << 1) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P2 (0x1u << 2) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P3 (0x1u << 3) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P4 (0x1u << 4) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P5 (0x1u << 5) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P6 (0x1u << 6) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P7 (0x1u << 7) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P8 (0x1u << 8) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P9 (0x1u << 9) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P10 (0x1u << 10) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P11 (0x1u << 11) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P12 (0x1u << 12) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P13 (0x1u << 13) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P14 (0x1u << 14) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P15 (0x1u << 15) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P16 (0x1u << 16) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P17 (0x1u << 17) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P18 (0x1u << 18) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P19 (0x1u << 19) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P20 (0x1u << 20) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P21 (0x1u << 21) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P22 (0x1u << 22) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P23 (0x1u << 23) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P24 (0x1u << 24) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P25 (0x1u << 25) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P26 (0x1u << 26) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P27 (0x1u << 27) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P28 (0x1u << 28) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P29 (0x1u << 29) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P30 (0x1u << 30) /**< \brief (PIO_CODR) Clear Output Data */
+#define PIO_CODR_P31 (0x1u << 31) /**< \brief (PIO_CODR) Clear Output Data */
+/* -------- PIO_ODSR : (PIO Offset: 0x0038) Output Data Status Register -------- */
+#define PIO_ODSR_P0 (0x1u << 0) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P1 (0x1u << 1) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P2 (0x1u << 2) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P3 (0x1u << 3) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P4 (0x1u << 4) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P5 (0x1u << 5) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P6 (0x1u << 6) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P7 (0x1u << 7) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P8 (0x1u << 8) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P9 (0x1u << 9) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P10 (0x1u << 10) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P11 (0x1u << 11) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P12 (0x1u << 12) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P13 (0x1u << 13) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P14 (0x1u << 14) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P15 (0x1u << 15) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P16 (0x1u << 16) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P17 (0x1u << 17) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P18 (0x1u << 18) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P19 (0x1u << 19) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P20 (0x1u << 20) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P21 (0x1u << 21) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P22 (0x1u << 22) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P23 (0x1u << 23) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P24 (0x1u << 24) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P25 (0x1u << 25) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P26 (0x1u << 26) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P27 (0x1u << 27) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P28 (0x1u << 28) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P29 (0x1u << 29) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P30 (0x1u << 30) /**< \brief (PIO_ODSR) Output Data Status */
+#define PIO_ODSR_P31 (0x1u << 31) /**< \brief (PIO_ODSR) Output Data Status */
+/* -------- PIO_PDSR : (PIO Offset: 0x003C) Pin Data Status Register -------- */
+#define PIO_PDSR_P0 (0x1u << 0) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P1 (0x1u << 1) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P2 (0x1u << 2) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P3 (0x1u << 3) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P4 (0x1u << 4) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P5 (0x1u << 5) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P6 (0x1u << 6) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P7 (0x1u << 7) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P8 (0x1u << 8) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P9 (0x1u << 9) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P10 (0x1u << 10) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P11 (0x1u << 11) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P12 (0x1u << 12) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P13 (0x1u << 13) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P14 (0x1u << 14) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P15 (0x1u << 15) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P16 (0x1u << 16) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P17 (0x1u << 17) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P18 (0x1u << 18) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P19 (0x1u << 19) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P20 (0x1u << 20) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P21 (0x1u << 21) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P22 (0x1u << 22) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P23 (0x1u << 23) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P24 (0x1u << 24) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P25 (0x1u << 25) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P26 (0x1u << 26) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P27 (0x1u << 27) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P28 (0x1u << 28) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P29 (0x1u << 29) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P30 (0x1u << 30) /**< \brief (PIO_PDSR) Output Data Status */
+#define PIO_PDSR_P31 (0x1u << 31) /**< \brief (PIO_PDSR) Output Data Status */
+/* -------- PIO_IER : (PIO Offset: 0x0040) Interrupt Enable Register -------- */
+#define PIO_IER_P0 (0x1u << 0) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P1 (0x1u << 1) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P2 (0x1u << 2) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P3 (0x1u << 3) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P4 (0x1u << 4) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P5 (0x1u << 5) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P6 (0x1u << 6) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P7 (0x1u << 7) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P8 (0x1u << 8) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P9 (0x1u << 9) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P10 (0x1u << 10) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P11 (0x1u << 11) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P12 (0x1u << 12) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P13 (0x1u << 13) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P14 (0x1u << 14) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P15 (0x1u << 15) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P16 (0x1u << 16) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P17 (0x1u << 17) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P18 (0x1u << 18) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P19 (0x1u << 19) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P20 (0x1u << 20) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P21 (0x1u << 21) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P22 (0x1u << 22) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P23 (0x1u << 23) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P24 (0x1u << 24) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P25 (0x1u << 25) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P26 (0x1u << 26) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P27 (0x1u << 27) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P28 (0x1u << 28) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P29 (0x1u << 29) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P30 (0x1u << 30) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+#define PIO_IER_P31 (0x1u << 31) /**< \brief (PIO_IER) Input Change Interrupt Enable */
+/* -------- PIO_IDR : (PIO Offset: 0x0044) Interrupt Disable Register -------- */
+#define PIO_IDR_P0 (0x1u << 0) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P1 (0x1u << 1) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P2 (0x1u << 2) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P3 (0x1u << 3) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P4 (0x1u << 4) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P5 (0x1u << 5) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P6 (0x1u << 6) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P7 (0x1u << 7) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P8 (0x1u << 8) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P9 (0x1u << 9) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P10 (0x1u << 10) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P11 (0x1u << 11) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P12 (0x1u << 12) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P13 (0x1u << 13) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P14 (0x1u << 14) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P15 (0x1u << 15) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P16 (0x1u << 16) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P17 (0x1u << 17) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P18 (0x1u << 18) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P19 (0x1u << 19) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P20 (0x1u << 20) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P21 (0x1u << 21) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P22 (0x1u << 22) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P23 (0x1u << 23) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P24 (0x1u << 24) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P25 (0x1u << 25) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P26 (0x1u << 26) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P27 (0x1u << 27) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P28 (0x1u << 28) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P29 (0x1u << 29) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P30 (0x1u << 30) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+#define PIO_IDR_P31 (0x1u << 31) /**< \brief (PIO_IDR) Input Change Interrupt Disable */
+/* -------- PIO_IMR : (PIO Offset: 0x0048) Interrupt Mask Register -------- */
+#define PIO_IMR_P0 (0x1u << 0) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P1 (0x1u << 1) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P2 (0x1u << 2) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P3 (0x1u << 3) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P4 (0x1u << 4) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P5 (0x1u << 5) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P6 (0x1u << 6) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P7 (0x1u << 7) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P8 (0x1u << 8) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P9 (0x1u << 9) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P10 (0x1u << 10) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P11 (0x1u << 11) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P12 (0x1u << 12) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P13 (0x1u << 13) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P14 (0x1u << 14) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P15 (0x1u << 15) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P16 (0x1u << 16) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P17 (0x1u << 17) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P18 (0x1u << 18) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P19 (0x1u << 19) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P20 (0x1u << 20) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P21 (0x1u << 21) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P22 (0x1u << 22) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P23 (0x1u << 23) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P24 (0x1u << 24) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P25 (0x1u << 25) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P26 (0x1u << 26) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P27 (0x1u << 27) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P28 (0x1u << 28) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P29 (0x1u << 29) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P30 (0x1u << 30) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+#define PIO_IMR_P31 (0x1u << 31) /**< \brief (PIO_IMR) Input Change Interrupt Mask */
+/* -------- PIO_ISR : (PIO Offset: 0x004C) Interrupt Status Register -------- */
+#define PIO_ISR_P0 (0x1u << 0) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P1 (0x1u << 1) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P2 (0x1u << 2) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P3 (0x1u << 3) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P4 (0x1u << 4) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P5 (0x1u << 5) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P6 (0x1u << 6) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P7 (0x1u << 7) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P8 (0x1u << 8) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P9 (0x1u << 9) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P10 (0x1u << 10) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P11 (0x1u << 11) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P12 (0x1u << 12) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P13 (0x1u << 13) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P14 (0x1u << 14) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P15 (0x1u << 15) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P16 (0x1u << 16) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P17 (0x1u << 17) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P18 (0x1u << 18) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P19 (0x1u << 19) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P20 (0x1u << 20) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P21 (0x1u << 21) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P22 (0x1u << 22) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P23 (0x1u << 23) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P24 (0x1u << 24) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P25 (0x1u << 25) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P26 (0x1u << 26) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P27 (0x1u << 27) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P28 (0x1u << 28) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P29 (0x1u << 29) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P30 (0x1u << 30) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+#define PIO_ISR_P31 (0x1u << 31) /**< \brief (PIO_ISR) Input Change Interrupt Status */
+/* -------- PIO_MDER : (PIO Offset: 0x0050) Multi-driver Enable Register -------- */
+#define PIO_MDER_P0 (0x1u << 0) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P1 (0x1u << 1) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P2 (0x1u << 2) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P3 (0x1u << 3) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P4 (0x1u << 4) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P5 (0x1u << 5) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P6 (0x1u << 6) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P7 (0x1u << 7) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P8 (0x1u << 8) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P9 (0x1u << 9) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P10 (0x1u << 10) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P11 (0x1u << 11) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P12 (0x1u << 12) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P13 (0x1u << 13) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P14 (0x1u << 14) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P15 (0x1u << 15) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P16 (0x1u << 16) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P17 (0x1u << 17) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P18 (0x1u << 18) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P19 (0x1u << 19) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P20 (0x1u << 20) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P21 (0x1u << 21) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P22 (0x1u << 22) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P23 (0x1u << 23) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P24 (0x1u << 24) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P25 (0x1u << 25) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P26 (0x1u << 26) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P27 (0x1u << 27) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P28 (0x1u << 28) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P29 (0x1u << 29) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P30 (0x1u << 30) /**< \brief (PIO_MDER) Multi Drive Enable. */
+#define PIO_MDER_P31 (0x1u << 31) /**< \brief (PIO_MDER) Multi Drive Enable. */
+/* -------- PIO_MDDR : (PIO Offset: 0x0054) Multi-driver Disable Register -------- */
+#define PIO_MDDR_P0 (0x1u << 0) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P1 (0x1u << 1) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P2 (0x1u << 2) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P3 (0x1u << 3) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P4 (0x1u << 4) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P5 (0x1u << 5) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P6 (0x1u << 6) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P7 (0x1u << 7) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P8 (0x1u << 8) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P9 (0x1u << 9) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P10 (0x1u << 10) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P11 (0x1u << 11) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P12 (0x1u << 12) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P13 (0x1u << 13) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P14 (0x1u << 14) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P15 (0x1u << 15) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P16 (0x1u << 16) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P17 (0x1u << 17) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P18 (0x1u << 18) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P19 (0x1u << 19) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P20 (0x1u << 20) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P21 (0x1u << 21) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P22 (0x1u << 22) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P23 (0x1u << 23) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P24 (0x1u << 24) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P25 (0x1u << 25) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P26 (0x1u << 26) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P27 (0x1u << 27) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P28 (0x1u << 28) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P29 (0x1u << 29) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P30 (0x1u << 30) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+#define PIO_MDDR_P31 (0x1u << 31) /**< \brief (PIO_MDDR) Multi Drive Disable. */
+/* -------- PIO_MDSR : (PIO Offset: 0x0058) Multi-driver Status Register -------- */
+#define PIO_MDSR_P0 (0x1u << 0) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P1 (0x1u << 1) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P2 (0x1u << 2) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P3 (0x1u << 3) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P4 (0x1u << 4) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P5 (0x1u << 5) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P6 (0x1u << 6) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P7 (0x1u << 7) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P8 (0x1u << 8) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P9 (0x1u << 9) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P10 (0x1u << 10) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P11 (0x1u << 11) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P12 (0x1u << 12) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P13 (0x1u << 13) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P14 (0x1u << 14) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P15 (0x1u << 15) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P16 (0x1u << 16) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P17 (0x1u << 17) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P18 (0x1u << 18) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P19 (0x1u << 19) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P20 (0x1u << 20) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P21 (0x1u << 21) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P22 (0x1u << 22) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P23 (0x1u << 23) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P24 (0x1u << 24) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P25 (0x1u << 25) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P26 (0x1u << 26) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P27 (0x1u << 27) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P28 (0x1u << 28) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P29 (0x1u << 29) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P30 (0x1u << 30) /**< \brief (PIO_MDSR) Multi Drive Status. */
+#define PIO_MDSR_P31 (0x1u << 31) /**< \brief (PIO_MDSR) Multi Drive Status. */
+/* -------- PIO_PUDR : (PIO Offset: 0x0060) Pull-up Disable Register -------- */
+#define PIO_PUDR_P0 (0x1u << 0) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P1 (0x1u << 1) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P2 (0x1u << 2) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P3 (0x1u << 3) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P4 (0x1u << 4) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P5 (0x1u << 5) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P6 (0x1u << 6) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P7 (0x1u << 7) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P8 (0x1u << 8) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P9 (0x1u << 9) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P10 (0x1u << 10) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P11 (0x1u << 11) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P12 (0x1u << 12) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P13 (0x1u << 13) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P14 (0x1u << 14) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P15 (0x1u << 15) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P16 (0x1u << 16) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P17 (0x1u << 17) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P18 (0x1u << 18) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P19 (0x1u << 19) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P20 (0x1u << 20) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P21 (0x1u << 21) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P22 (0x1u << 22) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P23 (0x1u << 23) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P24 (0x1u << 24) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P25 (0x1u << 25) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P26 (0x1u << 26) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P27 (0x1u << 27) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P28 (0x1u << 28) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P29 (0x1u << 29) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P30 (0x1u << 30) /**< \brief (PIO_PUDR) Pull Up Disable. */
+#define PIO_PUDR_P31 (0x1u << 31) /**< \brief (PIO_PUDR) Pull Up Disable. */
+/* -------- PIO_PUER : (PIO Offset: 0x0064) Pull-up Enable Register -------- */
+#define PIO_PUER_P0 (0x1u << 0) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P1 (0x1u << 1) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P2 (0x1u << 2) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P3 (0x1u << 3) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P4 (0x1u << 4) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P5 (0x1u << 5) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P6 (0x1u << 6) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P7 (0x1u << 7) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P8 (0x1u << 8) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P9 (0x1u << 9) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P10 (0x1u << 10) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P11 (0x1u << 11) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P12 (0x1u << 12) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P13 (0x1u << 13) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P14 (0x1u << 14) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P15 (0x1u << 15) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P16 (0x1u << 16) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P17 (0x1u << 17) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P18 (0x1u << 18) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P19 (0x1u << 19) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P20 (0x1u << 20) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P21 (0x1u << 21) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P22 (0x1u << 22) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P23 (0x1u << 23) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P24 (0x1u << 24) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P25 (0x1u << 25) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P26 (0x1u << 26) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P27 (0x1u << 27) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P28 (0x1u << 28) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P29 (0x1u << 29) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P30 (0x1u << 30) /**< \brief (PIO_PUER) Pull Up Enable. */
+#define PIO_PUER_P31 (0x1u << 31) /**< \brief (PIO_PUER) Pull Up Enable. */
+/* -------- PIO_PUSR : (PIO Offset: 0x0068) Pad Pull-up Status Register -------- */
+#define PIO_PUSR_P0 (0x1u << 0) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P1 (0x1u << 1) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P2 (0x1u << 2) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P3 (0x1u << 3) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P4 (0x1u << 4) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P5 (0x1u << 5) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P6 (0x1u << 6) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P7 (0x1u << 7) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P8 (0x1u << 8) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P9 (0x1u << 9) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P10 (0x1u << 10) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P11 (0x1u << 11) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P12 (0x1u << 12) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P13 (0x1u << 13) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P14 (0x1u << 14) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P15 (0x1u << 15) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P16 (0x1u << 16) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P17 (0x1u << 17) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P18 (0x1u << 18) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P19 (0x1u << 19) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P20 (0x1u << 20) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P21 (0x1u << 21) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P22 (0x1u << 22) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P23 (0x1u << 23) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P24 (0x1u << 24) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P25 (0x1u << 25) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P26 (0x1u << 26) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P27 (0x1u << 27) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P28 (0x1u << 28) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P29 (0x1u << 29) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P30 (0x1u << 30) /**< \brief (PIO_PUSR) Pull Up Status. */
+#define PIO_PUSR_P31 (0x1u << 31) /**< \brief (PIO_PUSR) Pull Up Status. */
+/* -------- PIO_ABCDSR[2] : (PIO Offset: 0x0070) Peripheral Select Register -------- */
+#define PIO_ABCDSR_P0 (0x1u << 0) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P1 (0x1u << 1) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P2 (0x1u << 2) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P3 (0x1u << 3) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P4 (0x1u << 4) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P5 (0x1u << 5) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P6 (0x1u << 6) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P7 (0x1u << 7) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P8 (0x1u << 8) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P9 (0x1u << 9) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P10 (0x1u << 10) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P11 (0x1u << 11) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P12 (0x1u << 12) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P13 (0x1u << 13) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P14 (0x1u << 14) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P15 (0x1u << 15) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P16 (0x1u << 16) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P17 (0x1u << 17) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P18 (0x1u << 18) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P19 (0x1u << 19) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P20 (0x1u << 20) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P21 (0x1u << 21) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P22 (0x1u << 22) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P23 (0x1u << 23) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P24 (0x1u << 24) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P25 (0x1u << 25) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P26 (0x1u << 26) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P27 (0x1u << 27) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P28 (0x1u << 28) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P29 (0x1u << 29) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P30 (0x1u << 30) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+#define PIO_ABCDSR_P31 (0x1u << 31) /**< \brief (PIO_ABCDSR[2]) Peripheral Select. */
+/* -------- PIO_IFSCDR : (PIO Offset: 0x0080) Input Filter Slow Clock Disable Register -------- */
+#define PIO_IFSCDR_P0 (0x1u << 0) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P1 (0x1u << 1) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P2 (0x1u << 2) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P3 (0x1u << 3) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P4 (0x1u << 4) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P5 (0x1u << 5) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P6 (0x1u << 6) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P7 (0x1u << 7) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P8 (0x1u << 8) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P9 (0x1u << 9) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P10 (0x1u << 10) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P11 (0x1u << 11) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P12 (0x1u << 12) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P13 (0x1u << 13) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P14 (0x1u << 14) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P15 (0x1u << 15) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P16 (0x1u << 16) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P17 (0x1u << 17) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P18 (0x1u << 18) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P19 (0x1u << 19) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P20 (0x1u << 20) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P21 (0x1u << 21) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P22 (0x1u << 22) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P23 (0x1u << 23) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P24 (0x1u << 24) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P25 (0x1u << 25) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P26 (0x1u << 26) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P27 (0x1u << 27) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P28 (0x1u << 28) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P29 (0x1u << 29) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P30 (0x1u << 30) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+#define PIO_IFSCDR_P31 (0x1u << 31) /**< \brief (PIO_IFSCDR) PIO Clock Glitch Filtering Select. */
+/* -------- PIO_IFSCER : (PIO Offset: 0x0084) Input Filter Slow Clock Enable Register -------- */
+#define PIO_IFSCER_P0 (0x1u << 0) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P1 (0x1u << 1) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P2 (0x1u << 2) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P3 (0x1u << 3) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P4 (0x1u << 4) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P5 (0x1u << 5) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P6 (0x1u << 6) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P7 (0x1u << 7) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P8 (0x1u << 8) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P9 (0x1u << 9) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P10 (0x1u << 10) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P11 (0x1u << 11) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P12 (0x1u << 12) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P13 (0x1u << 13) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P14 (0x1u << 14) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P15 (0x1u << 15) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P16 (0x1u << 16) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P17 (0x1u << 17) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P18 (0x1u << 18) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P19 (0x1u << 19) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P20 (0x1u << 20) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P21 (0x1u << 21) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P22 (0x1u << 22) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P23 (0x1u << 23) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P24 (0x1u << 24) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P25 (0x1u << 25) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P26 (0x1u << 26) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P27 (0x1u << 27) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P28 (0x1u << 28) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P29 (0x1u << 29) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P30 (0x1u << 30) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+#define PIO_IFSCER_P31 (0x1u << 31) /**< \brief (PIO_IFSCER) Debouncing Filtering Select. */
+/* -------- PIO_IFSCSR : (PIO Offset: 0x0088) Input Filter Slow Clock Status Register -------- */
+#define PIO_IFSCSR_P0 (0x1u << 0) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P1 (0x1u << 1) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P2 (0x1u << 2) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P3 (0x1u << 3) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P4 (0x1u << 4) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P5 (0x1u << 5) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P6 (0x1u << 6) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P7 (0x1u << 7) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P8 (0x1u << 8) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P9 (0x1u << 9) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P10 (0x1u << 10) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P11 (0x1u << 11) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P12 (0x1u << 12) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P13 (0x1u << 13) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P14 (0x1u << 14) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P15 (0x1u << 15) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P16 (0x1u << 16) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P17 (0x1u << 17) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P18 (0x1u << 18) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P19 (0x1u << 19) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P20 (0x1u << 20) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P21 (0x1u << 21) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P22 (0x1u << 22) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P23 (0x1u << 23) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P24 (0x1u << 24) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P25 (0x1u << 25) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P26 (0x1u << 26) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P27 (0x1u << 27) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P28 (0x1u << 28) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P29 (0x1u << 29) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P30 (0x1u << 30) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+#define PIO_IFSCSR_P31 (0x1u << 31) /**< \brief (PIO_IFSCSR) Glitch or Debouncing Filter Selection Status */
+/* -------- PIO_SCDR : (PIO Offset: 0x008C) Slow Clock Divider Debouncing Register -------- */
+#define PIO_SCDR_DIV_Pos 0
+#define PIO_SCDR_DIV_Msk (0x3fffu << PIO_SCDR_DIV_Pos) /**< \brief (PIO_SCDR)  */
+#define PIO_SCDR_DIV(value) ((PIO_SCDR_DIV_Msk & ((value) << PIO_SCDR_DIV_Pos)))
+/* -------- PIO_PPDDR : (PIO Offset: 0x0090) Pad Pull-down Disable Register -------- */
+#define PIO_PPDDR_P0 (0x1u << 0) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P1 (0x1u << 1) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P2 (0x1u << 2) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P3 (0x1u << 3) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P4 (0x1u << 4) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P5 (0x1u << 5) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P6 (0x1u << 6) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P7 (0x1u << 7) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P8 (0x1u << 8) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P9 (0x1u << 9) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P10 (0x1u << 10) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P11 (0x1u << 11) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P12 (0x1u << 12) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P13 (0x1u << 13) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P14 (0x1u << 14) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P15 (0x1u << 15) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P16 (0x1u << 16) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P17 (0x1u << 17) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P18 (0x1u << 18) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P19 (0x1u << 19) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P20 (0x1u << 20) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P21 (0x1u << 21) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P22 (0x1u << 22) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P23 (0x1u << 23) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P24 (0x1u << 24) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P25 (0x1u << 25) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P26 (0x1u << 26) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P27 (0x1u << 27) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P28 (0x1u << 28) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P29 (0x1u << 29) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P30 (0x1u << 30) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+#define PIO_PPDDR_P31 (0x1u << 31) /**< \brief (PIO_PPDDR) Pull Down Disable. */
+/* -------- PIO_PPDER : (PIO Offset: 0x0094) Pad Pull-down Enable Register -------- */
+#define PIO_PPDER_P0 (0x1u << 0) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P1 (0x1u << 1) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P2 (0x1u << 2) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P3 (0x1u << 3) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P4 (0x1u << 4) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P5 (0x1u << 5) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P6 (0x1u << 6) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P7 (0x1u << 7) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P8 (0x1u << 8) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P9 (0x1u << 9) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P10 (0x1u << 10) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P11 (0x1u << 11) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P12 (0x1u << 12) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P13 (0x1u << 13) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P14 (0x1u << 14) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P15 (0x1u << 15) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P16 (0x1u << 16) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P17 (0x1u << 17) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P18 (0x1u << 18) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P19 (0x1u << 19) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P20 (0x1u << 20) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P21 (0x1u << 21) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P22 (0x1u << 22) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P23 (0x1u << 23) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P24 (0x1u << 24) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P25 (0x1u << 25) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P26 (0x1u << 26) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P27 (0x1u << 27) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P28 (0x1u << 28) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P29 (0x1u << 29) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P30 (0x1u << 30) /**< \brief (PIO_PPDER) Pull Down Enable. */
+#define PIO_PPDER_P31 (0x1u << 31) /**< \brief (PIO_PPDER) Pull Down Enable. */
+/* -------- PIO_PPDSR : (PIO Offset: 0x0098) Pad Pull-down Status Register -------- */
+#define PIO_PPDSR_P0 (0x1u << 0) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P1 (0x1u << 1) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P2 (0x1u << 2) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P3 (0x1u << 3) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P4 (0x1u << 4) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P5 (0x1u << 5) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P6 (0x1u << 6) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P7 (0x1u << 7) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P8 (0x1u << 8) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P9 (0x1u << 9) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P10 (0x1u << 10) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P11 (0x1u << 11) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P12 (0x1u << 12) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P13 (0x1u << 13) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P14 (0x1u << 14) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P15 (0x1u << 15) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P16 (0x1u << 16) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P17 (0x1u << 17) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P18 (0x1u << 18) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P19 (0x1u << 19) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P20 (0x1u << 20) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P21 (0x1u << 21) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P22 (0x1u << 22) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P23 (0x1u << 23) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P24 (0x1u << 24) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P25 (0x1u << 25) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P26 (0x1u << 26) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P27 (0x1u << 27) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P28 (0x1u << 28) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P29 (0x1u << 29) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P30 (0x1u << 30) /**< \brief (PIO_PPDSR) Pull Down Status. */
+#define PIO_PPDSR_P31 (0x1u << 31) /**< \brief (PIO_PPDSR) Pull Down Status. */
+/* -------- PIO_OWER : (PIO Offset: 0x00A0) Output Write Enable -------- */
+#define PIO_OWER_P0 (0x1u << 0) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P1 (0x1u << 1) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P2 (0x1u << 2) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P3 (0x1u << 3) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P4 (0x1u << 4) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P5 (0x1u << 5) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P6 (0x1u << 6) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P7 (0x1u << 7) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P8 (0x1u << 8) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P9 (0x1u << 9) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P10 (0x1u << 10) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P11 (0x1u << 11) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P12 (0x1u << 12) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P13 (0x1u << 13) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P14 (0x1u << 14) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P15 (0x1u << 15) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P16 (0x1u << 16) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P17 (0x1u << 17) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P18 (0x1u << 18) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P19 (0x1u << 19) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P20 (0x1u << 20) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P21 (0x1u << 21) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P22 (0x1u << 22) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P23 (0x1u << 23) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P24 (0x1u << 24) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P25 (0x1u << 25) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P26 (0x1u << 26) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P27 (0x1u << 27) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P28 (0x1u << 28) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P29 (0x1u << 29) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P30 (0x1u << 30) /**< \brief (PIO_OWER) Output Write Enable. */
+#define PIO_OWER_P31 (0x1u << 31) /**< \brief (PIO_OWER) Output Write Enable. */
+/* -------- PIO_OWDR : (PIO Offset: 0x00A4) Output Write Disable -------- */
+#define PIO_OWDR_P0 (0x1u << 0) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P1 (0x1u << 1) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P2 (0x1u << 2) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P3 (0x1u << 3) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P4 (0x1u << 4) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P5 (0x1u << 5) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P6 (0x1u << 6) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P7 (0x1u << 7) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P8 (0x1u << 8) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P9 (0x1u << 9) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P10 (0x1u << 10) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P11 (0x1u << 11) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P12 (0x1u << 12) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P13 (0x1u << 13) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P14 (0x1u << 14) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P15 (0x1u << 15) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P16 (0x1u << 16) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P17 (0x1u << 17) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P18 (0x1u << 18) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P19 (0x1u << 19) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P20 (0x1u << 20) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P21 (0x1u << 21) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P22 (0x1u << 22) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P23 (0x1u << 23) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P24 (0x1u << 24) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P25 (0x1u << 25) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P26 (0x1u << 26) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P27 (0x1u << 27) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P28 (0x1u << 28) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P29 (0x1u << 29) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P30 (0x1u << 30) /**< \brief (PIO_OWDR) Output Write Disable. */
+#define PIO_OWDR_P31 (0x1u << 31) /**< \brief (PIO_OWDR) Output Write Disable. */
+/* -------- PIO_OWSR : (PIO Offset: 0x00A8) Output Write Status Register -------- */
+#define PIO_OWSR_P0 (0x1u << 0) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P1 (0x1u << 1) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P2 (0x1u << 2) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P3 (0x1u << 3) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P4 (0x1u << 4) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P5 (0x1u << 5) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P6 (0x1u << 6) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P7 (0x1u << 7) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P8 (0x1u << 8) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P9 (0x1u << 9) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P10 (0x1u << 10) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P11 (0x1u << 11) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P12 (0x1u << 12) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P13 (0x1u << 13) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P14 (0x1u << 14) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P15 (0x1u << 15) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P16 (0x1u << 16) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P17 (0x1u << 17) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P18 (0x1u << 18) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P19 (0x1u << 19) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P20 (0x1u << 20) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P21 (0x1u << 21) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P22 (0x1u << 22) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P23 (0x1u << 23) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P24 (0x1u << 24) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P25 (0x1u << 25) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P26 (0x1u << 26) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P27 (0x1u << 27) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P28 (0x1u << 28) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P29 (0x1u << 29) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P30 (0x1u << 30) /**< \brief (PIO_OWSR) Output Write Status. */
+#define PIO_OWSR_P31 (0x1u << 31) /**< \brief (PIO_OWSR) Output Write Status. */
+/* -------- PIO_AIMER : (PIO Offset: 0x00B0) Additional Interrupt Modes Enable Register -------- */
+#define PIO_AIMER_P0 (0x1u << 0) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P1 (0x1u << 1) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P2 (0x1u << 2) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P3 (0x1u << 3) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P4 (0x1u << 4) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P5 (0x1u << 5) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P6 (0x1u << 6) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P7 (0x1u << 7) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P8 (0x1u << 8) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P9 (0x1u << 9) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P10 (0x1u << 10) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P11 (0x1u << 11) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P12 (0x1u << 12) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P13 (0x1u << 13) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P14 (0x1u << 14) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P15 (0x1u << 15) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P16 (0x1u << 16) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P17 (0x1u << 17) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P18 (0x1u << 18) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P19 (0x1u << 19) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P20 (0x1u << 20) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P21 (0x1u << 21) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P22 (0x1u << 22) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P23 (0x1u << 23) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P24 (0x1u << 24) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P25 (0x1u << 25) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P26 (0x1u << 26) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P27 (0x1u << 27) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P28 (0x1u << 28) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P29 (0x1u << 29) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P30 (0x1u << 30) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+#define PIO_AIMER_P31 (0x1u << 31) /**< \brief (PIO_AIMER) Additional Interrupt Modes Enable. */
+/* -------- PIO_AIMDR : (PIO Offset: 0x00B4) Additional Interrupt Modes Disables Register -------- */
+#define PIO_AIMDR_P0 (0x1u << 0) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P1 (0x1u << 1) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P2 (0x1u << 2) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P3 (0x1u << 3) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P4 (0x1u << 4) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P5 (0x1u << 5) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P6 (0x1u << 6) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P7 (0x1u << 7) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P8 (0x1u << 8) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P9 (0x1u << 9) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P10 (0x1u << 10) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P11 (0x1u << 11) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P12 (0x1u << 12) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P13 (0x1u << 13) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P14 (0x1u << 14) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P15 (0x1u << 15) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P16 (0x1u << 16) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P17 (0x1u << 17) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P18 (0x1u << 18) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P19 (0x1u << 19) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P20 (0x1u << 20) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P21 (0x1u << 21) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P22 (0x1u << 22) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P23 (0x1u << 23) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P24 (0x1u << 24) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P25 (0x1u << 25) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P26 (0x1u << 26) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P27 (0x1u << 27) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P28 (0x1u << 28) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P29 (0x1u << 29) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P30 (0x1u << 30) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+#define PIO_AIMDR_P31 (0x1u << 31) /**< \brief (PIO_AIMDR) Additional Interrupt Modes Disable. */
+/* -------- PIO_AIMMR : (PIO Offset: 0x00B8) Additional Interrupt Modes Mask Register -------- */
+#define PIO_AIMMR_P0 (0x1u << 0) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P1 (0x1u << 1) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P2 (0x1u << 2) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P3 (0x1u << 3) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P4 (0x1u << 4) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P5 (0x1u << 5) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P6 (0x1u << 6) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P7 (0x1u << 7) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P8 (0x1u << 8) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P9 (0x1u << 9) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P10 (0x1u << 10) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P11 (0x1u << 11) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P12 (0x1u << 12) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P13 (0x1u << 13) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P14 (0x1u << 14) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P15 (0x1u << 15) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P16 (0x1u << 16) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P17 (0x1u << 17) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P18 (0x1u << 18) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P19 (0x1u << 19) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P20 (0x1u << 20) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P21 (0x1u << 21) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P22 (0x1u << 22) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P23 (0x1u << 23) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P24 (0x1u << 24) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P25 (0x1u << 25) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P26 (0x1u << 26) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P27 (0x1u << 27) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P28 (0x1u << 28) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P29 (0x1u << 29) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P30 (0x1u << 30) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+#define PIO_AIMMR_P31 (0x1u << 31) /**< \brief (PIO_AIMMR) Peripheral CD Status. */
+/* -------- PIO_ESR : (PIO Offset: 0x00C0) Edge Select Register -------- */
+#define PIO_ESR_P0 (0x1u << 0) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P1 (0x1u << 1) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P2 (0x1u << 2) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P3 (0x1u << 3) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P4 (0x1u << 4) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P5 (0x1u << 5) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P6 (0x1u << 6) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P7 (0x1u << 7) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P8 (0x1u << 8) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P9 (0x1u << 9) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P10 (0x1u << 10) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P11 (0x1u << 11) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P12 (0x1u << 12) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P13 (0x1u << 13) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P14 (0x1u << 14) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P15 (0x1u << 15) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P16 (0x1u << 16) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P17 (0x1u << 17) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P18 (0x1u << 18) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P19 (0x1u << 19) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P20 (0x1u << 20) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P21 (0x1u << 21) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P22 (0x1u << 22) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P23 (0x1u << 23) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P24 (0x1u << 24) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P25 (0x1u << 25) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P26 (0x1u << 26) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P27 (0x1u << 27) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P28 (0x1u << 28) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P29 (0x1u << 29) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P30 (0x1u << 30) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+#define PIO_ESR_P31 (0x1u << 31) /**< \brief (PIO_ESR) Edge Interrupt Selection. */
+/* -------- PIO_LSR : (PIO Offset: 0x00C4) Level Select Register -------- */
+#define PIO_LSR_P0 (0x1u << 0) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P1 (0x1u << 1) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P2 (0x1u << 2) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P3 (0x1u << 3) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P4 (0x1u << 4) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P5 (0x1u << 5) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P6 (0x1u << 6) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P7 (0x1u << 7) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P8 (0x1u << 8) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P9 (0x1u << 9) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P10 (0x1u << 10) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P11 (0x1u << 11) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P12 (0x1u << 12) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P13 (0x1u << 13) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P14 (0x1u << 14) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P15 (0x1u << 15) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P16 (0x1u << 16) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P17 (0x1u << 17) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P18 (0x1u << 18) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P19 (0x1u << 19) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P20 (0x1u << 20) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P21 (0x1u << 21) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P22 (0x1u << 22) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P23 (0x1u << 23) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P24 (0x1u << 24) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P25 (0x1u << 25) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P26 (0x1u << 26) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P27 (0x1u << 27) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P28 (0x1u << 28) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P29 (0x1u << 29) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P30 (0x1u << 30) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+#define PIO_LSR_P31 (0x1u << 31) /**< \brief (PIO_LSR) Level Interrupt Selection. */
+/* -------- PIO_ELSR : (PIO Offset: 0x00C8) Edge/Level Status Register -------- */
+#define PIO_ELSR_P0 (0x1u << 0) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P1 (0x1u << 1) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P2 (0x1u << 2) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P3 (0x1u << 3) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P4 (0x1u << 4) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P5 (0x1u << 5) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P6 (0x1u << 6) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P7 (0x1u << 7) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P8 (0x1u << 8) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P9 (0x1u << 9) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P10 (0x1u << 10) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P11 (0x1u << 11) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P12 (0x1u << 12) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P13 (0x1u << 13) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P14 (0x1u << 14) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P15 (0x1u << 15) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P16 (0x1u << 16) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P17 (0x1u << 17) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P18 (0x1u << 18) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P19 (0x1u << 19) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P20 (0x1u << 20) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P21 (0x1u << 21) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P22 (0x1u << 22) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P23 (0x1u << 23) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P24 (0x1u << 24) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P25 (0x1u << 25) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P26 (0x1u << 26) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P27 (0x1u << 27) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P28 (0x1u << 28) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P29 (0x1u << 29) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P30 (0x1u << 30) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+#define PIO_ELSR_P31 (0x1u << 31) /**< \brief (PIO_ELSR) Edge/Level Interrupt source selection. */
+/* -------- PIO_FELLSR : (PIO Offset: 0x00D0) Falling Edge/Low Level Select Register -------- */
+#define PIO_FELLSR_P0 (0x1u << 0) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P1 (0x1u << 1) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P2 (0x1u << 2) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P3 (0x1u << 3) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P4 (0x1u << 4) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P5 (0x1u << 5) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P6 (0x1u << 6) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P7 (0x1u << 7) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P8 (0x1u << 8) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P9 (0x1u << 9) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P10 (0x1u << 10) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P11 (0x1u << 11) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P12 (0x1u << 12) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P13 (0x1u << 13) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P14 (0x1u << 14) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P15 (0x1u << 15) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P16 (0x1u << 16) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P17 (0x1u << 17) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P18 (0x1u << 18) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P19 (0x1u << 19) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P20 (0x1u << 20) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P21 (0x1u << 21) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P22 (0x1u << 22) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P23 (0x1u << 23) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P24 (0x1u << 24) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P25 (0x1u << 25) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P26 (0x1u << 26) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P27 (0x1u << 27) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P28 (0x1u << 28) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P29 (0x1u << 29) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P30 (0x1u << 30) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+#define PIO_FELLSR_P31 (0x1u << 31) /**< \brief (PIO_FELLSR) Falling Edge/Low Level Interrupt Selection. */
+/* -------- PIO_REHLSR : (PIO Offset: 0x00D4) Rising Edge/ High Level Select Register -------- */
+#define PIO_REHLSR_P0 (0x1u << 0) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P1 (0x1u << 1) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P2 (0x1u << 2) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P3 (0x1u << 3) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P4 (0x1u << 4) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P5 (0x1u << 5) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P6 (0x1u << 6) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P7 (0x1u << 7) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P8 (0x1u << 8) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P9 (0x1u << 9) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P10 (0x1u << 10) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P11 (0x1u << 11) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P12 (0x1u << 12) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P13 (0x1u << 13) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P14 (0x1u << 14) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P15 (0x1u << 15) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P16 (0x1u << 16) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P17 (0x1u << 17) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P18 (0x1u << 18) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P19 (0x1u << 19) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P20 (0x1u << 20) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P21 (0x1u << 21) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P22 (0x1u << 22) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P23 (0x1u << 23) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P24 (0x1u << 24) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P25 (0x1u << 25) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P26 (0x1u << 26) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P27 (0x1u << 27) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P28 (0x1u << 28) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P29 (0x1u << 29) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P30 (0x1u << 30) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+#define PIO_REHLSR_P31 (0x1u << 31) /**< \brief (PIO_REHLSR) Rising Edge /High Level Interrupt Selection. */
+/* -------- PIO_FRLHSR : (PIO Offset: 0x00D8) Fall/Rise - Low/High Status Register -------- */
+#define PIO_FRLHSR_P0 (0x1u << 0) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P1 (0x1u << 1) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P2 (0x1u << 2) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P3 (0x1u << 3) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P4 (0x1u << 4) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P5 (0x1u << 5) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P6 (0x1u << 6) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P7 (0x1u << 7) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P8 (0x1u << 8) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P9 (0x1u << 9) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P10 (0x1u << 10) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P11 (0x1u << 11) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P12 (0x1u << 12) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P13 (0x1u << 13) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P14 (0x1u << 14) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P15 (0x1u << 15) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P16 (0x1u << 16) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P17 (0x1u << 17) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P18 (0x1u << 18) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P19 (0x1u << 19) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P20 (0x1u << 20) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P21 (0x1u << 21) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P22 (0x1u << 22) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P23 (0x1u << 23) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P24 (0x1u << 24) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P25 (0x1u << 25) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P26 (0x1u << 26) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P27 (0x1u << 27) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P28 (0x1u << 28) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P29 (0x1u << 29) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P30 (0x1u << 30) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+#define PIO_FRLHSR_P31 (0x1u << 31) /**< \brief (PIO_FRLHSR) Edge /Level Interrupt Source Selection. */
+/* -------- PIO_LOCKSR : (PIO Offset: 0x00E0) Lock Status -------- */
+#define PIO_LOCKSR_P0 (0x1u << 0) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P1 (0x1u << 1) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P2 (0x1u << 2) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P3 (0x1u << 3) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P4 (0x1u << 4) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P5 (0x1u << 5) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P6 (0x1u << 6) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P7 (0x1u << 7) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P8 (0x1u << 8) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P9 (0x1u << 9) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P10 (0x1u << 10) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P11 (0x1u << 11) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P12 (0x1u << 12) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P13 (0x1u << 13) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P14 (0x1u << 14) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P15 (0x1u << 15) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P16 (0x1u << 16) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P17 (0x1u << 17) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P18 (0x1u << 18) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P19 (0x1u << 19) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P20 (0x1u << 20) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P21 (0x1u << 21) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P22 (0x1u << 22) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P23 (0x1u << 23) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P24 (0x1u << 24) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P25 (0x1u << 25) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P26 (0x1u << 26) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P27 (0x1u << 27) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P28 (0x1u << 28) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P29 (0x1u << 29) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P30 (0x1u << 30) /**< \brief (PIO_LOCKSR) Lock Status. */
+#define PIO_LOCKSR_P31 (0x1u << 31) /**< \brief (PIO_LOCKSR) Lock Status. */
+/* -------- PIO_WPMR : (PIO Offset: 0x00E4) Write Protect Mode Register -------- */
+#define PIO_WPMR_WPEN (0x1u << 0) /**< \brief (PIO_WPMR) Write Protect Enable */
+#define PIO_WPMR_WPKEY_Pos 8
+#define PIO_WPMR_WPKEY_Msk (0xffffffu << PIO_WPMR_WPKEY_Pos) /**< \brief (PIO_WPMR) Write Protect KEY */
+#define PIO_WPMR_WPKEY(value) ((PIO_WPMR_WPKEY_Msk & ((value) << PIO_WPMR_WPKEY_Pos)))
+/* -------- PIO_WPSR : (PIO Offset: 0x00E8) Write Protect Status Register -------- */
+#define PIO_WPSR_WPVS (0x1u << 0) /**< \brief (PIO_WPSR) Write Protect Violation Status */
+#define PIO_WPSR_WPVSRC_Pos 8
+#define PIO_WPSR_WPVSRC_Msk (0xffffu << PIO_WPSR_WPVSRC_Pos) /**< \brief (PIO_WPSR) Write Protect Violation Source */
+/* -------- PIO_SCHMITT : (PIO Offset: 0x0100) Schmitt Trigger Register -------- */
+#define PIO_SCHMITT_SCHMITT0 (0x1u << 0) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT1 (0x1u << 1) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT2 (0x1u << 2) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT3 (0x1u << 3) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT4 (0x1u << 4) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT5 (0x1u << 5) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT6 (0x1u << 6) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT7 (0x1u << 7) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT8 (0x1u << 8) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT9 (0x1u << 9) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT10 (0x1u << 10) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT11 (0x1u << 11) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT12 (0x1u << 12) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT13 (0x1u << 13) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT14 (0x1u << 14) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT15 (0x1u << 15) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT16 (0x1u << 16) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT17 (0x1u << 17) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT18 (0x1u << 18) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT19 (0x1u << 19) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT20 (0x1u << 20) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT21 (0x1u << 21) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT22 (0x1u << 22) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT23 (0x1u << 23) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT24 (0x1u << 24) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT25 (0x1u << 25) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT26 (0x1u << 26) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT27 (0x1u << 27) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT28 (0x1u << 28) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT29 (0x1u << 29) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT30 (0x1u << 30) /**< \brief (PIO_SCHMITT)  */
+#define PIO_SCHMITT_SCHMITT31 (0x1u << 31) /**< \brief (PIO_SCHMITT)  */
+/* -------- PIO_DELAYR : (PIO Offset: 0x0110) IO Delay Register -------- */
+#define PIO_DELAYR_Delay0_Pos 0
+#define PIO_DELAYR_Delay0_Msk (0xfu << PIO_DELAYR_Delay0_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay0(value) ((PIO_DELAYR_Delay0_Msk & ((value) << PIO_DELAYR_Delay0_Pos)))
+#define PIO_DELAYR_Delay1_Pos 4
+#define PIO_DELAYR_Delay1_Msk (0xfu << PIO_DELAYR_Delay1_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay1(value) ((PIO_DELAYR_Delay1_Msk & ((value) << PIO_DELAYR_Delay1_Pos)))
+#define PIO_DELAYR_Delay2_Pos 8
+#define PIO_DELAYR_Delay2_Msk (0xfu << PIO_DELAYR_Delay2_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay2(value) ((PIO_DELAYR_Delay2_Msk & ((value) << PIO_DELAYR_Delay2_Pos)))
+#define PIO_DELAYR_Delay3_Pos 12
+#define PIO_DELAYR_Delay3_Msk (0xfu << PIO_DELAYR_Delay3_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay3(value) ((PIO_DELAYR_Delay3_Msk & ((value) << PIO_DELAYR_Delay3_Pos)))
+#define PIO_DELAYR_Delay4_Pos 16
+#define PIO_DELAYR_Delay4_Msk (0xfu << PIO_DELAYR_Delay4_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay4(value) ((PIO_DELAYR_Delay4_Msk & ((value) << PIO_DELAYR_Delay4_Pos)))
+#define PIO_DELAYR_Delay5_Pos 20
+#define PIO_DELAYR_Delay5_Msk (0xfu << PIO_DELAYR_Delay5_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay5(value) ((PIO_DELAYR_Delay5_Msk & ((value) << PIO_DELAYR_Delay5_Pos)))
+#define PIO_DELAYR_Delay6_Pos 24
+#define PIO_DELAYR_Delay6_Msk (0xfu << PIO_DELAYR_Delay6_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay6(value) ((PIO_DELAYR_Delay6_Msk & ((value) << PIO_DELAYR_Delay6_Pos)))
+#define PIO_DELAYR_Delay7_Pos 28
+#define PIO_DELAYR_Delay7_Msk (0xfu << PIO_DELAYR_Delay7_Pos) /**< \brief (PIO_DELAYR)  */
+#define PIO_DELAYR_Delay7(value) ((PIO_DELAYR_Delay7_Msk & ((value) << PIO_DELAYR_Delay7_Pos)))
+/* -------- PIO_PCMR : (PIO Offset: 0x150) Parallel Capture Mode Register -------- */
+#define PIO_PCMR_PCEN (0x1u << 0) /**< \brief (PIO_PCMR) Parallel Capture Mode Enable */
+#define PIO_PCMR_DSIZE_Pos 4
+#define PIO_PCMR_DSIZE_Msk (0x3u << PIO_PCMR_DSIZE_Pos) /**< \brief (PIO_PCMR) Parallel Capture Mode Data Size */
+#define   PIO_PCMR_DSIZE_BYTE (0x0u << 4) /**< \brief (PIO_PCMR) The reception data in the PIO_PCRHR register is a BYTE (8-bit) */
+#define   PIO_PCMR_DSIZE_HALFWORD (0x1u << 4) /**< \brief (PIO_PCMR) The reception data in the PIO_PCRHR register is a HALF-WORD (16-bit) */
+#define   PIO_PCMR_DSIZE_WORD (0x2u << 4) /**< \brief (PIO_PCMR) The reception data in the PIO_PCRHR register is a WORD (32-bit) */
+#define PIO_PCMR_ALWYS (0x1u << 9) /**< \brief (PIO_PCMR) Parallel Capture Mode Always Sampling */
+#define PIO_PCMR_HALFS (0x1u << 10) /**< \brief (PIO_PCMR) Parallel Capture Mode Half Sampling */
+#define PIO_PCMR_FRSTS (0x1u << 11) /**< \brief (PIO_PCMR) Parallel Capture Mode First Sample */
+/* -------- PIO_PCIER : (PIO Offset: 0x154) Parallel Capture Interrupt Enable Register -------- */
+#define PIO_PCIER_DRDY (0x1u << 0) /**< \brief (PIO_PCIER) Parallel Capture Mode Data Ready Interrupt Enable */
+#define PIO_PCIER_OVRE (0x1u << 1) /**< \brief (PIO_PCIER) Parallel Capture Mode Overrun Error Interrupt Enable */
+#define PIO_PCIER_ENDRX (0x1u << 2) /**< \brief (PIO_PCIER) End of Reception Transfer Interrupt Enable */
+#define PIO_PCIER_RXBUFF (0x1u << 3) /**< \brief (PIO_PCIER) Reception Buffer Full Interrupt Enable */
+/* -------- PIO_PCIDR : (PIO Offset: 0x158) Parallel Capture Interrupt Disable Register -------- */
+#define PIO_PCIDR_DRDY (0x1u << 0) /**< \brief (PIO_PCIDR) Parallel Capture Mode Data Ready Interrupt Disable */
+#define PIO_PCIDR_OVRE (0x1u << 1) /**< \brief (PIO_PCIDR) Parallel Capture Mode Overrun Error Interrupt Disable */
+#define PIO_PCIDR_ENDRX (0x1u << 2) /**< \brief (PIO_PCIDR) End of Reception Transfer Interrupt Disable */
+#define PIO_PCIDR_RXBUFF (0x1u << 3) /**< \brief (PIO_PCIDR) Reception Buffer Full Interrupt Disable */
+/* -------- PIO_PCIMR : (PIO Offset: 0x15C) Parallel Capture Interrupt Mask Register -------- */
+#define PIO_PCIMR_DRDY (0x1u << 0) /**< \brief (PIO_PCIMR) Parallel Capture Mode Data Ready Interrupt Mask */
+#define PIO_PCIMR_OVRE (0x1u << 1) /**< \brief (PIO_PCIMR) Parallel Capture Mode Overrun Error Interrupt Mask */
+#define PIO_PCIMR_ENDRX (0x1u << 2) /**< \brief (PIO_PCIMR) End of Reception Transfer Interrupt Mask */
+#define PIO_PCIMR_RXBUFF (0x1u << 3) /**< \brief (PIO_PCIMR) Reception Buffer Full Interrupt Mask */
+/* -------- PIO_PCISR : (PIO Offset: 0x160) Parallel Capture Interrupt Status Register -------- */
+#define PIO_PCISR_DRDY (0x1u << 0) /**< \brief (PIO_PCISR) Parallel Capture Mode Data Ready */
+#define PIO_PCISR_OVRE (0x1u << 1) /**< \brief (PIO_PCISR) Parallel Capture Mode Overrun Error. */
+#define PIO_PCISR_ENDRX (0x1u << 2) /**< \brief (PIO_PCISR) End of Reception Transfer. */
+#define PIO_PCISR_RXBUFF (0x1u << 3) /**< \brief (PIO_PCISR) Reception Buffer Full */
+/* -------- PIO_PCRHR : (PIO Offset: 0x164) Parallel Capture Reception Holding Register -------- */
+#define PIO_PCRHR_RDATA_Pos 0
+#define PIO_PCRHR_RDATA_Msk (0xffffffffu << PIO_PCRHR_RDATA_Pos) /**< \brief (PIO_PCRHR) Parallel Capture Mode Reception Data. */
+/* -------- PIO_RPR : (PIO Offset: 0x168) Receive Pointer Register -------- */
+#define PIO_RPR_RXPTR_Pos 0
+#define PIO_RPR_RXPTR_Msk (0xffffffffu << PIO_RPR_RXPTR_Pos) /**< \brief (PIO_RPR) Receive Pointer Register */
+#define PIO_RPR_RXPTR(value) ((PIO_RPR_RXPTR_Msk & ((value) << PIO_RPR_RXPTR_Pos)))
+/* -------- PIO_RCR : (PIO Offset: 0x16C) Receive Counter Register -------- */
+#define PIO_RCR_RXCTR_Pos 0
+#define PIO_RCR_RXCTR_Msk (0xffffu << PIO_RCR_RXCTR_Pos) /**< \brief (PIO_RCR) Receive Counter Register */
+#define PIO_RCR_RXCTR(value) ((PIO_RCR_RXCTR_Msk & ((value) << PIO_RCR_RXCTR_Pos)))
+/* -------- PIO_RNPR : (PIO Offset: 0x178) Receive Next Pointer Register -------- */
+#define PIO_RNPR_RXNPTR_Pos 0
+#define PIO_RNPR_RXNPTR_Msk (0xffffffffu << PIO_RNPR_RXNPTR_Pos) /**< \brief (PIO_RNPR) Receive Next Pointer */
+#define PIO_RNPR_RXNPTR(value) ((PIO_RNPR_RXNPTR_Msk & ((value) << PIO_RNPR_RXNPTR_Pos)))
+/* -------- PIO_RNCR : (PIO Offset: 0x17C) Receive Next Counter Register -------- */
+#define PIO_RNCR_RXNCTR_Pos 0
+#define PIO_RNCR_RXNCTR_Msk (0xffffu << PIO_RNCR_RXNCTR_Pos) /**< \brief (PIO_RNCR) Receive Next Counter */
+#define PIO_RNCR_RXNCTR(value) ((PIO_RNCR_RXNCTR_Msk & ((value) << PIO_RNCR_RXNCTR_Pos)))
+/* -------- PIO_PTCR : (PIO Offset: 0x188) Transfer Control Register -------- */
+#define PIO_PTCR_RXTEN (0x1u << 0) /**< \brief (PIO_PTCR) Receiver Transfer Enable */
+#define PIO_PTCR_RXTDIS (0x1u << 1) /**< \brief (PIO_PTCR) Receiver Transfer Disable */
+#define PIO_PTCR_TXTEN (0x1u << 8) /**< \brief (PIO_PTCR) Transmitter Transfer Enable */
+#define PIO_PTCR_TXTDIS (0x1u << 9) /**< \brief (PIO_PTCR) Transmitter Transfer Disable */
+/* -------- PIO_PTSR : (PIO Offset: 0x18C) Transfer Status Register -------- */
+#define PIO_PTSR_RXTEN (0x1u << 0) /**< \brief (PIO_PTSR) Receiver Transfer Enable */
+#define PIO_PTSR_TXTEN (0x1u << 8) /**< \brief (PIO_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_PIO_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/pmc.h
+++ b/asf/sam/include/sam4e/component/pmc.h
@@ -1,0 +1,393 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PMC_COMPONENT_
+#define _SAM4E_PMC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Power Management Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_PMC Power Management Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Pmc hardware registers */
+typedef struct {
+  WoReg PMC_SCER;      /**< \brief (Pmc Offset: 0x0000) System Clock Enable Register */
+  WoReg PMC_SCDR;      /**< \brief (Pmc Offset: 0x0004) System Clock Disable Register */
+  RoReg PMC_SCSR;      /**< \brief (Pmc Offset: 0x0008) System Clock Status Register */
+  RoReg Reserved1[1];
+  WoReg PMC_PCER0;     /**< \brief (Pmc Offset: 0x0010) Peripheral Clock Enable Register 0 */
+  WoReg PMC_PCDR0;     /**< \brief (Pmc Offset: 0x0014) Peripheral Clock Disable Register 0 */
+  RoReg PMC_PCSR0;     /**< \brief (Pmc Offset: 0x0018) Peripheral Clock Status Register 0 */
+  RoReg Reserved2[1];
+  RwReg CKGR_MOR;      /**< \brief (Pmc Offset: 0x0020) Main Oscillator Register */
+  RwReg CKGR_MCFR;     /**< \brief (Pmc Offset: 0x0024) Main Clock Frequency Register */
+  RwReg CKGR_PLLAR;    /**< \brief (Pmc Offset: 0x0028) PLLA Register */
+  RoReg Reserved3[1];
+  RwReg PMC_MCKR;      /**< \brief (Pmc Offset: 0x0030) Master Clock Register */
+  RoReg Reserved4[1];
+  RwReg PMC_USB;       /**< \brief (Pmc Offset: 0x0038) USB Clock Register */
+  RoReg Reserved5[1];
+  RwReg PMC_PCK[3];    /**< \brief (Pmc Offset: 0x0040) Programmable Clock 0 Register */
+  RoReg Reserved6[5];
+  WoReg PMC_IER;       /**< \brief (Pmc Offset: 0x0060) Interrupt Enable Register */
+  WoReg PMC_IDR;       /**< \brief (Pmc Offset: 0x0064) Interrupt Disable Register */
+  RoReg PMC_SR;        /**< \brief (Pmc Offset: 0x0068) Status Register */
+  RoReg PMC_IMR;       /**< \brief (Pmc Offset: 0x006C) Interrupt Mask Register */
+  RwReg PMC_FSMR;      /**< \brief (Pmc Offset: 0x0070) Fast Startup Mode Register */
+  RwReg PMC_FSPR;      /**< \brief (Pmc Offset: 0x0074) Fast Startup Polarity Register */
+  WoReg PMC_FOCR;      /**< \brief (Pmc Offset: 0x0078) Fault Output Clear Register */
+  RoReg Reserved7[26];
+  RwReg PMC_WPMR;      /**< \brief (Pmc Offset: 0x00E4) Write Protect Mode Register */
+  RoReg PMC_WPSR;      /**< \brief (Pmc Offset: 0x00E8) Write Protect Status Register */
+  RoReg Reserved8[5];
+  WoReg PMC_PCER1;     /**< \brief (Pmc Offset: 0x0100) Peripheral Clock Enable Register 1 */
+  WoReg PMC_PCDR1;     /**< \brief (Pmc Offset: 0x0104) Peripheral Clock Disable Register 1 */
+  RoReg PMC_PCSR1;     /**< \brief (Pmc Offset: 0x0108) Peripheral Clock Status Register 1 */
+  RoReg Reserved9[1];
+  RwReg PMC_OCR;       /**< \brief (Pmc Offset: 0x0110) Oscillator Calibration Register */
+} Pmc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- PMC_SCER : (PMC Offset: 0x0000) System Clock Enable Register -------- */
+#define PMC_SCER_UDP (0x1u << 7) /**< \brief (PMC_SCER) USB Device Port Clock Enable */
+#define PMC_SCER_PCK0 (0x1u << 8) /**< \brief (PMC_SCER) Programmable Clock 0 Output Enable */
+#define PMC_SCER_PCK1 (0x1u << 9) /**< \brief (PMC_SCER) Programmable Clock 1 Output Enable */
+#define PMC_SCER_PCK2 (0x1u << 10) /**< \brief (PMC_SCER) Programmable Clock 2 Output Enable */
+/* -------- PMC_SCDR : (PMC Offset: 0x0004) System Clock Disable Register -------- */
+#define PMC_SCDR_UDP (0x1u << 7) /**< \brief (PMC_SCDR) USB Device Port Clock Disable */
+#define PMC_SCDR_PCK0 (0x1u << 8) /**< \brief (PMC_SCDR) Programmable Clock 0 Output Disable */
+#define PMC_SCDR_PCK1 (0x1u << 9) /**< \brief (PMC_SCDR) Programmable Clock 1 Output Disable */
+#define PMC_SCDR_PCK2 (0x1u << 10) /**< \brief (PMC_SCDR) Programmable Clock 2 Output Disable */
+/* -------- PMC_SCSR : (PMC Offset: 0x0008) System Clock Status Register -------- */
+#define PMC_SCSR_UDP (0x1u << 7) /**< \brief (PMC_SCSR) USB Device Port Clock Status */
+#define PMC_SCSR_PCK0 (0x1u << 8) /**< \brief (PMC_SCSR) Programmable Clock 0 Output Status */
+#define PMC_SCSR_PCK1 (0x1u << 9) /**< \brief (PMC_SCSR) Programmable Clock 1 Output Status */
+#define PMC_SCSR_PCK2 (0x1u << 10) /**< \brief (PMC_SCSR) Programmable Clock 2 Output Status */
+/* -------- PMC_PCER0 : (PMC Offset: 0x0010) Peripheral Clock Enable Register 0 -------- */
+#define PMC_PCER0_PID9 (0x1u << 9) /**< \brief (PMC_PCER0) Peripheral Clock 9 Enable */
+#define PMC_PCER0_PID10 (0x1u << 10) /**< \brief (PMC_PCER0) Peripheral Clock 10 Enable */
+#define PMC_PCER0_PID11 (0x1u << 11) /**< \brief (PMC_PCER0) Peripheral Clock 11 Enable */
+#define PMC_PCER0_PID12 (0x1u << 12) /**< \brief (PMC_PCER0) Peripheral Clock 12 Enable */
+#define PMC_PCER0_PID13 (0x1u << 13) /**< \brief (PMC_PCER0) Peripheral Clock 13 Enable */
+#define PMC_PCER0_PID14 (0x1u << 14) /**< \brief (PMC_PCER0) Peripheral Clock 14 Enable */
+#define PMC_PCER0_PID15 (0x1u << 15) /**< \brief (PMC_PCER0) Peripheral Clock 15 Enable */
+#define PMC_PCER0_PID16 (0x1u << 16) /**< \brief (PMC_PCER0) Peripheral Clock 16 Enable */
+#define PMC_PCER0_PID17 (0x1u << 17) /**< \brief (PMC_PCER0) Peripheral Clock 17 Enable */
+#define PMC_PCER0_PID18 (0x1u << 18) /**< \brief (PMC_PCER0) Peripheral Clock 18 Enable */
+#define PMC_PCER0_PID19 (0x1u << 19) /**< \brief (PMC_PCER0) Peripheral Clock 19 Enable */
+#define PMC_PCER0_PID20 (0x1u << 20) /**< \brief (PMC_PCER0) Peripheral Clock 20 Enable */
+#define PMC_PCER0_PID21 (0x1u << 21) /**< \brief (PMC_PCER0) Peripheral Clock 21 Enable */
+#define PMC_PCER0_PID22 (0x1u << 22) /**< \brief (PMC_PCER0) Peripheral Clock 22 Enable */
+#define PMC_PCER0_PID23 (0x1u << 23) /**< \brief (PMC_PCER0) Peripheral Clock 23 Enable */
+#define PMC_PCER0_PID24 (0x1u << 24) /**< \brief (PMC_PCER0) Peripheral Clock 24 Enable */
+#define PMC_PCER0_PID25 (0x1u << 25) /**< \brief (PMC_PCER0) Peripheral Clock 25 Enable */
+#define PMC_PCER0_PID26 (0x1u << 26) /**< \brief (PMC_PCER0) Peripheral Clock 26 Enable */
+#define PMC_PCER0_PID27 (0x1u << 27) /**< \brief (PMC_PCER0) Peripheral Clock 27 Enable */
+#define PMC_PCER0_PID28 (0x1u << 28) /**< \brief (PMC_PCER0) Peripheral Clock 28 Enable */
+#define PMC_PCER0_PID29 (0x1u << 29) /**< \brief (PMC_PCER0) Peripheral Clock 29 Enable */
+#define PMC_PCER0_PID30 (0x1u << 30) /**< \brief (PMC_PCER0) Peripheral Clock 30 Enable */
+#define PMC_PCER0_PID31 (0x1u << 31) /**< \brief (PMC_PCER0) Peripheral Clock 31 Enable */
+/* -------- PMC_PCDR0 : (PMC Offset: 0x0014) Peripheral Clock Disable Register 0 -------- */
+#define PMC_PCDR0_PID9 (0x1u << 9) /**< \brief (PMC_PCDR0) Peripheral Clock 9 Disable */
+#define PMC_PCDR0_PID10 (0x1u << 10) /**< \brief (PMC_PCDR0) Peripheral Clock 10 Disable */
+#define PMC_PCDR0_PID11 (0x1u << 11) /**< \brief (PMC_PCDR0) Peripheral Clock 11 Disable */
+#define PMC_PCDR0_PID12 (0x1u << 12) /**< \brief (PMC_PCDR0) Peripheral Clock 12 Disable */
+#define PMC_PCDR0_PID13 (0x1u << 13) /**< \brief (PMC_PCDR0) Peripheral Clock 13 Disable */
+#define PMC_PCDR0_PID14 (0x1u << 14) /**< \brief (PMC_PCDR0) Peripheral Clock 14 Disable */
+#define PMC_PCDR0_PID15 (0x1u << 15) /**< \brief (PMC_PCDR0) Peripheral Clock 15 Disable */
+#define PMC_PCDR0_PID16 (0x1u << 16) /**< \brief (PMC_PCDR0) Peripheral Clock 16 Disable */
+#define PMC_PCDR0_PID17 (0x1u << 17) /**< \brief (PMC_PCDR0) Peripheral Clock 17 Disable */
+#define PMC_PCDR0_PID18 (0x1u << 18) /**< \brief (PMC_PCDR0) Peripheral Clock 18 Disable */
+#define PMC_PCDR0_PID19 (0x1u << 19) /**< \brief (PMC_PCDR0) Peripheral Clock 19 Disable */
+#define PMC_PCDR0_PID20 (0x1u << 20) /**< \brief (PMC_PCDR0) Peripheral Clock 20 Disable */
+#define PMC_PCDR0_PID21 (0x1u << 21) /**< \brief (PMC_PCDR0) Peripheral Clock 21 Disable */
+#define PMC_PCDR0_PID22 (0x1u << 22) /**< \brief (PMC_PCDR0) Peripheral Clock 22 Disable */
+#define PMC_PCDR0_PID23 (0x1u << 23) /**< \brief (PMC_PCDR0) Peripheral Clock 23 Disable */
+#define PMC_PCDR0_PID24 (0x1u << 24) /**< \brief (PMC_PCDR0) Peripheral Clock 24 Disable */
+#define PMC_PCDR0_PID25 (0x1u << 25) /**< \brief (PMC_PCDR0) Peripheral Clock 25 Disable */
+#define PMC_PCDR0_PID26 (0x1u << 26) /**< \brief (PMC_PCDR0) Peripheral Clock 26 Disable */
+#define PMC_PCDR0_PID27 (0x1u << 27) /**< \brief (PMC_PCDR0) Peripheral Clock 27 Disable */
+#define PMC_PCDR0_PID28 (0x1u << 28) /**< \brief (PMC_PCDR0) Peripheral Clock 28 Disable */
+#define PMC_PCDR0_PID29 (0x1u << 29) /**< \brief (PMC_PCDR0) Peripheral Clock 29 Disable */
+#define PMC_PCDR0_PID30 (0x1u << 30) /**< \brief (PMC_PCDR0) Peripheral Clock 30 Disable */
+#define PMC_PCDR0_PID31 (0x1u << 31) /**< \brief (PMC_PCDR0) Peripheral Clock 31 Disable */
+/* -------- PMC_PCSR0 : (PMC Offset: 0x0018) Peripheral Clock Status Register 0 -------- */
+#define PMC_PCSR0_PID9 (0x1u << 9) /**< \brief (PMC_PCSR0) Peripheral Clock 9 Status */
+#define PMC_PCSR0_PID10 (0x1u << 10) /**< \brief (PMC_PCSR0) Peripheral Clock 10 Status */
+#define PMC_PCSR0_PID11 (0x1u << 11) /**< \brief (PMC_PCSR0) Peripheral Clock 11 Status */
+#define PMC_PCSR0_PID12 (0x1u << 12) /**< \brief (PMC_PCSR0) Peripheral Clock 12 Status */
+#define PMC_PCSR0_PID13 (0x1u << 13) /**< \brief (PMC_PCSR0) Peripheral Clock 13 Status */
+#define PMC_PCSR0_PID14 (0x1u << 14) /**< \brief (PMC_PCSR0) Peripheral Clock 14 Status */
+#define PMC_PCSR0_PID15 (0x1u << 15) /**< \brief (PMC_PCSR0) Peripheral Clock 15 Status */
+#define PMC_PCSR0_PID16 (0x1u << 16) /**< \brief (PMC_PCSR0) Peripheral Clock 16 Status */
+#define PMC_PCSR0_PID17 (0x1u << 17) /**< \brief (PMC_PCSR0) Peripheral Clock 17 Status */
+#define PMC_PCSR0_PID18 (0x1u << 18) /**< \brief (PMC_PCSR0) Peripheral Clock 18 Status */
+#define PMC_PCSR0_PID19 (0x1u << 19) /**< \brief (PMC_PCSR0) Peripheral Clock 19 Status */
+#define PMC_PCSR0_PID20 (0x1u << 20) /**< \brief (PMC_PCSR0) Peripheral Clock 20 Status */
+#define PMC_PCSR0_PID21 (0x1u << 21) /**< \brief (PMC_PCSR0) Peripheral Clock 21 Status */
+#define PMC_PCSR0_PID22 (0x1u << 22) /**< \brief (PMC_PCSR0) Peripheral Clock 22 Status */
+#define PMC_PCSR0_PID23 (0x1u << 23) /**< \brief (PMC_PCSR0) Peripheral Clock 23 Status */
+#define PMC_PCSR0_PID24 (0x1u << 24) /**< \brief (PMC_PCSR0) Peripheral Clock 24 Status */
+#define PMC_PCSR0_PID25 (0x1u << 25) /**< \brief (PMC_PCSR0) Peripheral Clock 25 Status */
+#define PMC_PCSR0_PID26 (0x1u << 26) /**< \brief (PMC_PCSR0) Peripheral Clock 26 Status */
+#define PMC_PCSR0_PID27 (0x1u << 27) /**< \brief (PMC_PCSR0) Peripheral Clock 27 Status */
+#define PMC_PCSR0_PID28 (0x1u << 28) /**< \brief (PMC_PCSR0) Peripheral Clock 28 Status */
+#define PMC_PCSR0_PID29 (0x1u << 29) /**< \brief (PMC_PCSR0) Peripheral Clock 29 Status */
+#define PMC_PCSR0_PID30 (0x1u << 30) /**< \brief (PMC_PCSR0) Peripheral Clock 30 Status */
+#define PMC_PCSR0_PID31 (0x1u << 31) /**< \brief (PMC_PCSR0) Peripheral Clock 31 Status */
+/* -------- CKGR_MOR : (PMC Offset: 0x0020) Main Oscillator Register -------- */
+#define CKGR_MOR_MOSCXTEN (0x1u << 0) /**< \brief (CKGR_MOR) Main Crystal Oscillator Enable */
+#define CKGR_MOR_MOSCXTBY (0x1u << 1) /**< \brief (CKGR_MOR) Main Crystal Oscillator Bypass */
+#define CKGR_MOR_WAITMODE (0x1u << 2) /**< \brief (CKGR_MOR) Wait Mode Command */
+#define CKGR_MOR_MOSCRCEN (0x1u << 3) /**< \brief (CKGR_MOR) Main On-Chip RC Oscillator Enable */
+#define CKGR_MOR_MOSCRCF_Pos 4
+#define CKGR_MOR_MOSCRCF_Msk (0x7u << CKGR_MOR_MOSCRCF_Pos) /**< \brief (CKGR_MOR) Main On-Chip RC Oscillator Frequency Selection */
+#define   CKGR_MOR_MOSCRCF_4_MHz (0x0u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 4 MHz (default) */
+#define   CKGR_MOR_MOSCRCF_8_MHz (0x1u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 8 MHz */
+#define   CKGR_MOR_MOSCRCF_12_MHz (0x2u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 12 MHz */
+#define CKGR_MOR_MOSCXTST_Pos 8
+#define CKGR_MOR_MOSCXTST_Msk (0xffu << CKGR_MOR_MOSCXTST_Pos) /**< \brief (CKGR_MOR) Main Crystal Oscillator Start-up Time */
+#define CKGR_MOR_MOSCXTST(value) ((CKGR_MOR_MOSCXTST_Msk & ((value) << CKGR_MOR_MOSCXTST_Pos)))
+#define CKGR_MOR_KEY_Pos 16
+#define CKGR_MOR_KEY_Msk (0xffu << CKGR_MOR_KEY_Pos) /**< \brief (CKGR_MOR) Password */
+#define CKGR_MOR_KEY(value) ((CKGR_MOR_KEY_Msk & ((value) << CKGR_MOR_KEY_Pos)))
+#define CKGR_MOR_MOSCSEL (0x1u << 24) /**< \brief (CKGR_MOR) Main Oscillator Selection */
+#define CKGR_MOR_CFDEN (0x1u << 25) /**< \brief (CKGR_MOR) Clock Failure Detector Enable */
+/* -------- CKGR_MCFR : (PMC Offset: 0x0024) Main Clock Frequency Register -------- */
+#define CKGR_MCFR_MAINF_Pos 0
+#define CKGR_MCFR_MAINF_Msk (0xffffu << CKGR_MCFR_MAINF_Pos) /**< \brief (CKGR_MCFR) Main Clock Frequency */
+#define CKGR_MCFR_MAINF(value) ((CKGR_MCFR_MAINF_Msk & ((value) << CKGR_MCFR_MAINF_Pos)))
+#define CKGR_MCFR_MAINFRDY (0x1u << 16) /**< \brief (CKGR_MCFR) Main Clock Ready */
+#define CKGR_MCFR_RCMEAS (0x1u << 20) /**< \brief (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) */
+/* -------- CKGR_PLLAR : (PMC Offset: 0x0028) PLLA Register -------- */
+#define CKGR_PLLAR_DIVA_Pos 0
+#define CKGR_PLLAR_DIVA_Msk (0xffu << CKGR_PLLAR_DIVA_Pos) /**< \brief (CKGR_PLLAR) Divider */
+#define CKGR_PLLAR_DIVA(value) ((CKGR_PLLAR_DIVA_Msk & ((value) << CKGR_PLLAR_DIVA_Pos)))
+#define CKGR_PLLAR_PLLACOUNT_Pos 8
+#define CKGR_PLLAR_PLLACOUNT_Msk (0x3fu << CKGR_PLLAR_PLLACOUNT_Pos) /**< \brief (CKGR_PLLAR) PLLA Counter */
+#define CKGR_PLLAR_PLLACOUNT(value) ((CKGR_PLLAR_PLLACOUNT_Msk & ((value) << CKGR_PLLAR_PLLACOUNT_Pos)))
+#define CKGR_PLLAR_MULA_Pos 16
+#define CKGR_PLLAR_MULA_Msk (0x7ffu << CKGR_PLLAR_MULA_Pos) /**< \brief (CKGR_PLLAR) PLLA Multiplier */
+#define CKGR_PLLAR_MULA(value) ((CKGR_PLLAR_MULA_Msk & ((value) << CKGR_PLLAR_MULA_Pos)))
+#define CKGR_PLLAR_ONE (0x1u << 29) /**< \brief (CKGR_PLLAR) Must Be Set to 1 */
+/* -------- PMC_MCKR : (PMC Offset: 0x0030) Master Clock Register -------- */
+#define PMC_MCKR_CSS_Pos 0
+#define PMC_MCKR_CSS_Msk (0x3u << PMC_MCKR_CSS_Pos) /**< \brief (PMC_MCKR) Master Clock Source Selection */
+#define   PMC_MCKR_CSS_SLOW_CLK (0x0u << 0) /**< \brief (PMC_MCKR) Slow Clock is selected */
+#define   PMC_MCKR_CSS_MAIN_CLK (0x1u << 0) /**< \brief (PMC_MCKR) Main Clock is selected */
+#define   PMC_MCKR_CSS_PLLA_CLK (0x2u << 0) /**< \brief (PMC_MCKR) PLLA Clock is selected */
+#define PMC_MCKR_PRES_Pos 4
+#define PMC_MCKR_PRES_Msk (0x7u << PMC_MCKR_PRES_Pos) /**< \brief (PMC_MCKR) Processor Clock Prescaler */
+#define   PMC_MCKR_PRES_CLK_1 (0x0u << 4) /**< \brief (PMC_MCKR) Selected clock */
+#define   PMC_MCKR_PRES_CLK_2 (0x1u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 2 */
+#define   PMC_MCKR_PRES_CLK_4 (0x2u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 4 */
+#define   PMC_MCKR_PRES_CLK_8 (0x3u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 8 */
+#define   PMC_MCKR_PRES_CLK_16 (0x4u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 16 */
+#define   PMC_MCKR_PRES_CLK_32 (0x5u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 32 */
+#define   PMC_MCKR_PRES_CLK_64 (0x6u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 64 */
+#define   PMC_MCKR_PRES_CLK_3 (0x7u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 3 */
+#define PMC_MCKR_PLLADIV2 (0x1u << 12) /**< \brief (PMC_MCKR) PLLA Divisor by 2 */
+/* -------- PMC_USB : (PMC Offset: 0x0038) USB Clock Register -------- */
+#define PMC_USB_USBDIV_Pos 8
+#define PMC_USB_USBDIV_Msk (0xfu << PMC_USB_USBDIV_Pos) /**< \brief (PMC_USB) Divider for USB Clock. */
+#define PMC_USB_USBDIV(value) ((PMC_USB_USBDIV_Msk & ((value) << PMC_USB_USBDIV_Pos)))
+/* -------- PMC_PCK[3] : (PMC Offset: 0x0040) Programmable Clock 0 Register -------- */
+#define PMC_PCK_CSS_Pos 0
+#define PMC_PCK_CSS_Msk (0x7u << PMC_PCK_CSS_Pos) /**< \brief (PMC_PCK[3]) Master Clock Source Selection */
+#define   PMC_PCK_CSS_SLOW_CLK (0x0u << 0) /**< \brief (PMC_PCK[3]) Slow Clock is selected */
+#define   PMC_PCK_CSS_MAIN_CLK (0x1u << 0) /**< \brief (PMC_PCK[3]) Main Clock is selected */
+#define   PMC_PCK_CSS_PLLA_CLK (0x2u << 0) /**< \brief (PMC_PCK[3]) PLLA Clock is selected */
+#define   PMC_PCK_CSS_MCK (0x4u << 0) /**< \brief (PMC_PCK[3]) Master Clock is selected */
+#define PMC_PCK_PRES_Pos 4
+#define PMC_PCK_PRES_Msk (0x7u << PMC_PCK_PRES_Pos) /**< \brief (PMC_PCK[3]) Programmable Clock Prescaler */
+#define PMC_PCK_PRES(value) ((PMC_PCK_PRES_Msk & ((value) << PMC_PCK_PRES_Pos)))
+/* -------- PMC_IER : (PMC Offset: 0x0060) Interrupt Enable Register -------- */
+#define PMC_IER_MOSCXTS (0x1u << 0) /**< \brief (PMC_IER) Main Crystal Oscillator Status Interrupt Enable */
+#define PMC_IER_LOCKA (0x1u << 1) /**< \brief (PMC_IER) PLLA Lock Interrupt Enable */
+#define PMC_IER_MCKRDY (0x1u << 3) /**< \brief (PMC_IER) Master Clock Ready Interrupt Enable */
+#define PMC_IER_PCKRDY0 (0x1u << 8) /**< \brief (PMC_IER) Programmable Clock Ready 0 Interrupt Enable */
+#define PMC_IER_PCKRDY1 (0x1u << 9) /**< \brief (PMC_IER) Programmable Clock Ready 1 Interrupt Enable */
+#define PMC_IER_PCKRDY2 (0x1u << 10) /**< \brief (PMC_IER) Programmable Clock Ready 2 Interrupt Enable */
+#define PMC_IER_MOSCSELS (0x1u << 16) /**< \brief (PMC_IER) Main Oscillator Selection Status Interrupt Enable */
+#define PMC_IER_MOSCRCS (0x1u << 17) /**< \brief (PMC_IER) Main On-Chip RC Status Interrupt Enable */
+#define PMC_IER_CFDEV (0x1u << 18) /**< \brief (PMC_IER) Clock Failure Detector Event Interrupt Enable */
+/* -------- PMC_IDR : (PMC Offset: 0x0064) Interrupt Disable Register -------- */
+#define PMC_IDR_MOSCXTS (0x1u << 0) /**< \brief (PMC_IDR) Main Crystal Oscillator Status Interrupt Disable */
+#define PMC_IDR_LOCKA (0x1u << 1) /**< \brief (PMC_IDR) PLLA Lock Interrupt Disable */
+#define PMC_IDR_MCKRDY (0x1u << 3) /**< \brief (PMC_IDR) Master Clock Ready Interrupt Disable */
+#define PMC_IDR_PCKRDY0 (0x1u << 8) /**< \brief (PMC_IDR) Programmable Clock Ready 0 Interrupt Disable */
+#define PMC_IDR_PCKRDY1 (0x1u << 9) /**< \brief (PMC_IDR) Programmable Clock Ready 1 Interrupt Disable */
+#define PMC_IDR_PCKRDY2 (0x1u << 10) /**< \brief (PMC_IDR) Programmable Clock Ready 2 Interrupt Disable */
+#define PMC_IDR_MOSCSELS (0x1u << 16) /**< \brief (PMC_IDR) Main Oscillator Selection Status Interrupt Disable */
+#define PMC_IDR_MOSCRCS (0x1u << 17) /**< \brief (PMC_IDR) Main On-Chip RC Status Interrupt Disable */
+#define PMC_IDR_CFDEV (0x1u << 18) /**< \brief (PMC_IDR) Clock Failure Detector Event Interrupt Disable */
+/* -------- PMC_SR : (PMC Offset: 0x0068) Status Register -------- */
+#define PMC_SR_MOSCXTS (0x1u << 0) /**< \brief (PMC_SR) Main XTAL Oscillator Status */
+#define PMC_SR_LOCKA (0x1u << 1) /**< \brief (PMC_SR) PLLA Lock Status */
+#define PMC_SR_MCKRDY (0x1u << 3) /**< \brief (PMC_SR) Master Clock Status */
+#define PMC_SR_OSCSELS (0x1u << 7) /**< \brief (PMC_SR) Slow Clock Oscillator Selection */
+#define PMC_SR_PCKRDY0 (0x1u << 8) /**< \brief (PMC_SR) Programmable Clock Ready Status */
+#define PMC_SR_PCKRDY1 (0x1u << 9) /**< \brief (PMC_SR) Programmable Clock Ready Status */
+#define PMC_SR_PCKRDY2 (0x1u << 10) /**< \brief (PMC_SR) Programmable Clock Ready Status */
+#define PMC_SR_MOSCSELS (0x1u << 16) /**< \brief (PMC_SR) Main Oscillator Selection Status */
+#define PMC_SR_MOSCRCS (0x1u << 17) /**< \brief (PMC_SR) Main On-Chip RC Oscillator Status */
+#define PMC_SR_CFDEV (0x1u << 18) /**< \brief (PMC_SR) Clock Failure Detector Event */
+#define PMC_SR_CFDS (0x1u << 19) /**< \brief (PMC_SR) Clock Failure Detector Status */
+#define PMC_SR_FOS (0x1u << 20) /**< \brief (PMC_SR) Clock Failure Detector Fault Output Status */
+/* -------- PMC_IMR : (PMC Offset: 0x006C) Interrupt Mask Register -------- */
+#define PMC_IMR_MOSCXTS (0x1u << 0) /**< \brief (PMC_IMR) Main Crystal Oscillator Status Interrupt Mask */
+#define PMC_IMR_LOCKA (0x1u << 1) /**< \brief (PMC_IMR) PLLA Lock Interrupt Mask */
+#define PMC_IMR_MCKRDY (0x1u << 3) /**< \brief (PMC_IMR) Master Clock Ready Interrupt Mask */
+#define PMC_IMR_PCKRDY0 (0x1u << 8) /**< \brief (PMC_IMR) Programmable Clock Ready 0 Interrupt Mask */
+#define PMC_IMR_PCKRDY1 (0x1u << 9) /**< \brief (PMC_IMR) Programmable Clock Ready 1 Interrupt Mask */
+#define PMC_IMR_PCKRDY2 (0x1u << 10) /**< \brief (PMC_IMR) Programmable Clock Ready 2 Interrupt Mask */
+#define PMC_IMR_MOSCSELS (0x1u << 16) /**< \brief (PMC_IMR) Main Oscillator Selection Status Interrupt Mask */
+#define PMC_IMR_MOSCRCS (0x1u << 17) /**< \brief (PMC_IMR) Main On-Chip RC Status Interrupt Mask */
+#define PMC_IMR_CFDEV (0x1u << 18) /**< \brief (PMC_IMR) Clock Failure Detector Event Interrupt Mask */
+/* -------- PMC_FSMR : (PMC Offset: 0x0070) Fast Startup Mode Register -------- */
+#define PMC_FSMR_FSTT0 (0x1u << 0) /**< \brief (PMC_FSMR) Fast Startup Input Enable 0 */
+#define PMC_FSMR_FSTT1 (0x1u << 1) /**< \brief (PMC_FSMR) Fast Startup Input Enable 1 */
+#define PMC_FSMR_FSTT2 (0x1u << 2) /**< \brief (PMC_FSMR) Fast Startup Input Enable 2 */
+#define PMC_FSMR_FSTT3 (0x1u << 3) /**< \brief (PMC_FSMR) Fast Startup Input Enable 3 */
+#define PMC_FSMR_FSTT4 (0x1u << 4) /**< \brief (PMC_FSMR) Fast Startup Input Enable 4 */
+#define PMC_FSMR_FSTT5 (0x1u << 5) /**< \brief (PMC_FSMR) Fast Startup Input Enable 5 */
+#define PMC_FSMR_FSTT6 (0x1u << 6) /**< \brief (PMC_FSMR) Fast Startup Input Enable 6 */
+#define PMC_FSMR_FSTT7 (0x1u << 7) /**< \brief (PMC_FSMR) Fast Startup Input Enable 7 */
+#define PMC_FSMR_FSTT8 (0x1u << 8) /**< \brief (PMC_FSMR) Fast Startup Input Enable 8 */
+#define PMC_FSMR_FSTT9 (0x1u << 9) /**< \brief (PMC_FSMR) Fast Startup Input Enable 9 */
+#define PMC_FSMR_FSTT10 (0x1u << 10) /**< \brief (PMC_FSMR) Fast Startup Input Enable 10 */
+#define PMC_FSMR_FSTT11 (0x1u << 11) /**< \brief (PMC_FSMR) Fast Startup Input Enable 11 */
+#define PMC_FSMR_FSTT12 (0x1u << 12) /**< \brief (PMC_FSMR) Fast Startup Input Enable 12 */
+#define PMC_FSMR_FSTT13 (0x1u << 13) /**< \brief (PMC_FSMR) Fast Startup Input Enable 13 */
+#define PMC_FSMR_FSTT14 (0x1u << 14) /**< \brief (PMC_FSMR) Fast Startup Input Enable 14 */
+#define PMC_FSMR_FSTT15 (0x1u << 15) /**< \brief (PMC_FSMR) Fast Startup Input Enable 15 */
+#define PMC_FSMR_RTTAL (0x1u << 16) /**< \brief (PMC_FSMR) RTT Alarm Enable */
+#define PMC_FSMR_RTCAL (0x1u << 17) /**< \brief (PMC_FSMR) RTC Alarm Enable */
+#define PMC_FSMR_USBAL (0x1u << 18) /**< \brief (PMC_FSMR) USB Alarm Enable */
+#define PMC_FSMR_FLPM_Pos 21
+#define PMC_FSMR_FLPM_Msk (0x3u << PMC_FSMR_FLPM_Pos) /**< \brief (PMC_FSMR) Flash Low Power Mode */
+#define PMC_FSMR_FLPM(value) ((PMC_FSMR_FLPM_Msk & ((value) << PMC_FSMR_FLPM_Pos)))
+/* -------- PMC_FSPR : (PMC Offset: 0x0074) Fast Startup Polarity Register -------- */
+#define PMC_FSPR_FSTP0 (0x1u << 0) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP1 (0x1u << 1) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP2 (0x1u << 2) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP3 (0x1u << 3) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP4 (0x1u << 4) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP5 (0x1u << 5) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP6 (0x1u << 6) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP7 (0x1u << 7) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP8 (0x1u << 8) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP9 (0x1u << 9) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP10 (0x1u << 10) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP11 (0x1u << 11) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP12 (0x1u << 12) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP13 (0x1u << 13) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP14 (0x1u << 14) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+#define PMC_FSPR_FSTP15 (0x1u << 15) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
+/* -------- PMC_FOCR : (PMC Offset: 0x0078) Fault Output Clear Register -------- */
+#define PMC_FOCR_FOCLR (0x1u << 0) /**< \brief (PMC_FOCR) Fault Output Clear */
+/* -------- PMC_WPMR : (PMC Offset: 0x00E4) Write Protect Mode Register -------- */
+#define PMC_WPMR_WPEN (0x1u << 0) /**< \brief (PMC_WPMR) Write Protect Enable */
+#define PMC_WPMR_WPKEY_Pos 8
+#define PMC_WPMR_WPKEY_Msk (0xffffffu << PMC_WPMR_WPKEY_Pos) /**< \brief (PMC_WPMR) Write Protect KEY */
+#define PMC_WPMR_WPKEY(value) ((PMC_WPMR_WPKEY_Msk & ((value) << PMC_WPMR_WPKEY_Pos)))
+/* -------- PMC_WPSR : (PMC Offset: 0x00E8) Write Protect Status Register -------- */
+#define PMC_WPSR_WPVS (0x1u << 0) /**< \brief (PMC_WPSR) Write Protect Violation Status */
+#define PMC_WPSR_WPVSRC_Pos 8
+#define PMC_WPSR_WPVSRC_Msk (0xffffu << PMC_WPSR_WPVSRC_Pos) /**< \brief (PMC_WPSR) Write Protect Violation Source */
+/* -------- PMC_PCER1 : (PMC Offset: 0x0100) Peripheral Clock Enable Register 1 -------- */
+#define PMC_PCER1_PID32 (0x1u << 0) /**< \brief (PMC_PCER1) Peripheral Clock 32 Enable */
+#define PMC_PCER1_PID33 (0x1u << 1) /**< \brief (PMC_PCER1) Peripheral Clock 33 Enable */
+#define PMC_PCER1_PID34 (0x1u << 2) /**< \brief (PMC_PCER1) Peripheral Clock 34 Enable */
+#define PMC_PCER1_PID35 (0x1u << 3) /**< \brief (PMC_PCER1) Peripheral Clock 35 Enable */
+#define PMC_PCER1_PID36 (0x1u << 4) /**< \brief (PMC_PCER1) Peripheral Clock 36 Enable */
+#define PMC_PCER1_PID37 (0x1u << 5) /**< \brief (PMC_PCER1) Peripheral Clock 37 Enable */
+#define PMC_PCER1_PID38 (0x1u << 6) /**< \brief (PMC_PCER1) Peripheral Clock 38 Enable */
+#define PMC_PCER1_PID39 (0x1u << 7) /**< \brief (PMC_PCER1) Peripheral Clock 39 Enable */
+#define PMC_PCER1_PID40 (0x1u << 8) /**< \brief (PMC_PCER1) Peripheral Clock 40 Enable */
+#define PMC_PCER1_PID41 (0x1u << 9) /**< \brief (PMC_PCER1) Peripheral Clock 41 Enable */
+#define PMC_PCER1_PID42 (0x1u << 10) /**< \brief (PMC_PCER1) Peripheral Clock 42 Enable */
+#define PMC_PCER1_PID43 (0x1u << 11) /**< \brief (PMC_PCER1) Peripheral Clock 43 Enable */
+#define PMC_PCER1_PID44 (0x1u << 12) /**< \brief (PMC_PCER1) Peripheral Clock 44 Enable */
+#define PMC_PCER1_PID45 (0x1u << 13) /**< \brief (PMC_PCER1) Peripheral Clock 45 Enable */
+#define PMC_PCER1_PID46 (0x1u << 14) /**< \brief (PMC_PCER1) Peripheral Clock 46 Enable */
+#define PMC_PCER1_PID47 (0x1u << 15) /**< \brief (PMC_PCER1) Peripheral Clock 47 Enable */
+/* -------- PMC_PCDR1 : (PMC Offset: 0x0104) Peripheral Clock Disable Register 1 -------- */
+#define PMC_PCDR1_PID32 (0x1u << 0) /**< \brief (PMC_PCDR1) Peripheral Clock 32 Disable */
+#define PMC_PCDR1_PID33 (0x1u << 1) /**< \brief (PMC_PCDR1) Peripheral Clock 33 Disable */
+#define PMC_PCDR1_PID34 (0x1u << 2) /**< \brief (PMC_PCDR1) Peripheral Clock 34 Disable */
+#define PMC_PCDR1_PID35 (0x1u << 3) /**< \brief (PMC_PCDR1) Peripheral Clock 35 Disable */
+#define PMC_PCDR1_PID36 (0x1u << 4) /**< \brief (PMC_PCDR1) Peripheral Clock 36 Disable */
+#define PMC_PCDR1_PID37 (0x1u << 5) /**< \brief (PMC_PCDR1) Peripheral Clock 37 Disable */
+#define PMC_PCDR1_PID38 (0x1u << 6) /**< \brief (PMC_PCDR1) Peripheral Clock 38 Disable */
+#define PMC_PCDR1_PID39 (0x1u << 7) /**< \brief (PMC_PCDR1) Peripheral Clock 39 Disable */
+#define PMC_PCDR1_PID40 (0x1u << 8) /**< \brief (PMC_PCDR1) Peripheral Clock 40 Disable */
+#define PMC_PCDR1_PID41 (0x1u << 9) /**< \brief (PMC_PCDR1) Peripheral Clock 41 Disable */
+#define PMC_PCDR1_PID42 (0x1u << 10) /**< \brief (PMC_PCDR1) Peripheral Clock 42 Disable */
+#define PMC_PCDR1_PID43 (0x1u << 11) /**< \brief (PMC_PCDR1) Peripheral Clock 43 Disable */
+#define PMC_PCDR1_PID44 (0x1u << 12) /**< \brief (PMC_PCDR1) Peripheral Clock 44 Disable */
+#define PMC_PCDR1_PID45 (0x1u << 13) /**< \brief (PMC_PCDR1) Peripheral Clock 45 Disable */
+#define PMC_PCDR1_PID46 (0x1u << 14) /**< \brief (PMC_PCDR1) Peripheral Clock 46 Disable */
+#define PMC_PCDR1_PID47 (0x1u << 15) /**< \brief (PMC_PCDR1) Peripheral Clock 47 Disable */
+/* -------- PMC_PCSR1 : (PMC Offset: 0x0108) Peripheral Clock Status Register 1 -------- */
+#define PMC_PCSR1_PID32 (0x1u << 0) /**< \brief (PMC_PCSR1) Peripheral Clock 32 Status */
+#define PMC_PCSR1_PID33 (0x1u << 1) /**< \brief (PMC_PCSR1) Peripheral Clock 33 Status */
+#define PMC_PCSR1_PID34 (0x1u << 2) /**< \brief (PMC_PCSR1) Peripheral Clock 34 Status */
+#define PMC_PCSR1_PID35 (0x1u << 3) /**< \brief (PMC_PCSR1) Peripheral Clock 35 Status */
+#define PMC_PCSR1_PID36 (0x1u << 4) /**< \brief (PMC_PCSR1) Peripheral Clock 36 Status */
+#define PMC_PCSR1_PID37 (0x1u << 5) /**< \brief (PMC_PCSR1) Peripheral Clock 37 Status */
+#define PMC_PCSR1_PID38 (0x1u << 6) /**< \brief (PMC_PCSR1) Peripheral Clock 38 Status */
+#define PMC_PCSR1_PID39 (0x1u << 7) /**< \brief (PMC_PCSR1) Peripheral Clock 39 Status */
+#define PMC_PCSR1_PID40 (0x1u << 8) /**< \brief (PMC_PCSR1) Peripheral Clock 40 Status */
+#define PMC_PCSR1_PID41 (0x1u << 9) /**< \brief (PMC_PCSR1) Peripheral Clock 41 Status */
+#define PMC_PCSR1_PID42 (0x1u << 10) /**< \brief (PMC_PCSR1) Peripheral Clock 42 Status */
+#define PMC_PCSR1_PID43 (0x1u << 11) /**< \brief (PMC_PCSR1) Peripheral Clock 43 Status */
+#define PMC_PCSR1_PID44 (0x1u << 12) /**< \brief (PMC_PCSR1) Peripheral Clock 44 Status */
+#define PMC_PCSR1_PID45 (0x1u << 13) /**< \brief (PMC_PCSR1) Peripheral Clock 45 Status */
+#define PMC_PCSR1_PID46 (0x1u << 14) /**< \brief (PMC_PCSR1) Peripheral Clock 46 Status */
+#define PMC_PCSR1_PID47 (0x1u << 15) /**< \brief (PMC_PCSR1) Peripheral Clock 47 Status */
+/* -------- PMC_OCR : (PMC Offset: 0x0110) Oscillator Calibration Register -------- */
+#define PMC_OCR_CAL4_Pos 0
+#define PMC_OCR_CAL4_Msk (0x7fu << PMC_OCR_CAL4_Pos) /**< \brief (PMC_OCR) RC Oscillator Calibration bits for 4 MHz */
+#define PMC_OCR_CAL4(value) ((PMC_OCR_CAL4_Msk & ((value) << PMC_OCR_CAL4_Pos)))
+#define PMC_OCR_SEL4 (0x1u << 7) /**< \brief (PMC_OCR) Selection of RC Oscillator Calibration bits for 4 MHz */
+#define PMC_OCR_CAL8_Pos 8
+#define PMC_OCR_CAL8_Msk (0x7fu << PMC_OCR_CAL8_Pos) /**< \brief (PMC_OCR) RC Oscillator Calibration bits for 8 MHz */
+#define PMC_OCR_CAL8(value) ((PMC_OCR_CAL8_Msk & ((value) << PMC_OCR_CAL8_Pos)))
+#define PMC_OCR_SEL8 (0x1u << 15) /**< \brief (PMC_OCR) Selection of RC Oscillator Calibration bits for 8 MHz */
+#define PMC_OCR_CAL12_Pos 16
+#define PMC_OCR_CAL12_Msk (0x7fu << PMC_OCR_CAL12_Pos) /**< \brief (PMC_OCR) RC Oscillator Calibration bits for 12 MHz */
+#define PMC_OCR_CAL12(value) ((PMC_OCR_CAL12_Msk & ((value) << PMC_OCR_CAL12_Pos)))
+#define PMC_OCR_SEL12 (0x1u << 23) /**< \brief (PMC_OCR) Selection of RC Oscillator Calibration bits for 12 MHz */
+
+/*@}*/
+
+
+#endif /* _SAM4E_PMC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/pmc.h
+++ b/asf/sam/include/sam4e/component/pmc.h
@@ -91,6 +91,8 @@ typedef struct {
 #define PMC_SCSR_PCK1 (0x1u << 9) /**< \brief (PMC_SCSR) Programmable Clock 1 Output Status */
 #define PMC_SCSR_PCK2 (0x1u << 10) /**< \brief (PMC_SCSR) Programmable Clock 2 Output Status */
 /* -------- PMC_PCER0 : (PMC Offset: 0x0010) Peripheral Clock Enable Register 0 -------- */
+#define PMC_PCER0_PID7 (0x1u << 7) /**< \brief (PMC_PCER0) Peripheral Clock 7 Enable */
+#define PMC_PCER0_PID8 (0x1u << 8) /**< \brief (PMC_PCER0) Peripheral Clock 8 Enable */
 #define PMC_PCER0_PID9 (0x1u << 9) /**< \brief (PMC_PCER0) Peripheral Clock 9 Enable */
 #define PMC_PCER0_PID10 (0x1u << 10) /**< \brief (PMC_PCER0) Peripheral Clock 10 Enable */
 #define PMC_PCER0_PID11 (0x1u << 11) /**< \brief (PMC_PCER0) Peripheral Clock 11 Enable */
@@ -115,6 +117,8 @@ typedef struct {
 #define PMC_PCER0_PID30 (0x1u << 30) /**< \brief (PMC_PCER0) Peripheral Clock 30 Enable */
 #define PMC_PCER0_PID31 (0x1u << 31) /**< \brief (PMC_PCER0) Peripheral Clock 31 Enable */
 /* -------- PMC_PCDR0 : (PMC Offset: 0x0014) Peripheral Clock Disable Register 0 -------- */
+#define PMC_PCDR0_PID7 (0x1u << 7) /**< \brief (PMC_PCDR0) Peripheral Clock 7 Disable */
+#define PMC_PCDR0_PID8 (0x1u << 8) /**< \brief (PMC_PCDR0) Peripheral Clock 8 Disable */
 #define PMC_PCDR0_PID9 (0x1u << 9) /**< \brief (PMC_PCDR0) Peripheral Clock 9 Disable */
 #define PMC_PCDR0_PID10 (0x1u << 10) /**< \brief (PMC_PCDR0) Peripheral Clock 10 Disable */
 #define PMC_PCDR0_PID11 (0x1u << 11) /**< \brief (PMC_PCDR0) Peripheral Clock 11 Disable */
@@ -139,6 +143,8 @@ typedef struct {
 #define PMC_PCDR0_PID30 (0x1u << 30) /**< \brief (PMC_PCDR0) Peripheral Clock 30 Disable */
 #define PMC_PCDR0_PID31 (0x1u << 31) /**< \brief (PMC_PCDR0) Peripheral Clock 31 Disable */
 /* -------- PMC_PCSR0 : (PMC Offset: 0x0018) Peripheral Clock Status Register 0 -------- */
+#define PMC_PCSR0_PID7 (0x1u << 7) /**< \brief (PMC_PCSR0) Peripheral Clock 7 Status */
+#define PMC_PCSR0_PID8 (0x1u << 8) /**< \brief (PMC_PCSR0) Peripheral Clock 8 Status */
 #define PMC_PCSR0_PID9 (0x1u << 9) /**< \brief (PMC_PCSR0) Peripheral Clock 9 Status */
 #define PMC_PCSR0_PID10 (0x1u << 10) /**< \brief (PMC_PCSR0) Peripheral Clock 10 Status */
 #define PMC_PCSR0_PID11 (0x1u << 11) /**< \brief (PMC_PCSR0) Peripheral Clock 11 Status */
@@ -165,30 +171,32 @@ typedef struct {
 /* -------- CKGR_MOR : (PMC Offset: 0x0020) Main Oscillator Register -------- */
 #define CKGR_MOR_MOSCXTEN (0x1u << 0) /**< \brief (CKGR_MOR) Main Crystal Oscillator Enable */
 #define CKGR_MOR_MOSCXTBY (0x1u << 1) /**< \brief (CKGR_MOR) Main Crystal Oscillator Bypass */
-#define CKGR_MOR_WAITMODE (0x1u << 2) /**< \brief (CKGR_MOR) Wait Mode Command */
+#define CKGR_MOR_WAITMODE (0x1u << 2) /**< \brief (CKGR_MOR) Wait Mode Command (Write-only) */
 #define CKGR_MOR_MOSCRCEN (0x1u << 3) /**< \brief (CKGR_MOR) Main On-Chip RC Oscillator Enable */
 #define CKGR_MOR_MOSCRCF_Pos 4
 #define CKGR_MOR_MOSCRCF_Msk (0x7u << CKGR_MOR_MOSCRCF_Pos) /**< \brief (CKGR_MOR) Main On-Chip RC Oscillator Frequency Selection */
-#define   CKGR_MOR_MOSCRCF_4_MHz (0x0u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 4 MHz (default) */
-#define   CKGR_MOR_MOSCRCF_8_MHz (0x1u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 8 MHz */
-#define   CKGR_MOR_MOSCRCF_12_MHz (0x2u << 4) /**< \brief (CKGR_MOR) The Fast RC Oscillator Frequency is at 12 MHz */
+#define CKGR_MOR_MOSCRCF(value) ((CKGR_MOR_MOSCRCF_Msk & ((value) << CKGR_MOR_MOSCRCF_Pos)))
+#define   CKGR_MOR_MOSCRCF_4_MHz (0x0u << 4) /**< \brief (CKGR_MOR) The fast RC oscillator frequency is at 4 MHz (default) */
+#define   CKGR_MOR_MOSCRCF_8_MHz (0x1u << 4) /**< \brief (CKGR_MOR) The fast RC oscillator frequency is at 8 MHz */
+#define   CKGR_MOR_MOSCRCF_12_MHz (0x2u << 4) /**< \brief (CKGR_MOR) The fast RC oscillator frequency is at 12 MHz */
 #define CKGR_MOR_MOSCXTST_Pos 8
 #define CKGR_MOR_MOSCXTST_Msk (0xffu << CKGR_MOR_MOSCXTST_Pos) /**< \brief (CKGR_MOR) Main Crystal Oscillator Start-up Time */
 #define CKGR_MOR_MOSCXTST(value) ((CKGR_MOR_MOSCXTST_Msk & ((value) << CKGR_MOR_MOSCXTST_Pos)))
 #define CKGR_MOR_KEY_Pos 16
-#define CKGR_MOR_KEY_Msk (0xffu << CKGR_MOR_KEY_Pos) /**< \brief (CKGR_MOR) Password */
+#define CKGR_MOR_KEY_Msk (0xffu << CKGR_MOR_KEY_Pos) /**< \brief (CKGR_MOR) Write Access Password */
 #define CKGR_MOR_KEY(value) ((CKGR_MOR_KEY_Msk & ((value) << CKGR_MOR_KEY_Pos)))
+#define   CKGR_MOR_KEY_PASSWD (0x37u << 16) /**< \brief (CKGR_MOR) Writing any other value in this field aborts the write operation.Always reads as 0. */
 #define CKGR_MOR_MOSCSEL (0x1u << 24) /**< \brief (CKGR_MOR) Main Oscillator Selection */
 #define CKGR_MOR_CFDEN (0x1u << 25) /**< \brief (CKGR_MOR) Clock Failure Detector Enable */
 /* -------- CKGR_MCFR : (PMC Offset: 0x0024) Main Clock Frequency Register -------- */
 #define CKGR_MCFR_MAINF_Pos 0
 #define CKGR_MCFR_MAINF_Msk (0xffffu << CKGR_MCFR_MAINF_Pos) /**< \brief (CKGR_MCFR) Main Clock Frequency */
 #define CKGR_MCFR_MAINF(value) ((CKGR_MCFR_MAINF_Msk & ((value) << CKGR_MCFR_MAINF_Pos)))
-#define CKGR_MCFR_MAINFRDY (0x1u << 16) /**< \brief (CKGR_MCFR) Main Clock Ready */
+#define CKGR_MCFR_MAINFRDY (0x1u << 16) /**< \brief (CKGR_MCFR) Main Clock Frequency Measure Ready */
 #define CKGR_MCFR_RCMEAS (0x1u << 20) /**< \brief (CKGR_MCFR) RC Oscillator Frequency Measure (write-only) */
 /* -------- CKGR_PLLAR : (PMC Offset: 0x0028) PLLA Register -------- */
 #define CKGR_PLLAR_DIVA_Pos 0
-#define CKGR_PLLAR_DIVA_Msk (0xffu << CKGR_PLLAR_DIVA_Pos) /**< \brief (CKGR_PLLAR) Divider */
+#define CKGR_PLLAR_DIVA_Msk (0xffu << CKGR_PLLAR_DIVA_Pos) /**< \brief (CKGR_PLLAR) PLLA Front_End Divider */
 #define CKGR_PLLAR_DIVA(value) ((CKGR_PLLAR_DIVA_Msk & ((value) << CKGR_PLLAR_DIVA_Pos)))
 #define CKGR_PLLAR_PLLACOUNT_Pos 8
 #define CKGR_PLLAR_PLLACOUNT_Msk (0x3fu << CKGR_PLLAR_PLLACOUNT_Pos) /**< \brief (CKGR_PLLAR) PLLA Counter */
@@ -200,11 +208,13 @@ typedef struct {
 /* -------- PMC_MCKR : (PMC Offset: 0x0030) Master Clock Register -------- */
 #define PMC_MCKR_CSS_Pos 0
 #define PMC_MCKR_CSS_Msk (0x3u << PMC_MCKR_CSS_Pos) /**< \brief (PMC_MCKR) Master Clock Source Selection */
+#define PMC_MCKR_CSS(value) ((PMC_MCKR_CSS_Msk & ((value) << PMC_MCKR_CSS_Pos)))
 #define   PMC_MCKR_CSS_SLOW_CLK (0x0u << 0) /**< \brief (PMC_MCKR) Slow Clock is selected */
 #define   PMC_MCKR_CSS_MAIN_CLK (0x1u << 0) /**< \brief (PMC_MCKR) Main Clock is selected */
 #define   PMC_MCKR_CSS_PLLA_CLK (0x2u << 0) /**< \brief (PMC_MCKR) PLLA Clock is selected */
 #define PMC_MCKR_PRES_Pos 4
 #define PMC_MCKR_PRES_Msk (0x7u << PMC_MCKR_PRES_Pos) /**< \brief (PMC_MCKR) Processor Clock Prescaler */
+#define PMC_MCKR_PRES(value) ((PMC_MCKR_PRES_Msk & ((value) << PMC_MCKR_PRES_Pos)))
 #define   PMC_MCKR_PRES_CLK_1 (0x0u << 4) /**< \brief (PMC_MCKR) Selected clock */
 #define   PMC_MCKR_PRES_CLK_2 (0x1u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 2 */
 #define   PMC_MCKR_PRES_CLK_4 (0x2u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 4 */
@@ -215,12 +225,14 @@ typedef struct {
 #define   PMC_MCKR_PRES_CLK_3 (0x7u << 4) /**< \brief (PMC_MCKR) Selected clock divided by 3 */
 #define PMC_MCKR_PLLADIV2 (0x1u << 12) /**< \brief (PMC_MCKR) PLLA Divisor by 2 */
 /* -------- PMC_USB : (PMC Offset: 0x0038) USB Clock Register -------- */
+#define PMC_USB_USBS (0x1u << 0) /**< \brief (PMC_USB) USB Input Clock Selection */
 #define PMC_USB_USBDIV_Pos 8
-#define PMC_USB_USBDIV_Msk (0xfu << PMC_USB_USBDIV_Pos) /**< \brief (PMC_USB) Divider for USB Clock. */
+#define PMC_USB_USBDIV_Msk (0xfu << PMC_USB_USBDIV_Pos) /**< \brief (PMC_USB) Divider for USB Clock */
 #define PMC_USB_USBDIV(value) ((PMC_USB_USBDIV_Msk & ((value) << PMC_USB_USBDIV_Pos)))
 /* -------- PMC_PCK[3] : (PMC Offset: 0x0040) Programmable Clock 0 Register -------- */
 #define PMC_PCK_CSS_Pos 0
 #define PMC_PCK_CSS_Msk (0x7u << PMC_PCK_CSS_Pos) /**< \brief (PMC_PCK[3]) Master Clock Source Selection */
+#define PMC_PCK_CSS(value) ((PMC_PCK_CSS_Msk & ((value) << PMC_PCK_CSS_Pos)))
 #define   PMC_PCK_CSS_SLOW_CLK (0x0u << 0) /**< \brief (PMC_PCK[3]) Slow Clock is selected */
 #define   PMC_PCK_CSS_MAIN_CLK (0x1u << 0) /**< \brief (PMC_PCK[3]) Main Clock is selected */
 #define   PMC_PCK_CSS_PLLA_CLK (0x2u << 0) /**< \brief (PMC_PCK[3]) PLLA Clock is selected */
@@ -228,6 +240,13 @@ typedef struct {
 #define PMC_PCK_PRES_Pos 4
 #define PMC_PCK_PRES_Msk (0x7u << PMC_PCK_PRES_Pos) /**< \brief (PMC_PCK[3]) Programmable Clock Prescaler */
 #define PMC_PCK_PRES(value) ((PMC_PCK_PRES_Msk & ((value) << PMC_PCK_PRES_Pos)))
+#define   PMC_PCK_PRES_CLK_1 (0x0u << 4) /**< \brief (PMC_PCK[3]) Selected clock */
+#define   PMC_PCK_PRES_CLK_2 (0x1u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 2 */
+#define   PMC_PCK_PRES_CLK_4 (0x2u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 4 */
+#define   PMC_PCK_PRES_CLK_8 (0x3u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 8 */
+#define   PMC_PCK_PRES_CLK_16 (0x4u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 16 */
+#define   PMC_PCK_PRES_CLK_32 (0x5u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 32 */
+#define   PMC_PCK_PRES_CLK_64 (0x6u << 4) /**< \brief (PMC_PCK[3]) Selected clock divided by 64 */
 /* -------- PMC_IER : (PMC Offset: 0x0060) Interrupt Enable Register -------- */
 #define PMC_IER_MOSCXTS (0x1u << 0) /**< \brief (PMC_IER) Main Crystal Oscillator Status Interrupt Enable */
 #define PMC_IER_LOCKA (0x1u << 1) /**< \brief (PMC_IER) PLLA Lock Interrupt Enable */
@@ -249,7 +268,7 @@ typedef struct {
 #define PMC_IDR_MOSCRCS (0x1u << 17) /**< \brief (PMC_IDR) Main On-Chip RC Status Interrupt Disable */
 #define PMC_IDR_CFDEV (0x1u << 18) /**< \brief (PMC_IDR) Clock Failure Detector Event Interrupt Disable */
 /* -------- PMC_SR : (PMC Offset: 0x0068) Status Register -------- */
-#define PMC_SR_MOSCXTS (0x1u << 0) /**< \brief (PMC_SR) Main XTAL Oscillator Status */
+#define PMC_SR_MOSCXTS (0x1u << 0) /**< \brief (PMC_SR) Main Crystal Oscillator Status */
 #define PMC_SR_LOCKA (0x1u << 1) /**< \brief (PMC_SR) PLLA Lock Status */
 #define PMC_SR_MCKRDY (0x1u << 3) /**< \brief (PMC_SR) Master Clock Status */
 #define PMC_SR_OSCSELS (0x1u << 7) /**< \brief (PMC_SR) Slow Clock Oscillator Selection */
@@ -291,9 +310,13 @@ typedef struct {
 #define PMC_FSMR_RTTAL (0x1u << 16) /**< \brief (PMC_FSMR) RTT Alarm Enable */
 #define PMC_FSMR_RTCAL (0x1u << 17) /**< \brief (PMC_FSMR) RTC Alarm Enable */
 #define PMC_FSMR_USBAL (0x1u << 18) /**< \brief (PMC_FSMR) USB Alarm Enable */
+#define PMC_FSMR_LPM (0x1u << 20) /**< \brief (PMC_FSMR) Low-power Mode */
 #define PMC_FSMR_FLPM_Pos 21
-#define PMC_FSMR_FLPM_Msk (0x3u << PMC_FSMR_FLPM_Pos) /**< \brief (PMC_FSMR) Flash Low Power Mode */
+#define PMC_FSMR_FLPM_Msk (0x3u << PMC_FSMR_FLPM_Pos) /**< \brief (PMC_FSMR) Flash Low-power Mode */
 #define PMC_FSMR_FLPM(value) ((PMC_FSMR_FLPM_Msk & ((value) << PMC_FSMR_FLPM_Pos)))
+#define   PMC_FSMR_FLPM_FLASH_STANDBY (0x0u << 21) /**< \brief (PMC_FSMR) Flash is in Standby Mode when system enters Wait Mode */
+#define   PMC_FSMR_FLPM_FLASH_DEEP_POWERDOWN (0x1u << 21) /**< \brief (PMC_FSMR) Flash is in Deep-power-down mode when system enters Wait Mode */
+#define   PMC_FSMR_FLPM_FLASH_IDLE (0x2u << 21) /**< \brief (PMC_FSMR) Idle mode */
 /* -------- PMC_FSPR : (PMC Offset: 0x0074) Fast Startup Polarity Register -------- */
 #define PMC_FSPR_FSTP0 (0x1u << 0) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
 #define PMC_FSPR_FSTP1 (0x1u << 1) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
@@ -313,15 +336,16 @@ typedef struct {
 #define PMC_FSPR_FSTP15 (0x1u << 15) /**< \brief (PMC_FSPR) Fast Startup Input Polarityx */
 /* -------- PMC_FOCR : (PMC Offset: 0x0078) Fault Output Clear Register -------- */
 #define PMC_FOCR_FOCLR (0x1u << 0) /**< \brief (PMC_FOCR) Fault Output Clear */
-/* -------- PMC_WPMR : (PMC Offset: 0x00E4) Write Protect Mode Register -------- */
-#define PMC_WPMR_WPEN (0x1u << 0) /**< \brief (PMC_WPMR) Write Protect Enable */
+/* -------- PMC_WPMR : (PMC Offset: 0x00E4) Write Protection Mode Register -------- */
+#define PMC_WPMR_WPEN (0x1u << 0) /**< \brief (PMC_WPMR) Write Protection Enable */
 #define PMC_WPMR_WPKEY_Pos 8
-#define PMC_WPMR_WPKEY_Msk (0xffffffu << PMC_WPMR_WPKEY_Pos) /**< \brief (PMC_WPMR) Write Protect KEY */
+#define PMC_WPMR_WPKEY_Msk (0xffffffu << PMC_WPMR_WPKEY_Pos) /**< \brief (PMC_WPMR) Write Protection Key */
 #define PMC_WPMR_WPKEY(value) ((PMC_WPMR_WPKEY_Msk & ((value) << PMC_WPMR_WPKEY_Pos)))
-/* -------- PMC_WPSR : (PMC Offset: 0x00E8) Write Protect Status Register -------- */
-#define PMC_WPSR_WPVS (0x1u << 0) /**< \brief (PMC_WPSR) Write Protect Violation Status */
+#define   PMC_WPMR_WPKEY_PASSWD (0x504D43u << 8) /**< \brief (PMC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. */
+/* -------- PMC_WPSR : (PMC Offset: 0x00E8) Write Protection Status Register -------- */
+#define PMC_WPSR_WPVS (0x1u << 0) /**< \brief (PMC_WPSR) Write Protection Violation Status */
 #define PMC_WPSR_WPVSRC_Pos 8
-#define PMC_WPSR_WPVSRC_Msk (0xffffu << PMC_WPSR_WPVSRC_Pos) /**< \brief (PMC_WPSR) Write Protect Violation Source */
+#define PMC_WPSR_WPVSRC_Msk (0xffffu << PMC_WPSR_WPVSRC_Pos) /**< \brief (PMC_WPSR) Write Protection Violation Source */
 /* -------- PMC_PCER1 : (PMC Offset: 0x0100) Peripheral Clock Enable Register 1 -------- */
 #define PMC_PCER1_PID32 (0x1u << 0) /**< \brief (PMC_PCER1) Peripheral Clock 32 Enable */
 #define PMC_PCER1_PID33 (0x1u << 1) /**< \brief (PMC_PCER1) Peripheral Clock 33 Enable */

--- a/asf/sam/include/sam4e/component/pwm.h
+++ b/asf/sam/include/sam4e/component/pwm.h
@@ -1,0 +1,600 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PWM_COMPONENT_
+#define _SAM4E_PWM_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Pulse Width Modulation Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_PWM Pulse Width Modulation Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief PwmCh_num hardware registers */
+typedef struct {
+  RwReg            PWM_CMR;             /**< \brief (PwmCh_num Offset: 0x0) PWM Channel Mode Register */
+  RwReg            PWM_CDTY;            /**< \brief (PwmCh_num Offset: 0x4) PWM Channel Duty Cycle Register */
+  RwReg            PWM_CDTYUPD;         /**< \brief (PwmCh_num Offset: 0x8) PWM Channel Duty Cycle Update Register */
+  RwReg            PWM_CPRD;            /**< \brief (PwmCh_num Offset: 0xC) PWM Channel Period Register */
+  RwReg            PWM_CPRDUPD;         /**< \brief (PwmCh_num Offset: 0x10) PWM Channel Period Update Register */
+  RwReg            PWM_CCNT;            /**< \brief (PwmCh_num Offset: 0x14) PWM Channel Counter Register */
+  RwReg            PWM_DT;              /**< \brief (PwmCh_num Offset: 0x18) PWM Channel Dead Time Register */
+  RwReg            PWM_DTUPD;           /**< \brief (PwmCh_num Offset: 0x1C) PWM Channel Dead Time Update Register */
+} PwmCh_num;
+/** \brief PwmCh_num_0x400 hardware registers */
+typedef struct {
+  RwReg            PWM_CMUPD;           /**< \brief (PwmCh_num_0x400 Offset: 0x0) PWM Channel Mode Update Register */
+  RwReg            PWM_CAE;             /**< \brief (PwmCh_num_0x400 Offset: 0x4) PWM Channel Additional Edge Register */
+  RwReg            PWM_CAEUPD;          /**< \brief (PwmCh_num_0x400 Offset: 0x8) PWM Channel Additional Edge Update Register */
+  RoReg            Reserved1[5];
+} PwmCh_num_0x400;
+/** \brief PwmCmp hardware registers */
+typedef struct {
+  RwReg            PWM_CMPV;            /**< \brief (PwmCmp Offset: 0x0) PWM Comparison 0 Value Register */
+  RwReg            PWM_CMPVUPD;         /**< \brief (PwmCmp Offset: 0x4) PWM Comparison 0 Value Update Register */
+  RwReg            PWM_CMPM;            /**< \brief (PwmCmp Offset: 0x8) PWM Comparison 0 Mode Register */
+  RwReg            PWM_CMPMUPD;         /**< \brief (PwmCmp Offset: 0xC) PWM Comparison 0 Mode Update Register */
+} PwmCmp;
+/** \brief Pwm hardware registers */
+#define PWMCMP_NUMBER 8
+#define PWMCH_NUM_NUMBER 4
+#define PWMCH_NUM_0X400_NUMBER 4
+typedef struct {
+  RwReg            PWM_CLK;             /**< \brief (Pwm Offset: 0x00) PWM Clock Register */
+  WoReg            PWM_ENA;             /**< \brief (Pwm Offset: 0x04) PWM Enable Register */
+  WoReg            PWM_DIS;             /**< \brief (Pwm Offset: 0x08) PWM Disable Register */
+  RoReg            PWM_SR;              /**< \brief (Pwm Offset: 0x0C) PWM Status Register */
+  WoReg            PWM_IER1;            /**< \brief (Pwm Offset: 0x10) PWM Interrupt Enable Register 1 */
+  WoReg            PWM_IDR1;            /**< \brief (Pwm Offset: 0x14) PWM Interrupt Disable Register 1 */
+  RoReg            PWM_IMR1;            /**< \brief (Pwm Offset: 0x18) PWM Interrupt Mask Register 1 */
+  RoReg            PWM_ISR1;            /**< \brief (Pwm Offset: 0x1C) PWM Interrupt Status Register 1 */
+  RwReg            PWM_SCM;             /**< \brief (Pwm Offset: 0x20) PWM Sync Channels Mode Register */
+  RoReg            Reserved1[1];
+  RwReg            PWM_SCUC;            /**< \brief (Pwm Offset: 0x28) PWM Sync Channels Update Control Register */
+  RwReg            PWM_SCUP;            /**< \brief (Pwm Offset: 0x2C) PWM Sync Channels Update Period Register */
+  WoReg            PWM_SCUPUPD;         /**< \brief (Pwm Offset: 0x30) PWM Sync Channels Update Period Update Register */
+  WoReg            PWM_IER2;            /**< \brief (Pwm Offset: 0x34) PWM Interrupt Enable Register 2 */
+  WoReg            PWM_IDR2;            /**< \brief (Pwm Offset: 0x38) PWM Interrupt Disable Register 2 */
+  RoReg            PWM_IMR2;            /**< \brief (Pwm Offset: 0x3C) PWM Interrupt Mask Register 2 */
+  RoReg            PWM_ISR2;            /**< \brief (Pwm Offset: 0x40) PWM Interrupt Status Register 2 */
+  RwReg            PWM_OOV;             /**< \brief (Pwm Offset: 0x44) PWM Output Override Value Register */
+  RwReg            PWM_OS;              /**< \brief (Pwm Offset: 0x48) PWM Output Selection Register */
+  WoReg            PWM_OSS;             /**< \brief (Pwm Offset: 0x4C) PWM Output Selection Set Register */
+  WoReg            PWM_OSC;             /**< \brief (Pwm Offset: 0x50) PWM Output Selection Clear Register */
+  WoReg            PWM_OSSUPD;          /**< \brief (Pwm Offset: 0x54) PWM Output Selection Set Update Register */
+  WoReg            PWM_OSCUPD;          /**< \brief (Pwm Offset: 0x58) PWM Output Selection Clear Update Register */
+  RwReg            PWM_FMR;             /**< \brief (Pwm Offset: 0x5C) PWM Fault Mode Register */
+  RoReg            PWM_FSR;             /**< \brief (Pwm Offset: 0x60) PWM Fault Status Register */
+  WoReg            PWM_FCR;             /**< \brief (Pwm Offset: 0x64) PWM Fault Clear Register */
+  RwReg            PWM_FPV1;            /**< \brief (Pwm Offset: 0x68) PWM Fault Protection Value Register 1 */
+  RwReg            PWM_FPE;             /**< \brief (Pwm Offset: 0x6C) PWM Fault Protection Enable Register */
+  RoReg            Reserved2[3];
+  RwReg            PWM_ELMR[2];         /**< \brief (Pwm Offset: 0x7C) PWM Event Line 0 Mode Register */
+  RoReg            Reserved3[7];
+  RwReg            PWM_SSPR;            /**< \brief (Pwm Offset: 0xA0) PWM Spread Spectrum Register */
+  WoReg            PWM_SSPUP;           /**< \brief (Pwm Offset: 0xA4) PWM Spread Spectrum Update Register */
+  RoReg            Reserved4[2];
+  RwReg            PWM_SMMR;            /**< \brief (Pwm Offset: 0xB0) PWM Stepper Motor Mode Register */
+  RoReg            Reserved5[3];
+  RwReg            PWM_FPV2;            /**< \brief (Pwm Offset: 0xC0) PWM Fault Protection Value 2 Register */
+  RoReg            Reserved6[8];
+  WoReg            PWM_WPCR;            /**< \brief (Pwm Offset: 0xE4) PWM Write Protect Control Register */
+  RoReg            PWM_WPSR;            /**< \brief (Pwm Offset: 0xE8) PWM Write Protect Status Register */
+  RoReg            Reserved7[7];
+  RwReg            PWM_TPR;             /**< \brief (Pwm Offset: 0x108) Transmit Pointer Register */
+  RwReg            PWM_TCR;             /**< \brief (Pwm Offset: 0x10C) Transmit Counter Register */
+  RoReg            Reserved8[2];
+  RwReg            PWM_TNPR;            /**< \brief (Pwm Offset: 0x118) Transmit Next Pointer Register */
+  RwReg            PWM_TNCR;            /**< \brief (Pwm Offset: 0x11C) Transmit Next Counter Register */
+  WoReg            PWM_PTCR;            /**< \brief (Pwm Offset: 0x120) Transfer Control Register */
+  RoReg            PWM_PTSR;            /**< \brief (Pwm Offset: 0x124) Transfer Status Register */
+  RoReg            Reserved9[2];
+  PwmCmp           PWM_CMP[PWMCMP_NUMBER]; /**< \brief (Pwm Offset: 0x130) 0 .. 7 */
+  RoReg            Reserved10[20];
+  PwmCh_num        PWM_CH_NUM[PWMCH_NUM_NUMBER]; /**< \brief (Pwm Offset: 0x200) ch_num = 0 .. 3 */
+  RoReg            Reserved11[96];
+  PwmCh_num_0x400  PWM_CH_NUM_0X400[PWMCH_NUM_0X400_NUMBER]; /**< \brief (Pwm Offset: 0x400) ch_num = 0 .. 3 */
+} Pwm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- PWM_CLK : (PWM Offset: 0x00) PWM Clock Register -------- */
+#define PWM_CLK_DIVA_Pos 0
+#define PWM_CLK_DIVA_Msk (0xffu << PWM_CLK_DIVA_Pos) /**< \brief (PWM_CLK) CLKA, CLKB Divide Factor */
+#define PWM_CLK_DIVA(value) ((PWM_CLK_DIVA_Msk & ((value) << PWM_CLK_DIVA_Pos)))
+#define PWM_CLK_PREA_Pos 8
+#define PWM_CLK_PREA_Msk (0xfu << PWM_CLK_PREA_Pos) /**< \brief (PWM_CLK) CLKA, CLKB Source Clock Selection */
+#define PWM_CLK_PREA(value) ((PWM_CLK_PREA_Msk & ((value) << PWM_CLK_PREA_Pos)))
+#define PWM_CLK_DIVB_Pos 16
+#define PWM_CLK_DIVB_Msk (0xffu << PWM_CLK_DIVB_Pos) /**< \brief (PWM_CLK) CLKA, CLKB Divide Factor */
+#define PWM_CLK_DIVB(value) ((PWM_CLK_DIVB_Msk & ((value) << PWM_CLK_DIVB_Pos)))
+#define PWM_CLK_PREB_Pos 24
+#define PWM_CLK_PREB_Msk (0xfu << PWM_CLK_PREB_Pos) /**< \brief (PWM_CLK) CLKA, CLKB Source Clock Selection */
+#define PWM_CLK_PREB(value) ((PWM_CLK_PREB_Msk & ((value) << PWM_CLK_PREB_Pos)))
+/* -------- PWM_ENA : (PWM Offset: 0x04) PWM Enable Register -------- */
+#define PWM_ENA_CHID0 (0x1u << 0) /**< \brief (PWM_ENA) Channel ID */
+#define PWM_ENA_CHID1 (0x1u << 1) /**< \brief (PWM_ENA) Channel ID */
+#define PWM_ENA_CHID2 (0x1u << 2) /**< \brief (PWM_ENA) Channel ID */
+#define PWM_ENA_CHID3 (0x1u << 3) /**< \brief (PWM_ENA) Channel ID */
+/* -------- PWM_DIS : (PWM Offset: 0x08) PWM Disable Register -------- */
+#define PWM_DIS_CHID0 (0x1u << 0) /**< \brief (PWM_DIS) Channel ID */
+#define PWM_DIS_CHID1 (0x1u << 1) /**< \brief (PWM_DIS) Channel ID */
+#define PWM_DIS_CHID2 (0x1u << 2) /**< \brief (PWM_DIS) Channel ID */
+#define PWM_DIS_CHID3 (0x1u << 3) /**< \brief (PWM_DIS) Channel ID */
+/* -------- PWM_SR : (PWM Offset: 0x0C) PWM Status Register -------- */
+#define PWM_SR_CHID0 (0x1u << 0) /**< \brief (PWM_SR) Channel ID */
+#define PWM_SR_CHID1 (0x1u << 1) /**< \brief (PWM_SR) Channel ID */
+#define PWM_SR_CHID2 (0x1u << 2) /**< \brief (PWM_SR) Channel ID */
+#define PWM_SR_CHID3 (0x1u << 3) /**< \brief (PWM_SR) Channel ID */
+/* -------- PWM_IER1 : (PWM Offset: 0x10) PWM Interrupt Enable Register 1 -------- */
+#define PWM_IER1_CHID0 (0x1u << 0) /**< \brief (PWM_IER1) Counter Event on Channel 0 Interrupt Enable */
+#define PWM_IER1_CHID1 (0x1u << 1) /**< \brief (PWM_IER1) Counter Event on Channel 1 Interrupt Enable */
+#define PWM_IER1_CHID2 (0x1u << 2) /**< \brief (PWM_IER1) Counter Event on Channel 2 Interrupt Enable */
+#define PWM_IER1_CHID3 (0x1u << 3) /**< \brief (PWM_IER1) Counter Event on Channel 3 Interrupt Enable */
+#define PWM_IER1_FCHID0 (0x1u << 16) /**< \brief (PWM_IER1) Fault Protection Trigger on Channel 0 Interrupt Enable */
+#define PWM_IER1_FCHID1 (0x1u << 17) /**< \brief (PWM_IER1) Fault Protection Trigger on Channel 1 Interrupt Enable */
+#define PWM_IER1_FCHID2 (0x1u << 18) /**< \brief (PWM_IER1) Fault Protection Trigger on Channel 2 Interrupt Enable */
+#define PWM_IER1_FCHID3 (0x1u << 19) /**< \brief (PWM_IER1) Fault Protection Trigger on Channel 3 Interrupt Enable */
+/* -------- PWM_IDR1 : (PWM Offset: 0x14) PWM Interrupt Disable Register 1 -------- */
+#define PWM_IDR1_CHID0 (0x1u << 0) /**< \brief (PWM_IDR1) Counter Event on Channel 0 Interrupt Disable */
+#define PWM_IDR1_CHID1 (0x1u << 1) /**< \brief (PWM_IDR1) Counter Event on Channel 1 Interrupt Disable */
+#define PWM_IDR1_CHID2 (0x1u << 2) /**< \brief (PWM_IDR1) Counter Event on Channel 2 Interrupt Disable */
+#define PWM_IDR1_CHID3 (0x1u << 3) /**< \brief (PWM_IDR1) Counter Event on Channel 3 Interrupt Disable */
+#define PWM_IDR1_FCHID0 (0x1u << 16) /**< \brief (PWM_IDR1) Fault Protection Trigger on Channel 0 Interrupt Disable */
+#define PWM_IDR1_FCHID1 (0x1u << 17) /**< \brief (PWM_IDR1) Fault Protection Trigger on Channel 1 Interrupt Disable */
+#define PWM_IDR1_FCHID2 (0x1u << 18) /**< \brief (PWM_IDR1) Fault Protection Trigger on Channel 2 Interrupt Disable */
+#define PWM_IDR1_FCHID3 (0x1u << 19) /**< \brief (PWM_IDR1) Fault Protection Trigger on Channel 3 Interrupt Disable */
+/* -------- PWM_IMR1 : (PWM Offset: 0x18) PWM Interrupt Mask Register 1 -------- */
+#define PWM_IMR1_CHID0 (0x1u << 0) /**< \brief (PWM_IMR1) Counter Event on Channel 0 Interrupt Mask */
+#define PWM_IMR1_CHID1 (0x1u << 1) /**< \brief (PWM_IMR1) Counter Event on Channel 1 Interrupt Mask */
+#define PWM_IMR1_CHID2 (0x1u << 2) /**< \brief (PWM_IMR1) Counter Event on Channel 2 Interrupt Mask */
+#define PWM_IMR1_CHID3 (0x1u << 3) /**< \brief (PWM_IMR1) Counter Event on Channel 3 Interrupt Mask */
+#define PWM_IMR1_FCHID0 (0x1u << 16) /**< \brief (PWM_IMR1) Fault Protection Trigger on Channel 0 Interrupt Mask */
+#define PWM_IMR1_FCHID1 (0x1u << 17) /**< \brief (PWM_IMR1) Fault Protection Trigger on Channel 1 Interrupt Mask */
+#define PWM_IMR1_FCHID2 (0x1u << 18) /**< \brief (PWM_IMR1) Fault Protection Trigger on Channel 2 Interrupt Mask */
+#define PWM_IMR1_FCHID3 (0x1u << 19) /**< \brief (PWM_IMR1) Fault Protection Trigger on Channel 3 Interrupt Mask */
+/* -------- PWM_ISR1 : (PWM Offset: 0x1C) PWM Interrupt Status Register 1 -------- */
+#define PWM_ISR1_CHID0 (0x1u << 0) /**< \brief (PWM_ISR1) Counter Event on Channel 0 */
+#define PWM_ISR1_CHID1 (0x1u << 1) /**< \brief (PWM_ISR1) Counter Event on Channel 1 */
+#define PWM_ISR1_CHID2 (0x1u << 2) /**< \brief (PWM_ISR1) Counter Event on Channel 2 */
+#define PWM_ISR1_CHID3 (0x1u << 3) /**< \brief (PWM_ISR1) Counter Event on Channel 3 */
+#define PWM_ISR1_FCHID0 (0x1u << 16) /**< \brief (PWM_ISR1) Fault Protection Trigger on Channel 0 */
+#define PWM_ISR1_FCHID1 (0x1u << 17) /**< \brief (PWM_ISR1) Fault Protection Trigger on Channel 1 */
+#define PWM_ISR1_FCHID2 (0x1u << 18) /**< \brief (PWM_ISR1) Fault Protection Trigger on Channel 2 */
+#define PWM_ISR1_FCHID3 (0x1u << 19) /**< \brief (PWM_ISR1) Fault Protection Trigger on Channel 3 */
+/* -------- PWM_SCM : (PWM Offset: 0x20) PWM Sync Channels Mode Register -------- */
+#define PWM_SCM_SYNC0 (0x1u << 0) /**< \brief (PWM_SCM) Synchronous Channel 0 */
+#define PWM_SCM_SYNC1 (0x1u << 1) /**< \brief (PWM_SCM) Synchronous Channel 1 */
+#define PWM_SCM_SYNC2 (0x1u << 2) /**< \brief (PWM_SCM) Synchronous Channel 2 */
+#define PWM_SCM_SYNC3 (0x1u << 3) /**< \brief (PWM_SCM) Synchronous Channel 3 */
+#define PWM_SCM_UPDM_Pos 16
+#define PWM_SCM_UPDM_Msk (0x3u << PWM_SCM_UPDM_Pos) /**< \brief (PWM_SCM) Synchronous Channels Update Mode */
+#define   PWM_SCM_UPDM_MODE0 (0x0u << 16) /**< \brief (PWM_SCM) Manual write of double buffer registers and manual update of synchronous channels */
+#define   PWM_SCM_UPDM_MODE1 (0x1u << 16) /**< \brief (PWM_SCM) Manual write of double buffer registers and automatic update of synchronous channels */
+#define   PWM_SCM_UPDM_MODE2 (0x2u << 16) /**< \brief (PWM_SCM) Automatic write of duty-cycle update registers by the PDC and automatic update of synchronous channels */
+#define PWM_SCM_PTRM (0x1u << 20) /**< \brief (PWM_SCM) PDC Transfer Request Mode */
+#define PWM_SCM_PTRCS_Pos 21
+#define PWM_SCM_PTRCS_Msk (0x7u << PWM_SCM_PTRCS_Pos) /**< \brief (PWM_SCM) PDC Transfer Request Comparison Selection */
+#define PWM_SCM_PTRCS(value) ((PWM_SCM_PTRCS_Msk & ((value) << PWM_SCM_PTRCS_Pos)))
+/* -------- PWM_SCUC : (PWM Offset: 0x28) PWM Sync Channels Update Control Register -------- */
+#define PWM_SCUC_UPDULOCK (0x1u << 0) /**< \brief (PWM_SCUC) Synchronous Channels Update Unlock */
+/* -------- PWM_SCUP : (PWM Offset: 0x2C) PWM Sync Channels Update Period Register -------- */
+#define PWM_SCUP_UPR_Pos 0
+#define PWM_SCUP_UPR_Msk (0xfu << PWM_SCUP_UPR_Pos) /**< \brief (PWM_SCUP) Update Period */
+#define PWM_SCUP_UPR(value) ((PWM_SCUP_UPR_Msk & ((value) << PWM_SCUP_UPR_Pos)))
+#define PWM_SCUP_UPRCNT_Pos 4
+#define PWM_SCUP_UPRCNT_Msk (0xfu << PWM_SCUP_UPRCNT_Pos) /**< \brief (PWM_SCUP) Update Period Counter */
+#define PWM_SCUP_UPRCNT(value) ((PWM_SCUP_UPRCNT_Msk & ((value) << PWM_SCUP_UPRCNT_Pos)))
+/* -------- PWM_SCUPUPD : (PWM Offset: 0x30) PWM Sync Channels Update Period Update Register -------- */
+#define PWM_SCUPUPD_UPRUPD_Pos 0
+#define PWM_SCUPUPD_UPRUPD_Msk (0xfu << PWM_SCUPUPD_UPRUPD_Pos) /**< \brief (PWM_SCUPUPD) Update Period Update */
+#define PWM_SCUPUPD_UPRUPD(value) ((PWM_SCUPUPD_UPRUPD_Msk & ((value) << PWM_SCUPUPD_UPRUPD_Pos)))
+/* -------- PWM_IER2 : (PWM Offset: 0x34) PWM Interrupt Enable Register 2 -------- */
+#define PWM_IER2_WRDY (0x1u << 0) /**< \brief (PWM_IER2) Write Ready for Synchronous Channels Update Interrupt Enable */
+#define PWM_IER2_ENDTX (0x1u << 1) /**< \brief (PWM_IER2) PDC End of TX Buffer Interrupt Enable */
+#define PWM_IER2_TXBUFE (0x1u << 2) /**< \brief (PWM_IER2) PDC TX Buffer Empty Interrupt Enable */
+#define PWM_IER2_UNRE (0x1u << 3) /**< \brief (PWM_IER2) Synchronous Channels Update Underrun Error Interrupt Enable */
+#define PWM_IER2_CMPM0 (0x1u << 8) /**< \brief (PWM_IER2) Comparison 0 Match Interrupt Enable */
+#define PWM_IER2_CMPM1 (0x1u << 9) /**< \brief (PWM_IER2) Comparison 1 Match Interrupt Enable */
+#define PWM_IER2_CMPM2 (0x1u << 10) /**< \brief (PWM_IER2) Comparison 2 Match Interrupt Enable */
+#define PWM_IER2_CMPM3 (0x1u << 11) /**< \brief (PWM_IER2) Comparison 3 Match Interrupt Enable */
+#define PWM_IER2_CMPM4 (0x1u << 12) /**< \brief (PWM_IER2) Comparison 4 Match Interrupt Enable */
+#define PWM_IER2_CMPM5 (0x1u << 13) /**< \brief (PWM_IER2) Comparison 5 Match Interrupt Enable */
+#define PWM_IER2_CMPM6 (0x1u << 14) /**< \brief (PWM_IER2) Comparison 6 Match Interrupt Enable */
+#define PWM_IER2_CMPM7 (0x1u << 15) /**< \brief (PWM_IER2) Comparison 7 Match Interrupt Enable */
+#define PWM_IER2_CMPU0 (0x1u << 16) /**< \brief (PWM_IER2) Comparison 0 Update Interrupt Enable */
+#define PWM_IER2_CMPU1 (0x1u << 17) /**< \brief (PWM_IER2) Comparison 1 Update Interrupt Enable */
+#define PWM_IER2_CMPU2 (0x1u << 18) /**< \brief (PWM_IER2) Comparison 2 Update Interrupt Enable */
+#define PWM_IER2_CMPU3 (0x1u << 19) /**< \brief (PWM_IER2) Comparison 3 Update Interrupt Enable */
+#define PWM_IER2_CMPU4 (0x1u << 20) /**< \brief (PWM_IER2) Comparison 4 Update Interrupt Enable */
+#define PWM_IER2_CMPU5 (0x1u << 21) /**< \brief (PWM_IER2) Comparison 5 Update Interrupt Enable */
+#define PWM_IER2_CMPU6 (0x1u << 22) /**< \brief (PWM_IER2) Comparison 6 Update Interrupt Enable */
+#define PWM_IER2_CMPU7 (0x1u << 23) /**< \brief (PWM_IER2) Comparison 7 Update Interrupt Enable */
+/* -------- PWM_IDR2 : (PWM Offset: 0x38) PWM Interrupt Disable Register 2 -------- */
+#define PWM_IDR2_WRDY (0x1u << 0) /**< \brief (PWM_IDR2) Write Ready for Synchronous Channels Update Interrupt Disable */
+#define PWM_IDR2_ENDTX (0x1u << 1) /**< \brief (PWM_IDR2) PDC End of TX Buffer Interrupt Disable */
+#define PWM_IDR2_TXBUFE (0x1u << 2) /**< \brief (PWM_IDR2) PDC TX Buffer Empty Interrupt Disable */
+#define PWM_IDR2_UNRE (0x1u << 3) /**< \brief (PWM_IDR2) Synchronous Channels Update Underrun Error Interrupt Disable */
+#define PWM_IDR2_CMPM0 (0x1u << 8) /**< \brief (PWM_IDR2) Comparison 0 Match Interrupt Disable */
+#define PWM_IDR2_CMPM1 (0x1u << 9) /**< \brief (PWM_IDR2) Comparison 1 Match Interrupt Disable */
+#define PWM_IDR2_CMPM2 (0x1u << 10) /**< \brief (PWM_IDR2) Comparison 2 Match Interrupt Disable */
+#define PWM_IDR2_CMPM3 (0x1u << 11) /**< \brief (PWM_IDR2) Comparison 3 Match Interrupt Disable */
+#define PWM_IDR2_CMPM4 (0x1u << 12) /**< \brief (PWM_IDR2) Comparison 4 Match Interrupt Disable */
+#define PWM_IDR2_CMPM5 (0x1u << 13) /**< \brief (PWM_IDR2) Comparison 5 Match Interrupt Disable */
+#define PWM_IDR2_CMPM6 (0x1u << 14) /**< \brief (PWM_IDR2) Comparison 6 Match Interrupt Disable */
+#define PWM_IDR2_CMPM7 (0x1u << 15) /**< \brief (PWM_IDR2) Comparison 7 Match Interrupt Disable */
+#define PWM_IDR2_CMPU0 (0x1u << 16) /**< \brief (PWM_IDR2) Comparison 0 Update Interrupt Disable */
+#define PWM_IDR2_CMPU1 (0x1u << 17) /**< \brief (PWM_IDR2) Comparison 1 Update Interrupt Disable */
+#define PWM_IDR2_CMPU2 (0x1u << 18) /**< \brief (PWM_IDR2) Comparison 2 Update Interrupt Disable */
+#define PWM_IDR2_CMPU3 (0x1u << 19) /**< \brief (PWM_IDR2) Comparison 3 Update Interrupt Disable */
+#define PWM_IDR2_CMPU4 (0x1u << 20) /**< \brief (PWM_IDR2) Comparison 4 Update Interrupt Disable */
+#define PWM_IDR2_CMPU5 (0x1u << 21) /**< \brief (PWM_IDR2) Comparison 5 Update Interrupt Disable */
+#define PWM_IDR2_CMPU6 (0x1u << 22) /**< \brief (PWM_IDR2) Comparison 6 Update Interrupt Disable */
+#define PWM_IDR2_CMPU7 (0x1u << 23) /**< \brief (PWM_IDR2) Comparison 7 Update Interrupt Disable */
+/* -------- PWM_IMR2 : (PWM Offset: 0x3C) PWM Interrupt Mask Register 2 -------- */
+#define PWM_IMR2_WRDY (0x1u << 0) /**< \brief (PWM_IMR2) Write Ready for Synchronous Channels Update Interrupt Mask */
+#define PWM_IMR2_ENDTX (0x1u << 1) /**< \brief (PWM_IMR2) PDC End of TX Buffer Interrupt Mask */
+#define PWM_IMR2_TXBUFE (0x1u << 2) /**< \brief (PWM_IMR2) PDC TX Buffer Empty Interrupt Mask */
+#define PWM_IMR2_UNRE (0x1u << 3) /**< \brief (PWM_IMR2) Synchronous Channels Update Underrun Error Interrupt Mask */
+#define PWM_IMR2_CMPM0 (0x1u << 8) /**< \brief (PWM_IMR2) Comparison 0 Match Interrupt Mask */
+#define PWM_IMR2_CMPM1 (0x1u << 9) /**< \brief (PWM_IMR2) Comparison 1 Match Interrupt Mask */
+#define PWM_IMR2_CMPM2 (0x1u << 10) /**< \brief (PWM_IMR2) Comparison 2 Match Interrupt Mask */
+#define PWM_IMR2_CMPM3 (0x1u << 11) /**< \brief (PWM_IMR2) Comparison 3 Match Interrupt Mask */
+#define PWM_IMR2_CMPM4 (0x1u << 12) /**< \brief (PWM_IMR2) Comparison 4 Match Interrupt Mask */
+#define PWM_IMR2_CMPM5 (0x1u << 13) /**< \brief (PWM_IMR2) Comparison 5 Match Interrupt Mask */
+#define PWM_IMR2_CMPM6 (0x1u << 14) /**< \brief (PWM_IMR2) Comparison 6 Match Interrupt Mask */
+#define PWM_IMR2_CMPM7 (0x1u << 15) /**< \brief (PWM_IMR2) Comparison 7 Match Interrupt Mask */
+#define PWM_IMR2_CMPU0 (0x1u << 16) /**< \brief (PWM_IMR2) Comparison 0 Update Interrupt Mask */
+#define PWM_IMR2_CMPU1 (0x1u << 17) /**< \brief (PWM_IMR2) Comparison 1 Update Interrupt Mask */
+#define PWM_IMR2_CMPU2 (0x1u << 18) /**< \brief (PWM_IMR2) Comparison 2 Update Interrupt Mask */
+#define PWM_IMR2_CMPU3 (0x1u << 19) /**< \brief (PWM_IMR2) Comparison 3 Update Interrupt Mask */
+#define PWM_IMR2_CMPU4 (0x1u << 20) /**< \brief (PWM_IMR2) Comparison 4 Update Interrupt Mask */
+#define PWM_IMR2_CMPU5 (0x1u << 21) /**< \brief (PWM_IMR2) Comparison 5 Update Interrupt Mask */
+#define PWM_IMR2_CMPU6 (0x1u << 22) /**< \brief (PWM_IMR2) Comparison 6 Update Interrupt Mask */
+#define PWM_IMR2_CMPU7 (0x1u << 23) /**< \brief (PWM_IMR2) Comparison 7 Update Interrupt Mask */
+/* -------- PWM_ISR2 : (PWM Offset: 0x40) PWM Interrupt Status Register 2 -------- */
+#define PWM_ISR2_WRDY (0x1u << 0) /**< \brief (PWM_ISR2) Write Ready for Synchronous Channels Update */
+#define PWM_ISR2_ENDTX (0x1u << 1) /**< \brief (PWM_ISR2) PDC End of TX Buffer */
+#define PWM_ISR2_TXBUFE (0x1u << 2) /**< \brief (PWM_ISR2) PDC TX Buffer Empty */
+#define PWM_ISR2_UNRE (0x1u << 3) /**< \brief (PWM_ISR2) Synchronous Channels Update Underrun Error */
+#define PWM_ISR2_CMPM0 (0x1u << 8) /**< \brief (PWM_ISR2) Comparison 0 Match */
+#define PWM_ISR2_CMPM1 (0x1u << 9) /**< \brief (PWM_ISR2) Comparison 1 Match */
+#define PWM_ISR2_CMPM2 (0x1u << 10) /**< \brief (PWM_ISR2) Comparison 2 Match */
+#define PWM_ISR2_CMPM3 (0x1u << 11) /**< \brief (PWM_ISR2) Comparison 3 Match */
+#define PWM_ISR2_CMPM4 (0x1u << 12) /**< \brief (PWM_ISR2) Comparison 4 Match */
+#define PWM_ISR2_CMPM5 (0x1u << 13) /**< \brief (PWM_ISR2) Comparison 5 Match */
+#define PWM_ISR2_CMPM6 (0x1u << 14) /**< \brief (PWM_ISR2) Comparison 6 Match */
+#define PWM_ISR2_CMPM7 (0x1u << 15) /**< \brief (PWM_ISR2) Comparison 7 Match */
+#define PWM_ISR2_CMPU0 (0x1u << 16) /**< \brief (PWM_ISR2) Comparison 0 Update */
+#define PWM_ISR2_CMPU1 (0x1u << 17) /**< \brief (PWM_ISR2) Comparison 1 Update */
+#define PWM_ISR2_CMPU2 (0x1u << 18) /**< \brief (PWM_ISR2) Comparison 2 Update */
+#define PWM_ISR2_CMPU3 (0x1u << 19) /**< \brief (PWM_ISR2) Comparison 3 Update */
+#define PWM_ISR2_CMPU4 (0x1u << 20) /**< \brief (PWM_ISR2) Comparison 4 Update */
+#define PWM_ISR2_CMPU5 (0x1u << 21) /**< \brief (PWM_ISR2) Comparison 5 Update */
+#define PWM_ISR2_CMPU6 (0x1u << 22) /**< \brief (PWM_ISR2) Comparison 6 Update */
+#define PWM_ISR2_CMPU7 (0x1u << 23) /**< \brief (PWM_ISR2) Comparison 7 Update */
+/* -------- PWM_OOV : (PWM Offset: 0x44) PWM Output Override Value Register -------- */
+#define PWM_OOV_OOVH0 (0x1u << 0) /**< \brief (PWM_OOV) Output Override Value for PWMH output of the channel 0 */
+#define PWM_OOV_OOVH1 (0x1u << 1) /**< \brief (PWM_OOV) Output Override Value for PWMH output of the channel 1 */
+#define PWM_OOV_OOVH2 (0x1u << 2) /**< \brief (PWM_OOV) Output Override Value for PWMH output of the channel 2 */
+#define PWM_OOV_OOVH3 (0x1u << 3) /**< \brief (PWM_OOV) Output Override Value for PWMH output of the channel 3 */
+#define PWM_OOV_OOVL0 (0x1u << 16) /**< \brief (PWM_OOV) Output Override Value for PWML output of the channel 0 */
+#define PWM_OOV_OOVL1 (0x1u << 17) /**< \brief (PWM_OOV) Output Override Value for PWML output of the channel 1 */
+#define PWM_OOV_OOVL2 (0x1u << 18) /**< \brief (PWM_OOV) Output Override Value for PWML output of the channel 2 */
+#define PWM_OOV_OOVL3 (0x1u << 19) /**< \brief (PWM_OOV) Output Override Value for PWML output of the channel 3 */
+/* -------- PWM_OS : (PWM Offset: 0x48) PWM Output Selection Register -------- */
+#define PWM_OS_OSH0 (0x1u << 0) /**< \brief (PWM_OS) Output Selection for PWMH output of the channel 0 */
+#define PWM_OS_OSH1 (0x1u << 1) /**< \brief (PWM_OS) Output Selection for PWMH output of the channel 1 */
+#define PWM_OS_OSH2 (0x1u << 2) /**< \brief (PWM_OS) Output Selection for PWMH output of the channel 2 */
+#define PWM_OS_OSH3 (0x1u << 3) /**< \brief (PWM_OS) Output Selection for PWMH output of the channel 3 */
+#define PWM_OS_OSL0 (0x1u << 16) /**< \brief (PWM_OS) Output Selection for PWML output of the channel 0 */
+#define PWM_OS_OSL1 (0x1u << 17) /**< \brief (PWM_OS) Output Selection for PWML output of the channel 1 */
+#define PWM_OS_OSL2 (0x1u << 18) /**< \brief (PWM_OS) Output Selection for PWML output of the channel 2 */
+#define PWM_OS_OSL3 (0x1u << 19) /**< \brief (PWM_OS) Output Selection for PWML output of the channel 3 */
+/* -------- PWM_OSS : (PWM Offset: 0x4C) PWM Output Selection Set Register -------- */
+#define PWM_OSS_OSSH0 (0x1u << 0) /**< \brief (PWM_OSS) Output Selection Set for PWMH output of the channel 0 */
+#define PWM_OSS_OSSH1 (0x1u << 1) /**< \brief (PWM_OSS) Output Selection Set for PWMH output of the channel 1 */
+#define PWM_OSS_OSSH2 (0x1u << 2) /**< \brief (PWM_OSS) Output Selection Set for PWMH output of the channel 2 */
+#define PWM_OSS_OSSH3 (0x1u << 3) /**< \brief (PWM_OSS) Output Selection Set for PWMH output of the channel 3 */
+#define PWM_OSS_OSSL0 (0x1u << 16) /**< \brief (PWM_OSS) Output Selection Set for PWML output of the channel 0 */
+#define PWM_OSS_OSSL1 (0x1u << 17) /**< \brief (PWM_OSS) Output Selection Set for PWML output of the channel 1 */
+#define PWM_OSS_OSSL2 (0x1u << 18) /**< \brief (PWM_OSS) Output Selection Set for PWML output of the channel 2 */
+#define PWM_OSS_OSSL3 (0x1u << 19) /**< \brief (PWM_OSS) Output Selection Set for PWML output of the channel 3 */
+/* -------- PWM_OSC : (PWM Offset: 0x50) PWM Output Selection Clear Register -------- */
+#define PWM_OSC_OSCH0 (0x1u << 0) /**< \brief (PWM_OSC) Output Selection Clear for PWMH output of the channel 0 */
+#define PWM_OSC_OSCH1 (0x1u << 1) /**< \brief (PWM_OSC) Output Selection Clear for PWMH output of the channel 1 */
+#define PWM_OSC_OSCH2 (0x1u << 2) /**< \brief (PWM_OSC) Output Selection Clear for PWMH output of the channel 2 */
+#define PWM_OSC_OSCH3 (0x1u << 3) /**< \brief (PWM_OSC) Output Selection Clear for PWMH output of the channel 3 */
+#define PWM_OSC_OSCL0 (0x1u << 16) /**< \brief (PWM_OSC) Output Selection Clear for PWML output of the channel 0 */
+#define PWM_OSC_OSCL1 (0x1u << 17) /**< \brief (PWM_OSC) Output Selection Clear for PWML output of the channel 1 */
+#define PWM_OSC_OSCL2 (0x1u << 18) /**< \brief (PWM_OSC) Output Selection Clear for PWML output of the channel 2 */
+#define PWM_OSC_OSCL3 (0x1u << 19) /**< \brief (PWM_OSC) Output Selection Clear for PWML output of the channel 3 */
+/* -------- PWM_OSSUPD : (PWM Offset: 0x54) PWM Output Selection Set Update Register -------- */
+#define PWM_OSSUPD_OSSUPH0 (0x1u << 0) /**< \brief (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 0 */
+#define PWM_OSSUPD_OSSUPH1 (0x1u << 1) /**< \brief (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 1 */
+#define PWM_OSSUPD_OSSUPH2 (0x1u << 2) /**< \brief (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 2 */
+#define PWM_OSSUPD_OSSUPH3 (0x1u << 3) /**< \brief (PWM_OSSUPD) Output Selection Set for PWMH output of the channel 3 */
+#define PWM_OSSUPD_OSSUPL0 (0x1u << 16) /**< \brief (PWM_OSSUPD) Output Selection Set for PWML output of the channel 0 */
+#define PWM_OSSUPD_OSSUPL1 (0x1u << 17) /**< \brief (PWM_OSSUPD) Output Selection Set for PWML output of the channel 1 */
+#define PWM_OSSUPD_OSSUPL2 (0x1u << 18) /**< \brief (PWM_OSSUPD) Output Selection Set for PWML output of the channel 2 */
+#define PWM_OSSUPD_OSSUPL3 (0x1u << 19) /**< \brief (PWM_OSSUPD) Output Selection Set for PWML output of the channel 3 */
+/* -------- PWM_OSCUPD : (PWM Offset: 0x58) PWM Output Selection Clear Update Register -------- */
+#define PWM_OSCUPD_OSCUPH0 (0x1u << 0) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 0 */
+#define PWM_OSCUPD_OSCUPH1 (0x1u << 1) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 1 */
+#define PWM_OSCUPD_OSCUPH2 (0x1u << 2) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 2 */
+#define PWM_OSCUPD_OSCUPH3 (0x1u << 3) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWMH output of the channel 3 */
+#define PWM_OSCUPD_OSCUPL0 (0x1u << 16) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 0 */
+#define PWM_OSCUPD_OSCUPL1 (0x1u << 17) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 1 */
+#define PWM_OSCUPD_OSCUPL2 (0x1u << 18) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 2 */
+#define PWM_OSCUPD_OSCUPL3 (0x1u << 19) /**< \brief (PWM_OSCUPD) Output Selection Clear for PWML output of the channel 3 */
+/* -------- PWM_FMR : (PWM Offset: 0x5C) PWM Fault Mode Register -------- */
+#define PWM_FMR_FPOL_Pos 0
+#define PWM_FMR_FPOL_Msk (0xffu << PWM_FMR_FPOL_Pos) /**< \brief (PWM_FMR) Fault Polarity (fault input bit varies from 0 to 7) */
+#define PWM_FMR_FPOL(value) ((PWM_FMR_FPOL_Msk & ((value) << PWM_FMR_FPOL_Pos)))
+#define PWM_FMR_FMOD_Pos 8
+#define PWM_FMR_FMOD_Msk (0xffu << PWM_FMR_FMOD_Pos) /**< \brief (PWM_FMR) Fault Activation Mode (fault input bit varies from 0 to 7) */
+#define PWM_FMR_FMOD(value) ((PWM_FMR_FMOD_Msk & ((value) << PWM_FMR_FMOD_Pos)))
+#define PWM_FMR_FFIL_Pos 16
+#define PWM_FMR_FFIL_Msk (0xffu << PWM_FMR_FFIL_Pos) /**< \brief (PWM_FMR) Fault Filtering (fault input bit varies from 0 to 7) */
+#define PWM_FMR_FFIL(value) ((PWM_FMR_FFIL_Msk & ((value) << PWM_FMR_FFIL_Pos)))
+/* -------- PWM_FSR : (PWM Offset: 0x60) PWM Fault Status Register -------- */
+#define PWM_FSR_FIV_Pos 0
+#define PWM_FSR_FIV_Msk (0xffu << PWM_FSR_FIV_Pos) /**< \brief (PWM_FSR) Fault Input Value (fault input bit varies from 0 to 7) */
+#define PWM_FSR_FS_Pos 8
+#define PWM_FSR_FS_Msk (0xffu << PWM_FSR_FS_Pos) /**< \brief (PWM_FSR) Fault Status (fault input bit varies from 0 to 7) */
+/* -------- PWM_FCR : (PWM Offset: 0x64) PWM Fault Clear Register -------- */
+#define PWM_FCR_FCLR_Pos 0
+#define PWM_FCR_FCLR_Msk (0xffu << PWM_FCR_FCLR_Pos) /**< \brief (PWM_FCR) Fault Clear (fault input bit varies from 0 to 7) */
+#define PWM_FCR_FCLR(value) ((PWM_FCR_FCLR_Msk & ((value) << PWM_FCR_FCLR_Pos)))
+/* -------- PWM_FPV1 : (PWM Offset: 0x68) PWM Fault Protection Value Register 1 -------- */
+#define PWM_FPV1_FPVH0 (0x1u << 0) /**< \brief (PWM_FPV1) Fault Protection Value for PWMH output on channel 0 */
+#define PWM_FPV1_FPVH1 (0x1u << 1) /**< \brief (PWM_FPV1) Fault Protection Value for PWMH output on channel 1 */
+#define PWM_FPV1_FPVH2 (0x1u << 2) /**< \brief (PWM_FPV1) Fault Protection Value for PWMH output on channel 2 */
+#define PWM_FPV1_FPVH3 (0x1u << 3) /**< \brief (PWM_FPV1) Fault Protection Value for PWMH output on channel 3 */
+#define PWM_FPV1_FPVL0 (0x1u << 16) /**< \brief (PWM_FPV1) Fault Protection Value for PWML output on channel 0 */
+#define PWM_FPV1_FPVL1 (0x1u << 17) /**< \brief (PWM_FPV1) Fault Protection Value for PWML output on channel 1 */
+#define PWM_FPV1_FPVL2 (0x1u << 18) /**< \brief (PWM_FPV1) Fault Protection Value for PWML output on channel 2 */
+#define PWM_FPV1_FPVL3 (0x1u << 19) /**< \brief (PWM_FPV1) Fault Protection Value for PWML output on channel 3 */
+/* -------- PWM_FPE : (PWM Offset: 0x6C) PWM Fault Protection Enable Register -------- */
+#define PWM_FPE_FPE0_Pos 0
+#define PWM_FPE_FPE0_Msk (0xffu << PWM_FPE_FPE0_Pos) /**< \brief (PWM_FPE) Fault Protection Enable for channel 0 (fault input bit varies from 0 to 7) */
+#define PWM_FPE_FPE0(value) ((PWM_FPE_FPE0_Msk & ((value) << PWM_FPE_FPE0_Pos)))
+#define PWM_FPE_FPE1_Pos 8
+#define PWM_FPE_FPE1_Msk (0xffu << PWM_FPE_FPE1_Pos) /**< \brief (PWM_FPE) Fault Protection Enable for channel 1 (fault input bit varies from 0 to 7) */
+#define PWM_FPE_FPE1(value) ((PWM_FPE_FPE1_Msk & ((value) << PWM_FPE_FPE1_Pos)))
+#define PWM_FPE_FPE2_Pos 16
+#define PWM_FPE_FPE2_Msk (0xffu << PWM_FPE_FPE2_Pos) /**< \brief (PWM_FPE) Fault Protection Enable for channel 2 (fault input bit varies from 0 to 7) */
+#define PWM_FPE_FPE2(value) ((PWM_FPE_FPE2_Msk & ((value) << PWM_FPE_FPE2_Pos)))
+#define PWM_FPE_FPE3_Pos 24
+#define PWM_FPE_FPE3_Msk (0xffu << PWM_FPE_FPE3_Pos) /**< \brief (PWM_FPE) Fault Protection Enable for channel 3 (fault input bit varies from 0 to 7) */
+#define PWM_FPE_FPE3(value) ((PWM_FPE_FPE3_Msk & ((value) << PWM_FPE_FPE3_Pos)))
+/* -------- PWM_ELMR[2] : (PWM Offset: 0x7C) PWM Event Line 0 Mode Register -------- */
+#define PWM_ELMR_CSEL0 (0x1u << 0) /**< \brief (PWM_ELMR[2]) Comparison 0 Selection */
+#define PWM_ELMR_CSEL1 (0x1u << 1) /**< \brief (PWM_ELMR[2]) Comparison 1 Selection */
+#define PWM_ELMR_CSEL2 (0x1u << 2) /**< \brief (PWM_ELMR[2]) Comparison 2 Selection */
+#define PWM_ELMR_CSEL3 (0x1u << 3) /**< \brief (PWM_ELMR[2]) Comparison 3 Selection */
+#define PWM_ELMR_CSEL4 (0x1u << 4) /**< \brief (PWM_ELMR[2]) Comparison 4 Selection */
+#define PWM_ELMR_CSEL5 (0x1u << 5) /**< \brief (PWM_ELMR[2]) Comparison 5 Selection */
+#define PWM_ELMR_CSEL6 (0x1u << 6) /**< \brief (PWM_ELMR[2]) Comparison 6 Selection */
+#define PWM_ELMR_CSEL7 (0x1u << 7) /**< \brief (PWM_ELMR[2]) Comparison 7 Selection */
+/* -------- PWM_SSPR : (PWM Offset: 0xA0) PWM Spread Spectrum Register -------- */
+#define PWM_SSPR_SPRD_Pos 0
+#define PWM_SSPR_SPRD_Msk (0xffffffu << PWM_SSPR_SPRD_Pos) /**< \brief (PWM_SSPR) Spread Spectrum Limit Value */
+#define PWM_SSPR_SPRD(value) ((PWM_SSPR_SPRD_Msk & ((value) << PWM_SSPR_SPRD_Pos)))
+#define PWM_SSPR_SPRDM (0x1u << 24) /**< \brief (PWM_SSPR) Spread Spectrum Counter Mode */
+/* -------- PWM_SSPUP : (PWM Offset: 0xA4) PWM Spread Spectrum Update Register -------- */
+#define PWM_SSPUP_SPRDUP_Pos 0
+#define PWM_SSPUP_SPRDUP_Msk (0xffffffu << PWM_SSPUP_SPRDUP_Pos) /**< \brief (PWM_SSPUP) Spread Spectrum Limit Value Update */
+#define PWM_SSPUP_SPRDUP(value) ((PWM_SSPUP_SPRDUP_Msk & ((value) << PWM_SSPUP_SPRDUP_Pos)))
+/* -------- PWM_SMMR : (PWM Offset: 0xB0) PWM Stepper Motor Mode Register -------- */
+#define PWM_SMMR_GCEN0 (0x1u << 0) /**< \brief (PWM_SMMR) Gray Count ENable */
+#define PWM_SMMR_GCEN1 (0x1u << 1) /**< \brief (PWM_SMMR) Gray Count ENable */
+#define PWM_SMMR_DOWN0 (0x1u << 16) /**< \brief (PWM_SMMR) DOWN Count */
+#define PWM_SMMR_DOWN1 (0x1u << 17) /**< \brief (PWM_SMMR) DOWN Count */
+/* -------- PWM_FPV2 : (PWM Offset: 0xC0) PWM Fault Protection Value 2 Register -------- */
+#define PWM_FPV2_FPZH0 (0x1u << 0) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 0 */
+#define PWM_FPV2_FPZH1 (0x1u << 1) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 1 */
+#define PWM_FPV2_FPZH2 (0x1u << 2) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 2 */
+#define PWM_FPV2_FPZH3 (0x1u << 3) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWMH output on channel 3 */
+#define PWM_FPV2_FPZL0 (0x1u << 16) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 0 */
+#define PWM_FPV2_FPZL1 (0x1u << 17) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 1 */
+#define PWM_FPV2_FPZL2 (0x1u << 18) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 2 */
+#define PWM_FPV2_FPZL3 (0x1u << 19) /**< \brief (PWM_FPV2) Fault Protection to Hi-Z for PWML output on channel 3 */
+/* -------- PWM_WPCR : (PWM Offset: 0xE4) PWM Write Protect Control Register -------- */
+#define PWM_WPCR_WPCMD_Pos 0
+#define PWM_WPCR_WPCMD_Msk (0x3u << PWM_WPCR_WPCMD_Pos) /**< \brief (PWM_WPCR) Write Protect Command */
+#define PWM_WPCR_WPCMD(value) ((PWM_WPCR_WPCMD_Msk & ((value) << PWM_WPCR_WPCMD_Pos)))
+#define PWM_WPCR_WPRG0 (0x1u << 2) /**< \brief (PWM_WPCR) Write Protect Register Group 0 */
+#define PWM_WPCR_WPRG1 (0x1u << 3) /**< \brief (PWM_WPCR) Write Protect Register Group 1 */
+#define PWM_WPCR_WPRG2 (0x1u << 4) /**< \brief (PWM_WPCR) Write Protect Register Group 2 */
+#define PWM_WPCR_WPRG3 (0x1u << 5) /**< \brief (PWM_WPCR) Write Protect Register Group 3 */
+#define PWM_WPCR_WPRG4 (0x1u << 6) /**< \brief (PWM_WPCR) Write Protect Register Group 4 */
+#define PWM_WPCR_WPRG5 (0x1u << 7) /**< \brief (PWM_WPCR) Write Protect Register Group 5 */
+#define PWM_WPCR_WPKEY_Pos 8
+#define PWM_WPCR_WPKEY_Msk (0xffffffu << PWM_WPCR_WPKEY_Pos) /**< \brief (PWM_WPCR) Write Protect Key */
+#define PWM_WPCR_WPKEY(value) ((PWM_WPCR_WPKEY_Msk & ((value) << PWM_WPCR_WPKEY_Pos)))
+/* -------- PWM_WPSR : (PWM Offset: 0xE8) PWM Write Protect Status Register -------- */
+#define PWM_WPSR_WPSWS0 (0x1u << 0) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPSWS1 (0x1u << 1) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPSWS2 (0x1u << 2) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPSWS3 (0x1u << 3) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPSWS4 (0x1u << 4) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPSWS5 (0x1u << 5) /**< \brief (PWM_WPSR) Write Protect SW Status */
+#define PWM_WPSR_WPVS (0x1u << 7) /**< \brief (PWM_WPSR) Write Protect Violation Status */
+#define PWM_WPSR_WPHWS0 (0x1u << 8) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPHWS1 (0x1u << 9) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPHWS2 (0x1u << 10) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPHWS3 (0x1u << 11) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPHWS4 (0x1u << 12) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPHWS5 (0x1u << 13) /**< \brief (PWM_WPSR) Write Protect HW Status */
+#define PWM_WPSR_WPVSRC_Pos 16
+#define PWM_WPSR_WPVSRC_Msk (0xffffu << PWM_WPSR_WPVSRC_Pos) /**< \brief (PWM_WPSR) Write Protect Violation Source */
+/* -------- PWM_TPR : (PWM Offset: 0x108) Transmit Pointer Register -------- */
+#define PWM_TPR_TXPTR_Pos 0
+#define PWM_TPR_TXPTR_Msk (0xffffffffu << PWM_TPR_TXPTR_Pos) /**< \brief (PWM_TPR) Transmit Counter Register */
+#define PWM_TPR_TXPTR(value) ((PWM_TPR_TXPTR_Msk & ((value) << PWM_TPR_TXPTR_Pos)))
+/* -------- PWM_TCR : (PWM Offset: 0x10C) Transmit Counter Register -------- */
+#define PWM_TCR_TXCTR_Pos 0
+#define PWM_TCR_TXCTR_Msk (0xffffu << PWM_TCR_TXCTR_Pos) /**< \brief (PWM_TCR) Transmit Counter Register */
+#define PWM_TCR_TXCTR(value) ((PWM_TCR_TXCTR_Msk & ((value) << PWM_TCR_TXCTR_Pos)))
+/* -------- PWM_TNPR : (PWM Offset: 0x118) Transmit Next Pointer Register -------- */
+#define PWM_TNPR_TXNPTR_Pos 0
+#define PWM_TNPR_TXNPTR_Msk (0xffffffffu << PWM_TNPR_TXNPTR_Pos) /**< \brief (PWM_TNPR) Transmit Next Pointer */
+#define PWM_TNPR_TXNPTR(value) ((PWM_TNPR_TXNPTR_Msk & ((value) << PWM_TNPR_TXNPTR_Pos)))
+/* -------- PWM_TNCR : (PWM Offset: 0x11C) Transmit Next Counter Register -------- */
+#define PWM_TNCR_TXNCTR_Pos 0
+#define PWM_TNCR_TXNCTR_Msk (0xffffu << PWM_TNCR_TXNCTR_Pos) /**< \brief (PWM_TNCR) Transmit Counter Next */
+#define PWM_TNCR_TXNCTR(value) ((PWM_TNCR_TXNCTR_Msk & ((value) << PWM_TNCR_TXNCTR_Pos)))
+/* -------- PWM_PTCR : (PWM Offset: 0x120) Transfer Control Register -------- */
+#define PWM_PTCR_RXTEN (0x1u << 0) /**< \brief (PWM_PTCR) Receiver Transfer Enable */
+#define PWM_PTCR_RXTDIS (0x1u << 1) /**< \brief (PWM_PTCR) Receiver Transfer Disable */
+#define PWM_PTCR_TXTEN (0x1u << 8) /**< \brief (PWM_PTCR) Transmitter Transfer Enable */
+#define PWM_PTCR_TXTDIS (0x1u << 9) /**< \brief (PWM_PTCR) Transmitter Transfer Disable */
+/* -------- PWM_PTSR : (PWM Offset: 0x124) Transfer Status Register -------- */
+#define PWM_PTSR_RXTEN (0x1u << 0) /**< \brief (PWM_PTSR) Receiver Transfer Enable */
+#define PWM_PTSR_TXTEN (0x1u << 8) /**< \brief (PWM_PTSR) Transmitter Transfer Enable */
+/* -------- PWM_CMPV : (PWM Offset: N/A) PWM Comparison 0 Value Register -------- */
+#define PWM_CMPV_CV_Pos 0
+#define PWM_CMPV_CV_Msk (0xffffffu << PWM_CMPV_CV_Pos) /**< \brief (PWM_CMPV) Comparison x Value */
+#define PWM_CMPV_CV(value) ((PWM_CMPV_CV_Msk & ((value) << PWM_CMPV_CV_Pos)))
+#define PWM_CMPV_CVM (0x1u << 24) /**< \brief (PWM_CMPV) Comparison x Value Mode */
+/* -------- PWM_CMPVUPD : (PWM Offset: N/A) PWM Comparison 0 Value Update Register -------- */
+#define PWM_CMPVUPD_CVUPD_Pos 0
+#define PWM_CMPVUPD_CVUPD_Msk (0xffffffu << PWM_CMPVUPD_CVUPD_Pos) /**< \brief (PWM_CMPVUPD) Comparison x Value Update */
+#define PWM_CMPVUPD_CVUPD(value) ((PWM_CMPVUPD_CVUPD_Msk & ((value) << PWM_CMPVUPD_CVUPD_Pos)))
+#define PWM_CMPVUPD_CVMUPD (0x1u << 24) /**< \brief (PWM_CMPVUPD) Comparison x Value Mode Update */
+/* -------- PWM_CMPM : (PWM Offset: N/A) PWM Comparison 0 Mode Register -------- */
+#define PWM_CMPM_CEN (0x1u << 0) /**< \brief (PWM_CMPM) Comparison x Enable */
+#define PWM_CMPM_CTR_Pos 4
+#define PWM_CMPM_CTR_Msk (0xfu << PWM_CMPM_CTR_Pos) /**< \brief (PWM_CMPM) Comparison x Trigger */
+#define PWM_CMPM_CTR(value) ((PWM_CMPM_CTR_Msk & ((value) << PWM_CMPM_CTR_Pos)))
+#define PWM_CMPM_CPR_Pos 8
+#define PWM_CMPM_CPR_Msk (0xfu << PWM_CMPM_CPR_Pos) /**< \brief (PWM_CMPM) Comparison x Period */
+#define PWM_CMPM_CPR(value) ((PWM_CMPM_CPR_Msk & ((value) << PWM_CMPM_CPR_Pos)))
+#define PWM_CMPM_CPRCNT_Pos 12
+#define PWM_CMPM_CPRCNT_Msk (0xfu << PWM_CMPM_CPRCNT_Pos) /**< \brief (PWM_CMPM) Comparison x Period Counter */
+#define PWM_CMPM_CPRCNT(value) ((PWM_CMPM_CPRCNT_Msk & ((value) << PWM_CMPM_CPRCNT_Pos)))
+#define PWM_CMPM_CUPR_Pos 16
+#define PWM_CMPM_CUPR_Msk (0xfu << PWM_CMPM_CUPR_Pos) /**< \brief (PWM_CMPM) Comparison x Update Period */
+#define PWM_CMPM_CUPR(value) ((PWM_CMPM_CUPR_Msk & ((value) << PWM_CMPM_CUPR_Pos)))
+#define PWM_CMPM_CUPRCNT_Pos 20
+#define PWM_CMPM_CUPRCNT_Msk (0xfu << PWM_CMPM_CUPRCNT_Pos) /**< \brief (PWM_CMPM) Comparison x Update Period Counter */
+#define PWM_CMPM_CUPRCNT(value) ((PWM_CMPM_CUPRCNT_Msk & ((value) << PWM_CMPM_CUPRCNT_Pos)))
+/* -------- PWM_CMPMUPD : (PWM Offset: N/A) PWM Comparison 0 Mode Update Register -------- */
+#define PWM_CMPMUPD_CENUPD (0x1u << 0) /**< \brief (PWM_CMPMUPD) Comparison x Enable Update */
+#define PWM_CMPMUPD_CTRUPD_Pos 4
+#define PWM_CMPMUPD_CTRUPD_Msk (0xfu << PWM_CMPMUPD_CTRUPD_Pos) /**< \brief (PWM_CMPMUPD) Comparison x Trigger Update */
+#define PWM_CMPMUPD_CTRUPD(value) ((PWM_CMPMUPD_CTRUPD_Msk & ((value) << PWM_CMPMUPD_CTRUPD_Pos)))
+#define PWM_CMPMUPD_CPRUPD_Pos 8
+#define PWM_CMPMUPD_CPRUPD_Msk (0xfu << PWM_CMPMUPD_CPRUPD_Pos) /**< \brief (PWM_CMPMUPD) Comparison x Period Update */
+#define PWM_CMPMUPD_CPRUPD(value) ((PWM_CMPMUPD_CPRUPD_Msk & ((value) << PWM_CMPMUPD_CPRUPD_Pos)))
+#define PWM_CMPMUPD_CUPRUPD_Pos 16
+#define PWM_CMPMUPD_CUPRUPD_Msk (0xfu << PWM_CMPMUPD_CUPRUPD_Pos) /**< \brief (PWM_CMPMUPD) Comparison x Update Period Update */
+#define PWM_CMPMUPD_CUPRUPD(value) ((PWM_CMPMUPD_CUPRUPD_Msk & ((value) << PWM_CMPMUPD_CUPRUPD_Pos)))
+/* -------- PWM_CMR : (PWM Offset: N/A) PWM Channel Mode Register -------- */
+#define PWM_CMR_CPRE_Pos 0
+#define PWM_CMR_CPRE_Msk (0xfu << PWM_CMR_CPRE_Pos) /**< \brief (PWM_CMR) Channel Pre-scaler */
+#define   PWM_CMR_CPRE_MCK (0x0u << 0) /**< \brief (PWM_CMR) Master clock */
+#define   PWM_CMR_CPRE_MCK_DIV_2 (0x1u << 0) /**< \brief (PWM_CMR) Master clock/2 */
+#define   PWM_CMR_CPRE_MCK_DIV_4 (0x2u << 0) /**< \brief (PWM_CMR) Master clock/4 */
+#define   PWM_CMR_CPRE_MCK_DIV_8 (0x3u << 0) /**< \brief (PWM_CMR) Master clock/8 */
+#define   PWM_CMR_CPRE_MCK_DIV_16 (0x4u << 0) /**< \brief (PWM_CMR) Master clock/16 */
+#define   PWM_CMR_CPRE_MCK_DIV_32 (0x5u << 0) /**< \brief (PWM_CMR) Master clock/32 */
+#define   PWM_CMR_CPRE_MCK_DIV_64 (0x6u << 0) /**< \brief (PWM_CMR) Master clock/64 */
+#define   PWM_CMR_CPRE_MCK_DIV_128 (0x7u << 0) /**< \brief (PWM_CMR) Master clock/128 */
+#define   PWM_CMR_CPRE_MCK_DIV_256 (0x8u << 0) /**< \brief (PWM_CMR) Master clock/256 */
+#define   PWM_CMR_CPRE_MCK_DIV_512 (0x9u << 0) /**< \brief (PWM_CMR) Master clock/512 */
+#define   PWM_CMR_CPRE_MCK_DIV_1024 (0xAu << 0) /**< \brief (PWM_CMR) Master clock/1024 */
+#define   PWM_CMR_CPRE_CLKA (0xBu << 0) /**< \brief (PWM_CMR) Clock A */
+#define   PWM_CMR_CPRE_CLKB (0xCu << 0) /**< \brief (PWM_CMR) Clock B */
+#define PWM_CMR_CALG (0x1u << 8) /**< \brief (PWM_CMR) Channel Alignment */
+#define PWM_CMR_CPOL (0x1u << 9) /**< \brief (PWM_CMR) Channel Polarity */
+#define PWM_CMR_CES (0x1u << 10) /**< \brief (PWM_CMR) Counter Event Selection */
+#define PWM_CMR_UPDS (0x1u << 11) /**< \brief (PWM_CMR) Update Selection */
+#define PWM_CMR_DTE (0x1u << 16) /**< \brief (PWM_CMR) Dead-Time Generator Enable */
+#define PWM_CMR_DTHI (0x1u << 17) /**< \brief (PWM_CMR) Dead-Time PWMHx Output Inverted */
+#define PWM_CMR_DTLI (0x1u << 18) /**< \brief (PWM_CMR) Dead-Time PWMLx Output Inverted */
+/* -------- PWM_CDTY : (PWM Offset: N/A) PWM Channel Duty Cycle Register -------- */
+#define PWM_CDTY_CDTY_Pos 0
+#define PWM_CDTY_CDTY_Msk (0xffffffu << PWM_CDTY_CDTY_Pos) /**< \brief (PWM_CDTY) Channel Duty-Cycle */
+#define PWM_CDTY_CDTY(value) ((PWM_CDTY_CDTY_Msk & ((value) << PWM_CDTY_CDTY_Pos)))
+/* -------- PWM_CDTYUPD : (PWM Offset: N/A) PWM Channel Duty Cycle Update Register -------- */
+#define PWM_CDTYUPD_CDTYUPD_Pos 0
+#define PWM_CDTYUPD_CDTYUPD_Msk (0xffffffu << PWM_CDTYUPD_CDTYUPD_Pos) /**< \brief (PWM_CDTYUPD) Channel Duty-Cycle Update */
+#define PWM_CDTYUPD_CDTYUPD(value) ((PWM_CDTYUPD_CDTYUPD_Msk & ((value) << PWM_CDTYUPD_CDTYUPD_Pos)))
+/* -------- PWM_CPRD : (PWM Offset: N/A) PWM Channel Period Register -------- */
+#define PWM_CPRD_CPRD_Pos 0
+#define PWM_CPRD_CPRD_Msk (0xffffffu << PWM_CPRD_CPRD_Pos) /**< \brief (PWM_CPRD) Channel Period */
+#define PWM_CPRD_CPRD(value) ((PWM_CPRD_CPRD_Msk & ((value) << PWM_CPRD_CPRD_Pos)))
+/* -------- PWM_CPRDUPD : (PWM Offset: N/A) PWM Channel Period Update Register -------- */
+#define PWM_CPRDUPD_CPRDUPD_Pos 0
+#define PWM_CPRDUPD_CPRDUPD_Msk (0xffffffu << PWM_CPRDUPD_CPRDUPD_Pos) /**< \brief (PWM_CPRDUPD) Channel Period Update */
+#define PWM_CPRDUPD_CPRDUPD(value) ((PWM_CPRDUPD_CPRDUPD_Msk & ((value) << PWM_CPRDUPD_CPRDUPD_Pos)))
+/* -------- PWM_CCNT : (PWM Offset: N/A) PWM Channel Counter Register -------- */
+#define PWM_CCNT_CNT_Pos 0
+#define PWM_CCNT_CNT_Msk (0xffffffu << PWM_CCNT_CNT_Pos) /**< \brief (PWM_CCNT) Channel Counter Register */
+/* -------- PWM_DT : (PWM Offset: N/A) PWM Channel Dead Time Register -------- */
+#define PWM_DT_DTH_Pos 0
+#define PWM_DT_DTH_Msk (0xffffu << PWM_DT_DTH_Pos) /**< \brief (PWM_DT) Dead-Time Value for PWMHx Output */
+#define PWM_DT_DTH(value) ((PWM_DT_DTH_Msk & ((value) << PWM_DT_DTH_Pos)))
+#define PWM_DT_DTL_Pos 16
+#define PWM_DT_DTL_Msk (0xffffu << PWM_DT_DTL_Pos) /**< \brief (PWM_DT) Dead-Time Value for PWMLx Output */
+#define PWM_DT_DTL(value) ((PWM_DT_DTL_Msk & ((value) << PWM_DT_DTL_Pos)))
+/* -------- PWM_DTUPD : (PWM Offset: N/A) PWM Channel Dead Time Update Register -------- */
+#define PWM_DTUPD_DTHUPD_Pos 0
+#define PWM_DTUPD_DTHUPD_Msk (0xffffu << PWM_DTUPD_DTHUPD_Pos) /**< \brief (PWM_DTUPD) Dead-Time Value Update for PWMHx Output */
+#define PWM_DTUPD_DTHUPD(value) ((PWM_DTUPD_DTHUPD_Msk & ((value) << PWM_DTUPD_DTHUPD_Pos)))
+#define PWM_DTUPD_DTLUPD_Pos 16
+#define PWM_DTUPD_DTLUPD_Msk (0xffffu << PWM_DTUPD_DTLUPD_Pos) /**< \brief (PWM_DTUPD) Dead-Time Value Update for PWMLx Output */
+#define PWM_DTUPD_DTLUPD(value) ((PWM_DTUPD_DTLUPD_Msk & ((value) << PWM_DTUPD_DTLUPD_Pos)))
+/* -------- PWM_CMUPD : (PWM Offset: N/A) PWM Channel Mode Update Register -------- */
+#define PWM_CMUPD_CPOLUP (0x1u << 9) /**< \brief (PWM_CMUPD) Channel Polarity Update */
+#define PWM_CMUPD_CPOLINVUP (0x1u << 13) /**< \brief (PWM_CMUPD) Channel Polarity Inversion Update */
+/* -------- PWM_CAE : (PWM Offset: N/A) PWM Channel Additional Edge Register -------- */
+#define PWM_CAE_ADEDGV_Pos 0
+#define PWM_CAE_ADEDGV_Msk (0xffffffu << PWM_CAE_ADEDGV_Pos) /**< \brief (PWM_CAE) Channel Additional Edge Value */
+#define PWM_CAE_ADEDGV(value) ((PWM_CAE_ADEDGV_Msk & ((value) << PWM_CAE_ADEDGV_Pos)))
+#define PWM_CAE_ADEDGM_Pos 24
+#define PWM_CAE_ADEDGM_Msk (0x3u << PWM_CAE_ADEDGM_Pos) /**< \brief (PWM_CAE) Channel Additional Edge Mode */
+#define   PWM_CAE_ADEDGM_INC (0x0u << 24) /**< \brief (PWM_CAE) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGV and the counter of the channel x is incrementing. */
+#define   PWM_CAE_ADEDGM_DEC (0x1u << 24) /**< \brief (PWM_CAE) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGV and the counter of the channel x is incrementing. */
+#define   PWM_CAE_ADEDGM_BOTH (0x2u << 24) /**< \brief (PWM_CAE) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGV, whether the counter is incrementing or not. */
+/* -------- PWM_CAEUPD : (PWM Offset: N/A) PWM Channel Additional Edge Update Register -------- */
+#define PWM_CAEUPD_ADEDGVUP_Pos 0
+#define PWM_CAEUPD_ADEDGVUP_Msk (0xffffffu << PWM_CAEUPD_ADEDGVUP_Pos) /**< \brief (PWM_CAEUPD) Channel Additional Edge Value Update */
+#define PWM_CAEUPD_ADEDGVUP(value) ((PWM_CAEUPD_ADEDGVUP_Msk & ((value) << PWM_CAEUPD_ADEDGVUP_Pos)))
+#define PWM_CAEUPD_ADEDGMUP_Pos 24
+#define PWM_CAEUPD_ADEDGMUP_Msk (0x3u << PWM_CAEUPD_ADEDGMUP_Pos) /**< \brief (PWM_CAEUPD) Channel Additional Edge Mode Update */
+#define   PWM_CAEUPD_ADEDGMUP_INC (0x0u << 24) /**< \brief (PWM_CAEUPD) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGVUP and the counter of the channel x is incrementing. */
+#define   PWM_CAEUPD_ADEDGMUP_DEC (0x1u << 24) /**< \brief (PWM_CAEUPD) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGVUP and the counter of the channel x is incrementing. */
+#define   PWM_CAEUPD_ADEDGMUP_BOTH (0x2u << 24) /**< \brief (PWM_CAEUPD) The additional edge of the channel x output waveform occurs when CCNTx reaches ADEDGVUP, whether the counter is incrementing or not. */
+
+/*@}*/
+
+
+#endif /* _SAM4E_PWM_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/rstc.h
+++ b/asf/sam/include/sam4e/component/rstc.h
@@ -1,0 +1,73 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RSTC_COMPONENT_
+#define _SAM4E_RSTC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Reset Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_RSTC Reset Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Rstc hardware registers */
+typedef struct {
+  WoReg RSTC_CR; /**< \brief (Rstc Offset: 0x00) Control Register */
+  RoReg RSTC_SR; /**< \brief (Rstc Offset: 0x04) Status Register */
+  RwReg RSTC_MR; /**< \brief (Rstc Offset: 0x08) Mode Register */
+} Rstc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- RSTC_CR : (RSTC Offset: 0x00) Control Register -------- */
+#define RSTC_CR_PROCRST (0x1u << 0) /**< \brief (RSTC_CR) Processor Reset */
+#define RSTC_CR_PERRST (0x1u << 2) /**< \brief (RSTC_CR) Peripheral Reset */
+#define RSTC_CR_EXTRST (0x1u << 3) /**< \brief (RSTC_CR) External Reset */
+#define RSTC_CR_KEY_Pos 24
+#define RSTC_CR_KEY_Msk (0xffu << RSTC_CR_KEY_Pos) /**< \brief (RSTC_CR) System Reset Key */
+#define RSTC_CR_KEY(value) ((RSTC_CR_KEY_Msk & ((value) << RSTC_CR_KEY_Pos)))
+/* -------- RSTC_SR : (RSTC Offset: 0x04) Status Register -------- */
+#define RSTC_SR_URSTS (0x1u << 0) /**< \brief (RSTC_SR) User Reset Status */
+#define RSTC_SR_RSTTYP_Pos 8
+#define RSTC_SR_RSTTYP_Msk (0x7u << RSTC_SR_RSTTYP_Pos) /**< \brief (RSTC_SR) Reset Type */
+#define RSTC_SR_NRSTL (0x1u << 16) /**< \brief (RSTC_SR) NRST Pin Level */
+#define RSTC_SR_SRCMP (0x1u << 17) /**< \brief (RSTC_SR) Software Reset Command in Progress */
+/* -------- RSTC_MR : (RSTC Offset: 0x08) Mode Register -------- */
+#define RSTC_MR_URSTEN (0x1u << 0) /**< \brief (RSTC_MR) User Reset Enable */
+#define RSTC_MR_URSTIEN (0x1u << 4) /**< \brief (RSTC_MR) User Reset Interrupt Enable */
+#define RSTC_MR_ERSTL_Pos 8
+#define RSTC_MR_ERSTL_Msk (0xfu << RSTC_MR_ERSTL_Pos) /**< \brief (RSTC_MR) External Reset Length */
+#define RSTC_MR_ERSTL(value) ((RSTC_MR_ERSTL_Msk & ((value) << RSTC_MR_ERSTL_Pos)))
+#define RSTC_MR_KEY_Pos 24
+#define RSTC_MR_KEY_Msk (0xffu << RSTC_MR_KEY_Pos) /**< \brief (RSTC_MR) Password */
+#define RSTC_MR_KEY(value) ((RSTC_MR_KEY_Msk & ((value) << RSTC_MR_KEY_Pos)))
+
+/*@}*/
+
+
+#endif /* _SAM4E_RSTC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/rtc.h
+++ b/asf/sam/include/sam4e/component/rtc.h
@@ -1,0 +1,219 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RTC_COMPONENT_
+#define _SAM4E_RTC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Real-time Clock */
+/* ============================================================================= */
+/** \addtogroup SAM4E_RTC Real-time Clock */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Rtc hardware registers */
+typedef struct {
+  RwReg RTC_CR;     /**< \brief (Rtc Offset: 0x00) Control Register */
+  RwReg RTC_MR;     /**< \brief (Rtc Offset: 0x04) Mode Register */
+  RwReg RTC_TIMR;   /**< \brief (Rtc Offset: 0x08) Time Register */
+  RwReg RTC_CALR;   /**< \brief (Rtc Offset: 0x0C) Calendar Register */
+  RwReg RTC_TIMALR; /**< \brief (Rtc Offset: 0x10) Time Alarm Register */
+  RwReg RTC_CALALR; /**< \brief (Rtc Offset: 0x14) Calendar Alarm Register */
+  RoReg RTC_SR;     /**< \brief (Rtc Offset: 0x18) Status Register */
+  WoReg RTC_SCCR;   /**< \brief (Rtc Offset: 0x1C) Status Clear Command Register */
+  WoReg RTC_IER;    /**< \brief (Rtc Offset: 0x20) Interrupt Enable Register */
+  WoReg RTC_IDR;    /**< \brief (Rtc Offset: 0x24) Interrupt Disable Register */
+  RoReg RTC_IMR;    /**< \brief (Rtc Offset: 0x28) Interrupt Mask Register */
+  RoReg RTC_VER;    /**< \brief (Rtc Offset: 0x2C) Valid Entry Register */
+} Rtc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- RTC_CR : (RTC Offset: 0x00) Control Register -------- */
+#define RTC_CR_UPDTIM (0x1u << 0) /**< \brief (RTC_CR) Update Request Time Register */
+#define RTC_CR_UPDCAL (0x1u << 1) /**< \brief (RTC_CR) Update Request Calendar Register */
+#define RTC_CR_TIMEVSEL_Pos 8
+#define RTC_CR_TIMEVSEL_Msk (0x3u << RTC_CR_TIMEVSEL_Pos) /**< \brief (RTC_CR) Time Event Selection */
+#define   RTC_CR_TIMEVSEL_MINUTE (0x0u << 8) /**< \brief (RTC_CR) Minute change */
+#define   RTC_CR_TIMEVSEL_HOUR (0x1u << 8) /**< \brief (RTC_CR) Hour change */
+#define   RTC_CR_TIMEVSEL_MIDNIGHT (0x2u << 8) /**< \brief (RTC_CR) Every day at midnight */
+#define   RTC_CR_TIMEVSEL_NOON (0x3u << 8) /**< \brief (RTC_CR) Every day at noon */
+#define RTC_CR_CALEVSEL_Pos 16
+#define RTC_CR_CALEVSEL_Msk (0x3u << RTC_CR_CALEVSEL_Pos) /**< \brief (RTC_CR) Calendar Event Selection */
+#define   RTC_CR_CALEVSEL_WEEK (0x0u << 16) /**< \brief (RTC_CR) Week change (every Monday at time 00:00:00) */
+#define   RTC_CR_CALEVSEL_MONTH (0x1u << 16) /**< \brief (RTC_CR) Month change (every 01 of each month at time 00:00:00) */
+#define   RTC_CR_CALEVSEL_YEAR (0x2u << 16) /**< \brief (RTC_CR) Year change (every January 1 at time 00:00:00) */
+/* -------- RTC_MR : (RTC Offset: 0x04) Mode Register -------- */
+#define RTC_MR_HRMOD (0x1u << 0) /**< \brief (RTC_MR) 12-/24-hour Mode */
+#define RTC_MR_PERSIAN (0x1u << 1) /**< \brief (RTC_MR) PERSIAN Calendar */
+#define RTC_MR_NEGPPM (0x1u << 4) /**< \brief (RTC_MR) NEGative PPM Correction */
+#define RTC_MR_CORRECTION_Pos 8
+#define RTC_MR_CORRECTION_Msk (0x7fu << RTC_MR_CORRECTION_Pos) /**< \brief (RTC_MR) Slow Clock Correction */
+#define RTC_MR_CORRECTION(value) ((RTC_MR_CORRECTION_Msk & ((value) << RTC_MR_CORRECTION_Pos)))
+#define RTC_MR_HIGHPPM (0x1u << 15) /**< \brief (RTC_MR) HIGH PPM Correction */
+#define RTC_MR_OUT0_Pos 16
+#define RTC_MR_OUT0_Msk (0x7u << RTC_MR_OUT0_Pos) /**< \brief (RTC_MR) RTCOUT0 Output Source Selection */
+#define   RTC_MR_OUT0_NO_WAVE (0x0u << 16) /**< \brief (RTC_MR) no waveform, stuck at '0' */
+#define   RTC_MR_OUT0_FREQ1HZ (0x1u << 16) /**< \brief (RTC_MR) 1 Hz square wave */
+#define   RTC_MR_OUT0_FREQ32HZ (0x2u << 16) /**< \brief (RTC_MR) 32 Hz square wave */
+#define   RTC_MR_OUT0_FREQ64HZ (0x3u << 16) /**< \brief (RTC_MR) 64 Hz square wave */
+#define   RTC_MR_OUT0_FREQ512HZ (0x4u << 16) /**< \brief (RTC_MR) 512 Hz square wave */
+#define   RTC_MR_OUT0_ALARM_TOGGLE (0x5u << 16) /**< \brief (RTC_MR) output toggles when alarm flag rises */
+#define   RTC_MR_OUT0_ALARM_FLAG (0x6u << 16) /**< \brief (RTC_MR) output is a copy of the alarm flag */
+#define   RTC_MR_OUT0_PROG_PULSE (0x7u << 16) /**< \brief (RTC_MR) duty cycle programmable pulse */
+#define RTC_MR_OUT1_Pos 20
+#define RTC_MR_OUT1_Msk (0x7u << RTC_MR_OUT1_Pos) /**< \brief (RTC_MR) RTCOUT1 Output Source Selection */
+#define   RTC_MR_OUT1_NO_WAVE (0x0u << 20) /**< \brief (RTC_MR) no waveform, stuck at '0' */
+#define   RTC_MR_OUT1_FREQ1HZ (0x1u << 20) /**< \brief (RTC_MR) 1 Hz square wave */
+#define   RTC_MR_OUT1_FREQ32HZ (0x2u << 20) /**< \brief (RTC_MR) 32 Hz square wave */
+#define   RTC_MR_OUT1_FREQ64HZ (0x3u << 20) /**< \brief (RTC_MR) 64 Hz square wave */
+#define   RTC_MR_OUT1_FREQ512HZ (0x4u << 20) /**< \brief (RTC_MR) 512 Hz square wave */
+#define   RTC_MR_OUT1_ALARM_TOGGLE (0x5u << 20) /**< \brief (RTC_MR) output toggles when alarm flag rises */
+#define   RTC_MR_OUT1_ALARM_FLAG (0x6u << 20) /**< \brief (RTC_MR) output is a copy of the alarm flag */
+#define   RTC_MR_OUT1_PROG_PULSE (0x7u << 20) /**< \brief (RTC_MR) duty cycle programmable pulse */
+#define RTC_MR_THIGH_Pos 24
+#define RTC_MR_THIGH_Msk (0x7u << RTC_MR_THIGH_Pos) /**< \brief (RTC_MR) High Duration of the Output Pulse */
+#define   RTC_MR_THIGH_H_31MS (0x0u << 24) /**< \brief (RTC_MR) 31.2 ms */
+#define   RTC_MR_THIGH_H_16MS (0x1u << 24) /**< \brief (RTC_MR) 15.6 ms */
+#define   RTC_MR_THIGH_H_4MS (0x2u << 24) /**< \brief (RTC_MR) 3.91 Lms */
+#define   RTC_MR_THIGH_H_976US (0x3u << 24) /**< \brief (RTC_MR) 976 us */
+#define   RTC_MR_THIGH_H_488US (0x4u << 24) /**< \brief (RTC_MR) 488 us */
+#define   RTC_MR_THIGH_H_122US (0x5u << 24) /**< \brief (RTC_MR) 122 us */
+#define   RTC_MR_THIGH_H_30US (0x6u << 24) /**< \brief (RTC_MR) 30.5 us */
+#define   RTC_MR_THIGH_H_15US (0x7u << 24) /**< \brief (RTC_MR) 15.2 us */
+#define RTC_MR_TPERIOD_Pos 28
+#define RTC_MR_TPERIOD_Msk (0x3u << RTC_MR_TPERIOD_Pos) /**< \brief (RTC_MR) Period of the Output Pulse */
+#define   RTC_MR_TPERIOD_P_1S (0x0u << 28) /**< \brief (RTC_MR) 1 second */
+#define   RTC_MR_TPERIOD_P_500MS (0x1u << 28) /**< \brief (RTC_MR) 500 ms */
+#define   RTC_MR_TPERIOD_P_250MS (0x2u << 28) /**< \brief (RTC_MR) 250 ms */
+#define   RTC_MR_TPERIOD_P_125MS (0x3u << 28) /**< \brief (RTC_MR) 125 ms */
+/* -------- RTC_TIMR : (RTC Offset: 0x08) Time Register -------- */
+#define RTC_TIMR_SEC_Pos 0
+#define RTC_TIMR_SEC_Msk (0x7fu << RTC_TIMR_SEC_Pos) /**< \brief (RTC_TIMR) Current Second */
+#define RTC_TIMR_SEC(value) ((RTC_TIMR_SEC_Msk & ((value) << RTC_TIMR_SEC_Pos)))
+#define RTC_TIMR_MIN_Pos 8
+#define RTC_TIMR_MIN_Msk (0x7fu << RTC_TIMR_MIN_Pos) /**< \brief (RTC_TIMR) Current Minute */
+#define RTC_TIMR_MIN(value) ((RTC_TIMR_MIN_Msk & ((value) << RTC_TIMR_MIN_Pos)))
+#define RTC_TIMR_HOUR_Pos 16
+#define RTC_TIMR_HOUR_Msk (0x3fu << RTC_TIMR_HOUR_Pos) /**< \brief (RTC_TIMR) Current Hour */
+#define RTC_TIMR_HOUR(value) ((RTC_TIMR_HOUR_Msk & ((value) << RTC_TIMR_HOUR_Pos)))
+#define RTC_TIMR_AMPM (0x1u << 22) /**< \brief (RTC_TIMR) Ante Meridiem Post Meridiem Indicator */
+/* -------- RTC_CALR : (RTC Offset: 0x0C) Calendar Register -------- */
+#define RTC_CALR_CENT_Pos 0
+#define RTC_CALR_CENT_Msk (0x7fu << RTC_CALR_CENT_Pos) /**< \brief (RTC_CALR) Current Century */
+#define RTC_CALR_CENT(value) ((RTC_CALR_CENT_Msk & ((value) << RTC_CALR_CENT_Pos)))
+#define RTC_CALR_YEAR_Pos 8
+#define RTC_CALR_YEAR_Msk (0xffu << RTC_CALR_YEAR_Pos) /**< \brief (RTC_CALR) Current Year */
+#define RTC_CALR_YEAR(value) ((RTC_CALR_YEAR_Msk & ((value) << RTC_CALR_YEAR_Pos)))
+#define RTC_CALR_MONTH_Pos 16
+#define RTC_CALR_MONTH_Msk (0x1fu << RTC_CALR_MONTH_Pos) /**< \brief (RTC_CALR) Current Month */
+#define RTC_CALR_MONTH(value) ((RTC_CALR_MONTH_Msk & ((value) << RTC_CALR_MONTH_Pos)))
+#define RTC_CALR_DAY_Pos 21
+#define RTC_CALR_DAY_Msk (0x7u << RTC_CALR_DAY_Pos) /**< \brief (RTC_CALR) Current Day in Current Week */
+#define RTC_CALR_DAY(value) ((RTC_CALR_DAY_Msk & ((value) << RTC_CALR_DAY_Pos)))
+#define RTC_CALR_DATE_Pos 24
+#define RTC_CALR_DATE_Msk (0x3fu << RTC_CALR_DATE_Pos) /**< \brief (RTC_CALR) Current Day in Current Month */
+#define RTC_CALR_DATE(value) ((RTC_CALR_DATE_Msk & ((value) << RTC_CALR_DATE_Pos)))
+/* -------- RTC_TIMALR : (RTC Offset: 0x10) Time Alarm Register -------- */
+#define RTC_TIMALR_SEC_Pos 0
+#define RTC_TIMALR_SEC_Msk (0x7fu << RTC_TIMALR_SEC_Pos) /**< \brief (RTC_TIMALR) Second Alarm */
+#define RTC_TIMALR_SEC(value) ((RTC_TIMALR_SEC_Msk & ((value) << RTC_TIMALR_SEC_Pos)))
+#define RTC_TIMALR_SECEN (0x1u << 7) /**< \brief (RTC_TIMALR) Second Alarm Enable */
+#define RTC_TIMALR_MIN_Pos 8
+#define RTC_TIMALR_MIN_Msk (0x7fu << RTC_TIMALR_MIN_Pos) /**< \brief (RTC_TIMALR) Minute Alarm */
+#define RTC_TIMALR_MIN(value) ((RTC_TIMALR_MIN_Msk & ((value) << RTC_TIMALR_MIN_Pos)))
+#define RTC_TIMALR_MINEN (0x1u << 15) /**< \brief (RTC_TIMALR) Minute Alarm Enable */
+#define RTC_TIMALR_HOUR_Pos 16
+#define RTC_TIMALR_HOUR_Msk (0x3fu << RTC_TIMALR_HOUR_Pos) /**< \brief (RTC_TIMALR) Hour Alarm */
+#define RTC_TIMALR_HOUR(value) ((RTC_TIMALR_HOUR_Msk & ((value) << RTC_TIMALR_HOUR_Pos)))
+#define RTC_TIMALR_AMPM (0x1u << 22) /**< \brief (RTC_TIMALR) AM/PM Indicator */
+#define RTC_TIMALR_HOUREN (0x1u << 23) /**< \brief (RTC_TIMALR) Hour Alarm Enable */
+/* -------- RTC_CALALR : (RTC Offset: 0x14) Calendar Alarm Register -------- */
+#define RTC_CALALR_MONTH_Pos 16
+#define RTC_CALALR_MONTH_Msk (0x1fu << RTC_CALALR_MONTH_Pos) /**< \brief (RTC_CALALR) Month Alarm */
+#define RTC_CALALR_MONTH(value) ((RTC_CALALR_MONTH_Msk & ((value) << RTC_CALALR_MONTH_Pos)))
+#define RTC_CALALR_MTHEN (0x1u << 23) /**< \brief (RTC_CALALR) Month Alarm Enable */
+#define RTC_CALALR_DATE_Pos 24
+#define RTC_CALALR_DATE_Msk (0x3fu << RTC_CALALR_DATE_Pos) /**< \brief (RTC_CALALR) Date Alarm */
+#define RTC_CALALR_DATE(value) ((RTC_CALALR_DATE_Msk & ((value) << RTC_CALALR_DATE_Pos)))
+#define RTC_CALALR_DATEEN (0x1u << 31) /**< \brief (RTC_CALALR) Date Alarm Enable */
+/* -------- RTC_SR : (RTC Offset: 0x18) Status Register -------- */
+#define RTC_SR_ACKUPD (0x1u << 0) /**< \brief (RTC_SR) Acknowledge for Update */
+#define   RTC_SR_ACKUPD_FREERUN (0x0u << 0) /**< \brief (RTC_SR) Time and calendar registers cannot be updated. */
+#define   RTC_SR_ACKUPD_UPDATE (0x1u << 0) /**< \brief (RTC_SR) Time and calendar registers can be updated. */
+#define RTC_SR_ALARM (0x1u << 1) /**< \brief (RTC_SR) Alarm Flag */
+#define   RTC_SR_ALARM_NO_ALARMEVENT (0x0u << 1) /**< \brief (RTC_SR) No alarm matching condition occurred. */
+#define   RTC_SR_ALARM_ALARMEVENT (0x1u << 1) /**< \brief (RTC_SR) An alarm matching condition has occurred. */
+#define RTC_SR_SEC (0x1u << 2) /**< \brief (RTC_SR) Second Event */
+#define   RTC_SR_SEC_NO_SECEVENT (0x0u << 2) /**< \brief (RTC_SR) No second event has occurred since the last clear. */
+#define   RTC_SR_SEC_SECEVENT (0x1u << 2) /**< \brief (RTC_SR) At least one second event has occurred since the last clear. */
+#define RTC_SR_TIMEV (0x1u << 3) /**< \brief (RTC_SR) Time Event */
+#define   RTC_SR_TIMEV_NO_TIMEVENT (0x0u << 3) /**< \brief (RTC_SR) No time event has occurred since the last clear. */
+#define   RTC_SR_TIMEV_TIMEVENT (0x1u << 3) /**< \brief (RTC_SR) At least one time event has occurred since the last clear. */
+#define RTC_SR_CALEV (0x1u << 4) /**< \brief (RTC_SR) Calendar Event */
+#define   RTC_SR_CALEV_NO_CALEVENT (0x0u << 4) /**< \brief (RTC_SR) No calendar event has occurred since the last clear. */
+#define   RTC_SR_CALEV_CALEVENT (0x1u << 4) /**< \brief (RTC_SR) At least one calendar event has occurred since the last clear. */
+#define RTC_SR_TDERR (0x1u << 5) /**< \brief (RTC_SR) Time and/or Date Free Running Error */
+#define   RTC_SR_TDERR_CORRECT (0x0u << 5) /**< \brief (RTC_SR) The internal free running counters are carrying valid values since the last read of RTC_SR. */
+#define   RTC_SR_TDERR_ERR_TIMEDATE (0x1u << 5) /**< \brief (RTC_SR) The internal free running counters have been corrupted (invalid date or time, non-BCD values) since the last read and/or they are still invalid. */
+/* -------- RTC_SCCR : (RTC Offset: 0x1C) Status Clear Command Register -------- */
+#define RTC_SCCR_ACKCLR (0x1u << 0) /**< \brief (RTC_SCCR) Acknowledge Clear */
+#define RTC_SCCR_ALRCLR (0x1u << 1) /**< \brief (RTC_SCCR) Alarm Clear */
+#define RTC_SCCR_SECCLR (0x1u << 2) /**< \brief (RTC_SCCR) Second Clear */
+#define RTC_SCCR_TIMCLR (0x1u << 3) /**< \brief (RTC_SCCR) Time Clear */
+#define RTC_SCCR_CALCLR (0x1u << 4) /**< \brief (RTC_SCCR) Calendar Clear */
+#define RTC_SCCR_TDERRCLR (0x1u << 5) /**< \brief (RTC_SCCR) Time and/or Date Free Running Error Clear */
+/* -------- RTC_IER : (RTC Offset: 0x20) Interrupt Enable Register -------- */
+#define RTC_IER_ACKEN (0x1u << 0) /**< \brief (RTC_IER) Acknowledge Update Interrupt Enable */
+#define RTC_IER_ALREN (0x1u << 1) /**< \brief (RTC_IER) Alarm Interrupt Enable */
+#define RTC_IER_SECEN (0x1u << 2) /**< \brief (RTC_IER) Second Event Interrupt Enable */
+#define RTC_IER_TIMEN (0x1u << 3) /**< \brief (RTC_IER) Time Event Interrupt Enable */
+#define RTC_IER_CALEN (0x1u << 4) /**< \brief (RTC_IER) Calendar Event Interrupt Enable */
+#define RTC_IER_TDERREN (0x1u << 5) /**< \brief (RTC_IER) Time and/or Date Error Interrupt Enable */
+/* -------- RTC_IDR : (RTC Offset: 0x24) Interrupt Disable Register -------- */
+#define RTC_IDR_ACKDIS (0x1u << 0) /**< \brief (RTC_IDR) Acknowledge Update Interrupt Disable */
+#define RTC_IDR_ALRDIS (0x1u << 1) /**< \brief (RTC_IDR) Alarm Interrupt Disable */
+#define RTC_IDR_SECDIS (0x1u << 2) /**< \brief (RTC_IDR) Second Event Interrupt Disable */
+#define RTC_IDR_TIMDIS (0x1u << 3) /**< \brief (RTC_IDR) Time Event Interrupt Disable */
+#define RTC_IDR_CALDIS (0x1u << 4) /**< \brief (RTC_IDR) Calendar Event Interrupt Disable */
+#define RTC_IDR_TDERRDIS (0x1u << 5) /**< \brief (RTC_IDR) Time and/or Date Error Interrupt Disable */
+/* -------- RTC_IMR : (RTC Offset: 0x28) Interrupt Mask Register -------- */
+#define RTC_IMR_ACK (0x1u << 0) /**< \brief (RTC_IMR) Acknowledge Update Interrupt Mask */
+#define RTC_IMR_ALR (0x1u << 1) /**< \brief (RTC_IMR) Alarm Interrupt Mask */
+#define RTC_IMR_SEC (0x1u << 2) /**< \brief (RTC_IMR) Second Event Interrupt Mask */
+#define RTC_IMR_TIM (0x1u << 3) /**< \brief (RTC_IMR) Time Event Interrupt Mask */
+#define RTC_IMR_CAL (0x1u << 4) /**< \brief (RTC_IMR) Calendar Event Interrupt Mask */
+/* -------- RTC_VER : (RTC Offset: 0x2C) Valid Entry Register -------- */
+#define RTC_VER_NVTIM (0x1u << 0) /**< \brief (RTC_VER) Non-valid Time */
+#define RTC_VER_NVCAL (0x1u << 1) /**< \brief (RTC_VER) Non-valid Calendar */
+#define RTC_VER_NVTIMALR (0x1u << 2) /**< \brief (RTC_VER) Non-valid Time Alarm */
+#define RTC_VER_NVCALALR (0x1u << 3) /**< \brief (RTC_VER) Non-valid Calendar Alarm */
+
+/*@}*/
+
+
+#endif /* _SAM4E_RTC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/rtt.h
+++ b/asf/sam/include/sam4e/component/rtt.h
@@ -1,0 +1,71 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RTT_COMPONENT_
+#define _SAM4E_RTT_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Real-time Timer */
+/* ============================================================================= */
+/** \addtogroup SAM4E_RTT Real-time Timer */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Rtt hardware registers */
+typedef struct {
+  RwReg RTT_MR; /**< \brief (Rtt Offset: 0x00) Mode Register */
+  RwReg RTT_AR; /**< \brief (Rtt Offset: 0x04) Alarm Register */
+  RoReg RTT_VR; /**< \brief (Rtt Offset: 0x08) Value Register */
+  RoReg RTT_SR; /**< \brief (Rtt Offset: 0x0C) Status Register */
+} Rtt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- RTT_MR : (RTT Offset: 0x00) Mode Register -------- */
+#define RTT_MR_RTPRES_Pos 0
+#define RTT_MR_RTPRES_Msk (0xffffu << RTT_MR_RTPRES_Pos) /**< \brief (RTT_MR) Real-time Timer Prescaler Value */
+#define RTT_MR_RTPRES(value) ((RTT_MR_RTPRES_Msk & ((value) << RTT_MR_RTPRES_Pos)))
+#define RTT_MR_ALMIEN (0x1u << 16) /**< \brief (RTT_MR) Alarm Interrupt Enable */
+#define RTT_MR_RTTINCIEN (0x1u << 17) /**< \brief (RTT_MR) Real-time Timer Increment Interrupt Enable */
+#define RTT_MR_RTTRST (0x1u << 18) /**< \brief (RTT_MR) Real-time Timer Restart */
+#define RTT_MR_RTTDIS (0x1u << 20) /**< \brief (RTT_MR) Real-time Timer Disable */
+#define RTT_MR_RTC1HZ (0x1u << 24) /**< \brief (RTT_MR) Real-Time Clock 1Hz Clock Selection */
+/* -------- RTT_AR : (RTT Offset: 0x04) Alarm Register -------- */
+#define RTT_AR_ALMV_Pos 0
+#define RTT_AR_ALMV_Msk (0xffffffffu << RTT_AR_ALMV_Pos) /**< \brief (RTT_AR) Alarm Value */
+#define RTT_AR_ALMV(value) ((RTT_AR_ALMV_Msk & ((value) << RTT_AR_ALMV_Pos)))
+/* -------- RTT_VR : (RTT Offset: 0x08) Value Register -------- */
+#define RTT_VR_CRTV_Pos 0
+#define RTT_VR_CRTV_Msk (0xffffffffu << RTT_VR_CRTV_Pos) /**< \brief (RTT_VR) Current Real-time Value */
+/* -------- RTT_SR : (RTT Offset: 0x0C) Status Register -------- */
+#define RTT_SR_ALMS (0x1u << 0) /**< \brief (RTT_SR) Real-time Alarm Status */
+#define RTT_SR_RTTINC (0x1u << 1) /**< \brief (RTT_SR) Real-time Timer Increment */
+
+/*@}*/
+
+
+#endif /* _SAM4E_RTT_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/smc.h
+++ b/asf/sam/include/sam4e/component/smc.h
@@ -1,0 +1,139 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SMC_COMPONENT_
+#define _SAM4E_SMC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Static Memory Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_SMC Static Memory Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief SmcCs_number hardware registers */
+typedef struct {
+  RwReg         SMC_SETUP;        /**< \brief (SmcCs_number Offset: 0x0) SMC Setup Register */
+  RwReg         SMC_PULSE;        /**< \brief (SmcCs_number Offset: 0x4) SMC Pulse Register */
+  RwReg         SMC_CYCLE;        /**< \brief (SmcCs_number Offset: 0x8) SMC Cycle Register */
+  RwReg         SMC_MODE;         /**< \brief (SmcCs_number Offset: 0xC) SMC Mode Register */
+} SmcCs_number;
+/** \brief Smc hardware registers */
+#define SMCCS_NUMBER_NUMBER 4
+typedef struct {
+  SmcCs_number  SMC_CS_NUMBER[SMCCS_NUMBER_NUMBER]; /**< \brief (Smc Offset: 0x0) CS_number = 0 .. 3 */
+  RoReg         Reserved1[16];
+  RwReg         SMC_OCMS;         /**< \brief (Smc Offset: 0x80) SMC OCMS MODE Register */
+  WoReg         SMC_KEY1;         /**< \brief (Smc Offset: 0x84) SMC OCMS KEY1 Register */
+  WoReg         SMC_KEY2;         /**< \brief (Smc Offset: 0x88) SMC OCMS KEY2 Register */
+  RoReg         Reserved2[22];
+  RwReg         SMC_WPMR;         /**< \brief (Smc Offset: 0xE4) SMC Write Protect Mode Register */
+  RoReg         SMC_WPSR;         /**< \brief (Smc Offset: 0xE8) SMC Write Protect Status Register */
+} Smc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- SMC_SETUP : (SMC Offset: N/A) SMC Setup Register -------- */
+#define SMC_SETUP_NWE_SETUP_Pos 0
+#define SMC_SETUP_NWE_SETUP_Msk (0x3fu << SMC_SETUP_NWE_SETUP_Pos) /**< \brief (SMC_SETUP) NWE Setup Length */
+#define SMC_SETUP_NWE_SETUP(value) ((SMC_SETUP_NWE_SETUP_Msk & ((value) << SMC_SETUP_NWE_SETUP_Pos)))
+#define SMC_SETUP_NCS_WR_SETUP_Pos 8
+#define SMC_SETUP_NCS_WR_SETUP_Msk (0x3fu << SMC_SETUP_NCS_WR_SETUP_Pos) /**< \brief (SMC_SETUP) NCS Setup Length in WRITE Access */
+#define SMC_SETUP_NCS_WR_SETUP(value) ((SMC_SETUP_NCS_WR_SETUP_Msk & ((value) << SMC_SETUP_NCS_WR_SETUP_Pos)))
+#define SMC_SETUP_NRD_SETUP_Pos 16
+#define SMC_SETUP_NRD_SETUP_Msk (0x3fu << SMC_SETUP_NRD_SETUP_Pos) /**< \brief (SMC_SETUP) NRD Setup Length */
+#define SMC_SETUP_NRD_SETUP(value) ((SMC_SETUP_NRD_SETUP_Msk & ((value) << SMC_SETUP_NRD_SETUP_Pos)))
+#define SMC_SETUP_NCS_RD_SETUP_Pos 24
+#define SMC_SETUP_NCS_RD_SETUP_Msk (0x3fu << SMC_SETUP_NCS_RD_SETUP_Pos) /**< \brief (SMC_SETUP) NCS Setup Length in READ Access */
+#define SMC_SETUP_NCS_RD_SETUP(value) ((SMC_SETUP_NCS_RD_SETUP_Msk & ((value) << SMC_SETUP_NCS_RD_SETUP_Pos)))
+/* -------- SMC_PULSE : (SMC Offset: N/A) SMC Pulse Register -------- */
+#define SMC_PULSE_NWE_PULSE_Pos 0
+#define SMC_PULSE_NWE_PULSE_Msk (0x7fu << SMC_PULSE_NWE_PULSE_Pos) /**< \brief (SMC_PULSE) NWE Pulse Length */
+#define SMC_PULSE_NWE_PULSE(value) ((SMC_PULSE_NWE_PULSE_Msk & ((value) << SMC_PULSE_NWE_PULSE_Pos)))
+#define SMC_PULSE_NCS_WR_PULSE_Pos 8
+#define SMC_PULSE_NCS_WR_PULSE_Msk (0x7fu << SMC_PULSE_NCS_WR_PULSE_Pos) /**< \brief (SMC_PULSE) NCS Pulse Length in WRITE Access */
+#define SMC_PULSE_NCS_WR_PULSE(value) ((SMC_PULSE_NCS_WR_PULSE_Msk & ((value) << SMC_PULSE_NCS_WR_PULSE_Pos)))
+#define SMC_PULSE_NRD_PULSE_Pos 16
+#define SMC_PULSE_NRD_PULSE_Msk (0x7fu << SMC_PULSE_NRD_PULSE_Pos) /**< \brief (SMC_PULSE) NRD Pulse Length */
+#define SMC_PULSE_NRD_PULSE(value) ((SMC_PULSE_NRD_PULSE_Msk & ((value) << SMC_PULSE_NRD_PULSE_Pos)))
+#define SMC_PULSE_NCS_RD_PULSE_Pos 24
+#define SMC_PULSE_NCS_RD_PULSE_Msk (0x7fu << SMC_PULSE_NCS_RD_PULSE_Pos) /**< \brief (SMC_PULSE) NCS Pulse Length in READ Access */
+#define SMC_PULSE_NCS_RD_PULSE(value) ((SMC_PULSE_NCS_RD_PULSE_Msk & ((value) << SMC_PULSE_NCS_RD_PULSE_Pos)))
+/* -------- SMC_CYCLE : (SMC Offset: N/A) SMC Cycle Register -------- */
+#define SMC_CYCLE_NWE_CYCLE_Pos 0
+#define SMC_CYCLE_NWE_CYCLE_Msk (0x1ffu << SMC_CYCLE_NWE_CYCLE_Pos) /**< \brief (SMC_CYCLE) Total Write Cycle Length */
+#define SMC_CYCLE_NWE_CYCLE(value) ((SMC_CYCLE_NWE_CYCLE_Msk & ((value) << SMC_CYCLE_NWE_CYCLE_Pos)))
+#define SMC_CYCLE_NRD_CYCLE_Pos 16
+#define SMC_CYCLE_NRD_CYCLE_Msk (0x1ffu << SMC_CYCLE_NRD_CYCLE_Pos) /**< \brief (SMC_CYCLE) Total Read Cycle Length */
+#define SMC_CYCLE_NRD_CYCLE(value) ((SMC_CYCLE_NRD_CYCLE_Msk & ((value) << SMC_CYCLE_NRD_CYCLE_Pos)))
+/* -------- SMC_MODE : (SMC Offset: N/A) SMC Mode Register -------- */
+#define SMC_MODE_READ_MODE (0x1u << 0) /**< \brief (SMC_MODE)  */
+#define SMC_MODE_WRITE_MODE (0x1u << 1) /**< \brief (SMC_MODE)  */
+#define SMC_MODE_EXNW_MODE_Pos 4
+#define SMC_MODE_EXNW_MODE_Msk (0x3u << SMC_MODE_EXNW_MODE_Pos) /**< \brief (SMC_MODE) NWAIT Mode */
+#define   SMC_MODE_EXNW_MODE_DISABLED (0x0u << 4) /**< \brief (SMC_MODE) Disabled */
+#define   SMC_MODE_EXNW_MODE_FROZEN (0x2u << 4) /**< \brief (SMC_MODE) Frozen Mode */
+#define   SMC_MODE_EXNW_MODE_READY (0x3u << 4) /**< \brief (SMC_MODE) Ready Mode */
+#define SMC_MODE_TDF_CYCLES_Pos 16
+#define SMC_MODE_TDF_CYCLES_Msk (0xfu << SMC_MODE_TDF_CYCLES_Pos) /**< \brief (SMC_MODE) Data Float Time */
+#define SMC_MODE_TDF_CYCLES(value) ((SMC_MODE_TDF_CYCLES_Msk & ((value) << SMC_MODE_TDF_CYCLES_Pos)))
+#define SMC_MODE_TDF_MODE (0x1u << 20) /**< \brief (SMC_MODE) TDF Optimization */
+#define SMC_MODE_PMEN (0x1u << 24) /**< \brief (SMC_MODE) Page Mode Enabled */
+#define SMC_MODE_PS_Pos 28
+#define SMC_MODE_PS_Msk (0x3u << SMC_MODE_PS_Pos) /**< \brief (SMC_MODE) Page Size */
+#define   SMC_MODE_PS_4_BYTE (0x0u << 28) /**< \brief (SMC_MODE) 4-byte page */
+#define   SMC_MODE_PS_8_BYTE (0x1u << 28) /**< \brief (SMC_MODE) 8-byte page */
+#define   SMC_MODE_PS_16_BYTE (0x2u << 28) /**< \brief (SMC_MODE) 16-byte page */
+#define   SMC_MODE_PS_32_BYTE (0x3u << 28) /**< \brief (SMC_MODE) 32-byte page */
+/* -------- SMC_OCMS : (SMC Offset: 0x80) SMC OCMS MODE Register -------- */
+#define SMC_OCMS_SMSE (0x1u << 0) /**< \brief (SMC_OCMS) Static Memory Controller Scrambling Enable */
+#define SMC_OCMS_CS0SE (0x1u << 16) /**< \brief (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable */
+#define SMC_OCMS_CS1SE (0x1u << 17) /**< \brief (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable */
+#define SMC_OCMS_CS2SE (0x1u << 18) /**< \brief (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable */
+#define SMC_OCMS_CS3SE (0x1u << 19) /**< \brief (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable */
+/* -------- SMC_KEY1 : (SMC Offset: 0x84) SMC OCMS KEY1 Register -------- */
+#define SMC_KEY1_KEY1_Pos 0
+#define SMC_KEY1_KEY1_Msk (0xffffffffu << SMC_KEY1_KEY1_Pos) /**< \brief (SMC_KEY1) Off Chip Memory Scrambling (OCMS) Key Part 1 */
+#define SMC_KEY1_KEY1(value) ((SMC_KEY1_KEY1_Msk & ((value) << SMC_KEY1_KEY1_Pos)))
+/* -------- SMC_KEY2 : (SMC Offset: 0x88) SMC OCMS KEY2 Register -------- */
+#define SMC_KEY2_KEY2_Pos 0
+#define SMC_KEY2_KEY2_Msk (0xffffffffu << SMC_KEY2_KEY2_Pos) /**< \brief (SMC_KEY2) Off Chip Memory Scrambling (OCMS) Key Part 2 */
+#define SMC_KEY2_KEY2(value) ((SMC_KEY2_KEY2_Msk & ((value) << SMC_KEY2_KEY2_Pos)))
+/* -------- SMC_WPMR : (SMC Offset: 0xE4) SMC Write Protect Mode Register -------- */
+#define SMC_WPMR_WPEN (0x1u << 0) /**< \brief (SMC_WPMR) Write Protect Enable */
+#define SMC_WPMR_WPKEY_Pos 8
+#define SMC_WPMR_WPKEY_Msk (0xffffffu << SMC_WPMR_WPKEY_Pos) /**< \brief (SMC_WPMR) Write Protect KEY */
+#define SMC_WPMR_WPKEY(value) ((SMC_WPMR_WPKEY_Msk & ((value) << SMC_WPMR_WPKEY_Pos)))
+/* -------- SMC_WPSR : (SMC Offset: 0xE8) SMC Write Protect Status Register -------- */
+#define SMC_WPSR_WPVS (0x1u << 0) /**< \brief (SMC_WPSR) Write Protect Enable */
+#define SMC_WPSR_WPVSRC_Pos 8
+#define SMC_WPSR_WPVSRC_Msk (0xffffu << SMC_WPSR_WPVSRC_Pos) /**< \brief (SMC_WPSR) Write Protect Violation Source */
+
+/*@}*/
+
+
+#endif /* _SAM4E_SMC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/spi.h
+++ b/asf/sam/include/sam4e/component/spi.h
@@ -1,0 +1,226 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SPI_COMPONENT_
+#define _SAM4E_SPI_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Serial Peripheral Interface */
+/* ============================================================================= */
+/** \addtogroup SAM4E_SPI Serial Peripheral Interface */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Spi hardware registers */
+typedef struct {
+  WoReg SPI_CR;        /**< \brief (Spi Offset: 0x00) Control Register */
+  RwReg SPI_MR;        /**< \brief (Spi Offset: 0x04) Mode Register */
+  RoReg SPI_RDR;       /**< \brief (Spi Offset: 0x08) Receive Data Register */
+  WoReg SPI_TDR;       /**< \brief (Spi Offset: 0x0C) Transmit Data Register */
+  RoReg SPI_SR;        /**< \brief (Spi Offset: 0x10) Status Register */
+  WoReg SPI_IER;       /**< \brief (Spi Offset: 0x14) Interrupt Enable Register */
+  WoReg SPI_IDR;       /**< \brief (Spi Offset: 0x18) Interrupt Disable Register */
+  RoReg SPI_IMR;       /**< \brief (Spi Offset: 0x1C) Interrupt Mask Register */
+  RoReg Reserved1[4];
+  RwReg SPI_CSR[4];    /**< \brief (Spi Offset: 0x30) Chip Select Register */
+  RoReg Reserved2[41];
+  RwReg SPI_WPMR;      /**< \brief (Spi Offset: 0xE4) Write Protection Control Register */
+  RoReg SPI_WPSR;      /**< \brief (Spi Offset: 0xE8) Write Protection Status Register */
+  RoReg Reserved3[5];
+  RwReg SPI_RPR;       /**< \brief (Spi Offset: 0x100) Receive Pointer Register */
+  RwReg SPI_RCR;       /**< \brief (Spi Offset: 0x104) Receive Counter Register */
+  RwReg SPI_TPR;       /**< \brief (Spi Offset: 0x108) Transmit Pointer Register */
+  RwReg SPI_TCR;       /**< \brief (Spi Offset: 0x10C) Transmit Counter Register */
+  RwReg SPI_RNPR;      /**< \brief (Spi Offset: 0x110) Receive Next Pointer Register */
+  RwReg SPI_RNCR;      /**< \brief (Spi Offset: 0x114) Receive Next Counter Register */
+  RwReg SPI_TNPR;      /**< \brief (Spi Offset: 0x118) Transmit Next Pointer Register */
+  RwReg SPI_TNCR;      /**< \brief (Spi Offset: 0x11C) Transmit Next Counter Register */
+  WoReg SPI_PTCR;      /**< \brief (Spi Offset: 0x120) Transfer Control Register */
+  RoReg SPI_PTSR;      /**< \brief (Spi Offset: 0x124) Transfer Status Register */
+} Spi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- SPI_CR : (SPI Offset: 0x00) Control Register -------- */
+#define SPI_CR_SPIEN (0x1u << 0) /**< \brief (SPI_CR) SPI Enable */
+#define SPI_CR_SPIDIS (0x1u << 1) /**< \brief (SPI_CR) SPI Disable */
+#define SPI_CR_SWRST (0x1u << 7) /**< \brief (SPI_CR) SPI Software Reset */
+#define SPI_CR_LASTXFER (0x1u << 24) /**< \brief (SPI_CR) Last Transfer */
+/* -------- SPI_MR : (SPI Offset: 0x04) Mode Register -------- */
+#define SPI_MR_MSTR (0x1u << 0) /**< \brief (SPI_MR) Master/Slave Mode */
+#define SPI_MR_PS (0x1u << 1) /**< \brief (SPI_MR) Peripheral Select */
+#define SPI_MR_PCSDEC (0x1u << 2) /**< \brief (SPI_MR) Chip Select Decode */
+#define SPI_MR_MODFDIS (0x1u << 4) /**< \brief (SPI_MR) Mode Fault Detection */
+#define SPI_MR_WDRBT (0x1u << 5) /**< \brief (SPI_MR) Wait Data Read Before Transfer */
+#define SPI_MR_LLB (0x1u << 7) /**< \brief (SPI_MR) Local Loopback Enable */
+#define SPI_MR_PCS_Pos 16
+#define SPI_MR_PCS_Msk (0xfu << SPI_MR_PCS_Pos) /**< \brief (SPI_MR) Peripheral Chip Select */
+#define SPI_MR_PCS(value) ((SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos)))
+#define SPI_MR_DLYBCS_Pos 24
+#define SPI_MR_DLYBCS_Msk (0xffu << SPI_MR_DLYBCS_Pos) /**< \brief (SPI_MR) Delay Between Chip Selects */
+#define SPI_MR_DLYBCS(value) ((SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos)))
+/* -------- SPI_RDR : (SPI Offset: 0x08) Receive Data Register -------- */
+#define SPI_RDR_RD_Pos 0
+#define SPI_RDR_RD_Msk (0xffffu << SPI_RDR_RD_Pos) /**< \brief (SPI_RDR) Receive Data */
+#define SPI_RDR_PCS_Pos 16
+#define SPI_RDR_PCS_Msk (0xfu << SPI_RDR_PCS_Pos) /**< \brief (SPI_RDR) Peripheral Chip Select */
+/* -------- SPI_TDR : (SPI Offset: 0x0C) Transmit Data Register -------- */
+#define SPI_TDR_TD_Pos 0
+#define SPI_TDR_TD_Msk (0xffffu << SPI_TDR_TD_Pos) /**< \brief (SPI_TDR) Transmit Data */
+#define SPI_TDR_TD(value) ((SPI_TDR_TD_Msk & ((value) << SPI_TDR_TD_Pos)))
+#define SPI_TDR_PCS_Pos 16
+#define SPI_TDR_PCS_Msk (0xfu << SPI_TDR_PCS_Pos) /**< \brief (SPI_TDR) Peripheral Chip Select */
+#define SPI_TDR_PCS(value) ((SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos)))
+#define SPI_TDR_LASTXFER (0x1u << 24) /**< \brief (SPI_TDR) Last Transfer */
+/* -------- SPI_SR : (SPI Offset: 0x10) Status Register -------- */
+#define SPI_SR_RDRF (0x1u << 0) /**< \brief (SPI_SR) Receive Data Register Full */
+#define SPI_SR_TDRE (0x1u << 1) /**< \brief (SPI_SR) Transmit Data Register Empty */
+#define SPI_SR_MODF (0x1u << 2) /**< \brief (SPI_SR) Mode Fault Error */
+#define SPI_SR_OVRES (0x1u << 3) /**< \brief (SPI_SR) Overrun Error Status */
+#define SPI_SR_ENDRX (0x1u << 4) /**< \brief (SPI_SR) End of RX buffer */
+#define SPI_SR_ENDTX (0x1u << 5) /**< \brief (SPI_SR) End of TX buffer */
+#define SPI_SR_RXBUFF (0x1u << 6) /**< \brief (SPI_SR) RX Buffer Full */
+#define SPI_SR_TXBUFE (0x1u << 7) /**< \brief (SPI_SR) TX Buffer Empty */
+#define SPI_SR_NSSR (0x1u << 8) /**< \brief (SPI_SR) NSS Rising */
+#define SPI_SR_TXEMPTY (0x1u << 9) /**< \brief (SPI_SR) Transmission Registers Empty */
+#define SPI_SR_UNDES (0x1u << 10) /**< \brief (SPI_SR) Underrun Error Status (Slave Mode Only) */
+#define SPI_SR_SPIENS (0x1u << 16) /**< \brief (SPI_SR) SPI Enable Status */
+/* -------- SPI_IER : (SPI Offset: 0x14) Interrupt Enable Register -------- */
+#define SPI_IER_RDRF (0x1u << 0) /**< \brief (SPI_IER) Receive Data Register Full Interrupt Enable */
+#define SPI_IER_TDRE (0x1u << 1) /**< \brief (SPI_IER) SPI Transmit Data Register Empty Interrupt Enable */
+#define SPI_IER_MODF (0x1u << 2) /**< \brief (SPI_IER) Mode Fault Error Interrupt Enable */
+#define SPI_IER_OVRES (0x1u << 3) /**< \brief (SPI_IER) Overrun Error Interrupt Enable */
+#define SPI_IER_ENDRX (0x1u << 4) /**< \brief (SPI_IER) End of Receive Buffer Interrupt Enable */
+#define SPI_IER_ENDTX (0x1u << 5) /**< \brief (SPI_IER) End of Transmit Buffer Interrupt Enable */
+#define SPI_IER_RXBUFF (0x1u << 6) /**< \brief (SPI_IER) Receive Buffer Full Interrupt Enable */
+#define SPI_IER_TXBUFE (0x1u << 7) /**< \brief (SPI_IER) Transmit Buffer Empty Interrupt Enable */
+#define SPI_IER_NSSR (0x1u << 8) /**< \brief (SPI_IER) NSS Rising Interrupt Enable */
+#define SPI_IER_TXEMPTY (0x1u << 9) /**< \brief (SPI_IER) Transmission Registers Empty Enable */
+#define SPI_IER_UNDES (0x1u << 10) /**< \brief (SPI_IER) Underrun Error Interrupt Enable */
+/* -------- SPI_IDR : (SPI Offset: 0x18) Interrupt Disable Register -------- */
+#define SPI_IDR_RDRF (0x1u << 0) /**< \brief (SPI_IDR) Receive Data Register Full Interrupt Disable */
+#define SPI_IDR_TDRE (0x1u << 1) /**< \brief (SPI_IDR) SPI Transmit Data Register Empty Interrupt Disable */
+#define SPI_IDR_MODF (0x1u << 2) /**< \brief (SPI_IDR) Mode Fault Error Interrupt Disable */
+#define SPI_IDR_OVRES (0x1u << 3) /**< \brief (SPI_IDR) Overrun Error Interrupt Disable */
+#define SPI_IDR_ENDRX (0x1u << 4) /**< \brief (SPI_IDR) End of Receive Buffer Interrupt Disable */
+#define SPI_IDR_ENDTX (0x1u << 5) /**< \brief (SPI_IDR) End of Transmit Buffer Interrupt Disable */
+#define SPI_IDR_RXBUFF (0x1u << 6) /**< \brief (SPI_IDR) Receive Buffer Full Interrupt Disable */
+#define SPI_IDR_TXBUFE (0x1u << 7) /**< \brief (SPI_IDR) Transmit Buffer Empty Interrupt Disable */
+#define SPI_IDR_NSSR (0x1u << 8) /**< \brief (SPI_IDR) NSS Rising Interrupt Disable */
+#define SPI_IDR_TXEMPTY (0x1u << 9) /**< \brief (SPI_IDR) Transmission Registers Empty Disable */
+#define SPI_IDR_UNDES (0x1u << 10) /**< \brief (SPI_IDR) Underrun Error Interrupt Disable */
+/* -------- SPI_IMR : (SPI Offset: 0x1C) Interrupt Mask Register -------- */
+#define SPI_IMR_RDRF (0x1u << 0) /**< \brief (SPI_IMR) Receive Data Register Full Interrupt Mask */
+#define SPI_IMR_TDRE (0x1u << 1) /**< \brief (SPI_IMR) SPI Transmit Data Register Empty Interrupt Mask */
+#define SPI_IMR_MODF (0x1u << 2) /**< \brief (SPI_IMR) Mode Fault Error Interrupt Mask */
+#define SPI_IMR_OVRES (0x1u << 3) /**< \brief (SPI_IMR) Overrun Error Interrupt Mask */
+#define SPI_IMR_ENDRX (0x1u << 4) /**< \brief (SPI_IMR) End of Receive Buffer Interrupt Mask */
+#define SPI_IMR_ENDTX (0x1u << 5) /**< \brief (SPI_IMR) End of Transmit Buffer Interrupt Mask */
+#define SPI_IMR_RXBUFF (0x1u << 6) /**< \brief (SPI_IMR) Receive Buffer Full Interrupt Mask */
+#define SPI_IMR_TXBUFE (0x1u << 7) /**< \brief (SPI_IMR) Transmit Buffer Empty Interrupt Mask */
+#define SPI_IMR_NSSR (0x1u << 8) /**< \brief (SPI_IMR) NSS Rising Interrupt Mask */
+#define SPI_IMR_TXEMPTY (0x1u << 9) /**< \brief (SPI_IMR) Transmission Registers Empty Mask */
+#define SPI_IMR_UNDES (0x1u << 10) /**< \brief (SPI_IMR) Underrun Error Interrupt Mask */
+/* -------- SPI_CSR[4] : (SPI Offset: 0x30) Chip Select Register -------- */
+#define SPI_CSR_CPOL (0x1u << 0) /**< \brief (SPI_CSR[4]) Clock Polarity */
+#define SPI_CSR_NCPHA (0x1u << 1) /**< \brief (SPI_CSR[4]) Clock Phase */
+#define SPI_CSR_CSNAAT (0x1u << 2) /**< \brief (SPI_CSR[4]) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) */
+#define SPI_CSR_CSAAT (0x1u << 3) /**< \brief (SPI_CSR[4]) Chip Select Active After Transfer */
+#define SPI_CSR_BITS_Pos 4
+#define SPI_CSR_BITS_Msk (0xfu << SPI_CSR_BITS_Pos) /**< \brief (SPI_CSR[4]) Bits Per Transfer */
+#define   SPI_CSR_BITS_8_BIT (0x0u << 4) /**< \brief (SPI_CSR[4]) 8 bits for transfer */
+#define   SPI_CSR_BITS_9_BIT (0x1u << 4) /**< \brief (SPI_CSR[4]) 9 bits for transfer */
+#define   SPI_CSR_BITS_10_BIT (0x2u << 4) /**< \brief (SPI_CSR[4]) 10 bits for transfer */
+#define   SPI_CSR_BITS_11_BIT (0x3u << 4) /**< \brief (SPI_CSR[4]) 11 bits for transfer */
+#define   SPI_CSR_BITS_12_BIT (0x4u << 4) /**< \brief (SPI_CSR[4]) 12 bits for transfer */
+#define   SPI_CSR_BITS_13_BIT (0x5u << 4) /**< \brief (SPI_CSR[4]) 13 bits for transfer */
+#define   SPI_CSR_BITS_14_BIT (0x6u << 4) /**< \brief (SPI_CSR[4]) 14 bits for transfer */
+#define   SPI_CSR_BITS_15_BIT (0x7u << 4) /**< \brief (SPI_CSR[4]) 15 bits for transfer */
+#define   SPI_CSR_BITS_16_BIT (0x8u << 4) /**< \brief (SPI_CSR[4]) 16 bits for transfer */
+#define SPI_CSR_SCBR_Pos 8
+#define SPI_CSR_SCBR_Msk (0xffu << SPI_CSR_SCBR_Pos) /**< \brief (SPI_CSR[4]) Serial Clock Baud Rate */
+#define SPI_CSR_SCBR(value) ((SPI_CSR_SCBR_Msk & ((value) << SPI_CSR_SCBR_Pos)))
+#define SPI_CSR_DLYBS_Pos 16
+#define SPI_CSR_DLYBS_Msk (0xffu << SPI_CSR_DLYBS_Pos) /**< \brief (SPI_CSR[4]) Delay Before SPCK */
+#define SPI_CSR_DLYBS(value) ((SPI_CSR_DLYBS_Msk & ((value) << SPI_CSR_DLYBS_Pos)))
+#define SPI_CSR_DLYBCT_Pos 24
+#define SPI_CSR_DLYBCT_Msk (0xffu << SPI_CSR_DLYBCT_Pos) /**< \brief (SPI_CSR[4]) Delay Between Consecutive Transfers */
+#define SPI_CSR_DLYBCT(value) ((SPI_CSR_DLYBCT_Msk & ((value) << SPI_CSR_DLYBCT_Pos)))
+/* -------- SPI_WPMR : (SPI Offset: 0xE4) Write Protection Control Register -------- */
+#define SPI_WPMR_WPEN (0x1u << 0) /**< \brief (SPI_WPMR) Write Protection Enable */
+#define SPI_WPMR_WPKEY_Pos 8
+#define SPI_WPMR_WPKEY_Msk (0xffffffu << SPI_WPMR_WPKEY_Pos) /**< \brief (SPI_WPMR) Write Protection Key Password */
+#define SPI_WPMR_WPKEY(value) ((SPI_WPMR_WPKEY_Msk & ((value) << SPI_WPMR_WPKEY_Pos)))
+/* -------- SPI_WPSR : (SPI Offset: 0xE8) Write Protection Status Register -------- */
+#define SPI_WPSR_WPVS (0x1u << 0) /**< \brief (SPI_WPSR) Write Protection Violation Status */
+#define SPI_WPSR_WPVSRC_Pos 8
+#define SPI_WPSR_WPVSRC_Msk (0xffu << SPI_WPSR_WPVSRC_Pos) /**< \brief (SPI_WPSR) Write Protection Violation Source */
+/* -------- SPI_RPR : (SPI Offset: 0x100) Receive Pointer Register -------- */
+#define SPI_RPR_RXPTR_Pos 0
+#define SPI_RPR_RXPTR_Msk (0xffffffffu << SPI_RPR_RXPTR_Pos) /**< \brief (SPI_RPR) Receive Pointer Register */
+#define SPI_RPR_RXPTR(value) ((SPI_RPR_RXPTR_Msk & ((value) << SPI_RPR_RXPTR_Pos)))
+/* -------- SPI_RCR : (SPI Offset: 0x104) Receive Counter Register -------- */
+#define SPI_RCR_RXCTR_Pos 0
+#define SPI_RCR_RXCTR_Msk (0xffffu << SPI_RCR_RXCTR_Pos) /**< \brief (SPI_RCR) Receive Counter Register */
+#define SPI_RCR_RXCTR(value) ((SPI_RCR_RXCTR_Msk & ((value) << SPI_RCR_RXCTR_Pos)))
+/* -------- SPI_TPR : (SPI Offset: 0x108) Transmit Pointer Register -------- */
+#define SPI_TPR_TXPTR_Pos 0
+#define SPI_TPR_TXPTR_Msk (0xffffffffu << SPI_TPR_TXPTR_Pos) /**< \brief (SPI_TPR) Transmit Counter Register */
+#define SPI_TPR_TXPTR(value) ((SPI_TPR_TXPTR_Msk & ((value) << SPI_TPR_TXPTR_Pos)))
+/* -------- SPI_TCR : (SPI Offset: 0x10C) Transmit Counter Register -------- */
+#define SPI_TCR_TXCTR_Pos 0
+#define SPI_TCR_TXCTR_Msk (0xffffu << SPI_TCR_TXCTR_Pos) /**< \brief (SPI_TCR) Transmit Counter Register */
+#define SPI_TCR_TXCTR(value) ((SPI_TCR_TXCTR_Msk & ((value) << SPI_TCR_TXCTR_Pos)))
+/* -------- SPI_RNPR : (SPI Offset: 0x110) Receive Next Pointer Register -------- */
+#define SPI_RNPR_RXNPTR_Pos 0
+#define SPI_RNPR_RXNPTR_Msk (0xffffffffu << SPI_RNPR_RXNPTR_Pos) /**< \brief (SPI_RNPR) Receive Next Pointer */
+#define SPI_RNPR_RXNPTR(value) ((SPI_RNPR_RXNPTR_Msk & ((value) << SPI_RNPR_RXNPTR_Pos)))
+/* -------- SPI_RNCR : (SPI Offset: 0x114) Receive Next Counter Register -------- */
+#define SPI_RNCR_RXNCTR_Pos 0
+#define SPI_RNCR_RXNCTR_Msk (0xffffu << SPI_RNCR_RXNCTR_Pos) /**< \brief (SPI_RNCR) Receive Next Counter */
+#define SPI_RNCR_RXNCTR(value) ((SPI_RNCR_RXNCTR_Msk & ((value) << SPI_RNCR_RXNCTR_Pos)))
+/* -------- SPI_TNPR : (SPI Offset: 0x118) Transmit Next Pointer Register -------- */
+#define SPI_TNPR_TXNPTR_Pos 0
+#define SPI_TNPR_TXNPTR_Msk (0xffffffffu << SPI_TNPR_TXNPTR_Pos) /**< \brief (SPI_TNPR) Transmit Next Pointer */
+#define SPI_TNPR_TXNPTR(value) ((SPI_TNPR_TXNPTR_Msk & ((value) << SPI_TNPR_TXNPTR_Pos)))
+/* -------- SPI_TNCR : (SPI Offset: 0x11C) Transmit Next Counter Register -------- */
+#define SPI_TNCR_TXNCTR_Pos 0
+#define SPI_TNCR_TXNCTR_Msk (0xffffu << SPI_TNCR_TXNCTR_Pos) /**< \brief (SPI_TNCR) Transmit Counter Next */
+#define SPI_TNCR_TXNCTR(value) ((SPI_TNCR_TXNCTR_Msk & ((value) << SPI_TNCR_TXNCTR_Pos)))
+/* -------- SPI_PTCR : (SPI Offset: 0x120) Transfer Control Register -------- */
+#define SPI_PTCR_RXTEN (0x1u << 0) /**< \brief (SPI_PTCR) Receiver Transfer Enable */
+#define SPI_PTCR_RXTDIS (0x1u << 1) /**< \brief (SPI_PTCR) Receiver Transfer Disable */
+#define SPI_PTCR_TXTEN (0x1u << 8) /**< \brief (SPI_PTCR) Transmitter Transfer Enable */
+#define SPI_PTCR_TXTDIS (0x1u << 9) /**< \brief (SPI_PTCR) Transmitter Transfer Disable */
+/* -------- SPI_PTSR : (SPI Offset: 0x124) Transfer Status Register -------- */
+#define SPI_PTSR_RXTEN (0x1u << 0) /**< \brief (SPI_PTSR) Receiver Transfer Enable */
+#define SPI_PTSR_TXTEN (0x1u << 8) /**< \brief (SPI_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_SPI_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/spi.h
+++ b/asf/sam/include/sam4e/component/spi.h
@@ -152,6 +152,7 @@ typedef struct {
 #define SPI_CSR_CSAAT (0x1u << 3) /**< \brief (SPI_CSR[4]) Chip Select Active After Transfer */
 #define SPI_CSR_BITS_Pos 4
 #define SPI_CSR_BITS_Msk (0xfu << SPI_CSR_BITS_Pos) /**< \brief (SPI_CSR[4]) Bits Per Transfer */
+#define SPI_CSR_BITS(value) ((SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos)))
 #define   SPI_CSR_BITS_8_BIT (0x0u << 4) /**< \brief (SPI_CSR[4]) 8 bits for transfer */
 #define   SPI_CSR_BITS_9_BIT (0x1u << 4) /**< \brief (SPI_CSR[4]) 9 bits for transfer */
 #define   SPI_CSR_BITS_10_BIT (0x2u << 4) /**< \brief (SPI_CSR[4]) 10 bits for transfer */

--- a/asf/sam/include/sam4e/component/supc.h
+++ b/asf/sam/include/sam4e/component/supc.h
@@ -1,0 +1,324 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SUPC_COMPONENT_
+#define _SAM4E_SUPC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Supply Controller */
+/* ============================================================================= */
+/** \addtogroup SAM4E_SUPC Supply Controller */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Supc hardware registers */
+typedef struct {
+  WoReg SUPC_CR;   /**< \brief (Supc Offset: 0x00) Supply Controller Control Register */
+  RwReg SUPC_SMMR; /**< \brief (Supc Offset: 0x04) Supply Controller Supply Monitor Mode Register */
+  RwReg SUPC_MR;   /**< \brief (Supc Offset: 0x08) Supply Controller Mode Register */
+  RwReg SUPC_WUMR; /**< \brief (Supc Offset: 0x0C) Supply Controller Wake Up Mode Register */
+  RwReg SUPC_WUIR; /**< \brief (Supc Offset: 0x10) Supply Controller Wake Up Inputs Register */
+  RoReg SUPC_SR;   /**< \brief (Supc Offset: 0x14) Supply Controller Status Register */
+} Supc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- SUPC_CR : (SUPC Offset: 0x00) Supply Controller Control Register -------- */
+#define SUPC_CR_VROFF (0x1u << 2) /**< \brief (SUPC_CR) Voltage Regulator Off */
+#define   SUPC_CR_VROFF_NO_EFFECT (0x0u << 2) /**< \brief (SUPC_CR) no effect. */
+#define   SUPC_CR_VROFF_STOP_VREG (0x1u << 2) /**< \brief (SUPC_CR) if KEY is correct, asserts the vddcore_nreset and stops the voltage regulator. */
+#define SUPC_CR_XTALSEL (0x1u << 3) /**< \brief (SUPC_CR) Crystal Oscillator Select */
+#define   SUPC_CR_XTALSEL_NO_EFFECT (0x0u << 3) /**< \brief (SUPC_CR) no effect. */
+#define   SUPC_CR_XTALSEL_CRYSTAL_SEL (0x1u << 3) /**< \brief (SUPC_CR) if KEY is correct, switches the slow clock on the crystal oscillator output. */
+#define SUPC_CR_KEY_Pos 24
+#define SUPC_CR_KEY_Msk (0xffu << SUPC_CR_KEY_Pos) /**< \brief (SUPC_CR) Password */
+#define SUPC_CR_KEY(value) ((SUPC_CR_KEY_Msk & ((value) << SUPC_CR_KEY_Pos)))
+/* -------- SUPC_SMMR : (SUPC Offset: 0x04) Supply Controller Supply Monitor Mode Register -------- */
+#define SUPC_SMMR_SMTH_Pos 0
+#define SUPC_SMMR_SMTH_Msk (0xfu << SUPC_SMMR_SMTH_Pos) /**< \brief (SUPC_SMMR) Supply Monitor Threshold */
+#define SUPC_SMMR_SMTH(value) ((SUPC_SMMR_SMTH_Msk & ((value) << SUPC_SMMR_SMTH_Pos)))
+#define SUPC_SMMR_SMSMPL_Pos 8
+#define SUPC_SMMR_SMSMPL_Msk (0x7u << SUPC_SMMR_SMSMPL_Pos) /**< \brief (SUPC_SMMR) Supply Monitor Sampling Period */
+#define   SUPC_SMMR_SMSMPL_SMD (0x0u << 8) /**< \brief (SUPC_SMMR) Supply Monitor disabled */
+#define   SUPC_SMMR_SMSMPL_CSM (0x1u << 8) /**< \brief (SUPC_SMMR) Continuous Supply Monitor */
+#define   SUPC_SMMR_SMSMPL_32SLCK (0x2u << 8) /**< \brief (SUPC_SMMR) Supply Monitor enabled one SLCK period every 32 SLCK periods */
+#define   SUPC_SMMR_SMSMPL_256SLCK (0x3u << 8) /**< \brief (SUPC_SMMR) Supply Monitor enabled one SLCK period every 256 SLCK periods */
+#define   SUPC_SMMR_SMSMPL_2048SLCK (0x4u << 8) /**< \brief (SUPC_SMMR) Supply Monitor enabled one SLCK period every 2,048 SLCK periods */
+#define SUPC_SMMR_SMRSTEN (0x1u << 12) /**< \brief (SUPC_SMMR) Supply Monitor Reset Enable */
+#define   SUPC_SMMR_SMRSTEN_NOT_ENABLE (0x0u << 12) /**< \brief (SUPC_SMMR) the core reset signal "vddcore_nreset" is not affected when a supply monitor detection occurs. */
+#define   SUPC_SMMR_SMRSTEN_ENABLE (0x1u << 12) /**< \brief (SUPC_SMMR) the core reset signal, vddcore_nreset is asserted when a supply monitor detection occurs. */
+#define SUPC_SMMR_SMIEN (0x1u << 13) /**< \brief (SUPC_SMMR) Supply Monitor Interrupt Enable */
+#define   SUPC_SMMR_SMIEN_NOT_ENABLE (0x0u << 13) /**< \brief (SUPC_SMMR) the SUPC interrupt signal is not affected when a supply monitor detection occurs. */
+#define   SUPC_SMMR_SMIEN_ENABLE (0x1u << 13) /**< \brief (SUPC_SMMR) the SUPC interrupt signal is asserted when a supply monitor detection occurs. */
+/* -------- SUPC_MR : (SUPC Offset: 0x08) Supply Controller Mode Register -------- */
+#define SUPC_MR_BODRSTEN (0x1u << 12) /**< \brief (SUPC_MR) Brownout Detector Reset Enable */
+#define   SUPC_MR_BODRSTEN_NOT_ENABLE (0x0u << 12) /**< \brief (SUPC_MR) the core reset signal "vddcore_nreset" is not affected when a brownout detection occurs. */
+#define   SUPC_MR_BODRSTEN_ENABLE (0x1u << 12) /**< \brief (SUPC_MR) the core reset signal, vddcore_nreset is asserted when a brownout detection occurs. */
+#define SUPC_MR_BODDIS (0x1u << 13) /**< \brief (SUPC_MR) Brownout Detector Disable */
+#define   SUPC_MR_BODDIS_ENABLE (0x0u << 13) /**< \brief (SUPC_MR) the core brownout detector is enabled. */
+#define   SUPC_MR_BODDIS_DISABLE (0x1u << 13) /**< \brief (SUPC_MR) the core brownout detector is disabled. */
+#define SUPC_MR_ONREG (0x1u << 14) /**< \brief (SUPC_MR) Voltage Regulator enable */
+#define   SUPC_MR_ONREG_ONREG_UNUSED (0x0u << 14) /**< \brief (SUPC_MR) Internal voltage regulator is not used (external power supply is used) */
+#define   SUPC_MR_ONREG_ONREG_USED (0x1u << 14) /**< \brief (SUPC_MR) internal voltage regulator is used */
+#define SUPC_MR_OSCBYPASS (0x1u << 20) /**< \brief (SUPC_MR) Oscillator Bypass */
+#define   SUPC_MR_OSCBYPASS_NO_EFFECT (0x0u << 20) /**< \brief (SUPC_MR) no effect. Clock selection depends on XTALSEL value. */
+#define   SUPC_MR_OSCBYPASS_BYPASS (0x1u << 20) /**< \brief (SUPC_MR) the 32-KHz XTAL oscillator is selected and is put in bypass mode. */
+#define SUPC_MR_KEY_Pos 24
+#define SUPC_MR_KEY_Msk (0xffu << SUPC_MR_KEY_Pos) /**< \brief (SUPC_MR) Password Key */
+#define SUPC_MR_KEY(value) ((SUPC_MR_KEY_Msk & ((value) << SUPC_MR_KEY_Pos)))
+/* -------- SUPC_WUMR : (SUPC Offset: 0x0C) Supply Controller Wake Up Mode Register -------- */
+#define SUPC_WUMR_FWUPEN (0x1u << 0) /**< \brief (SUPC_WUMR) Force Wake Up Enable */
+#define   SUPC_WUMR_FWUPEN_NOT_ENABLE (0x0u << 0) /**< \brief (SUPC_WUMR) the Force Wake Up pin has no wake up effect. */
+#define   SUPC_WUMR_FWUPEN_ENABLE (0x1u << 0) /**< \brief (SUPC_WUMR) the Force Wake Up pin low forces the wake up of the core power supply. */
+#define SUPC_WUMR_SMEN (0x1u << 1) /**< \brief (SUPC_WUMR) Supply Monitor Wake Up Enable */
+#define   SUPC_WUMR_SMEN_NOT_ENABLE (0x0u << 1) /**< \brief (SUPC_WUMR) the supply monitor detection has no wake up effect. */
+#define   SUPC_WUMR_SMEN_ENABLE (0x1u << 1) /**< \brief (SUPC_WUMR) the supply monitor detection forces the wake up of the core power supply. */
+#define SUPC_WUMR_RTTEN (0x1u << 2) /**< \brief (SUPC_WUMR) Real Time Timer Wake Up Enable */
+#define   SUPC_WUMR_RTTEN_NOT_ENABLE (0x0u << 2) /**< \brief (SUPC_WUMR) the RTT alarm signal has no wake up effect. */
+#define   SUPC_WUMR_RTTEN_ENABLE (0x1u << 2) /**< \brief (SUPC_WUMR) the RTT alarm signal forces the wake up of the core power supply. */
+#define SUPC_WUMR_RTCEN (0x1u << 3) /**< \brief (SUPC_WUMR) Real Time Clock Wake Up Enable */
+#define   SUPC_WUMR_RTCEN_NOT_ENABLE (0x0u << 3) /**< \brief (SUPC_WUMR) the RTC alarm signal has no wake up effect. */
+#define   SUPC_WUMR_RTCEN_ENABLE (0x1u << 3) /**< \brief (SUPC_WUMR) the RTC alarm signal forces the wake up of the core power supply. */
+#define SUPC_WUMR_LPDBCEN0 (0x1u << 5) /**< \brief (SUPC_WUMR) Low power Debouncer ENable WKUP0 */
+#define   SUPC_WUMR_LPDBCEN0_NOT_ENABLE (0x0u << 5) /**< \brief (SUPC_WUMR) the WKUP0 input pin is not connected with low power debouncer. */
+#define   SUPC_WUMR_LPDBCEN0_ENABLE (0x1u << 5) /**< \brief (SUPC_WUMR) the WKUP0 input pin is connected with low power debouncer and can force a core wake up. */
+#define SUPC_WUMR_LPDBCEN1 (0x1u << 6) /**< \brief (SUPC_WUMR) Low power Debouncer ENable WKUP1 */
+#define   SUPC_WUMR_LPDBCEN1_NOT_ENABLE (0x0u << 6) /**< \brief (SUPC_WUMR) the WKUP1input pin is not connected with low power debouncer. */
+#define   SUPC_WUMR_LPDBCEN1_ENABLE (0x1u << 6) /**< \brief (SUPC_WUMR) the WKUP1 input pin is connected with low power debouncer and can force a core wake up. */
+#define SUPC_WUMR_LPDBCCLR (0x1u << 7) /**< \brief (SUPC_WUMR) Low power Debouncer Clear */
+#define   SUPC_WUMR_LPDBCCLR_NOT_ENABLE (0x0u << 7) /**< \brief (SUPC_WUMR) a low power debounce event does not create an immediate clear on first half GPBR registers. */
+#define   SUPC_WUMR_LPDBCCLR_ENABLE (0x1u << 7) /**< \brief (SUPC_WUMR) a low power debounce event on WKUP0 or WKUP1 generates an immediate clear on first half GPBR registers. */
+#define SUPC_WUMR_FWUPDBC_Pos 8
+#define SUPC_WUMR_FWUPDBC_Msk (0x7u << SUPC_WUMR_FWUPDBC_Pos) /**< \brief (SUPC_WUMR) Force Wake Up Debouncer Period */
+#define   SUPC_WUMR_FWUPDBC_IMMEDIATE (0x0u << 8) /**< \brief (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge. */
+#define   SUPC_WUMR_FWUPDBC_3_SCLK (0x1u << 8) /**< \brief (SUPC_WUMR) FWUP shall be low for at least 3 SLCK periods */
+#define   SUPC_WUMR_FWUPDBC_32_SCLK (0x2u << 8) /**< \brief (SUPC_WUMR) FWUP shall be low for at least 32 SLCK periods */
+#define   SUPC_WUMR_FWUPDBC_512_SCLK (0x3u << 8) /**< \brief (SUPC_WUMR) FWUP shall be low for at least 512 SLCK periods */
+#define   SUPC_WUMR_FWUPDBC_4096_SCLK (0x4u << 8) /**< \brief (SUPC_WUMR) FWUP shall be low for at least 4,096 SLCK periods */
+#define   SUPC_WUMR_FWUPDBC_32768_SCLK (0x5u << 8) /**< \brief (SUPC_WUMR) FWUP shall be low for at least 32,768 SLCK periods */
+#define SUPC_WUMR_WKUPDBC_Pos 12
+#define SUPC_WUMR_WKUPDBC_Msk (0x7u << SUPC_WUMR_WKUPDBC_Pos) /**< \brief (SUPC_WUMR) Wake Up Inputs Debouncer Period */
+#define   SUPC_WUMR_WKUPDBC_IMMEDIATE (0x0u << 12) /**< \brief (SUPC_WUMR) Immediate, no debouncing, detected active at least on one Slow Clock edge. */
+#define   SUPC_WUMR_WKUPDBC_3_SCLK (0x1u << 12) /**< \brief (SUPC_WUMR) WKUPx shall be in its active state for at least 3 SLCK periods */
+#define   SUPC_WUMR_WKUPDBC_32_SCLK (0x2u << 12) /**< \brief (SUPC_WUMR) WKUPx shall be in its active state for at least 32 SLCK periods */
+#define   SUPC_WUMR_WKUPDBC_512_SCLK (0x3u << 12) /**< \brief (SUPC_WUMR) WKUPx shall be in its active state for at least 512 SLCK periods */
+#define   SUPC_WUMR_WKUPDBC_4096_SCLK (0x4u << 12) /**< \brief (SUPC_WUMR) WKUPx shall be in its active state for at least 4,096 SLCK periods */
+#define   SUPC_WUMR_WKUPDBC_32768_SCLK (0x5u << 12) /**< \brief (SUPC_WUMR) WKUPx shall be in its active state for at least 32,768 SLCK periods */
+#define SUPC_WUMR_LPDBC_Pos 16
+#define SUPC_WUMR_LPDBC_Msk (0x7u << SUPC_WUMR_LPDBC_Pos) /**< \brief (SUPC_WUMR) Low Power DeBounCer Period */
+#define   SUPC_WUMR_LPDBC_DISABLE (0x0u << 16) /**< \brief (SUPC_WUMR) Disable the low power debouncer. */
+#define   SUPC_WUMR_LPDBC_2_RTCOUT0 (0x1u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 2 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_3_RTCOUT0 (0x2u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 3 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_4_RTCOUT0 (0x3u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 4 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_5_RTCOUT0 (0x4u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 5 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_6_RTCOUT0 (0x5u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 6 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_7_RTCOUT0 (0x6u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 7 RTCOUT0 periods */
+#define   SUPC_WUMR_LPDBC_8_RTCOUT0 (0x7u << 16) /**< \brief (SUPC_WUMR) WKUP0/1 in its active state for at least 8 RTCOUT0 periods */
+/* -------- SUPC_WUIR : (SUPC Offset: 0x10) Supply Controller Wake Up Inputs Register -------- */
+#define SUPC_WUIR_WKUPEN0 (0x1u << 0) /**< \brief (SUPC_WUIR) Wake Up Input Enable 0 */
+#define   SUPC_WUIR_WKUPEN0_DISABLE (0x0u << 0) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN0_ENABLE (0x1u << 0) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN1 (0x1u << 1) /**< \brief (SUPC_WUIR) Wake Up Input Enable 1 */
+#define   SUPC_WUIR_WKUPEN1_DISABLE (0x0u << 1) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN1_ENABLE (0x1u << 1) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN2 (0x1u << 2) /**< \brief (SUPC_WUIR) Wake Up Input Enable 2 */
+#define   SUPC_WUIR_WKUPEN2_DISABLE (0x0u << 2) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN2_ENABLE (0x1u << 2) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN3 (0x1u << 3) /**< \brief (SUPC_WUIR) Wake Up Input Enable 3 */
+#define   SUPC_WUIR_WKUPEN3_DISABLE (0x0u << 3) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN3_ENABLE (0x1u << 3) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN4 (0x1u << 4) /**< \brief (SUPC_WUIR) Wake Up Input Enable 4 */
+#define   SUPC_WUIR_WKUPEN4_DISABLE (0x0u << 4) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN4_ENABLE (0x1u << 4) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN5 (0x1u << 5) /**< \brief (SUPC_WUIR) Wake Up Input Enable 5 */
+#define   SUPC_WUIR_WKUPEN5_DISABLE (0x0u << 5) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN5_ENABLE (0x1u << 5) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN6 (0x1u << 6) /**< \brief (SUPC_WUIR) Wake Up Input Enable 6 */
+#define   SUPC_WUIR_WKUPEN6_DISABLE (0x0u << 6) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN6_ENABLE (0x1u << 6) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN7 (0x1u << 7) /**< \brief (SUPC_WUIR) Wake Up Input Enable 7 */
+#define   SUPC_WUIR_WKUPEN7_DISABLE (0x0u << 7) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN7_ENABLE (0x1u << 7) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN8 (0x1u << 8) /**< \brief (SUPC_WUIR) Wake Up Input Enable 8 */
+#define   SUPC_WUIR_WKUPEN8_DISABLE (0x0u << 8) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN8_ENABLE (0x1u << 8) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN9 (0x1u << 9) /**< \brief (SUPC_WUIR) Wake Up Input Enable 9 */
+#define   SUPC_WUIR_WKUPEN9_DISABLE (0x0u << 9) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN9_ENABLE (0x1u << 9) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN10 (0x1u << 10) /**< \brief (SUPC_WUIR) Wake Up Input Enable 10 */
+#define   SUPC_WUIR_WKUPEN10_DISABLE (0x0u << 10) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN10_ENABLE (0x1u << 10) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN11 (0x1u << 11) /**< \brief (SUPC_WUIR) Wake Up Input Enable 11 */
+#define   SUPC_WUIR_WKUPEN11_DISABLE (0x0u << 11) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN11_ENABLE (0x1u << 11) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN12 (0x1u << 12) /**< \brief (SUPC_WUIR) Wake Up Input Enable 12 */
+#define   SUPC_WUIR_WKUPEN12_DISABLE (0x0u << 12) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN12_ENABLE (0x1u << 12) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN13 (0x1u << 13) /**< \brief (SUPC_WUIR) Wake Up Input Enable 13 */
+#define   SUPC_WUIR_WKUPEN13_DISABLE (0x0u << 13) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN13_ENABLE (0x1u << 13) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN14 (0x1u << 14) /**< \brief (SUPC_WUIR) Wake Up Input Enable 14 */
+#define   SUPC_WUIR_WKUPEN14_DISABLE (0x0u << 14) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN14_ENABLE (0x1u << 14) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPEN15 (0x1u << 15) /**< \brief (SUPC_WUIR) Wake Up Input Enable 15 */
+#define   SUPC_WUIR_WKUPEN15_DISABLE (0x0u << 15) /**< \brief (SUPC_WUIR) the corresponding wake-up input has no wake up effect. */
+#define   SUPC_WUIR_WKUPEN15_ENABLE (0x1u << 15) /**< \brief (SUPC_WUIR) the corresponding wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT0 (0x1u << 16) /**< \brief (SUPC_WUIR) Wake Up Input Type 0 */
+#define   SUPC_WUIR_WKUPT0_LOW (0x0u << 16) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT0_HIGH (0x1u << 16) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT1 (0x1u << 17) /**< \brief (SUPC_WUIR) Wake Up Input Type 1 */
+#define   SUPC_WUIR_WKUPT1_LOW (0x0u << 17) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT1_HIGH (0x1u << 17) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT2 (0x1u << 18) /**< \brief (SUPC_WUIR) Wake Up Input Type 2 */
+#define   SUPC_WUIR_WKUPT2_LOW (0x0u << 18) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT2_HIGH (0x1u << 18) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT3 (0x1u << 19) /**< \brief (SUPC_WUIR) Wake Up Input Type 3 */
+#define   SUPC_WUIR_WKUPT3_LOW (0x0u << 19) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT3_HIGH (0x1u << 19) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT4 (0x1u << 20) /**< \brief (SUPC_WUIR) Wake Up Input Type 4 */
+#define   SUPC_WUIR_WKUPT4_LOW (0x0u << 20) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT4_HIGH (0x1u << 20) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT5 (0x1u << 21) /**< \brief (SUPC_WUIR) Wake Up Input Type 5 */
+#define   SUPC_WUIR_WKUPT5_LOW (0x0u << 21) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT5_HIGH (0x1u << 21) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT6 (0x1u << 22) /**< \brief (SUPC_WUIR) Wake Up Input Type 6 */
+#define   SUPC_WUIR_WKUPT6_LOW (0x0u << 22) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT6_HIGH (0x1u << 22) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT7 (0x1u << 23) /**< \brief (SUPC_WUIR) Wake Up Input Type 7 */
+#define   SUPC_WUIR_WKUPT7_LOW (0x0u << 23) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT7_HIGH (0x1u << 23) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT8 (0x1u << 24) /**< \brief (SUPC_WUIR) Wake Up Input Type 8 */
+#define   SUPC_WUIR_WKUPT8_LOW (0x0u << 24) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT8_HIGH (0x1u << 24) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT9 (0x1u << 25) /**< \brief (SUPC_WUIR) Wake Up Input Type 9 */
+#define   SUPC_WUIR_WKUPT9_LOW (0x0u << 25) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT9_HIGH (0x1u << 25) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT10 (0x1u << 26) /**< \brief (SUPC_WUIR) Wake Up Input Type 10 */
+#define   SUPC_WUIR_WKUPT10_LOW (0x0u << 26) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT10_HIGH (0x1u << 26) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT11 (0x1u << 27) /**< \brief (SUPC_WUIR) Wake Up Input Type 11 */
+#define   SUPC_WUIR_WKUPT11_LOW (0x0u << 27) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT11_HIGH (0x1u << 27) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT12 (0x1u << 28) /**< \brief (SUPC_WUIR) Wake Up Input Type 12 */
+#define   SUPC_WUIR_WKUPT12_LOW (0x0u << 28) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT12_HIGH (0x1u << 28) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT13 (0x1u << 29) /**< \brief (SUPC_WUIR) Wake Up Input Type 13 */
+#define   SUPC_WUIR_WKUPT13_LOW (0x0u << 29) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT13_HIGH (0x1u << 29) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT14 (0x1u << 30) /**< \brief (SUPC_WUIR) Wake Up Input Type 14 */
+#define   SUPC_WUIR_WKUPT14_LOW (0x0u << 30) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT14_HIGH (0x1u << 30) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+#define SUPC_WUIR_WKUPT15 (0x1u << 31) /**< \brief (SUPC_WUIR) Wake Up Input Type 15 */
+#define   SUPC_WUIR_WKUPT15_LOW (0x0u << 31) /**< \brief (SUPC_WUIR) a low level for a period defined by WKUPDBC on the corresponding wake-up input forces the wake up of the core power supply. */
+#define   SUPC_WUIR_WKUPT15_HIGH (0x1u << 31) /**< \brief (SUPC_WUIR) a high level for a period defined by WKUPDBC on the correspond-ing wake-up input forces the wake up of the core power supply. */
+/* -------- SUPC_SR : (SUPC Offset: 0x14) Supply Controller Status Register -------- */
+#define SUPC_SR_FWUPS (0x1u << 0) /**< \brief (SUPC_SR) FWUP Wake Up Status */
+#define   SUPC_SR_FWUPS_NO (0x0u << 0) /**< \brief (SUPC_SR) no wake up due to the assertion of the FWUP pin has occurred since the last read of SUPC_SR. */
+#define   SUPC_SR_FWUPS_PRESENT (0x1u << 0) /**< \brief (SUPC_SR) at least one wake up due to the assertion of the FWUP pin has occurred since the last read of SUPC_SR. */
+#define SUPC_SR_WKUPS (0x1u << 1) /**< \brief (SUPC_SR) WKUP Wake Up Status */
+#define   SUPC_SR_WKUPS_NO (0x0u << 1) /**< \brief (SUPC_SR) no wake up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. */
+#define   SUPC_SR_WKUPS_PRESENT (0x1u << 1) /**< \brief (SUPC_SR) at least one wake up due to the assertion of the WKUP pins has occurred since the last read of SUPC_SR. */
+#define SUPC_SR_SMWS (0x1u << 2) /**< \brief (SUPC_SR) Supply Monitor Detection Wake Up Status */
+#define   SUPC_SR_SMWS_NO (0x0u << 2) /**< \brief (SUPC_SR) no wake up due to a supply monitor detection has occurred since the last read of SUPC_SR. */
+#define   SUPC_SR_SMWS_PRESENT (0x1u << 2) /**< \brief (SUPC_SR) at least one wake up due to a supply monitor detection has occurred since the last read of SUPC_SR. */
+#define SUPC_SR_BODRSTS (0x1u << 3) /**< \brief (SUPC_SR) Brownout Detector Reset Status */
+#define   SUPC_SR_BODRSTS_NO (0x0u << 3) /**< \brief (SUPC_SR) no core brownout rising edge event has been detected since the last read of the SUPC_SR. */
+#define   SUPC_SR_BODRSTS_PRESENT (0x1u << 3) /**< \brief (SUPC_SR) at least one brownout output rising edge event has been detected since the last read of the SUPC_SR. */
+#define SUPC_SR_SMRSTS (0x1u << 4) /**< \brief (SUPC_SR) Supply Monitor Reset Status */
+#define   SUPC_SR_SMRSTS_NO (0x0u << 4) /**< \brief (SUPC_SR) no supply monitor detection has generated a core reset since the last read of the SUPC_SR. */
+#define   SUPC_SR_SMRSTS_PRESENT (0x1u << 4) /**< \brief (SUPC_SR) at least one supply monitor detection has generated a core reset since the last read of the SUPC_SR. */
+#define SUPC_SR_SMS (0x1u << 5) /**< \brief (SUPC_SR) Supply Monitor Status */
+#define   SUPC_SR_SMS_NO (0x0u << 5) /**< \brief (SUPC_SR) no supply monitor detection since the last read of SUPC_SR. */
+#define   SUPC_SR_SMS_PRESENT (0x1u << 5) /**< \brief (SUPC_SR) at least one supply monitor detection since the last read of SUPC_SR. */
+#define SUPC_SR_SMOS (0x1u << 6) /**< \brief (SUPC_SR) Supply Monitor Output Status */
+#define   SUPC_SR_SMOS_HIGH (0x0u << 6) /**< \brief (SUPC_SR) the supply monitor detected VDDIO higher than its threshold at its last measurement. */
+#define   SUPC_SR_SMOS_LOW (0x1u << 6) /**< \brief (SUPC_SR) the supply monitor detected VDDIO lower than its threshold at its last measurement. */
+#define SUPC_SR_OSCSEL (0x1u << 7) /**< \brief (SUPC_SR) 32-kHz Oscillator Selection Status */
+#define   SUPC_SR_OSCSEL_RC (0x0u << 7) /**< \brief (SUPC_SR) the slow clock, SLCK is generated by the embedded 32-kHz RC oscillator. */
+#define   SUPC_SR_OSCSEL_CRYST (0x1u << 7) /**< \brief (SUPC_SR) the slow clock, SLCK is generated by the 32-kHz crystal oscillator. */
+#define SUPC_SR_FWUPIS (0x1u << 12) /**< \brief (SUPC_SR) FWUP Input Status */
+#define   SUPC_SR_FWUPIS_LOW (0x0u << 12) /**< \brief (SUPC_SR) FWUP input is tied low. */
+#define   SUPC_SR_FWUPIS_HIGH (0x1u << 12) /**< \brief (SUPC_SR) FWUP input is tied high. */
+#define SUPC_SR_LPDBCS0 (0x1u << 13) /**< \brief (SUPC_SR) Low Power Debouncer Wake Up Status on WKUP0 */
+#define   SUPC_SR_LPDBCS0_NO (0x0u << 13) /**< \brief (SUPC_SR) no wake up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. */
+#define   SUPC_SR_LPDBCS0_PRESENT (0x1u << 13) /**< \brief (SUPC_SR) at least one wake up due to the assertion of the WKUP0 pin has occurred since the last read of SUPC_SR. */
+#define SUPC_SR_LPDBCS1 (0x1u << 14) /**< \brief (SUPC_SR) Low Power Debouncer Wake Up Status on WKUP1 */
+#define   SUPC_SR_LPDBCS1_NO (0x0u << 14) /**< \brief (SUPC_SR) no wake up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. */
+#define   SUPC_SR_LPDBCS1_PRESENT (0x1u << 14) /**< \brief (SUPC_SR) at least one wake up due to the assertion of the WKUP1 pin has occurred since the last read of SUPC_SR. */
+#define SUPC_SR_WKUPIS0 (0x1u << 16) /**< \brief (SUPC_SR) WKUP Input Status 0 */
+#define   SUPC_SR_WKUPIS0_DIS (0x0u << 16) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS0_EN (0x1u << 16) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS1 (0x1u << 17) /**< \brief (SUPC_SR) WKUP Input Status 1 */
+#define   SUPC_SR_WKUPIS1_DIS (0x0u << 17) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS1_EN (0x1u << 17) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS2 (0x1u << 18) /**< \brief (SUPC_SR) WKUP Input Status 2 */
+#define   SUPC_SR_WKUPIS2_DIS (0x0u << 18) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS2_EN (0x1u << 18) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS3 (0x1u << 19) /**< \brief (SUPC_SR) WKUP Input Status 3 */
+#define   SUPC_SR_WKUPIS3_DIS (0x0u << 19) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS3_EN (0x1u << 19) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS4 (0x1u << 20) /**< \brief (SUPC_SR) WKUP Input Status 4 */
+#define   SUPC_SR_WKUPIS4_DIS (0x0u << 20) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS4_EN (0x1u << 20) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS5 (0x1u << 21) /**< \brief (SUPC_SR) WKUP Input Status 5 */
+#define   SUPC_SR_WKUPIS5_DIS (0x0u << 21) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS5_EN (0x1u << 21) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS6 (0x1u << 22) /**< \brief (SUPC_SR) WKUP Input Status 6 */
+#define   SUPC_SR_WKUPIS6_DIS (0x0u << 22) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS6_EN (0x1u << 22) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS7 (0x1u << 23) /**< \brief (SUPC_SR) WKUP Input Status 7 */
+#define   SUPC_SR_WKUPIS7_DIS (0x0u << 23) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS7_EN (0x1u << 23) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS8 (0x1u << 24) /**< \brief (SUPC_SR) WKUP Input Status 8 */
+#define   SUPC_SR_WKUPIS8_DIS (0x0u << 24) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS8_EN (0x1u << 24) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS9 (0x1u << 25) /**< \brief (SUPC_SR) WKUP Input Status 9 */
+#define   SUPC_SR_WKUPIS9_DIS (0x0u << 25) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS9_EN (0x1u << 25) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS10 (0x1u << 26) /**< \brief (SUPC_SR) WKUP Input Status 10 */
+#define   SUPC_SR_WKUPIS10_DIS (0x0u << 26) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS10_EN (0x1u << 26) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS11 (0x1u << 27) /**< \brief (SUPC_SR) WKUP Input Status 11 */
+#define   SUPC_SR_WKUPIS11_DIS (0x0u << 27) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS11_EN (0x1u << 27) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS12 (0x1u << 28) /**< \brief (SUPC_SR) WKUP Input Status 12 */
+#define   SUPC_SR_WKUPIS12_DIS (0x0u << 28) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS12_EN (0x1u << 28) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS13 (0x1u << 29) /**< \brief (SUPC_SR) WKUP Input Status 13 */
+#define   SUPC_SR_WKUPIS13_DIS (0x0u << 29) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS13_EN (0x1u << 29) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS14 (0x1u << 30) /**< \brief (SUPC_SR) WKUP Input Status 14 */
+#define   SUPC_SR_WKUPIS14_DIS (0x0u << 30) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS14_EN (0x1u << 30) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+#define SUPC_SR_WKUPIS15 (0x1u << 31) /**< \brief (SUPC_SR) WKUP Input Status 15 */
+#define   SUPC_SR_WKUPIS15_DIS (0x0u << 31) /**< \brief (SUPC_SR) the corresponding wake-up input is disabled, or was inactive at the time the debouncer triggered a wake up event. */
+#define   SUPC_SR_WKUPIS15_EN (0x1u << 31) /**< \brief (SUPC_SR) the corresponding wake-up input was active at the time the debouncer triggered a wake up event. */
+
+/*@}*/
+
+
+#endif /* _SAM4E_SUPC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/tc.h
+++ b/asf/sam/include/sam4e/component/tc.h
@@ -1,0 +1,371 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TC_COMPONENT_
+#define _SAM4E_TC_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Timer Counter */
+/* ============================================================================= */
+/** \addtogroup SAM4E_TC Timer Counter */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief TcChannel hardware registers */
+typedef struct {
+  RwReg      TC_CCR;        /**< \brief (TcChannel Offset: 0x0) Channel Control Register */
+  RwReg      TC_CMR;        /**< \brief (TcChannel Offset: 0x4) Channel Mode Register */
+  RwReg      TC_SMMR;       /**< \brief (TcChannel Offset: 0x8) Stepper Motor Mode Register */
+  RwReg      TC_RAB;        /**< \brief (TcChannel Offset: 0xC) Register AB */
+  RwReg      TC_CV;         /**< \brief (TcChannel Offset: 0x10) Counter Value */
+  RwReg      TC_RA;         /**< \brief (TcChannel Offset: 0x14) Register A */
+  RwReg      TC_RB;         /**< \brief (TcChannel Offset: 0x18) Register B */
+  RwReg      TC_RC;         /**< \brief (TcChannel Offset: 0x1C) Register C */
+  RwReg      TC_SR;         /**< \brief (TcChannel Offset: 0x20) Status Register */
+  RwReg      TC_IER;        /**< \brief (TcChannel Offset: 0x24) Interrupt Enable Register */
+  RwReg      TC_IDR;        /**< \brief (TcChannel Offset: 0x28) Interrupt Disable Register */
+  RwReg      TC_IMR;        /**< \brief (TcChannel Offset: 0x2C) Interrupt Mask Register */
+  RwReg      TC_EMR;        /**< \brief (TcChannel Offset: 0x30) Extended Mode Register */
+  RoReg      Reserved1[3];
+} TcChannel;
+/** \brief TcPdc hardware registers */
+typedef struct {
+  RwReg      TC_RPR;        /**< \brief (TcPdc Offset: 0x0) Receive Pointer Register */
+  RwReg      TC_RCR;        /**< \brief (TcPdc Offset: 0x4) Receive Counter Register */
+  RoReg      Reserved2[2];
+  RwReg      TC_RNPR;       /**< \brief (TcPdc Offset: 0x10) Receive Next Pointer Register */
+  RwReg      TC_RNCR;       /**< \brief (TcPdc Offset: 0x14) Receive Next Counter Register */
+  RoReg      Reserved3[2];
+  RwReg      TC_PTCR;       /**< \brief (TcPdc Offset: 0x20) Transfer Control Register */
+  RwReg      TC_PTSR;       /**< \brief (TcPdc Offset: 0x24) Transfer Status Register */
+  RoReg      Reserved4[6];
+} TcPdc;
+/** \brief Tc hardware registers */
+#define TCCHANNEL_NUMBER 3
+#define TCPDC_NUMBER 3
+typedef struct {
+  TcChannel  TC_CHANNEL[TCCHANNEL_NUMBER]; /**< \brief (Tc Offset: 0x0) channel = 0 .. 2 */
+  WoReg      TC_BCR;        /**< \brief (Tc Offset: 0xC0) Block Control Register */
+  RwReg      TC_BMR;        /**< \brief (Tc Offset: 0xC4) Block Mode Register */
+  WoReg      TC_QIER;       /**< \brief (Tc Offset: 0xC8) QDEC Interrupt Enable Register */
+  WoReg      TC_QIDR;       /**< \brief (Tc Offset: 0xCC) QDEC Interrupt Disable Register */
+  RoReg      TC_QIMR;       /**< \brief (Tc Offset: 0xD0) QDEC Interrupt Mask Register */
+  RoReg      TC_QISR;       /**< \brief (Tc Offset: 0xD4) QDEC Interrupt Status Register */
+  RwReg      TC_FMR;        /**< \brief (Tc Offset: 0xD8) Fault Mode Register */
+  RoReg      Reserved1[2];
+  RwReg      TC_WPMR;       /**< \brief (Tc Offset: 0xE4) Write Protect Mode Register */
+  RoReg      Reserved2[6];
+  TcPdc      TC_PDC[TCPDC_NUMBER]; /**< \brief (Tc Offset: 0x100) pdc = 0 .. 2 */
+} Tc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- TC_CCR : (TC Offset: N/A) Channel Control Register -------- */
+#define TC_CCR_CLKEN (0x1u << 0) /**< \brief (TC_CCR) Counter Clock Enable Command */
+#define TC_CCR_CLKDIS (0x1u << 1) /**< \brief (TC_CCR) Counter Clock Disable Command */
+#define TC_CCR_SWTRG (0x1u << 2) /**< \brief (TC_CCR) Software Trigger Command */
+/* -------- TC_CMR : (TC Offset: N/A) Channel Mode Register -------- */
+#define TC_CMR_TCCLKS_Pos 0
+#define TC_CMR_TCCLKS_Msk (0x7u << TC_CMR_TCCLKS_Pos) /**< \brief (TC_CMR) Clock Selection */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK1 (0x0u << 0) /**< \brief (TC_CMR) Clock selected: TCLK1 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK2 (0x1u << 0) /**< \brief (TC_CMR) Clock selected: TCLK2 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK3 (0x2u << 0) /**< \brief (TC_CMR) Clock selected: TCLK3 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK4 (0x3u << 0) /**< \brief (TC_CMR) Clock selected: TCLK4 */
+#define   TC_CMR_TCCLKS_TIMER_CLOCK5 (0x4u << 0) /**< \brief (TC_CMR) Clock selected: TCLK5 */
+#define   TC_CMR_TCCLKS_XC0 (0x5u << 0) /**< \brief (TC_CMR) Clock selected: XC0 */
+#define   TC_CMR_TCCLKS_XC1 (0x6u << 0) /**< \brief (TC_CMR) Clock selected: XC1 */
+#define   TC_CMR_TCCLKS_XC2 (0x7u << 0) /**< \brief (TC_CMR) Clock selected: XC2 */
+#define TC_CMR_CLKI (0x1u << 3) /**< \brief (TC_CMR) Clock Invert */
+#define TC_CMR_BURST_Pos 4
+#define TC_CMR_BURST_Msk (0x3u << TC_CMR_BURST_Pos) /**< \brief (TC_CMR) Burst Signal Selection */
+#define   TC_CMR_BURST_NONE (0x0u << 4) /**< \brief (TC_CMR) The clock is not gated by an external signal. */
+#define   TC_CMR_BURST_XC0 (0x1u << 4) /**< \brief (TC_CMR) XC0 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_XC1 (0x2u << 4) /**< \brief (TC_CMR) XC1 is ANDed with the selected clock. */
+#define   TC_CMR_BURST_XC2 (0x3u << 4) /**< \brief (TC_CMR) XC2 is ANDed with the selected clock. */
+#define TC_CMR_LDBSTOP (0x1u << 6) /**< \brief (TC_CMR) Counter Clock Stopped with RB Loading */
+#define TC_CMR_LDBDIS (0x1u << 7) /**< \brief (TC_CMR) Counter Clock Disable with RB Loading */
+#define TC_CMR_ETRGEDG_Pos 8
+#define TC_CMR_ETRGEDG_Msk (0x3u << TC_CMR_ETRGEDG_Pos) /**< \brief (TC_CMR) External Trigger Edge Selection */
+#define   TC_CMR_ETRGEDG_NONE (0x0u << 8) /**< \brief (TC_CMR) The clock is not gated by an external signal. */
+#define   TC_CMR_ETRGEDG_RISING (0x1u << 8) /**< \brief (TC_CMR) Rising edge */
+#define   TC_CMR_ETRGEDG_FALLING (0x2u << 8) /**< \brief (TC_CMR) Falling edge */
+#define   TC_CMR_ETRGEDG_EDGE (0x3u << 8) /**< \brief (TC_CMR) Each edge */
+#define TC_CMR_ABETRG (0x1u << 10) /**< \brief (TC_CMR) TIOA or TIOB External Trigger Selection */
+#define TC_CMR_CPCTRG (0x1u << 14) /**< \brief (TC_CMR) RC Compare Trigger Enable */
+#define TC_CMR_WAVE (0x1u << 15) /**< \brief (TC_CMR) Waveform Mode */
+#define TC_CMR_LDRA_Pos 16
+#define TC_CMR_LDRA_Msk (0x3u << TC_CMR_LDRA_Pos) /**< \brief (TC_CMR) RA Loading Edge Selection */
+#define   TC_CMR_LDRA_NONE (0x0u << 16) /**< \brief (TC_CMR) None */
+#define   TC_CMR_LDRA_RISING (0x1u << 16) /**< \brief (TC_CMR) Rising edge of TIOA */
+#define   TC_CMR_LDRA_FALLING (0x2u << 16) /**< \brief (TC_CMR) Falling edge of TIOA */
+#define   TC_CMR_LDRA_EDGE (0x3u << 16) /**< \brief (TC_CMR) Each edge of TIOA */
+#define TC_CMR_LDRB_Pos 18
+#define TC_CMR_LDRB_Msk (0x3u << TC_CMR_LDRB_Pos) /**< \brief (TC_CMR) RB Loading Edge Selection */
+#define   TC_CMR_LDRB_NONE (0x0u << 18) /**< \brief (TC_CMR) None */
+#define   TC_CMR_LDRB_RISING (0x1u << 18) /**< \brief (TC_CMR) Rising edge of TIOA */
+#define   TC_CMR_LDRB_FALLING (0x2u << 18) /**< \brief (TC_CMR) Falling edge of TIOA */
+#define   TC_CMR_LDRB_EDGE (0x3u << 18) /**< \brief (TC_CMR) Each edge of TIOA */
+#define TC_CMR_SBSMPLR_Pos 20
+#define TC_CMR_SBSMPLR_Msk (0x7u << TC_CMR_SBSMPLR_Pos) /**< \brief (TC_CMR) Loading Edge Subsampling Ratio */
+#define   TC_CMR_SBSMPLR_ONE (0x0u << 20) /**< \brief (TC_CMR) Load a Capture Register each selected edge */
+#define   TC_CMR_SBSMPLR_HALF (0x1u << 20) /**< \brief (TC_CMR) Load a Capture Register every 2 selected edges */
+#define   TC_CMR_SBSMPLR_FOURTH (0x2u << 20) /**< \brief (TC_CMR) Load a Capture Register every 4 selected edges */
+#define   TC_CMR_SBSMPLR_EIGHTH (0x3u << 20) /**< \brief (TC_CMR) Load a Capture Register every 8 selected edges */
+#define   TC_CMR_SBSMPLR_SIXTEENTH (0x4u << 20) /**< \brief (TC_CMR) Load a Capture Register every 16 selected edges */
+#define TC_CMR_CPCSTOP (0x1u << 6) /**< \brief (TC_CMR) Counter Clock Stopped with RC Compare */
+#define TC_CMR_CPCDIS (0x1u << 7) /**< \brief (TC_CMR) Counter Clock Disable with RC Compare */
+#define TC_CMR_EEVTEDG_Pos 8
+#define TC_CMR_EEVTEDG_Msk (0x3u << TC_CMR_EEVTEDG_Pos) /**< \brief (TC_CMR) External Event Edge Selection */
+#define   TC_CMR_EEVTEDG_NONE (0x0u << 8) /**< \brief (TC_CMR) None */
+#define   TC_CMR_EEVTEDG_RISING (0x1u << 8) /**< \brief (TC_CMR) Rising edge */
+#define   TC_CMR_EEVTEDG_FALLING (0x2u << 8) /**< \brief (TC_CMR) Falling edge */
+#define   TC_CMR_EEVTEDG_EDGE (0x3u << 8) /**< \brief (TC_CMR) Each edge */
+#define TC_CMR_EEVT_Pos 10
+#define TC_CMR_EEVT_Msk (0x3u << TC_CMR_EEVT_Pos) /**< \brief (TC_CMR) External Event Selection */
+#define   TC_CMR_EEVT_TIOB (0x0u << 10) /**< \brief (TC_CMR) TIOB */
+#define   TC_CMR_EEVT_XC0 (0x1u << 10) /**< \brief (TC_CMR) XC0 */
+#define   TC_CMR_EEVT_XC1 (0x2u << 10) /**< \brief (TC_CMR) XC1 */
+#define   TC_CMR_EEVT_XC2 (0x3u << 10) /**< \brief (TC_CMR) XC2 */
+#define TC_CMR_ENETRG (0x1u << 12) /**< \brief (TC_CMR) External Event Trigger Enable */
+#define TC_CMR_WAVSEL_Pos 13
+#define TC_CMR_WAVSEL_Msk (0x3u << TC_CMR_WAVSEL_Pos) /**< \brief (TC_CMR) Waveform Selection */
+#define   TC_CMR_WAVSEL_UP (0x0u << 13) /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN (0x1u << 13) /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UP_RC (0x2u << 13) /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
+#define   TC_CMR_WAVSEL_UPDOWN_RC (0x3u << 13) /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
+#define TC_CMR_ACPA_Pos 16
+#define TC_CMR_ACPA_Msk (0x3u << TC_CMR_ACPA_Pos) /**< \brief (TC_CMR) RA Compare Effect on TIOA */
+#define   TC_CMR_ACPA_NONE (0x0u << 16) /**< \brief (TC_CMR) None */
+#define   TC_CMR_ACPA_SET (0x1u << 16) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_ACPA_CLEAR (0x2u << 16) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_ACPA_TOGGLE (0x3u << 16) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_ACPC_Pos 18
+#define TC_CMR_ACPC_Msk (0x3u << TC_CMR_ACPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOA */
+#define   TC_CMR_ACPC_NONE (0x0u << 18) /**< \brief (TC_CMR) None */
+#define   TC_CMR_ACPC_SET (0x1u << 18) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_ACPC_CLEAR (0x2u << 18) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_ACPC_TOGGLE (0x3u << 18) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_AEEVT_Pos 20
+#define TC_CMR_AEEVT_Msk (0x3u << TC_CMR_AEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOA */
+#define   TC_CMR_AEEVT_NONE (0x0u << 20) /**< \brief (TC_CMR) None */
+#define   TC_CMR_AEEVT_SET (0x1u << 20) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_AEEVT_CLEAR (0x2u << 20) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_AEEVT_TOGGLE (0x3u << 20) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_ASWTRG_Pos 22
+#define TC_CMR_ASWTRG_Msk (0x3u << TC_CMR_ASWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOA */
+#define   TC_CMR_ASWTRG_NONE (0x0u << 22) /**< \brief (TC_CMR) None */
+#define   TC_CMR_ASWTRG_SET (0x1u << 22) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_ASWTRG_CLEAR (0x2u << 22) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_ASWTRG_TOGGLE (0x3u << 22) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_BCPB_Pos 24
+#define TC_CMR_BCPB_Msk (0x3u << TC_CMR_BCPB_Pos) /**< \brief (TC_CMR) RB Compare Effect on TIOB */
+#define   TC_CMR_BCPB_NONE (0x0u << 24) /**< \brief (TC_CMR) None */
+#define   TC_CMR_BCPB_SET (0x1u << 24) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_BCPB_CLEAR (0x2u << 24) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_BCPB_TOGGLE (0x3u << 24) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_BCPC_Pos 26
+#define TC_CMR_BCPC_Msk (0x3u << TC_CMR_BCPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOB */
+#define   TC_CMR_BCPC_NONE (0x0u << 26) /**< \brief (TC_CMR) None */
+#define   TC_CMR_BCPC_SET (0x1u << 26) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_BCPC_CLEAR (0x2u << 26) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_BCPC_TOGGLE (0x3u << 26) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_BEEVT_Pos 28
+#define TC_CMR_BEEVT_Msk (0x3u << TC_CMR_BEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOB */
+#define   TC_CMR_BEEVT_NONE (0x0u << 28) /**< \brief (TC_CMR) None */
+#define   TC_CMR_BEEVT_SET (0x1u << 28) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_BEEVT_CLEAR (0x2u << 28) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_BEEVT_TOGGLE (0x3u << 28) /**< \brief (TC_CMR) Toggle */
+#define TC_CMR_BSWTRG_Pos 30
+#define TC_CMR_BSWTRG_Msk (0x3u << TC_CMR_BSWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOB */
+#define   TC_CMR_BSWTRG_NONE (0x0u << 30) /**< \brief (TC_CMR) None */
+#define   TC_CMR_BSWTRG_SET (0x1u << 30) /**< \brief (TC_CMR) Set */
+#define   TC_CMR_BSWTRG_CLEAR (0x2u << 30) /**< \brief (TC_CMR) Clear */
+#define   TC_CMR_BSWTRG_TOGGLE (0x3u << 30) /**< \brief (TC_CMR) Toggle */
+/* -------- TC_SMMR : (TC Offset: N/A) Stepper Motor Mode Register -------- */
+#define TC_SMMR_GCEN (0x1u << 0) /**< \brief (TC_SMMR) Gray Count Enable */
+#define TC_SMMR_DOWN (0x1u << 1) /**< \brief (TC_SMMR) DOWN Count */
+/* -------- TC_RAB : (TC Offset: N/A) Register AB -------- */
+#define TC_RAB_RAB_Pos 0
+#define TC_RAB_RAB_Msk (0xffffffffu << TC_RAB_RAB_Pos) /**< \brief (TC_RAB) Register A or Register B */
+/* -------- TC_CV : (TC Offset: N/A) Counter Value -------- */
+#define TC_CV_CV_Pos 0
+#define TC_CV_CV_Msk (0xffffffffu << TC_CV_CV_Pos) /**< \brief (TC_CV) Counter Value */
+/* -------- TC_RA : (TC Offset: N/A) Register A -------- */
+#define TC_RA_RA_Pos 0
+#define TC_RA_RA_Msk (0xffffffffu << TC_RA_RA_Pos) /**< \brief (TC_RA) Register A */
+#define TC_RA_RA(value) ((TC_RA_RA_Msk & ((value) << TC_RA_RA_Pos)))
+/* -------- TC_RB : (TC Offset: N/A) Register B -------- */
+#define TC_RB_RB_Pos 0
+#define TC_RB_RB_Msk (0xffffffffu << TC_RB_RB_Pos) /**< \brief (TC_RB) Register B */
+#define TC_RB_RB(value) ((TC_RB_RB_Msk & ((value) << TC_RB_RB_Pos)))
+/* -------- TC_RC : (TC Offset: N/A) Register C -------- */
+#define TC_RC_RC_Pos 0
+#define TC_RC_RC_Msk (0xffffffffu << TC_RC_RC_Pos) /**< \brief (TC_RC) Register C */
+#define TC_RC_RC(value) ((TC_RC_RC_Msk & ((value) << TC_RC_RC_Pos)))
+/* -------- TC_SR : (TC Offset: N/A) Status Register -------- */
+#define TC_SR_COVFS (0x1u << 0) /**< \brief (TC_SR) Counter Overflow Status */
+#define TC_SR_LOVRS (0x1u << 1) /**< \brief (TC_SR) Load Overrun Status */
+#define TC_SR_CPAS (0x1u << 2) /**< \brief (TC_SR) RA Compare Status */
+#define TC_SR_CPBS (0x1u << 3) /**< \brief (TC_SR) RB Compare Status */
+#define TC_SR_CPCS (0x1u << 4) /**< \brief (TC_SR) RC Compare Status */
+#define TC_SR_LDRAS (0x1u << 5) /**< \brief (TC_SR) RA Loading Status */
+#define TC_SR_LDRBS (0x1u << 6) /**< \brief (TC_SR) RB Loading Status */
+#define TC_SR_ETRGS (0x1u << 7) /**< \brief (TC_SR) External Trigger Status */
+#define TC_SR_ENDRX (0x1u << 8) /**< \brief (TC_SR) End of Receiver Transfer */
+#define TC_SR_RXBUFF (0x1u << 9) /**< \brief (TC_SR) Reception Buffer Full */
+#define TC_SR_CLKSTA (0x1u << 16) /**< \brief (TC_SR) Clock Enabling Status */
+#define TC_SR_MTIOA (0x1u << 17) /**< \brief (TC_SR) TIOA Mirror */
+#define TC_SR_MTIOB (0x1u << 18) /**< \brief (TC_SR) TIOB Mirror */
+/* -------- TC_IER : (TC Offset: N/A) Interrupt Enable Register -------- */
+#define TC_IER_COVFS (0x1u << 0) /**< \brief (TC_IER) Counter Overflow */
+#define TC_IER_LOVRS (0x1u << 1) /**< \brief (TC_IER) Load Overrun */
+#define TC_IER_CPAS (0x1u << 2) /**< \brief (TC_IER) RA Compare */
+#define TC_IER_CPBS (0x1u << 3) /**< \brief (TC_IER) RB Compare */
+#define TC_IER_CPCS (0x1u << 4) /**< \brief (TC_IER) RC Compare */
+#define TC_IER_LDRAS (0x1u << 5) /**< \brief (TC_IER) RA Loading */
+#define TC_IER_LDRBS (0x1u << 6) /**< \brief (TC_IER) RB Loading */
+#define TC_IER_ETRGS (0x1u << 7) /**< \brief (TC_IER) External Trigger */
+#define TC_IER_ENDRX (0x1u << 8) /**< \brief (TC_IER) End of Receiver Transfer */
+#define TC_IER_RXBUFF (0x1u << 9) /**< \brief (TC_IER) Reception Buffer Full */
+/* -------- TC_IDR : (TC Offset: N/A) Interrupt Disable Register -------- */
+#define TC_IDR_COVFS (0x1u << 0) /**< \brief (TC_IDR) Counter Overflow */
+#define TC_IDR_LOVRS (0x1u << 1) /**< \brief (TC_IDR) Load Overrun */
+#define TC_IDR_CPAS (0x1u << 2) /**< \brief (TC_IDR) RA Compare */
+#define TC_IDR_CPBS (0x1u << 3) /**< \brief (TC_IDR) RB Compare */
+#define TC_IDR_CPCS (0x1u << 4) /**< \brief (TC_IDR) RC Compare */
+#define TC_IDR_LDRAS (0x1u << 5) /**< \brief (TC_IDR) RA Loading */
+#define TC_IDR_LDRBS (0x1u << 6) /**< \brief (TC_IDR) RB Loading */
+#define TC_IDR_ETRGS (0x1u << 7) /**< \brief (TC_IDR) External Trigger */
+#define TC_IDR_ENDRX (0x1u << 8) /**< \brief (TC_IDR) End of Receiver Transfer */
+#define TC_IDR_RXBUFF (0x1u << 9) /**< \brief (TC_IDR) Reception Buffer Full */
+/* -------- TC_IMR : (TC Offset: N/A) Interrupt Mask Register -------- */
+#define TC_IMR_COVFS (0x1u << 0) /**< \brief (TC_IMR) Counter Overflow */
+#define TC_IMR_LOVRS (0x1u << 1) /**< \brief (TC_IMR) Load Overrun */
+#define TC_IMR_CPAS (0x1u << 2) /**< \brief (TC_IMR) RA Compare */
+#define TC_IMR_CPBS (0x1u << 3) /**< \brief (TC_IMR) RB Compare */
+#define TC_IMR_CPCS (0x1u << 4) /**< \brief (TC_IMR) RC Compare */
+#define TC_IMR_LDRAS (0x1u << 5) /**< \brief (TC_IMR) RA Loading */
+#define TC_IMR_LDRBS (0x1u << 6) /**< \brief (TC_IMR) RB Loading */
+#define TC_IMR_ETRGS (0x1u << 7) /**< \brief (TC_IMR) External Trigger */
+#define TC_IMR_ENDRX (0x1u << 8) /**< \brief (TC_IMR) End of Receiver Transfer */
+#define TC_IMR_RXBUFF (0x1u << 9) /**< \brief (TC_IMR) Reception Buffer Full */
+/* -------- TC_EMR : (TC Offset: N/A) Extended Mode Register -------- */
+#define TC_EMR_TRIGSRCA_Pos 0
+#define TC_EMR_TRIGSRCA_Msk (0x3u << TC_EMR_TRIGSRCA_Pos) /**< \brief (TC_EMR) TRIGger SouRCe for input A */
+#define   TC_EMR_TRIGSRCA_EXTERNAL_TIOAx (0x0u << 0) /**< \brief (TC_EMR) the trigger/capture input A is driven by external pin TIOAx */
+#define   TC_EMR_TRIGSRCA_PWMx (0x1u << 0) /**< \brief (TC_EMR) the trigger/capture input A is driven internally by PWMx */
+#define TC_EMR_TRIGSRCB_Pos 4
+#define TC_EMR_TRIGSRCB_Msk (0x3u << TC_EMR_TRIGSRCB_Pos) /**< \brief (TC_EMR) TRIGger SouRCe for input B */
+#define   TC_EMR_TRIGSRCB_EXTERNAL_TIOBx (0x0u << 4) /**< \brief (TC_EMR) the trigger/capture input B is driven by external pin TIOBx */
+#define   TC_EMR_TRIGSRCB_PWMx (0x1u << 4) /**< \brief (TC_EMR) the trigger/capture input B is driven internally by PWMx */
+#define TC_EMR_NODIVCLK (0x1u << 8) /**< \brief (TC_EMR) NO DIVided CLocK */
+/* -------- TC_BCR : (TC Offset: 0xC0) Block Control Register -------- */
+#define TC_BCR_SYNC (0x1u << 0) /**< \brief (TC_BCR) Synchro Command */
+/* -------- TC_BMR : (TC Offset: 0xC4) Block Mode Register -------- */
+#define TC_BMR_TC0XC0S_Pos 0
+#define TC_BMR_TC0XC0S_Msk (0x3u << TC_BMR_TC0XC0S_Pos) /**< \brief (TC_BMR) External Clock Signal 0 Selection */
+#define   TC_BMR_TC0XC0S_TCLK0 (0x0u << 0) /**< \brief (TC_BMR) Signal connected to XC0: TCLK0 */
+#define   TC_BMR_TC0XC0S_TIOA1 (0x2u << 0) /**< \brief (TC_BMR) Signal connected to XC0: TIOA1 */
+#define   TC_BMR_TC0XC0S_TIOA2 (0x3u << 0) /**< \brief (TC_BMR) Signal connected to XC0: TIOA2 */
+#define TC_BMR_TC1XC1S_Pos 2
+#define TC_BMR_TC1XC1S_Msk (0x3u << TC_BMR_TC1XC1S_Pos) /**< \brief (TC_BMR) External Clock Signal 1 Selection */
+#define   TC_BMR_TC1XC1S_TCLK1 (0x0u << 2) /**< \brief (TC_BMR) Signal connected to XC1: TCLK1 */
+#define   TC_BMR_TC1XC1S_TIOA0 (0x2u << 2) /**< \brief (TC_BMR) Signal connected to XC1: TIOA0 */
+#define   TC_BMR_TC1XC1S_TIOA2 (0x3u << 2) /**< \brief (TC_BMR) Signal connected to XC1: TIOA2 */
+#define TC_BMR_TC2XC2S_Pos 4
+#define TC_BMR_TC2XC2S_Msk (0x3u << TC_BMR_TC2XC2S_Pos) /**< \brief (TC_BMR) External Clock Signal 2 Selection */
+#define   TC_BMR_TC2XC2S_TCLK2 (0x0u << 4) /**< \brief (TC_BMR) Signal connected to XC2: TCLK2 */
+#define   TC_BMR_TC2XC2S_TIOA1 (0x2u << 4) /**< \brief (TC_BMR) Signal connected to XC2: TIOA1 */
+#define   TC_BMR_TC2XC2S_TIOA2 (0x3u << 4) /**< \brief (TC_BMR) Signal connected to XC2: TIOA2 */
+#define TC_BMR_QDEN (0x1u << 8) /**< \brief (TC_BMR) Quadrature Decoder ENabled */
+#define TC_BMR_POSEN (0x1u << 9) /**< \brief (TC_BMR) POSition ENabled */
+#define TC_BMR_SPEEDEN (0x1u << 10) /**< \brief (TC_BMR) SPEED ENabled */
+#define TC_BMR_QDTRANS (0x1u << 11) /**< \brief (TC_BMR) Quadrature Decoding TRANSparent */
+#define TC_BMR_EDGPHA (0x1u << 12) /**< \brief (TC_BMR) EDGe on PHA count mode */
+#define TC_BMR_INVA (0x1u << 13) /**< \brief (TC_BMR) INVerted phA */
+#define TC_BMR_INVB (0x1u << 14) /**< \brief (TC_BMR) INVerted phB */
+#define TC_BMR_INVIDX (0x1u << 15) /**< \brief (TC_BMR) INVerted InDeX */
+#define TC_BMR_SWAP (0x1u << 16) /**< \brief (TC_BMR) SWAP PHA and PHB */
+#define TC_BMR_IDXPHB (0x1u << 17) /**< \brief (TC_BMR) InDeX pin is PHB pin */
+#define TC_BMR_FILTER (0x1u << 19) /**< \brief (TC_BMR)  */
+#define TC_BMR_MAXFILT_Pos 20
+#define TC_BMR_MAXFILT_Msk (0x3fu << TC_BMR_MAXFILT_Pos) /**< \brief (TC_BMR) MAXimum FILTer */
+#define TC_BMR_MAXFILT(value) ((TC_BMR_MAXFILT_Msk & ((value) << TC_BMR_MAXFILT_Pos)))
+/* -------- TC_QIER : (TC Offset: 0xC8) QDEC Interrupt Enable Register -------- */
+#define TC_QIER_IDX (0x1u << 0) /**< \brief (TC_QIER) InDeX */
+#define TC_QIER_DIRCHG (0x1u << 1) /**< \brief (TC_QIER) DIRection CHanGe */
+#define TC_QIER_QERR (0x1u << 2) /**< \brief (TC_QIER) Quadrature ERRor */
+/* -------- TC_QIDR : (TC Offset: 0xCC) QDEC Interrupt Disable Register -------- */
+#define TC_QIDR_IDX (0x1u << 0) /**< \brief (TC_QIDR) InDeX */
+#define TC_QIDR_DIRCHG (0x1u << 1) /**< \brief (TC_QIDR) DIRection CHanGe */
+#define TC_QIDR_QERR (0x1u << 2) /**< \brief (TC_QIDR) Quadrature ERRor */
+/* -------- TC_QIMR : (TC Offset: 0xD0) QDEC Interrupt Mask Register -------- */
+#define TC_QIMR_IDX (0x1u << 0) /**< \brief (TC_QIMR) InDeX */
+#define TC_QIMR_DIRCHG (0x1u << 1) /**< \brief (TC_QIMR) DIRection CHanGe */
+#define TC_QIMR_QERR (0x1u << 2) /**< \brief (TC_QIMR) Quadrature ERRor */
+/* -------- TC_QISR : (TC Offset: 0xD4) QDEC Interrupt Status Register -------- */
+#define TC_QISR_IDX (0x1u << 0) /**< \brief (TC_QISR) InDeX */
+#define TC_QISR_DIRCHG (0x1u << 1) /**< \brief (TC_QISR) DIRection CHanGe */
+#define TC_QISR_QERR (0x1u << 2) /**< \brief (TC_QISR) Quadrature ERRor */
+#define TC_QISR_DIR (0x1u << 8) /**< \brief (TC_QISR) DIRection */
+/* -------- TC_FMR : (TC Offset: 0xD8) Fault Mode Register -------- */
+#define TC_FMR_ENCF0 (0x1u << 0) /**< \brief (TC_FMR) ENable Compare Fault Channel 0 */
+#define TC_FMR_ENCF1 (0x1u << 1) /**< \brief (TC_FMR) ENable Compare Fault Channel 1 */
+/* -------- TC_WPMR : (TC Offset: 0xE4) Write Protect Mode Register -------- */
+#define TC_WPMR_WPEN (0x1u << 0) /**< \brief (TC_WPMR) Write Protect Enable */
+#define TC_WPMR_WPKEY_Pos 8
+#define TC_WPMR_WPKEY_Msk (0xffffffu << TC_WPMR_WPKEY_Pos) /**< \brief (TC_WPMR) Write Protect KEY */
+#define TC_WPMR_WPKEY(value) ((TC_WPMR_WPKEY_Msk & ((value) << TC_WPMR_WPKEY_Pos)))
+/* -------- TC_RPR : (TC Offset: N/A) Receive Pointer Register -------- */
+#define TC_RPR_RXPTR_Pos 0
+#define TC_RPR_RXPTR_Msk (0xffffffffu << TC_RPR_RXPTR_Pos) /**< \brief (TC_RPR) Receive Pointer Register */
+#define TC_RPR_RXPTR(value) ((TC_RPR_RXPTR_Msk & ((value) << TC_RPR_RXPTR_Pos)))
+/* -------- TC_RCR : (TC Offset: N/A) Receive Counter Register -------- */
+#define TC_RCR_RXCTR_Pos 0
+#define TC_RCR_RXCTR_Msk (0xffffu << TC_RCR_RXCTR_Pos) /**< \brief (TC_RCR) Receive Counter Register */
+#define TC_RCR_RXCTR(value) ((TC_RCR_RXCTR_Msk & ((value) << TC_RCR_RXCTR_Pos)))
+/* -------- TC_RNPR : (TC Offset: N/A) Receive Next Pointer Register -------- */
+#define TC_RNPR_RXNPTR_Pos 0
+#define TC_RNPR_RXNPTR_Msk (0xffffffffu << TC_RNPR_RXNPTR_Pos) /**< \brief (TC_RNPR) Receive Next Pointer */
+#define TC_RNPR_RXNPTR(value) ((TC_RNPR_RXNPTR_Msk & ((value) << TC_RNPR_RXNPTR_Pos)))
+/* -------- TC_RNCR : (TC Offset: N/A) Receive Next Counter Register -------- */
+#define TC_RNCR_RXNCTR_Pos 0
+#define TC_RNCR_RXNCTR_Msk (0xffffu << TC_RNCR_RXNCTR_Pos) /**< \brief (TC_RNCR) Receive Next Counter */
+#define TC_RNCR_RXNCTR(value) ((TC_RNCR_RXNCTR_Msk & ((value) << TC_RNCR_RXNCTR_Pos)))
+/* -------- TC_PTCR : (TC Offset: N/A) Transfer Control Register -------- */
+#define TC_PTCR_RXTEN (0x1u << 0) /**< \brief (TC_PTCR) Receiver Transfer Enable */
+#define TC_PTCR_RXTDIS (0x1u << 1) /**< \brief (TC_PTCR) Receiver Transfer Disable */
+#define TC_PTCR_TXTEN (0x1u << 8) /**< \brief (TC_PTCR) Transmitter Transfer Enable */
+#define TC_PTCR_TXTDIS (0x1u << 9) /**< \brief (TC_PTCR) Transmitter Transfer Disable */
+/* -------- TC_PTSR : (TC Offset: N/A) Transfer Status Register -------- */
+#define TC_PTSR_RXTEN (0x1u << 0) /**< \brief (TC_PTSR) Receiver Transfer Enable */
+#define TC_PTSR_TXTEN (0x1u << 8) /**< \brief (TC_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_TC_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/twi.h
+++ b/asf/sam/include/sam4e/component/twi.h
@@ -1,0 +1,229 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TWI_COMPONENT_
+#define _SAM4E_TWI_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Two-wire Interface */
+/* ============================================================================= */
+/** \addtogroup SAM4E_TWI Two-wire Interface */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Twi hardware registers */
+typedef struct {
+  WoReg TWI_CR;           /**< \brief (Twi Offset: 0x00) Control Register */
+  RwReg TWI_MMR;          /**< \brief (Twi Offset: 0x04) Master Mode Register */
+  RwReg TWI_SMR;          /**< \brief (Twi Offset: 0x08) Slave Mode Register */
+  RwReg TWI_IADR;         /**< \brief (Twi Offset: 0x0C) Internal Address Register */
+  RwReg TWI_CWGR;         /**< \brief (Twi Offset: 0x10) Clock Waveform Generator Register */
+  RoReg Reserved1[3];
+  RoReg TWI_SR;           /**< \brief (Twi Offset: 0x20) Status Register */
+  WoReg TWI_IER;          /**< \brief (Twi Offset: 0x24) Interrupt Enable Register */
+  WoReg TWI_IDR;          /**< \brief (Twi Offset: 0x28) Interrupt Disable Register */
+  RoReg TWI_IMR;          /**< \brief (Twi Offset: 0x2C) Interrupt Mask Register */
+  RoReg TWI_RHR;          /**< \brief (Twi Offset: 0x30) Receive Holding Register */
+  WoReg TWI_THR;          /**< \brief (Twi Offset: 0x34) Transmit Holding Register */
+  RoReg Reserved2[43];
+  RwReg TWI_WPROT_MODE;   /**< \brief (Twi Offset: 0xE4) Protection Mode Register */
+  RoReg TWI_WPROT_STATUS; /**< \brief (Twi Offset: 0xE8) Protection Status Register */
+  RoReg Reserved3[5];
+  RwReg TWI_RPR;          /**< \brief (Twi Offset: 0x100) Receive Pointer Register */
+  RwReg TWI_RCR;          /**< \brief (Twi Offset: 0x104) Receive Counter Register */
+  RwReg TWI_TPR;          /**< \brief (Twi Offset: 0x108) Transmit Pointer Register */
+  RwReg TWI_TCR;          /**< \brief (Twi Offset: 0x10C) Transmit Counter Register */
+  RwReg TWI_RNPR;         /**< \brief (Twi Offset: 0x110) Receive Next Pointer Register */
+  RwReg TWI_RNCR;         /**< \brief (Twi Offset: 0x114) Receive Next Counter Register */
+  RwReg TWI_TNPR;         /**< \brief (Twi Offset: 0x118) Transmit Next Pointer Register */
+  RwReg TWI_TNCR;         /**< \brief (Twi Offset: 0x11C) Transmit Next Counter Register */
+  WoReg TWI_PTCR;         /**< \brief (Twi Offset: 0x120) Transfer Control Register */
+  RoReg TWI_PTSR;         /**< \brief (Twi Offset: 0x124) Transfer Status Register */
+} Twi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- TWI_CR : (TWI Offset: 0x00) Control Register -------- */
+#define TWI_CR_START (0x1u << 0) /**< \brief (TWI_CR) Send a START Condition */
+#define TWI_CR_STOP (0x1u << 1) /**< \brief (TWI_CR) Send a STOP Condition */
+#define TWI_CR_MSEN (0x1u << 2) /**< \brief (TWI_CR) TWI Master Mode Enabled */
+#define TWI_CR_MSDIS (0x1u << 3) /**< \brief (TWI_CR) TWI Master Mode Disabled */
+#define TWI_CR_SVEN (0x1u << 4) /**< \brief (TWI_CR) TWI Slave Mode Enabled */
+#define TWI_CR_SVDIS (0x1u << 5) /**< \brief (TWI_CR) TWI Slave Mode Disabled */
+#define TWI_CR_QUICK (0x1u << 6) /**< \brief (TWI_CR) SMBUS Quick Command */
+#define TWI_CR_SWRST (0x1u << 7) /**< \brief (TWI_CR) Software Reset */
+/* -------- TWI_MMR : (TWI Offset: 0x04) Master Mode Register -------- */
+#define TWI_MMR_IADRSZ_Pos 8
+#define TWI_MMR_IADRSZ_Msk (0x3u << TWI_MMR_IADRSZ_Pos) /**< \brief (TWI_MMR) Internal Device Address Size */
+#define   TWI_MMR_IADRSZ_NONE (0x0u << 8) /**< \brief (TWI_MMR) No internal device address */
+#define   TWI_MMR_IADRSZ_1_BYTE (0x1u << 8) /**< \brief (TWI_MMR) One-byte internal device address */
+#define   TWI_MMR_IADRSZ_2_BYTE (0x2u << 8) /**< \brief (TWI_MMR) Two-byte internal device address */
+#define   TWI_MMR_IADRSZ_3_BYTE (0x3u << 8) /**< \brief (TWI_MMR) Three-byte internal device address */
+#define TWI_MMR_MREAD (0x1u << 12) /**< \brief (TWI_MMR) Master Read Direction */
+#define TWI_MMR_DADR_Pos 16
+#define TWI_MMR_DADR_Msk (0x7fu << TWI_MMR_DADR_Pos) /**< \brief (TWI_MMR) Device Address */
+#define TWI_MMR_DADR(value) ((TWI_MMR_DADR_Msk & ((value) << TWI_MMR_DADR_Pos)))
+/* -------- TWI_SMR : (TWI Offset: 0x08) Slave Mode Register -------- */
+#define TWI_SMR_SADR_Pos 16
+#define TWI_SMR_SADR_Msk (0x7fu << TWI_SMR_SADR_Pos) /**< \brief (TWI_SMR) Slave Address */
+#define TWI_SMR_SADR(value) ((TWI_SMR_SADR_Msk & ((value) << TWI_SMR_SADR_Pos)))
+/* -------- TWI_IADR : (TWI Offset: 0x0C) Internal Address Register -------- */
+#define TWI_IADR_IADR_Pos 0
+#define TWI_IADR_IADR_Msk (0xffffffu << TWI_IADR_IADR_Pos) /**< \brief (TWI_IADR) Internal Address */
+#define TWI_IADR_IADR(value) ((TWI_IADR_IADR_Msk & ((value) << TWI_IADR_IADR_Pos)))
+/* -------- TWI_CWGR : (TWI Offset: 0x10) Clock Waveform Generator Register -------- */
+#define TWI_CWGR_CLDIV_Pos 0
+#define TWI_CWGR_CLDIV_Msk (0xffu << TWI_CWGR_CLDIV_Pos) /**< \brief (TWI_CWGR) Clock Low Divider */
+#define TWI_CWGR_CLDIV(value) ((TWI_CWGR_CLDIV_Msk & ((value) << TWI_CWGR_CLDIV_Pos)))
+#define TWI_CWGR_CHDIV_Pos 8
+#define TWI_CWGR_CHDIV_Msk (0xffu << TWI_CWGR_CHDIV_Pos) /**< \brief (TWI_CWGR) Clock High Divider */
+#define TWI_CWGR_CHDIV(value) ((TWI_CWGR_CHDIV_Msk & ((value) << TWI_CWGR_CHDIV_Pos)))
+#define TWI_CWGR_CKDIV_Pos 16
+#define TWI_CWGR_CKDIV_Msk (0x7u << TWI_CWGR_CKDIV_Pos) /**< \brief (TWI_CWGR) Clock Divider */
+#define TWI_CWGR_CKDIV(value) ((TWI_CWGR_CKDIV_Msk & ((value) << TWI_CWGR_CKDIV_Pos)))
+/* -------- TWI_SR : (TWI Offset: 0x20) Status Register -------- */
+#define TWI_SR_TXCOMP (0x1u << 0) /**< \brief (TWI_SR) Transmission Completed (automatically set / reset) */
+#define TWI_SR_RXRDY (0x1u << 1) /**< \brief (TWI_SR) Receive Holding Register Ready (automatically set / reset) */
+#define TWI_SR_TXRDY (0x1u << 2) /**< \brief (TWI_SR) Transmit Holding Register Ready (automatically set / reset) */
+#define TWI_SR_SVREAD (0x1u << 3) /**< \brief (TWI_SR) Slave Read (automatically set / reset) */
+#define TWI_SR_SVACC (0x1u << 4) /**< \brief (TWI_SR) Slave Access (automatically set / reset) */
+#define TWI_SR_GACC (0x1u << 5) /**< \brief (TWI_SR) General Call Access (clear on read) */
+#define TWI_SR_OVRE (0x1u << 6) /**< \brief (TWI_SR) Overrun Error (clear on read) */
+#define TWI_SR_NACK (0x1u << 8) /**< \brief (TWI_SR) Not Acknowledged (clear on read) */
+#define TWI_SR_ARBLST (0x1u << 9) /**< \brief (TWI_SR) Arbitration Lost (clear on read) */
+#define TWI_SR_SCLWS (0x1u << 10) /**< \brief (TWI_SR) Clock Wait State (automatically set / reset) */
+#define TWI_SR_EOSACC (0x1u << 11) /**< \brief (TWI_SR) End Of Slave Access (clear on read) */
+#define TWI_SR_ENDRX (0x1u << 12) /**< \brief (TWI_SR) End of RX buffer */
+#define TWI_SR_ENDTX (0x1u << 13) /**< \brief (TWI_SR) End of TX buffer */
+#define TWI_SR_RXBUFF (0x1u << 14) /**< \brief (TWI_SR) RX Buffer Full */
+#define TWI_SR_TXBUFE (0x1u << 15) /**< \brief (TWI_SR) TX Buffer Empty */
+/* -------- TWI_IER : (TWI Offset: 0x24) Interrupt Enable Register -------- */
+#define TWI_IER_TXCOMP (0x1u << 0) /**< \brief (TWI_IER) Transmission Completed Interrupt Enable */
+#define TWI_IER_RXRDY (0x1u << 1) /**< \brief (TWI_IER) Receive Holding Register Ready Interrupt Enable */
+#define TWI_IER_TXRDY (0x1u << 2) /**< \brief (TWI_IER) Transmit Holding Register Ready Interrupt Enable */
+#define TWI_IER_SVACC (0x1u << 4) /**< \brief (TWI_IER) Slave Access Interrupt Enable */
+#define TWI_IER_GACC (0x1u << 5) /**< \brief (TWI_IER) General Call Access Interrupt Enable */
+#define TWI_IER_OVRE (0x1u << 6) /**< \brief (TWI_IER) Overrun Error Interrupt Enable */
+#define TWI_IER_NACK (0x1u << 8) /**< \brief (TWI_IER) Not Acknowledge Interrupt Enable */
+#define TWI_IER_ARBLST (0x1u << 9) /**< \brief (TWI_IER) Arbitration Lost Interrupt Enable */
+#define TWI_IER_SCL_WS (0x1u << 10) /**< \brief (TWI_IER) Clock Wait State Interrupt Enable */
+#define TWI_IER_EOSACC (0x1u << 11) /**< \brief (TWI_IER) End Of Slave Access Interrupt Enable */
+#define TWI_IER_ENDRX (0x1u << 12) /**< \brief (TWI_IER) End of Receive Buffer Interrupt Enable */
+#define TWI_IER_ENDTX (0x1u << 13) /**< \brief (TWI_IER) End of Transmit Buffer Interrupt Enable */
+#define TWI_IER_RXBUFF (0x1u << 14) /**< \brief (TWI_IER) Receive Buffer Full Interrupt Enable */
+#define TWI_IER_TXBUFE (0x1u << 15) /**< \brief (TWI_IER) Transmit Buffer Empty Interrupt Enable */
+/* -------- TWI_IDR : (TWI Offset: 0x28) Interrupt Disable Register -------- */
+#define TWI_IDR_TXCOMP (0x1u << 0) /**< \brief (TWI_IDR) Transmission Completed Interrupt Disable */
+#define TWI_IDR_RXRDY (0x1u << 1) /**< \brief (TWI_IDR) Receive Holding Register Ready Interrupt Disable */
+#define TWI_IDR_TXRDY (0x1u << 2) /**< \brief (TWI_IDR) Transmit Holding Register Ready Interrupt Disable */
+#define TWI_IDR_SVACC (0x1u << 4) /**< \brief (TWI_IDR) Slave Access Interrupt Disable */
+#define TWI_IDR_GACC (0x1u << 5) /**< \brief (TWI_IDR) General Call Access Interrupt Disable */
+#define TWI_IDR_OVRE (0x1u << 6) /**< \brief (TWI_IDR) Overrun Error Interrupt Disable */
+#define TWI_IDR_NACK (0x1u << 8) /**< \brief (TWI_IDR) Not Acknowledge Interrupt Disable */
+#define TWI_IDR_ARBLST (0x1u << 9) /**< \brief (TWI_IDR) Arbitration Lost Interrupt Disable */
+#define TWI_IDR_SCL_WS (0x1u << 10) /**< \brief (TWI_IDR) Clock Wait State Interrupt Disable */
+#define TWI_IDR_EOSACC (0x1u << 11) /**< \brief (TWI_IDR) End Of Slave Access Interrupt Disable */
+#define TWI_IDR_ENDRX (0x1u << 12) /**< \brief (TWI_IDR) End of Receive Buffer Interrupt Disable */
+#define TWI_IDR_ENDTX (0x1u << 13) /**< \brief (TWI_IDR) End of Transmit Buffer Interrupt Disable */
+#define TWI_IDR_RXBUFF (0x1u << 14) /**< \brief (TWI_IDR) Receive Buffer Full Interrupt Disable */
+#define TWI_IDR_TXBUFE (0x1u << 15) /**< \brief (TWI_IDR) Transmit Buffer Empty Interrupt Disable */
+/* -------- TWI_IMR : (TWI Offset: 0x2C) Interrupt Mask Register -------- */
+#define TWI_IMR_TXCOMP (0x1u << 0) /**< \brief (TWI_IMR) Transmission Completed Interrupt Mask */
+#define TWI_IMR_RXRDY (0x1u << 1) /**< \brief (TWI_IMR) Receive Holding Register Ready Interrupt Mask */
+#define TWI_IMR_TXRDY (0x1u << 2) /**< \brief (TWI_IMR) Transmit Holding Register Ready Interrupt Mask */
+#define TWI_IMR_SVACC (0x1u << 4) /**< \brief (TWI_IMR) Slave Access Interrupt Mask */
+#define TWI_IMR_GACC (0x1u << 5) /**< \brief (TWI_IMR) General Call Access Interrupt Mask */
+#define TWI_IMR_OVRE (0x1u << 6) /**< \brief (TWI_IMR) Overrun Error Interrupt Mask */
+#define TWI_IMR_NACK (0x1u << 8) /**< \brief (TWI_IMR) Not Acknowledge Interrupt Mask */
+#define TWI_IMR_ARBLST (0x1u << 9) /**< \brief (TWI_IMR) Arbitration Lost Interrupt Mask */
+#define TWI_IMR_SCL_WS (0x1u << 10) /**< \brief (TWI_IMR) Clock Wait State Interrupt Mask */
+#define TWI_IMR_EOSACC (0x1u << 11) /**< \brief (TWI_IMR) End Of Slave Access Interrupt Mask */
+#define TWI_IMR_ENDRX (0x1u << 12) /**< \brief (TWI_IMR) End of Receive Buffer Interrupt Mask */
+#define TWI_IMR_ENDTX (0x1u << 13) /**< \brief (TWI_IMR) End of Transmit Buffer Interrupt Mask */
+#define TWI_IMR_RXBUFF (0x1u << 14) /**< \brief (TWI_IMR) Receive Buffer Full Interrupt Mask */
+#define TWI_IMR_TXBUFE (0x1u << 15) /**< \brief (TWI_IMR) Transmit Buffer Empty Interrupt Mask */
+/* -------- TWI_RHR : (TWI Offset: 0x30) Receive Holding Register -------- */
+#define TWI_RHR_RXDATA_Pos 0
+#define TWI_RHR_RXDATA_Msk (0xffu << TWI_RHR_RXDATA_Pos) /**< \brief (TWI_RHR) Master or Slave Receive Holding Data */
+/* -------- TWI_THR : (TWI Offset: 0x34) Transmit Holding Register -------- */
+#define TWI_THR_TXDATA_Pos 0
+#define TWI_THR_TXDATA_Msk (0xffu << TWI_THR_TXDATA_Pos) /**< \brief (TWI_THR) Master or Slave Transmit Holding Data */
+#define TWI_THR_TXDATA(value) ((TWI_THR_TXDATA_Msk & ((value) << TWI_THR_TXDATA_Pos)))
+/* -------- TWI_WPROT_MODE : (TWI Offset: 0xE4) Protection Mode Register -------- */
+#define TWI_WPROT_MODE_WPROT (0x1u << 0) /**< \brief (TWI_WPROT_MODE) Write protection bit */
+#define TWI_WPROT_MODE_SECURITY_CODE_Pos 8
+#define TWI_WPROT_MODE_SECURITY_CODE_Msk (0xffffffu << TWI_WPROT_MODE_SECURITY_CODE_Pos) /**< \brief (TWI_WPROT_MODE) Write protection mode security code */
+#define TWI_WPROT_MODE_SECURITY_CODE(value) ((TWI_WPROT_MODE_SECURITY_CODE_Msk & ((value) << TWI_WPROT_MODE_SECURITY_CODE_Pos)))
+/* -------- TWI_WPROT_STATUS : (TWI Offset: 0xE8) Protection Status Register -------- */
+#define TWI_WPROT_STATUS_WPROTERR (0x1u << 0) /**< \brief (TWI_WPROT_STATUS) Write Protection Error */
+#define TWI_WPROT_STATUS_WPROTADDR_Pos 8
+#define TWI_WPROT_STATUS_WPROTADDR_Msk (0xffffffu << TWI_WPROT_STATUS_WPROTADDR_Pos) /**< \brief (TWI_WPROT_STATUS) Write Protection Error Address */
+/* -------- TWI_RPR : (TWI Offset: 0x100) Receive Pointer Register -------- */
+#define TWI_RPR_RXPTR_Pos 0
+#define TWI_RPR_RXPTR_Msk (0xffffffffu << TWI_RPR_RXPTR_Pos) /**< \brief (TWI_RPR) Receive Pointer Register */
+#define TWI_RPR_RXPTR(value) ((TWI_RPR_RXPTR_Msk & ((value) << TWI_RPR_RXPTR_Pos)))
+/* -------- TWI_RCR : (TWI Offset: 0x104) Receive Counter Register -------- */
+#define TWI_RCR_RXCTR_Pos 0
+#define TWI_RCR_RXCTR_Msk (0xffffu << TWI_RCR_RXCTR_Pos) /**< \brief (TWI_RCR) Receive Counter Register */
+#define TWI_RCR_RXCTR(value) ((TWI_RCR_RXCTR_Msk & ((value) << TWI_RCR_RXCTR_Pos)))
+/* -------- TWI_TPR : (TWI Offset: 0x108) Transmit Pointer Register -------- */
+#define TWI_TPR_TXPTR_Pos 0
+#define TWI_TPR_TXPTR_Msk (0xffffffffu << TWI_TPR_TXPTR_Pos) /**< \brief (TWI_TPR) Transmit Counter Register */
+#define TWI_TPR_TXPTR(value) ((TWI_TPR_TXPTR_Msk & ((value) << TWI_TPR_TXPTR_Pos)))
+/* -------- TWI_TCR : (TWI Offset: 0x10C) Transmit Counter Register -------- */
+#define TWI_TCR_TXCTR_Pos 0
+#define TWI_TCR_TXCTR_Msk (0xffffu << TWI_TCR_TXCTR_Pos) /**< \brief (TWI_TCR) Transmit Counter Register */
+#define TWI_TCR_TXCTR(value) ((TWI_TCR_TXCTR_Msk & ((value) << TWI_TCR_TXCTR_Pos)))
+/* -------- TWI_RNPR : (TWI Offset: 0x110) Receive Next Pointer Register -------- */
+#define TWI_RNPR_RXNPTR_Pos 0
+#define TWI_RNPR_RXNPTR_Msk (0xffffffffu << TWI_RNPR_RXNPTR_Pos) /**< \brief (TWI_RNPR) Receive Next Pointer */
+#define TWI_RNPR_RXNPTR(value) ((TWI_RNPR_RXNPTR_Msk & ((value) << TWI_RNPR_RXNPTR_Pos)))
+/* -------- TWI_RNCR : (TWI Offset: 0x114) Receive Next Counter Register -------- */
+#define TWI_RNCR_RXNCTR_Pos 0
+#define TWI_RNCR_RXNCTR_Msk (0xffffu << TWI_RNCR_RXNCTR_Pos) /**< \brief (TWI_RNCR) Receive Next Counter */
+#define TWI_RNCR_RXNCTR(value) ((TWI_RNCR_RXNCTR_Msk & ((value) << TWI_RNCR_RXNCTR_Pos)))
+/* -------- TWI_TNPR : (TWI Offset: 0x118) Transmit Next Pointer Register -------- */
+#define TWI_TNPR_TXNPTR_Pos 0
+#define TWI_TNPR_TXNPTR_Msk (0xffffffffu << TWI_TNPR_TXNPTR_Pos) /**< \brief (TWI_TNPR) Transmit Next Pointer */
+#define TWI_TNPR_TXNPTR(value) ((TWI_TNPR_TXNPTR_Msk & ((value) << TWI_TNPR_TXNPTR_Pos)))
+/* -------- TWI_TNCR : (TWI Offset: 0x11C) Transmit Next Counter Register -------- */
+#define TWI_TNCR_TXNCTR_Pos 0
+#define TWI_TNCR_TXNCTR_Msk (0xffffu << TWI_TNCR_TXNCTR_Pos) /**< \brief (TWI_TNCR) Transmit Counter Next */
+#define TWI_TNCR_TXNCTR(value) ((TWI_TNCR_TXNCTR_Msk & ((value) << TWI_TNCR_TXNCTR_Pos)))
+/* -------- TWI_PTCR : (TWI Offset: 0x120) Transfer Control Register -------- */
+#define TWI_PTCR_RXTEN (0x1u << 0) /**< \brief (TWI_PTCR) Receiver Transfer Enable */
+#define TWI_PTCR_RXTDIS (0x1u << 1) /**< \brief (TWI_PTCR) Receiver Transfer Disable */
+#define TWI_PTCR_TXTEN (0x1u << 8) /**< \brief (TWI_PTCR) Transmitter Transfer Enable */
+#define TWI_PTCR_TXTDIS (0x1u << 9) /**< \brief (TWI_PTCR) Transmitter Transfer Disable */
+/* -------- TWI_PTSR : (TWI Offset: 0x124) Transfer Status Register -------- */
+#define TWI_PTSR_RXTEN (0x1u << 0) /**< \brief (TWI_PTSR) Receiver Transfer Enable */
+#define TWI_PTSR_TXTEN (0x1u << 8) /**< \brief (TWI_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_TWI_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/uart.h
+++ b/asf/sam/include/sam4e/component/uart.h
@@ -1,0 +1,185 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_UART_COMPONENT_
+#define _SAM4E_UART_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Universal Asynchronous Receiver Transmitter */
+/* ============================================================================= */
+/** \addtogroup SAM4E_UART Universal Asynchronous Receiver Transmitter */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Uart hardware registers */
+typedef struct {
+  WoReg UART_CR;       /**< \brief (Uart Offset: 0x0000) Control Register */
+  RwReg UART_MR;       /**< \brief (Uart Offset: 0x0004) Mode Register */
+  WoReg UART_IER;      /**< \brief (Uart Offset: 0x0008) Interrupt Enable Register */
+  WoReg UART_IDR;      /**< \brief (Uart Offset: 0x000C) Interrupt Disable Register */
+  RoReg UART_IMR;      /**< \brief (Uart Offset: 0x0010) Interrupt Mask Register */
+  RoReg UART_SR;       /**< \brief (Uart Offset: 0x0014) Status Register */
+  RoReg UART_RHR;      /**< \brief (Uart Offset: 0x0018) Receive Holding Register */
+  WoReg UART_THR;      /**< \brief (Uart Offset: 0x001C) Transmit Holding Register */
+  RwReg UART_BRGR;     /**< \brief (Uart Offset: 0x0020) Baud Rate Generator Register */
+  RoReg Reserved1[55];
+  RwReg UART_RPR;      /**< \brief (Uart Offset: 0x100) Receive Pointer Register */
+  RwReg UART_RCR;      /**< \brief (Uart Offset: 0x104) Receive Counter Register */
+  RwReg UART_TPR;      /**< \brief (Uart Offset: 0x108) Transmit Pointer Register */
+  RwReg UART_TCR;      /**< \brief (Uart Offset: 0x10C) Transmit Counter Register */
+  RwReg UART_RNPR;     /**< \brief (Uart Offset: 0x110) Receive Next Pointer Register */
+  RwReg UART_RNCR;     /**< \brief (Uart Offset: 0x114) Receive Next Counter Register */
+  RwReg UART_TNPR;     /**< \brief (Uart Offset: 0x118) Transmit Next Pointer Register */
+  RwReg UART_TNCR;     /**< \brief (Uart Offset: 0x11C) Transmit Next Counter Register */
+  WoReg UART_PTCR;     /**< \brief (Uart Offset: 0x120) Transfer Control Register */
+  RoReg UART_PTSR;     /**< \brief (Uart Offset: 0x124) Transfer Status Register */
+} Uart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- UART_CR : (UART Offset: 0x0000) Control Register -------- */
+#define UART_CR_RSTRX (0x1u << 2) /**< \brief (UART_CR) Reset Receiver */
+#define UART_CR_RSTTX (0x1u << 3) /**< \brief (UART_CR) Reset Transmitter */
+#define UART_CR_RXEN (0x1u << 4) /**< \brief (UART_CR) Receiver Enable */
+#define UART_CR_RXDIS (0x1u << 5) /**< \brief (UART_CR) Receiver Disable */
+#define UART_CR_TXEN (0x1u << 6) /**< \brief (UART_CR) Transmitter Enable */
+#define UART_CR_TXDIS (0x1u << 7) /**< \brief (UART_CR) Transmitter Disable */
+#define UART_CR_RSTSTA (0x1u << 8) /**< \brief (UART_CR) Reset Status Bits */
+/* -------- UART_MR : (UART Offset: 0x0004) Mode Register -------- */
+#define UART_MR_PAR_Pos 9
+#define UART_MR_PAR_Msk (0x7u << UART_MR_PAR_Pos) /**< \brief (UART_MR) Parity Type */
+#define   UART_MR_PAR_EVEN (0x0u << 9) /**< \brief (UART_MR) Even Parity */
+#define   UART_MR_PAR_ODD (0x1u << 9) /**< \brief (UART_MR) Odd Parity */
+#define   UART_MR_PAR_SPACE (0x2u << 9) /**< \brief (UART_MR) Space: parity forced to 0 */
+#define   UART_MR_PAR_MARK (0x3u << 9) /**< \brief (UART_MR) Mark: parity forced to 1 */
+#define   UART_MR_PAR_NO (0x4u << 9) /**< \brief (UART_MR) No Parity */
+#define UART_MR_CHMODE_Pos 14
+#define UART_MR_CHMODE_Msk (0x3u << UART_MR_CHMODE_Pos) /**< \brief (UART_MR) Channel Mode */
+#define   UART_MR_CHMODE_NORMAL (0x0u << 14) /**< \brief (UART_MR) Normal Mode */
+#define   UART_MR_CHMODE_AUTOMATIC (0x1u << 14) /**< \brief (UART_MR) Automatic Echo */
+#define   UART_MR_CHMODE_LOCAL_LOOPBACK (0x2u << 14) /**< \brief (UART_MR) Local Loopback */
+#define   UART_MR_CHMODE_REMOTE_LOOPBACK (0x3u << 14) /**< \brief (UART_MR) Remote Loopback */
+/* -------- UART_IER : (UART Offset: 0x0008) Interrupt Enable Register -------- */
+#define UART_IER_RXRDY (0x1u << 0) /**< \brief (UART_IER) Enable RXRDY Interrupt */
+#define UART_IER_TXRDY (0x1u << 1) /**< \brief (UART_IER) Enable TXRDY Interrupt */
+#define UART_IER_ENDRX (0x1u << 3) /**< \brief (UART_IER) Enable End of Receive Transfer Interrupt */
+#define UART_IER_ENDTX (0x1u << 4) /**< \brief (UART_IER) Enable End of Transmit Interrupt */
+#define UART_IER_OVRE (0x1u << 5) /**< \brief (UART_IER) Enable Overrun Error Interrupt */
+#define UART_IER_FRAME (0x1u << 6) /**< \brief (UART_IER) Enable Framing Error Interrupt */
+#define UART_IER_PARE (0x1u << 7) /**< \brief (UART_IER) Enable Parity Error Interrupt */
+#define UART_IER_TXEMPTY (0x1u << 9) /**< \brief (UART_IER) Enable TXEMPTY Interrupt */
+#define UART_IER_TXBUFE (0x1u << 11) /**< \brief (UART_IER) Enable Buffer Empty Interrupt */
+#define UART_IER_RXBUFF (0x1u << 12) /**< \brief (UART_IER) Enable Buffer Full Interrupt */
+/* -------- UART_IDR : (UART Offset: 0x000C) Interrupt Disable Register -------- */
+#define UART_IDR_RXRDY (0x1u << 0) /**< \brief (UART_IDR) Disable RXRDY Interrupt */
+#define UART_IDR_TXRDY (0x1u << 1) /**< \brief (UART_IDR) Disable TXRDY Interrupt */
+#define UART_IDR_ENDRX (0x1u << 3) /**< \brief (UART_IDR) Disable End of Receive Transfer Interrupt */
+#define UART_IDR_ENDTX (0x1u << 4) /**< \brief (UART_IDR) Disable End of Transmit Interrupt */
+#define UART_IDR_OVRE (0x1u << 5) /**< \brief (UART_IDR) Disable Overrun Error Interrupt */
+#define UART_IDR_FRAME (0x1u << 6) /**< \brief (UART_IDR) Disable Framing Error Interrupt */
+#define UART_IDR_PARE (0x1u << 7) /**< \brief (UART_IDR) Disable Parity Error Interrupt */
+#define UART_IDR_TXEMPTY (0x1u << 9) /**< \brief (UART_IDR) Disable TXEMPTY Interrupt */
+#define UART_IDR_TXBUFE (0x1u << 11) /**< \brief (UART_IDR) Disable Buffer Empty Interrupt */
+#define UART_IDR_RXBUFF (0x1u << 12) /**< \brief (UART_IDR) Disable Buffer Full Interrupt */
+/* -------- UART_IMR : (UART Offset: 0x0010) Interrupt Mask Register -------- */
+#define UART_IMR_RXRDY (0x1u << 0) /**< \brief (UART_IMR) Mask RXRDY Interrupt */
+#define UART_IMR_TXRDY (0x1u << 1) /**< \brief (UART_IMR) Disable TXRDY Interrupt */
+#define UART_IMR_ENDRX (0x1u << 3) /**< \brief (UART_IMR) Mask End of Receive Transfer Interrupt */
+#define UART_IMR_ENDTX (0x1u << 4) /**< \brief (UART_IMR) Mask End of Transmit Interrupt */
+#define UART_IMR_OVRE (0x1u << 5) /**< \brief (UART_IMR) Mask Overrun Error Interrupt */
+#define UART_IMR_FRAME (0x1u << 6) /**< \brief (UART_IMR) Mask Framing Error Interrupt */
+#define UART_IMR_PARE (0x1u << 7) /**< \brief (UART_IMR) Mask Parity Error Interrupt */
+#define UART_IMR_TXEMPTY (0x1u << 9) /**< \brief (UART_IMR) Mask TXEMPTY Interrupt */
+#define UART_IMR_TXBUFE (0x1u << 11) /**< \brief (UART_IMR) Mask TXBUFE Interrupt */
+#define UART_IMR_RXBUFF (0x1u << 12) /**< \brief (UART_IMR) Mask RXBUFF Interrupt */
+/* -------- UART_SR : (UART Offset: 0x0014) Status Register -------- */
+#define UART_SR_RXRDY (0x1u << 0) /**< \brief (UART_SR) Receiver Ready */
+#define UART_SR_TXRDY (0x1u << 1) /**< \brief (UART_SR) Transmitter Ready */
+#define UART_SR_ENDRX (0x1u << 3) /**< \brief (UART_SR) End of Receiver Transfer */
+#define UART_SR_ENDTX (0x1u << 4) /**< \brief (UART_SR) End of Transmitter Transfer */
+#define UART_SR_OVRE (0x1u << 5) /**< \brief (UART_SR) Overrun Error */
+#define UART_SR_FRAME (0x1u << 6) /**< \brief (UART_SR) Framing Error */
+#define UART_SR_PARE (0x1u << 7) /**< \brief (UART_SR) Parity Error */
+#define UART_SR_TXEMPTY (0x1u << 9) /**< \brief (UART_SR) Transmitter Empty */
+#define UART_SR_TXBUFE (0x1u << 11) /**< \brief (UART_SR) Transmission Buffer Empty */
+#define UART_SR_RXBUFF (0x1u << 12) /**< \brief (UART_SR) Receive Buffer Full */
+/* -------- UART_RHR : (UART Offset: 0x0018) Receive Holding Register -------- */
+#define UART_RHR_RXCHR_Pos 0
+#define UART_RHR_RXCHR_Msk (0xffu << UART_RHR_RXCHR_Pos) /**< \brief (UART_RHR) Received Character */
+/* -------- UART_THR : (UART Offset: 0x001C) Transmit Holding Register -------- */
+#define UART_THR_TXCHR_Pos 0
+#define UART_THR_TXCHR_Msk (0xffu << UART_THR_TXCHR_Pos) /**< \brief (UART_THR) Character to be Transmitted */
+#define UART_THR_TXCHR(value) ((UART_THR_TXCHR_Msk & ((value) << UART_THR_TXCHR_Pos)))
+/* -------- UART_BRGR : (UART Offset: 0x0020) Baud Rate Generator Register -------- */
+#define UART_BRGR_CD_Pos 0
+#define UART_BRGR_CD_Msk (0xffffu << UART_BRGR_CD_Pos) /**< \brief (UART_BRGR) Clock Divisor */
+#define UART_BRGR_CD(value) ((UART_BRGR_CD_Msk & ((value) << UART_BRGR_CD_Pos)))
+/* -------- UART_RPR : (UART Offset: 0x100) Receive Pointer Register -------- */
+#define UART_RPR_RXPTR_Pos 0
+#define UART_RPR_RXPTR_Msk (0xffffffffu << UART_RPR_RXPTR_Pos) /**< \brief (UART_RPR) Receive Pointer Register */
+#define UART_RPR_RXPTR(value) ((UART_RPR_RXPTR_Msk & ((value) << UART_RPR_RXPTR_Pos)))
+/* -------- UART_RCR : (UART Offset: 0x104) Receive Counter Register -------- */
+#define UART_RCR_RXCTR_Pos 0
+#define UART_RCR_RXCTR_Msk (0xffffu << UART_RCR_RXCTR_Pos) /**< \brief (UART_RCR) Receive Counter Register */
+#define UART_RCR_RXCTR(value) ((UART_RCR_RXCTR_Msk & ((value) << UART_RCR_RXCTR_Pos)))
+/* -------- UART_TPR : (UART Offset: 0x108) Transmit Pointer Register -------- */
+#define UART_TPR_TXPTR_Pos 0
+#define UART_TPR_TXPTR_Msk (0xffffffffu << UART_TPR_TXPTR_Pos) /**< \brief (UART_TPR) Transmit Counter Register */
+#define UART_TPR_TXPTR(value) ((UART_TPR_TXPTR_Msk & ((value) << UART_TPR_TXPTR_Pos)))
+/* -------- UART_TCR : (UART Offset: 0x10C) Transmit Counter Register -------- */
+#define UART_TCR_TXCTR_Pos 0
+#define UART_TCR_TXCTR_Msk (0xffffu << UART_TCR_TXCTR_Pos) /**< \brief (UART_TCR) Transmit Counter Register */
+#define UART_TCR_TXCTR(value) ((UART_TCR_TXCTR_Msk & ((value) << UART_TCR_TXCTR_Pos)))
+/* -------- UART_RNPR : (UART Offset: 0x110) Receive Next Pointer Register -------- */
+#define UART_RNPR_RXNPTR_Pos 0
+#define UART_RNPR_RXNPTR_Msk (0xffffffffu << UART_RNPR_RXNPTR_Pos) /**< \brief (UART_RNPR) Receive Next Pointer */
+#define UART_RNPR_RXNPTR(value) ((UART_RNPR_RXNPTR_Msk & ((value) << UART_RNPR_RXNPTR_Pos)))
+/* -------- UART_RNCR : (UART Offset: 0x114) Receive Next Counter Register -------- */
+#define UART_RNCR_RXNCTR_Pos 0
+#define UART_RNCR_RXNCTR_Msk (0xffffu << UART_RNCR_RXNCTR_Pos) /**< \brief (UART_RNCR) Receive Next Counter */
+#define UART_RNCR_RXNCTR(value) ((UART_RNCR_RXNCTR_Msk & ((value) << UART_RNCR_RXNCTR_Pos)))
+/* -------- UART_TNPR : (UART Offset: 0x118) Transmit Next Pointer Register -------- */
+#define UART_TNPR_TXNPTR_Pos 0
+#define UART_TNPR_TXNPTR_Msk (0xffffffffu << UART_TNPR_TXNPTR_Pos) /**< \brief (UART_TNPR) Transmit Next Pointer */
+#define UART_TNPR_TXNPTR(value) ((UART_TNPR_TXNPTR_Msk & ((value) << UART_TNPR_TXNPTR_Pos)))
+/* -------- UART_TNCR : (UART Offset: 0x11C) Transmit Next Counter Register -------- */
+#define UART_TNCR_TXNCTR_Pos 0
+#define UART_TNCR_TXNCTR_Msk (0xffffu << UART_TNCR_TXNCTR_Pos) /**< \brief (UART_TNCR) Transmit Counter Next */
+#define UART_TNCR_TXNCTR(value) ((UART_TNCR_TXNCTR_Msk & ((value) << UART_TNCR_TXNCTR_Pos)))
+/* -------- UART_PTCR : (UART Offset: 0x120) Transfer Control Register -------- */
+#define UART_PTCR_RXTEN (0x1u << 0) /**< \brief (UART_PTCR) Receiver Transfer Enable */
+#define UART_PTCR_RXTDIS (0x1u << 1) /**< \brief (UART_PTCR) Receiver Transfer Disable */
+#define UART_PTCR_TXTEN (0x1u << 8) /**< \brief (UART_PTCR) Transmitter Transfer Enable */
+#define UART_PTCR_TXTDIS (0x1u << 9) /**< \brief (UART_PTCR) Transmitter Transfer Disable */
+/* -------- UART_PTSR : (UART Offset: 0x124) Transfer Status Register -------- */
+#define UART_PTSR_RXTEN (0x1u << 0) /**< \brief (UART_PTSR) Receiver Transfer Enable */
+#define UART_PTSR_TXTEN (0x1u << 8) /**< \brief (UART_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_UART_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/udp.h
+++ b/asf/sam/include/sam4e/component/udp.h
@@ -1,0 +1,185 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_UDP_COMPONENT_
+#define _SAM4E_UDP_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR USB Device Port */
+/* ============================================================================= */
+/** \addtogroup SAM4E_UDP USB Device Port */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Udp hardware registers */
+typedef struct {
+  RoReg UDP_FRM_NUM;  /**< \brief (Udp Offset: 0x000) Frame Number Register */
+  RwReg UDP_GLB_STAT; /**< \brief (Udp Offset: 0x004) Global State Register */
+  RwReg UDP_FADDR;    /**< \brief (Udp Offset: 0x008) Function Address Register */
+  RoReg Reserved1[1];
+  WoReg UDP_IER;      /**< \brief (Udp Offset: 0x010) Interrupt Enable Register */
+  WoReg UDP_IDR;      /**< \brief (Udp Offset: 0x014) Interrupt Disable Register */
+  RoReg UDP_IMR;      /**< \brief (Udp Offset: 0x018) Interrupt Mask Register */
+  RoReg UDP_ISR;      /**< \brief (Udp Offset: 0x01C) Interrupt Status Register */
+  WoReg UDP_ICR;      /**< \brief (Udp Offset: 0x020) Interrupt Clear Register */
+  RoReg Reserved2[1];
+  RwReg UDP_RST_EP;   /**< \brief (Udp Offset: 0x028) Reset Endpoint Register */
+  RoReg Reserved3[1];
+  RwReg UDP_CSR[8];   /**< \brief (Udp Offset: 0x030) Endpoint Control and Status Register */
+  RwReg UDP_FDR[8];   /**< \brief (Udp Offset: 0x050) Endpoint FIFO Data Register */
+  RoReg Reserved4[1];
+  RwReg UDP_TXVC;     /**< \brief (Udp Offset: 0x074) Transceiver Control Register */
+} Udp;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- UDP_FRM_NUM : (UDP Offset: 0x000) Frame Number Register -------- */
+#define UDP_FRM_NUM_FRM_NUM_Pos 0
+#define UDP_FRM_NUM_FRM_NUM_Msk (0x7ffu << UDP_FRM_NUM_FRM_NUM_Pos) /**< \brief (UDP_FRM_NUM) Frame Number as Defined in the Packet Field Formats */
+#define UDP_FRM_NUM_FRM_ERR (0x1u << 16) /**< \brief (UDP_FRM_NUM) Frame Error */
+#define UDP_FRM_NUM_FRM_OK (0x1u << 17) /**< \brief (UDP_FRM_NUM) Frame OK */
+/* -------- UDP_GLB_STAT : (UDP Offset: 0x004) Global State Register -------- */
+#define UDP_GLB_STAT_FADDEN (0x1u << 0) /**< \brief (UDP_GLB_STAT) Function Address Enable */
+#define UDP_GLB_STAT_CONFG (0x1u << 1) /**< \brief (UDP_GLB_STAT) Configured */
+#define UDP_GLB_STAT_ESR (0x1u << 2) /**< \brief (UDP_GLB_STAT) Enable Send Resume */
+#define UDP_GLB_STAT_RSMINPR (0x1u << 3) /**< \brief (UDP_GLB_STAT)  */
+#define UDP_GLB_STAT_RMWUPE (0x1u << 4) /**< \brief (UDP_GLB_STAT) Remote Wake Up Enable */
+/* -------- UDP_FADDR : (UDP Offset: 0x008) Function Address Register -------- */
+#define UDP_FADDR_FADD_Pos 0
+#define UDP_FADDR_FADD_Msk (0x7fu << UDP_FADDR_FADD_Pos) /**< \brief (UDP_FADDR) Function Address Value */
+#define UDP_FADDR_FADD(value) ((UDP_FADDR_FADD_Msk & ((value) << UDP_FADDR_FADD_Pos)))
+#define UDP_FADDR_FEN (0x1u << 8) /**< \brief (UDP_FADDR) Function Enable */
+/* -------- UDP_IER : (UDP Offset: 0x010) Interrupt Enable Register -------- */
+#define UDP_IER_EP0INT (0x1u << 0) /**< \brief (UDP_IER) Enable Endpoint 0 Interrupt */
+#define UDP_IER_EP1INT (0x1u << 1) /**< \brief (UDP_IER) Enable Endpoint 1 Interrupt */
+#define UDP_IER_EP2INT (0x1u << 2) /**< \brief (UDP_IER) Enable Endpoint 2Interrupt */
+#define UDP_IER_EP3INT (0x1u << 3) /**< \brief (UDP_IER) Enable Endpoint 3 Interrupt */
+#define UDP_IER_EP4INT (0x1u << 4) /**< \brief (UDP_IER) Enable Endpoint 4 Interrupt */
+#define UDP_IER_EP5INT (0x1u << 5) /**< \brief (UDP_IER) Enable Endpoint 5 Interrupt */
+#define UDP_IER_EP6INT (0x1u << 6) /**< \brief (UDP_IER) Enable Endpoint 6 Interrupt */
+#define UDP_IER_EP7INT (0x1u << 7) /**< \brief (UDP_IER) Enable Endpoint 7 Interrupt */
+#define UDP_IER_RXSUSP (0x1u << 8) /**< \brief (UDP_IER) Enable UDP Suspend Interrupt */
+#define UDP_IER_RXRSM (0x1u << 9) /**< \brief (UDP_IER) Enable UDP Resume Interrupt */
+#define UDP_IER_EXTRSM (0x1u << 10) /**< \brief (UDP_IER)  */
+#define UDP_IER_SOFINT (0x1u << 11) /**< \brief (UDP_IER) Enable Start Of Frame Interrupt */
+#define UDP_IER_WAKEUP (0x1u << 13) /**< \brief (UDP_IER) Enable UDP bus Wakeup Interrupt */
+/* -------- UDP_IDR : (UDP Offset: 0x014) Interrupt Disable Register -------- */
+#define UDP_IDR_EP0INT (0x1u << 0) /**< \brief (UDP_IDR) Disable Endpoint 0 Interrupt */
+#define UDP_IDR_EP1INT (0x1u << 1) /**< \brief (UDP_IDR) Disable Endpoint 1 Interrupt */
+#define UDP_IDR_EP2INT (0x1u << 2) /**< \brief (UDP_IDR) Disable Endpoint 2 Interrupt */
+#define UDP_IDR_EP3INT (0x1u << 3) /**< \brief (UDP_IDR) Disable Endpoint 3 Interrupt */
+#define UDP_IDR_EP4INT (0x1u << 4) /**< \brief (UDP_IDR) Disable Endpoint 4 Interrupt */
+#define UDP_IDR_EP5INT (0x1u << 5) /**< \brief (UDP_IDR) Disable Endpoint 5 Interrupt */
+#define UDP_IDR_EP6INT (0x1u << 6) /**< \brief (UDP_IDR) Disable Endpoint 6 Interrupt */
+#define UDP_IDR_EP7INT (0x1u << 7) /**< \brief (UDP_IDR) Disable Endpoint 7 Interrupt */
+#define UDP_IDR_RXSUSP (0x1u << 8) /**< \brief (UDP_IDR) Disable UDP Suspend Interrupt */
+#define UDP_IDR_RXRSM (0x1u << 9) /**< \brief (UDP_IDR) Disable UDP Resume Interrupt */
+#define UDP_IDR_EXTRSM (0x1u << 10) /**< \brief (UDP_IDR)  */
+#define UDP_IDR_SOFINT (0x1u << 11) /**< \brief (UDP_IDR) Disable Start Of Frame Interrupt */
+#define UDP_IDR_WAKEUP (0x1u << 13) /**< \brief (UDP_IDR) Disable USB Bus Interrupt */
+/* -------- UDP_IMR : (UDP Offset: 0x018) Interrupt Mask Register -------- */
+#define UDP_IMR_EP0INT (0x1u << 0) /**< \brief (UDP_IMR) Mask Endpoint 0 Interrupt */
+#define UDP_IMR_EP1INT (0x1u << 1) /**< \brief (UDP_IMR) Mask Endpoint 1 Interrupt */
+#define UDP_IMR_EP2INT (0x1u << 2) /**< \brief (UDP_IMR) Mask Endpoint 2 Interrupt */
+#define UDP_IMR_EP3INT (0x1u << 3) /**< \brief (UDP_IMR) Mask Endpoint 3 Interrupt */
+#define UDP_IMR_EP4INT (0x1u << 4) /**< \brief (UDP_IMR) Mask Endpoint 4 Interrupt */
+#define UDP_IMR_EP5INT (0x1u << 5) /**< \brief (UDP_IMR) Mask Endpoint 5 Interrupt */
+#define UDP_IMR_EP6INT (0x1u << 6) /**< \brief (UDP_IMR) Mask Endpoint 6 Interrupt */
+#define UDP_IMR_EP7INT (0x1u << 7) /**< \brief (UDP_IMR) Mask Endpoint 7 Interrupt */
+#define UDP_IMR_RXSUSP (0x1u << 8) /**< \brief (UDP_IMR) Mask UDP Suspend Interrupt */
+#define UDP_IMR_RXRSM (0x1u << 9) /**< \brief (UDP_IMR) Mask UDP Resume Interrupt. */
+#define UDP_IMR_EXTRSM (0x1u << 10) /**< \brief (UDP_IMR)  */
+#define UDP_IMR_SOFINT (0x1u << 11) /**< \brief (UDP_IMR) Mask Start Of Frame Interrupt */
+#define UDP_IMR_BIT12 (0x1u << 12) /**< \brief (UDP_IMR) UDP_IMR Bit 12 */
+#define UDP_IMR_WAKEUP (0x1u << 13) /**< \brief (UDP_IMR) USB Bus WAKEUP Interrupt */
+/* -------- UDP_ISR : (UDP Offset: 0x01C) Interrupt Status Register -------- */
+#define UDP_ISR_EP0INT (0x1u << 0) /**< \brief (UDP_ISR) Endpoint 0 Interrupt Status */
+#define UDP_ISR_EP1INT (0x1u << 1) /**< \brief (UDP_ISR) Endpoint 1 Interrupt Status */
+#define UDP_ISR_EP2INT (0x1u << 2) /**< \brief (UDP_ISR) Endpoint 2 Interrupt Status */
+#define UDP_ISR_EP3INT (0x1u << 3) /**< \brief (UDP_ISR) Endpoint 3 Interrupt Status */
+#define UDP_ISR_EP4INT (0x1u << 4) /**< \brief (UDP_ISR) Endpoint 4 Interrupt Status */
+#define UDP_ISR_EP5INT (0x1u << 5) /**< \brief (UDP_ISR) Endpoint 5 Interrupt Status */
+#define UDP_ISR_EP6INT (0x1u << 6) /**< \brief (UDP_ISR) Endpoint 6 Interrupt Status */
+#define UDP_ISR_EP7INT (0x1u << 7) /**< \brief (UDP_ISR) Endpoint 7Interrupt Status */
+#define UDP_ISR_RXSUSP (0x1u << 8) /**< \brief (UDP_ISR) UDP Suspend Interrupt Status */
+#define UDP_ISR_RXRSM (0x1u << 9) /**< \brief (UDP_ISR) UDP Resume Interrupt Status */
+#define UDP_ISR_EXTRSM (0x1u << 10) /**< \brief (UDP_ISR)  */
+#define UDP_ISR_SOFINT (0x1u << 11) /**< \brief (UDP_ISR) Start of Frame Interrupt Status */
+#define UDP_ISR_ENDBUSRES (0x1u << 12) /**< \brief (UDP_ISR) End of BUS Reset Interrupt Status */
+#define UDP_ISR_WAKEUP (0x1u << 13) /**< \brief (UDP_ISR) UDP Resume Interrupt Status */
+/* -------- UDP_ICR : (UDP Offset: 0x020) Interrupt Clear Register -------- */
+#define UDP_ICR_RXSUSP (0x1u << 8) /**< \brief (UDP_ICR) Clear UDP Suspend Interrupt */
+#define UDP_ICR_RXRSM (0x1u << 9) /**< \brief (UDP_ICR) Clear UDP Resume Interrupt */
+#define UDP_ICR_EXTRSM (0x1u << 10) /**< \brief (UDP_ICR)  */
+#define UDP_ICR_SOFINT (0x1u << 11) /**< \brief (UDP_ICR) Clear Start Of Frame Interrupt */
+#define UDP_ICR_ENDBUSRES (0x1u << 12) /**< \brief (UDP_ICR) Clear End of Bus Reset Interrupt */
+#define UDP_ICR_WAKEUP (0x1u << 13) /**< \brief (UDP_ICR) Clear Wakeup Interrupt */
+/* -------- UDP_RST_EP : (UDP Offset: 0x028) Reset Endpoint Register -------- */
+#define UDP_RST_EP_EP0 (0x1u << 0) /**< \brief (UDP_RST_EP) Reset Endpoint 0 */
+#define UDP_RST_EP_EP1 (0x1u << 1) /**< \brief (UDP_RST_EP) Reset Endpoint 1 */
+#define UDP_RST_EP_EP2 (0x1u << 2) /**< \brief (UDP_RST_EP) Reset Endpoint 2 */
+#define UDP_RST_EP_EP3 (0x1u << 3) /**< \brief (UDP_RST_EP) Reset Endpoint 3 */
+#define UDP_RST_EP_EP4 (0x1u << 4) /**< \brief (UDP_RST_EP) Reset Endpoint 4 */
+#define UDP_RST_EP_EP5 (0x1u << 5) /**< \brief (UDP_RST_EP) Reset Endpoint 5 */
+#define UDP_RST_EP_EP6 (0x1u << 6) /**< \brief (UDP_RST_EP) Reset Endpoint 6 */
+#define UDP_RST_EP_EP7 (0x1u << 7) /**< \brief (UDP_RST_EP) Reset Endpoint 7 */
+/* -------- UDP_CSR[8] : (UDP Offset: 0x030) Endpoint Control and Status Register -------- */
+#define UDP_CSR_TXCOMP (0x1u << 0) /**< \brief (UDP_CSR[8]) Generates an IN Packet with Data Previously Written in the DPR */
+#define UDP_CSR_RX_DATA_BK0 (0x1u << 1) /**< \brief (UDP_CSR[8]) Receive Data Bank 0 */
+#define UDP_CSR_RXSETUP (0x1u << 2) /**< \brief (UDP_CSR[8]) Received Setup */
+#define UDP_CSR_STALLSENT (0x1u << 3) /**< \brief (UDP_CSR[8]) Stall Sent */
+#define UDP_CSR_TXPKTRDY (0x1u << 4) /**< \brief (UDP_CSR[8]) Transmit Packet Ready */
+#define UDP_CSR_FORCESTALL (0x1u << 5) /**< \brief (UDP_CSR[8]) Force Stall (used by Control, Bulk and Isochronous Endpoints) */
+#define UDP_CSR_RX_DATA_BK1 (0x1u << 6) /**< \brief (UDP_CSR[8]) Receive Data Bank 1 (only used by endpoints with ping-pong attributes) */
+#define UDP_CSR_DIR (0x1u << 7) /**< \brief (UDP_CSR[8]) Transfer Direction (only available for control endpoints) */
+#define UDP_CSR_EPTYPE_Pos 8
+#define UDP_CSR_EPTYPE_Msk (0x7u << UDP_CSR_EPTYPE_Pos) /**< \brief (UDP_CSR[8]) Endpoint Type */
+#define   UDP_CSR_EPTYPE_CTRL (0x0u << 8) /**< \brief (UDP_CSR[8]) Control */
+#define   UDP_CSR_EPTYPE_ISO_OUT (0x1u << 8) /**< \brief (UDP_CSR[8]) Isochronous OUT */
+#define   UDP_CSR_EPTYPE_BULK_OUT (0x2u << 8) /**< \brief (UDP_CSR[8]) Bulk OUT */
+#define   UDP_CSR_EPTYPE_INT_OUT (0x3u << 8) /**< \brief (UDP_CSR[8]) Interrupt OUT */
+#define   UDP_CSR_EPTYPE_ISO_IN (0x5u << 8) /**< \brief (UDP_CSR[8]) Isochronous IN */
+#define   UDP_CSR_EPTYPE_BULK_IN (0x6u << 8) /**< \brief (UDP_CSR[8]) Bulk IN */
+#define   UDP_CSR_EPTYPE_INT_IN (0x7u << 8) /**< \brief (UDP_CSR[8]) Interrupt IN */
+#define UDP_CSR_DTGLE (0x1u << 11) /**< \brief (UDP_CSR[8]) Data Toggle */
+#define UDP_CSR_EPEDS (0x1u << 15) /**< \brief (UDP_CSR[8]) Endpoint Enable Disable */
+#define UDP_CSR_RXBYTECNT_Pos 16
+#define UDP_CSR_RXBYTECNT_Msk (0x7ffu << UDP_CSR_RXBYTECNT_Pos) /**< \brief (UDP_CSR[8]) Number of Bytes Available in the FIFO */
+#define UDP_CSR_RXBYTECNT(value) ((UDP_CSR_RXBYTECNT_Msk & ((value) << UDP_CSR_RXBYTECNT_Pos)))
+#define UDP_CSR_ISOERROR (0x1u << 3) /**< \brief (UDP_CSR[8]) A CRC error has been detected in an isochronous transfer */
+/* -------- UDP_FDR[8] : (UDP Offset: 0x050) Endpoint FIFO Data Register -------- */
+#define UDP_FDR_FIFO_DATA_Pos 0
+#define UDP_FDR_FIFO_DATA_Msk (0xffu << UDP_FDR_FIFO_DATA_Pos) /**< \brief (UDP_FDR[8]) FIFO Data Value */
+#define UDP_FDR_FIFO_DATA(value) ((UDP_FDR_FIFO_DATA_Msk & ((value) << UDP_FDR_FIFO_DATA_Pos)))
+/* -------- UDP_TXVC : (UDP Offset: 0x074) Transceiver Control Register -------- */
+#define UDP_TXVC_TXVDIS (0x1u << 8) /**< \brief (UDP_TXVC) Transceiver Disable */
+#define UDP_TXVC_PUON (0x1u << 9) /**< \brief (UDP_TXVC) Pull-up On */
+
+/*@}*/
+
+
+#endif /* _SAM4E_UDP_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/usart.h
+++ b/asf/sam/include/sam4e/component/usart.h
@@ -1,0 +1,356 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_USART_COMPONENT_
+#define _SAM4E_USART_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Universal Synchronous Asynchronous Receiver Transmitter */
+/* ============================================================================= */
+/** \addtogroup SAM4E_USART Universal Synchronous Asynchronous Receiver Transmitter */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Usart hardware registers */
+typedef struct {
+  WoReg US_CR;         /**< \brief (Usart Offset: 0x0000) Control Register */
+  RwReg US_MR;         /**< \brief (Usart Offset: 0x0004) Mode Register */
+  WoReg US_IER;        /**< \brief (Usart Offset: 0x0008) Interrupt Enable Register */
+  WoReg US_IDR;        /**< \brief (Usart Offset: 0x000C) Interrupt Disable Register */
+  RoReg US_IMR;        /**< \brief (Usart Offset: 0x0010) Interrupt Mask Register */
+  RoReg US_CSR;        /**< \brief (Usart Offset: 0x0014) Channel Status Register */
+  RoReg US_RHR;        /**< \brief (Usart Offset: 0x0018) Receiver Holding Register */
+  WoReg US_THR;        /**< \brief (Usart Offset: 0x001C) Transmitter Holding Register */
+  RwReg US_BRGR;       /**< \brief (Usart Offset: 0x0020) Baud Rate Generator Register */
+  RwReg US_RTOR;       /**< \brief (Usart Offset: 0x0024) Receiver Time-out Register */
+  RwReg US_TTGR;       /**< \brief (Usart Offset: 0x0028) Transmitter Timeguard Register */
+  RoReg Reserved1[5];
+  RwReg US_FIDI;       /**< \brief (Usart Offset: 0x0040) FI DI Ratio Register */
+  RoReg US_NER;        /**< \brief (Usart Offset: 0x0044) Number of Errors Register */
+  RoReg Reserved2[1];
+  RwReg US_IF;         /**< \brief (Usart Offset: 0x004C) IrDA Filter Register */
+  RwReg US_MAN;        /**< \brief (Usart Offset: 0x0050) Manchester Encoder Decoder Register */
+  RoReg Reserved3[36];
+  RwReg US_WPMR;       /**< \brief (Usart Offset: 0xE4) Write Protect Mode Register */
+  RoReg US_WPSR;       /**< \brief (Usart Offset: 0xE8) Write Protect Status Register */
+  RoReg Reserved4[5];
+  RwReg US_RPR;        /**< \brief (Usart Offset: 0x100) Receive Pointer Register */
+  RwReg US_RCR;        /**< \brief (Usart Offset: 0x104) Receive Counter Register */
+  RwReg US_TPR;        /**< \brief (Usart Offset: 0x108) Transmit Pointer Register */
+  RwReg US_TCR;        /**< \brief (Usart Offset: 0x10C) Transmit Counter Register */
+  RwReg US_RNPR;       /**< \brief (Usart Offset: 0x110) Receive Next Pointer Register */
+  RwReg US_RNCR;       /**< \brief (Usart Offset: 0x114) Receive Next Counter Register */
+  RwReg US_TNPR;       /**< \brief (Usart Offset: 0x118) Transmit Next Pointer Register */
+  RwReg US_TNCR;       /**< \brief (Usart Offset: 0x11C) Transmit Next Counter Register */
+  WoReg US_PTCR;       /**< \brief (Usart Offset: 0x120) Transfer Control Register */
+  RoReg US_PTSR;       /**< \brief (Usart Offset: 0x124) Transfer Status Register */
+} Usart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- US_CR : (USART Offset: 0x0000) Control Register -------- */
+#define US_CR_RSTRX (0x1u << 2) /**< \brief (US_CR) Reset Receiver */
+#define US_CR_RSTTX (0x1u << 3) /**< \brief (US_CR) Reset Transmitter */
+#define US_CR_RXEN (0x1u << 4) /**< \brief (US_CR) Receiver Enable */
+#define US_CR_RXDIS (0x1u << 5) /**< \brief (US_CR) Receiver Disable */
+#define US_CR_TXEN (0x1u << 6) /**< \brief (US_CR) Transmitter Enable */
+#define US_CR_TXDIS (0x1u << 7) /**< \brief (US_CR) Transmitter Disable */
+#define US_CR_RSTSTA (0x1u << 8) /**< \brief (US_CR) Reset Status Bits */
+#define US_CR_STTBRK (0x1u << 9) /**< \brief (US_CR) Start Break */
+#define US_CR_STPBRK (0x1u << 10) /**< \brief (US_CR) Stop Break */
+#define US_CR_STTTO (0x1u << 11) /**< \brief (US_CR) Start Time-out */
+#define US_CR_SENDA (0x1u << 12) /**< \brief (US_CR) Send Address */
+#define US_CR_RSTIT (0x1u << 13) /**< \brief (US_CR) Reset Iterations */
+#define US_CR_RSTNACK (0x1u << 14) /**< \brief (US_CR) Reset Non Acknowledge */
+#define US_CR_RETTO (0x1u << 15) /**< \brief (US_CR) Rearm Time-out */
+#define US_CR_DTREN (0x1u << 16) /**< \brief (US_CR) Data Terminal Ready Enable */
+#define US_CR_DTRDIS (0x1u << 17) /**< \brief (US_CR) Data Terminal Ready Disable */
+#define US_CR_RTSEN (0x1u << 18) /**< \brief (US_CR) Request to Send Enable */
+#define US_CR_RTSDIS (0x1u << 19) /**< \brief (US_CR) Request to Send Disable */
+#define US_CR_FCS (0x1u << 18) /**< \brief (US_CR) Force SPI Chip Select */
+#define US_CR_RCS (0x1u << 19) /**< \brief (US_CR) Release SPI Chip Select */
+/* -------- US_MR : (USART Offset: 0x0004) Mode Register -------- */
+#define US_MR_USART_MODE_Pos 0
+#define US_MR_USART_MODE_Msk (0xfu << US_MR_USART_MODE_Pos) /**< \brief (US_MR) USART Mode of Operation */
+#define   US_MR_USART_MODE_NORMAL (0x0u << 0) /**< \brief (US_MR) Normal mode */
+#define   US_MR_USART_MODE_RS485 (0x1u << 0) /**< \brief (US_MR) RS485 */
+#define   US_MR_USART_MODE_HW_HANDSHAKING (0x2u << 0) /**< \brief (US_MR) Hardware Handshaking */
+#define   US_MR_USART_MODE_MODEM (0x3u << 0) /**< \brief (US_MR) Modem */
+#define   US_MR_USART_MODE_IS07816_T_0 (0x4u << 0) /**< \brief (US_MR) IS07816 Protocol: T = 0 */
+#define   US_MR_USART_MODE_IS07816_T_1 (0x6u << 0) /**< \brief (US_MR) IS07816 Protocol: T = 1 */
+#define   US_MR_USART_MODE_IRDA (0x8u << 0) /**< \brief (US_MR) IrDA */
+#define   US_MR_USART_MODE_SPI_MASTER (0xEu << 0) /**< \brief (US_MR) SPI Master */
+#define   US_MR_USART_MODE_SPI_SLAVE (0xFu << 0) /**< \brief (US_MR) SPI Slave */
+#define US_MR_USCLKS_Pos 4
+#define US_MR_USCLKS_Msk (0x3u << US_MR_USCLKS_Pos) /**< \brief (US_MR) Clock Selection */
+#define   US_MR_USCLKS_MCK (0x0u << 4) /**< \brief (US_MR) Master Clock MCK is selected */
+#define   US_MR_USCLKS_DIV (0x1u << 4) /**< \brief (US_MR) Internal Clock Divided MCK/DIV (DIV=8) is selected */
+#define   US_MR_USCLKS_SCK (0x3u << 4) /**< \brief (US_MR) Serial Clock SLK is selected */
+#define US_MR_CHRL_Pos 6
+#define US_MR_CHRL_Msk (0x3u << US_MR_CHRL_Pos) /**< \brief (US_MR) Character Length. */
+#define   US_MR_CHRL_5_BIT (0x0u << 6) /**< \brief (US_MR) Character length is 5 bits */
+#define   US_MR_CHRL_6_BIT (0x1u << 6) /**< \brief (US_MR) Character length is 6 bits */
+#define   US_MR_CHRL_7_BIT (0x2u << 6) /**< \brief (US_MR) Character length is 7 bits */
+#define   US_MR_CHRL_8_BIT (0x3u << 6) /**< \brief (US_MR) Character length is 8 bits */
+#define US_MR_SYNC (0x1u << 8) /**< \brief (US_MR) Synchronous Mode Select */
+#define US_MR_PAR_Pos 9
+#define US_MR_PAR_Msk (0x7u << US_MR_PAR_Pos) /**< \brief (US_MR) Parity Type */
+#define   US_MR_PAR_EVEN (0x0u << 9) /**< \brief (US_MR) Even parity */
+#define   US_MR_PAR_ODD (0x1u << 9) /**< \brief (US_MR) Odd parity */
+#define   US_MR_PAR_SPACE (0x2u << 9) /**< \brief (US_MR) Parity forced to 0 (Space) */
+#define   US_MR_PAR_MARK (0x3u << 9) /**< \brief (US_MR) Parity forced to 1 (Mark) */
+#define   US_MR_PAR_NO (0x4u << 9) /**< \brief (US_MR) No parity */
+#define   US_MR_PAR_MULTIDROP (0x6u << 9) /**< \brief (US_MR) Multidrop mode */
+#define US_MR_NBSTOP_Pos 12
+#define US_MR_NBSTOP_Msk (0x3u << US_MR_NBSTOP_Pos) /**< \brief (US_MR) Number of Stop Bits */
+#define   US_MR_NBSTOP_1_BIT (0x0u << 12) /**< \brief (US_MR) 1 stop bit */
+#define   US_MR_NBSTOP_1_5_BIT (0x1u << 12) /**< \brief (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) */
+#define   US_MR_NBSTOP_2_BIT (0x2u << 12) /**< \brief (US_MR) 2 stop bits */
+#define US_MR_CHMODE_Pos 14
+#define US_MR_CHMODE_Msk (0x3u << US_MR_CHMODE_Pos) /**< \brief (US_MR) Channel Mode */
+#define   US_MR_CHMODE_NORMAL (0x0u << 14) /**< \brief (US_MR) Normal Mode */
+#define   US_MR_CHMODE_AUTOMATIC (0x1u << 14) /**< \brief (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. */
+#define   US_MR_CHMODE_LOCAL_LOOPBACK (0x2u << 14) /**< \brief (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. */
+#define   US_MR_CHMODE_REMOTE_LOOPBACK (0x3u << 14) /**< \brief (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. */
+#define US_MR_MSBF (0x1u << 16) /**< \brief (US_MR) Bit Order */
+#define US_MR_MODE9 (0x1u << 17) /**< \brief (US_MR) 9-bit Character Length */
+#define US_MR_CLKO (0x1u << 18) /**< \brief (US_MR) Clock Output Select */
+#define US_MR_OVER (0x1u << 19) /**< \brief (US_MR) Oversampling Mode */
+#define US_MR_INACK (0x1u << 20) /**< \brief (US_MR) Inhibit Non Acknowledge */
+#define US_MR_DSNACK (0x1u << 21) /**< \brief (US_MR) Disable Successive NACK */
+#define US_MR_VAR_SYNC (0x1u << 22) /**< \brief (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter */
+#define US_MR_INVDATA (0x1u << 23) /**< \brief (US_MR) Inverted Data */
+#define US_MR_MAX_ITERATION_Pos 24
+#define US_MR_MAX_ITERATION_Msk (0x7u << US_MR_MAX_ITERATION_Pos) /**< \brief (US_MR) Maximum Number of Automatic Iteration */
+#define US_MR_MAX_ITERATION(value) ((US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos)))
+#define US_MR_FILTER (0x1u << 28) /**< \brief (US_MR) Infrared Receive Line Filter */
+#define US_MR_MAN (0x1u << 29) /**< \brief (US_MR) Manchester Encoder/Decoder Enable */
+#define US_MR_MODSYNC (0x1u << 30) /**< \brief (US_MR) Manchester Synchronization Mode */
+#define US_MR_ONEBIT (0x1u << 31) /**< \brief (US_MR) Start Frame Delimiter Selector */
+#define US_MR_CPHA (0x1u << 8) /**< \brief (US_MR) SPI Clock Phase */
+#define US_MR_CPOL (0x1u << 16) /**< \brief (US_MR) SPI Clock Polarity */
+#define US_MR_WRDBT (0x1u << 20) /**< \brief (US_MR) Wait Read Data Before Transfer */
+/* -------- US_IER : (USART Offset: 0x0008) Interrupt Enable Register -------- */
+#define US_IER_RXRDY (0x1u << 0) /**< \brief (US_IER) RXRDY Interrupt Enable */
+#define US_IER_TXRDY (0x1u << 1) /**< \brief (US_IER) TXRDY Interrupt Enable */
+#define US_IER_RXBRK (0x1u << 2) /**< \brief (US_IER) Receiver Break Interrupt Enable */
+#define US_IER_ENDRX (0x1u << 3) /**< \brief (US_IER) End of Receive Transfer Interrupt Enable (available in all USART modes of operation) */
+#define US_IER_ENDTX (0x1u << 4) /**< \brief (US_IER) End of Transmit Interrupt Enable (available in all USART modes of operation) */
+#define US_IER_OVRE (0x1u << 5) /**< \brief (US_IER) Overrun Error Interrupt Enable */
+#define US_IER_FRAME (0x1u << 6) /**< \brief (US_IER) Framing Error Interrupt Enable */
+#define US_IER_PARE (0x1u << 7) /**< \brief (US_IER) Parity Error Interrupt Enable */
+#define US_IER_TIMEOUT (0x1u << 8) /**< \brief (US_IER) Time-out Interrupt Enable */
+#define US_IER_TXEMPTY (0x1u << 9) /**< \brief (US_IER) TXEMPTY Interrupt Enable */
+#define US_IER_ITER (0x1u << 10) /**< \brief (US_IER) Max number of Repetitions Reached Interrupt Enable */
+#define US_IER_TXBUFE (0x1u << 11) /**< \brief (US_IER) Buffer Empty Interrupt Enable (available in all USART modes of operation) */
+#define US_IER_RXBUFF (0x1u << 12) /**< \brief (US_IER) Buffer Full Interrupt Enable (available in all USART modes of operation) */
+#define US_IER_NACK (0x1u << 13) /**< \brief (US_IER) Non AcknowledgeInterrupt Enable */
+#define US_IER_RIIC (0x1u << 16) /**< \brief (US_IER) Ring Indicator Input Change Enable */
+#define US_IER_DSRIC (0x1u << 17) /**< \brief (US_IER) Data Set Ready Input Change Enable */
+#define US_IER_DCDIC (0x1u << 18) /**< \brief (US_IER) Data Carrier Detect Input Change Interrupt Enable */
+#define US_IER_CTSIC (0x1u << 19) /**< \brief (US_IER) Clear to Send Input Change Interrupt Enable */
+#define US_IER_MANE (0x1u << 24) /**< \brief (US_IER) Manchester Error Interrupt Enable */
+#define US_IER_UNRE (0x1u << 10) /**< \brief (US_IER) SPI Underrun Error Interrupt Enable */
+/* -------- US_IDR : (USART Offset: 0x000C) Interrupt Disable Register -------- */
+#define US_IDR_RXRDY (0x1u << 0) /**< \brief (US_IDR) RXRDY Interrupt Disable */
+#define US_IDR_TXRDY (0x1u << 1) /**< \brief (US_IDR) TXRDY Interrupt Disable */
+#define US_IDR_RXBRK (0x1u << 2) /**< \brief (US_IDR) Receiver Break Interrupt Disable */
+#define US_IDR_ENDRX (0x1u << 3) /**< \brief (US_IDR) End of Receive Transfer Interrupt Disable (available in all USART modes of operation) */
+#define US_IDR_ENDTX (0x1u << 4) /**< \brief (US_IDR) End of Transmit Interrupt Disable (available in all USART modes of operation) */
+#define US_IDR_OVRE (0x1u << 5) /**< \brief (US_IDR) Overrun Error Interrupt Enable */
+#define US_IDR_FRAME (0x1u << 6) /**< \brief (US_IDR) Framing Error Interrupt Disable */
+#define US_IDR_PARE (0x1u << 7) /**< \brief (US_IDR) Parity Error Interrupt Disable */
+#define US_IDR_TIMEOUT (0x1u << 8) /**< \brief (US_IDR) Time-out Interrupt Disable */
+#define US_IDR_TXEMPTY (0x1u << 9) /**< \brief (US_IDR) TXEMPTY Interrupt Disable */
+#define US_IDR_ITER (0x1u << 10) /**< \brief (US_IDR) Max Number of Repetitions Reached Interrupt Disable */
+#define US_IDR_TXBUFE (0x1u << 11) /**< \brief (US_IDR) Buffer Empty Interrupt Disable (available in all USART modes of operation) */
+#define US_IDR_RXBUFF (0x1u << 12) /**< \brief (US_IDR) Buffer Full Interrupt Disable (available in all USART modes of operation) */
+#define US_IDR_NACK (0x1u << 13) /**< \brief (US_IDR) Non AcknowledgeInterrupt Disable */
+#define US_IDR_RIIC (0x1u << 16) /**< \brief (US_IDR) Ring Indicator Input Change Disable */
+#define US_IDR_DSRIC (0x1u << 17) /**< \brief (US_IDR) Data Set Ready Input Change Disable */
+#define US_IDR_DCDIC (0x1u << 18) /**< \brief (US_IDR) Data Carrier Detect Input Change Interrupt Disable */
+#define US_IDR_CTSIC (0x1u << 19) /**< \brief (US_IDR) Clear to Send Input Change Interrupt Disable */
+#define US_IDR_MANE (0x1u << 24) /**< \brief (US_IDR) Manchester Error Interrupt Disable */
+#define US_IDR_UNRE (0x1u << 10) /**< \brief (US_IDR) SPI Underrun Error Interrupt Disable */
+/* -------- US_IMR : (USART Offset: 0x0010) Interrupt Mask Register -------- */
+#define US_IMR_RXRDY (0x1u << 0) /**< \brief (US_IMR) RXRDY Interrupt Mask */
+#define US_IMR_TXRDY (0x1u << 1) /**< \brief (US_IMR) TXRDY Interrupt Mask */
+#define US_IMR_RXBRK (0x1u << 2) /**< \brief (US_IMR) Receiver Break Interrupt Mask */
+#define US_IMR_ENDRX (0x1u << 3) /**< \brief (US_IMR) End of Receive Transfer Interrupt Mask (available in all USART modes of operation) */
+#define US_IMR_ENDTX (0x1u << 4) /**< \brief (US_IMR) End of Transmit Interrupt Mask (available in all USART modes of operation) */
+#define US_IMR_OVRE (0x1u << 5) /**< \brief (US_IMR) Overrun Error Interrupt Mask */
+#define US_IMR_FRAME (0x1u << 6) /**< \brief (US_IMR) Framing Error Interrupt Mask */
+#define US_IMR_PARE (0x1u << 7) /**< \brief (US_IMR) Parity Error Interrupt Mask */
+#define US_IMR_TIMEOUT (0x1u << 8) /**< \brief (US_IMR) Time-out Interrupt Mask */
+#define US_IMR_TXEMPTY (0x1u << 9) /**< \brief (US_IMR) TXEMPTY Interrupt Mask */
+#define US_IMR_ITER (0x1u << 10) /**< \brief (US_IMR) Max Number of Repetitions Reached Interrupt Mask */
+#define US_IMR_TXBUFE (0x1u << 11) /**< \brief (US_IMR) Buffer Empty Interrupt Mask (available in all USART modes of operation) */
+#define US_IMR_RXBUFF (0x1u << 12) /**< \brief (US_IMR) Buffer Full Interrupt Mask (available in all USART modes of operation) */
+#define US_IMR_NACK (0x1u << 13) /**< \brief (US_IMR) Non AcknowledgeInterrupt Mask */
+#define US_IMR_RIIC (0x1u << 16) /**< \brief (US_IMR) Ring Indicator Input Change Mask */
+#define US_IMR_DSRIC (0x1u << 17) /**< \brief (US_IMR) Data Set Ready Input Change Mask */
+#define US_IMR_DCDIC (0x1u << 18) /**< \brief (US_IMR) Data Carrier Detect Input Change Interrupt Mask */
+#define US_IMR_CTSIC (0x1u << 19) /**< \brief (US_IMR) Clear to Send Input Change Interrupt Mask */
+#define US_IMR_MANE (0x1u << 24) /**< \brief (US_IMR) Manchester Error Interrupt Mask */
+#define US_IMR_UNRE (0x1u << 10) /**< \brief (US_IMR) SPI Underrun Error Interrupt Mask */
+/* -------- US_CSR : (USART Offset: 0x0014) Channel Status Register -------- */
+#define US_CSR_RXRDY (0x1u << 0) /**< \brief (US_CSR) Receiver Ready */
+#define US_CSR_TXRDY (0x1u << 1) /**< \brief (US_CSR) Transmitter Ready */
+#define US_CSR_RXBRK (0x1u << 2) /**< \brief (US_CSR) Break Received/End of Break */
+#define US_CSR_ENDRX (0x1u << 3) /**< \brief (US_CSR) End of Receiver Transfer */
+#define US_CSR_ENDTX (0x1u << 4) /**< \brief (US_CSR) End of Transmitter Transfer */
+#define US_CSR_OVRE (0x1u << 5) /**< \brief (US_CSR) Overrun Error */
+#define US_CSR_FRAME (0x1u << 6) /**< \brief (US_CSR) Framing Error */
+#define US_CSR_PARE (0x1u << 7) /**< \brief (US_CSR) Parity Error */
+#define US_CSR_TIMEOUT (0x1u << 8) /**< \brief (US_CSR) Receiver Time-out */
+#define US_CSR_TXEMPTY (0x1u << 9) /**< \brief (US_CSR) Transmitter Empty */
+#define US_CSR_ITER (0x1u << 10) /**< \brief (US_CSR) MaxNumber of Repetitions Reached */
+#define US_CSR_TXBUFE (0x1u << 11) /**< \brief (US_CSR) Transmission Buffer Empty */
+#define US_CSR_RXBUFF (0x1u << 12) /**< \brief (US_CSR) Reception Buffer Full */
+#define US_CSR_NACK (0x1u << 13) /**< \brief (US_CSR) Non AcknowledgeInterrupt */
+#define US_CSR_RIIC (0x1u << 16) /**< \brief (US_CSR) Ring Indicator Input Change Flag */
+#define US_CSR_DSRIC (0x1u << 17) /**< \brief (US_CSR) Data Set Ready Input Change Flag */
+#define US_CSR_DCDIC (0x1u << 18) /**< \brief (US_CSR) Data Carrier Detect Input Change Flag */
+#define US_CSR_CTSIC (0x1u << 19) /**< \brief (US_CSR) Clear to Send Input Change Flag */
+#define US_CSR_RI (0x1u << 20) /**< \brief (US_CSR) Image of RI Input */
+#define US_CSR_DSR (0x1u << 21) /**< \brief (US_CSR) Image of DSR Input */
+#define US_CSR_DCD (0x1u << 22) /**< \brief (US_CSR) Image of DCD Input */
+#define US_CSR_CTS (0x1u << 23) /**< \brief (US_CSR) Image of CTS Input */
+#define US_CSR_MANERR (0x1u << 24) /**< \brief (US_CSR) Manchester Error */
+#define US_CSR_UNRE (0x1u << 10) /**< \brief (US_CSR) Underrun Error */
+/* -------- US_RHR : (USART Offset: 0x0018) Receiver Holding Register -------- */
+#define US_RHR_RXCHR_Pos 0
+#define US_RHR_RXCHR_Msk (0x1ffu << US_RHR_RXCHR_Pos) /**< \brief (US_RHR) Received Character */
+#define US_RHR_RXSYNH (0x1u << 15) /**< \brief (US_RHR) Received Sync */
+/* -------- US_THR : (USART Offset: 0x001C) Transmitter Holding Register -------- */
+#define US_THR_TXCHR_Pos 0
+#define US_THR_TXCHR_Msk (0x1ffu << US_THR_TXCHR_Pos) /**< \brief (US_THR) Character to be Transmitted */
+#define US_THR_TXCHR(value) ((US_THR_TXCHR_Msk & ((value) << US_THR_TXCHR_Pos)))
+#define US_THR_TXSYNH (0x1u << 15) /**< \brief (US_THR) Sync Field to be Transmitted */
+/* -------- US_BRGR : (USART Offset: 0x0020) Baud Rate Generator Register -------- */
+#define US_BRGR_CD_Pos 0
+#define US_BRGR_CD_Msk (0xffffu << US_BRGR_CD_Pos) /**< \brief (US_BRGR) Clock Divider */
+#define US_BRGR_CD(value) ((US_BRGR_CD_Msk & ((value) << US_BRGR_CD_Pos)))
+#define US_BRGR_FP_Pos 16
+#define US_BRGR_FP_Msk (0x7u << US_BRGR_FP_Pos) /**< \brief (US_BRGR) Fractional Part */
+#define US_BRGR_FP(value) ((US_BRGR_FP_Msk & ((value) << US_BRGR_FP_Pos)))
+/* -------- US_RTOR : (USART Offset: 0x0024) Receiver Time-out Register -------- */
+#define US_RTOR_TO_Pos 0
+#define US_RTOR_TO_Msk (0xffffu << US_RTOR_TO_Pos) /**< \brief (US_RTOR) Time-out Value */
+#define US_RTOR_TO(value) ((US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos)))
+/* -------- US_TTGR : (USART Offset: 0x0028) Transmitter Timeguard Register -------- */
+#define US_TTGR_TG_Pos 0
+#define US_TTGR_TG_Msk (0xffu << US_TTGR_TG_Pos) /**< \brief (US_TTGR) Timeguard Value */
+#define US_TTGR_TG(value) ((US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos)))
+/* -------- US_FIDI : (USART Offset: 0x0040) FI DI Ratio Register -------- */
+#define US_FIDI_FI_DI_RATIO_Pos 0
+#define US_FIDI_FI_DI_RATIO_Msk (0x7ffu << US_FIDI_FI_DI_RATIO_Pos) /**< \brief (US_FIDI) FI Over DI Ratio Value */
+#define US_FIDI_FI_DI_RATIO(value) ((US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos)))
+/* -------- US_NER : (USART Offset: 0x0044) Number of Errors Register -------- */
+#define US_NER_NB_ERRORS_Pos 0
+#define US_NER_NB_ERRORS_Msk (0xffu << US_NER_NB_ERRORS_Pos) /**< \brief (US_NER) Number of Errors */
+/* -------- US_IF : (USART Offset: 0x004C) IrDA Filter Register -------- */
+#define US_IF_IRDA_FILTER_Pos 0
+#define US_IF_IRDA_FILTER_Msk (0xffu << US_IF_IRDA_FILTER_Pos) /**< \brief (US_IF) IrDA Filter */
+#define US_IF_IRDA_FILTER(value) ((US_IF_IRDA_FILTER_Msk & ((value) << US_IF_IRDA_FILTER_Pos)))
+/* -------- US_MAN : (USART Offset: 0x0050) Manchester Encoder Decoder Register -------- */
+#define US_MAN_TX_PL_Pos 0
+#define US_MAN_TX_PL_Msk (0xfu << US_MAN_TX_PL_Pos) /**< \brief (US_MAN) Transmitter Preamble Length */
+#define US_MAN_TX_PL(value) ((US_MAN_TX_PL_Msk & ((value) << US_MAN_TX_PL_Pos)))
+#define US_MAN_TX_PP_Pos 8
+#define US_MAN_TX_PP_Msk (0x3u << US_MAN_TX_PP_Pos) /**< \brief (US_MAN) Transmitter Preamble Pattern */
+#define   US_MAN_TX_PP_ALL_ONE (0x0u << 8) /**< \brief (US_MAN) The preamble is composed of '1's */
+#define   US_MAN_TX_PP_ALL_ZERO (0x1u << 8) /**< \brief (US_MAN) The preamble is composed of '0's */
+#define   US_MAN_TX_PP_ZERO_ONE (0x2u << 8) /**< \brief (US_MAN) The preamble is composed of '01's */
+#define   US_MAN_TX_PP_ONE_ZERO (0x3u << 8) /**< \brief (US_MAN) The preamble is composed of '10's */
+#define US_MAN_TX_MPOL (0x1u << 12) /**< \brief (US_MAN) Transmitter Manchester Polarity */
+#define US_MAN_RX_PL_Pos 16
+#define US_MAN_RX_PL_Msk (0xfu << US_MAN_RX_PL_Pos) /**< \brief (US_MAN) Receiver Preamble Length */
+#define US_MAN_RX_PL(value) ((US_MAN_RX_PL_Msk & ((value) << US_MAN_RX_PL_Pos)))
+#define US_MAN_RX_PP_Pos 24
+#define US_MAN_RX_PP_Msk (0x3u << US_MAN_RX_PP_Pos) /**< \brief (US_MAN) Receiver Preamble Pattern detected */
+#define   US_MAN_RX_PP_ALL_ONE (0x0u << 24) /**< \brief (US_MAN) The preamble is composed of '1's */
+#define   US_MAN_RX_PP_ALL_ZERO (0x1u << 24) /**< \brief (US_MAN) The preamble is composed of '0's */
+#define   US_MAN_RX_PP_ZERO_ONE (0x2u << 24) /**< \brief (US_MAN) The preamble is composed of '01's */
+#define   US_MAN_RX_PP_ONE_ZERO (0x3u << 24) /**< \brief (US_MAN) The preamble is composed of '10's */
+#define US_MAN_RX_MPOL (0x1u << 28) /**< \brief (US_MAN) Receiver Manchester Polarity */
+#define US_MAN_ONE (0x1u << 29) /**< \brief (US_MAN) Must Be Set to 1 */
+#define US_MAN_DRIFT (0x1u << 30) /**< \brief (US_MAN) Drift Compensation */
+/* -------- US_WPMR : (USART Offset: 0xE4) Write Protect Mode Register -------- */
+#define US_WPMR_WPEN (0x1u << 0) /**< \brief (US_WPMR) Write Protect Enable */
+#define US_WPMR_WPKEY_Pos 8
+#define US_WPMR_WPKEY_Msk (0xffffffu << US_WPMR_WPKEY_Pos) /**< \brief (US_WPMR) Write Protect KEY */
+#define US_WPMR_WPKEY(value) ((US_WPMR_WPKEY_Msk & ((value) << US_WPMR_WPKEY_Pos)))
+/* -------- US_WPSR : (USART Offset: 0xE8) Write Protect Status Register -------- */
+#define US_WPSR_WPVS (0x1u << 0) /**< \brief (US_WPSR) Write Protect Violation Status */
+#define US_WPSR_WPVSRC_Pos 8
+#define US_WPSR_WPVSRC_Msk (0xffffu << US_WPSR_WPVSRC_Pos) /**< \brief (US_WPSR) Write Protect Violation Source */
+/* -------- US_RPR : (USART Offset: 0x100) Receive Pointer Register -------- */
+#define US_RPR_RXPTR_Pos 0
+#define US_RPR_RXPTR_Msk (0xffffffffu << US_RPR_RXPTR_Pos) /**< \brief (US_RPR) Receive Pointer Register */
+#define US_RPR_RXPTR(value) ((US_RPR_RXPTR_Msk & ((value) << US_RPR_RXPTR_Pos)))
+/* -------- US_RCR : (USART Offset: 0x104) Receive Counter Register -------- */
+#define US_RCR_RXCTR_Pos 0
+#define US_RCR_RXCTR_Msk (0xffffu << US_RCR_RXCTR_Pos) /**< \brief (US_RCR) Receive Counter Register */
+#define US_RCR_RXCTR(value) ((US_RCR_RXCTR_Msk & ((value) << US_RCR_RXCTR_Pos)))
+/* -------- US_TPR : (USART Offset: 0x108) Transmit Pointer Register -------- */
+#define US_TPR_TXPTR_Pos 0
+#define US_TPR_TXPTR_Msk (0xffffffffu << US_TPR_TXPTR_Pos) /**< \brief (US_TPR) Transmit Counter Register */
+#define US_TPR_TXPTR(value) ((US_TPR_TXPTR_Msk & ((value) << US_TPR_TXPTR_Pos)))
+/* -------- US_TCR : (USART Offset: 0x10C) Transmit Counter Register -------- */
+#define US_TCR_TXCTR_Pos 0
+#define US_TCR_TXCTR_Msk (0xffffu << US_TCR_TXCTR_Pos) /**< \brief (US_TCR) Transmit Counter Register */
+#define US_TCR_TXCTR(value) ((US_TCR_TXCTR_Msk & ((value) << US_TCR_TXCTR_Pos)))
+/* -------- US_RNPR : (USART Offset: 0x110) Receive Next Pointer Register -------- */
+#define US_RNPR_RXNPTR_Pos 0
+#define US_RNPR_RXNPTR_Msk (0xffffffffu << US_RNPR_RXNPTR_Pos) /**< \brief (US_RNPR) Receive Next Pointer */
+#define US_RNPR_RXNPTR(value) ((US_RNPR_RXNPTR_Msk & ((value) << US_RNPR_RXNPTR_Pos)))
+/* -------- US_RNCR : (USART Offset: 0x114) Receive Next Counter Register -------- */
+#define US_RNCR_RXNCTR_Pos 0
+#define US_RNCR_RXNCTR_Msk (0xffffu << US_RNCR_RXNCTR_Pos) /**< \brief (US_RNCR) Receive Next Counter */
+#define US_RNCR_RXNCTR(value) ((US_RNCR_RXNCTR_Msk & ((value) << US_RNCR_RXNCTR_Pos)))
+/* -------- US_TNPR : (USART Offset: 0x118) Transmit Next Pointer Register -------- */
+#define US_TNPR_TXNPTR_Pos 0
+#define US_TNPR_TXNPTR_Msk (0xffffffffu << US_TNPR_TXNPTR_Pos) /**< \brief (US_TNPR) Transmit Next Pointer */
+#define US_TNPR_TXNPTR(value) ((US_TNPR_TXNPTR_Msk & ((value) << US_TNPR_TXNPTR_Pos)))
+/* -------- US_TNCR : (USART Offset: 0x11C) Transmit Next Counter Register -------- */
+#define US_TNCR_TXNCTR_Pos 0
+#define US_TNCR_TXNCTR_Msk (0xffffu << US_TNCR_TXNCTR_Pos) /**< \brief (US_TNCR) Transmit Counter Next */
+#define US_TNCR_TXNCTR(value) ((US_TNCR_TXNCTR_Msk & ((value) << US_TNCR_TXNCTR_Pos)))
+/* -------- US_PTCR : (USART Offset: 0x120) Transfer Control Register -------- */
+#define US_PTCR_RXTEN (0x1u << 0) /**< \brief (US_PTCR) Receiver Transfer Enable */
+#define US_PTCR_RXTDIS (0x1u << 1) /**< \brief (US_PTCR) Receiver Transfer Disable */
+#define US_PTCR_TXTEN (0x1u << 8) /**< \brief (US_PTCR) Transmitter Transfer Enable */
+#define US_PTCR_TXTDIS (0x1u << 9) /**< \brief (US_PTCR) Transmitter Transfer Disable */
+/* -------- US_PTSR : (USART Offset: 0x124) Transfer Status Register -------- */
+#define US_PTSR_RXTEN (0x1u << 0) /**< \brief (US_PTSR) Receiver Transfer Enable */
+#define US_PTSR_TXTEN (0x1u << 8) /**< \brief (US_PTSR) Transmitter Transfer Enable */
+
+/*@}*/
+
+
+#endif /* _SAM4E_USART_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/wdt.h
+++ b/asf/sam/include/sam4e/component/wdt.h
@@ -1,0 +1,72 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_WDT_COMPONENT_
+#define _SAM4E_WDT_COMPONENT_
+
+/* ============================================================================= */
+/**  SOFTWARE API DEFINITION FOR Watchdog Timer */
+/* ============================================================================= */
+/** \addtogroup SAM4E_WDT Watchdog Timer */
+/*@{*/
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/** \brief Wdt hardware registers */
+typedef struct {
+  WoReg WDT_CR; /**< \brief (Wdt Offset: 0x00) Control Register */
+  RwReg WDT_MR; /**< \brief (Wdt Offset: 0x04) Mode Register */
+  RoReg WDT_SR; /**< \brief (Wdt Offset: 0x08) Status Register */
+} Wdt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/* -------- WDT_CR : (WDT Offset: 0x00) Control Register -------- */
+#define WDT_CR_WDRSTT (0x1u << 0) /**< \brief (WDT_CR) Watchdog Restart */
+#define WDT_CR_KEY_Pos 24
+#define WDT_CR_KEY_Msk (0xffu << WDT_CR_KEY_Pos) /**< \brief (WDT_CR) Password */
+#define WDT_CR_KEY(value) ((WDT_CR_KEY_Msk & ((value) << WDT_CR_KEY_Pos)))
+/* -------- WDT_MR : (WDT Offset: 0x04) Mode Register -------- */
+#define WDT_MR_WDV_Pos 0
+#define WDT_MR_WDV_Msk (0xfffu << WDT_MR_WDV_Pos) /**< \brief (WDT_MR) Watchdog Counter Value */
+#define WDT_MR_WDV(value) ((WDT_MR_WDV_Msk & ((value) << WDT_MR_WDV_Pos)))
+#define WDT_MR_WDFIEN (0x1u << 12) /**< \brief (WDT_MR) Watchdog Fault Interrupt Enable */
+#define WDT_MR_WDRSTEN (0x1u << 13) /**< \brief (WDT_MR) Watchdog Reset Enable */
+#define WDT_MR_WDRPROC (0x1u << 14) /**< \brief (WDT_MR) Watchdog Reset Processor */
+#define WDT_MR_WDDIS (0x1u << 15) /**< \brief (WDT_MR) Watchdog Disable */
+#define WDT_MR_WDD_Pos 16
+#define WDT_MR_WDD_Msk (0xfffu << WDT_MR_WDD_Pos) /**< \brief (WDT_MR) Watchdog Delta Value */
+#define WDT_MR_WDD(value) ((WDT_MR_WDD_Msk & ((value) << WDT_MR_WDD_Pos)))
+#define WDT_MR_WDDBGHLT (0x1u << 28) /**< \brief (WDT_MR) Watchdog Debug Halt */
+#define WDT_MR_WDIDLEHLT (0x1u << 29) /**< \brief (WDT_MR) Watchdog Idle Halt */
+/* -------- WDT_SR : (WDT Offset: 0x08) Status Register -------- */
+#define WDT_SR_WDUNF (0x1u << 0) /**< \brief (WDT_SR) Watchdog Underflow */
+#define WDT_SR_WDERR (0x1u << 1) /**< \brief (WDT_SR) Watchdog Error */
+
+/*@}*/
+
+
+#endif /* _SAM4E_WDT_COMPONENT_ */

--- a/asf/sam/include/sam4e/component/wdt.h
+++ b/asf/sam/include/sam4e/component/wdt.h
@@ -49,6 +49,7 @@ typedef struct {
 #define WDT_CR_KEY_Pos 24
 #define WDT_CR_KEY_Msk (0xffu << WDT_CR_KEY_Pos) /**< \brief (WDT_CR) Password */
 #define WDT_CR_KEY(value) ((WDT_CR_KEY_Msk & ((value) << WDT_CR_KEY_Pos)))
+#define   WDT_CR_KEY_PASSWD (0xA5u << 24) /**< \brief (WDT_CR) Writing any other value in this field aborts the write operation. */
 /* -------- WDT_MR : (WDT Offset: 0x04) Mode Register -------- */
 #define WDT_MR_WDV_Pos 0
 #define WDT_MR_WDV_Msk (0xfffu << WDT_MR_WDV_Pos) /**< \brief (WDT_MR) Watchdog Counter Value */

--- a/asf/sam/include/sam4e/instance/acc.h
+++ b/asf/sam/include/sam4e/instance/acc.h
@@ -1,0 +1,56 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_ACC_INSTANCE_
+#define _SAM4E_ACC_INSTANCE_
+
+/* ========== Register definition for ACC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ACC_CR            (0x400BC000U) /**< \brief (ACC) Control Register */
+#define REG_ACC_MR            (0x400BC004U) /**< \brief (ACC) Mode Register */
+#define REG_ACC_IER           (0x400BC024U) /**< \brief (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR           (0x400BC028U) /**< \brief (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR           (0x400BC02CU) /**< \brief (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR           (0x400BC030U) /**< \brief (ACC) Interrupt Status Register */
+#define REG_ACC_ACR           (0x400BC094U) /**< \brief (ACC) Analog Control Register */
+#define REG_ACC_WPMR          (0x400BC0E4U) /**< \brief (ACC) Write Protect Mode Register */
+#define REG_ACC_WPSR          (0x400BC0E8U) /**< \brief (ACC) Write Protect Status Register */
+#else
+#define REG_ACC_CR   (*(WoReg*)0x400BC000U) /**< \brief (ACC) Control Register */
+#define REG_ACC_MR   (*(RwReg*)0x400BC004U) /**< \brief (ACC) Mode Register */
+#define REG_ACC_IER  (*(WoReg*)0x400BC024U) /**< \brief (ACC) Interrupt Enable Register */
+#define REG_ACC_IDR  (*(WoReg*)0x400BC028U) /**< \brief (ACC) Interrupt Disable Register */
+#define REG_ACC_IMR  (*(RoReg*)0x400BC02CU) /**< \brief (ACC) Interrupt Mask Register */
+#define REG_ACC_ISR  (*(RoReg*)0x400BC030U) /**< \brief (ACC) Interrupt Status Register */
+#define REG_ACC_ACR  (*(RwReg*)0x400BC094U) /**< \brief (ACC) Analog Control Register */
+#define REG_ACC_WPMR (*(RwReg*)0x400BC0E4U) /**< \brief (ACC) Write Protect Mode Register */
+#define REG_ACC_WPSR (*(RoReg*)0x400BC0E8U) /**< \brief (ACC) Write Protect Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_ACC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/aes.h
+++ b/asf/sam/include/sam4e/instance/aes.h
@@ -1,0 +1,58 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_AES_INSTANCE_
+#define _SAM4E_AES_INSTANCE_
+
+/* ========== Register definition for AES peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AES_CR                 (0x40004000U) /**< \brief (AES) Control Register */
+#define REG_AES_MR                 (0x40004004U) /**< \brief (AES) Mode Register */
+#define REG_AES_IER                (0x40004010U) /**< \brief (AES) Interrupt Enable Register */
+#define REG_AES_IDR                (0x40004014U) /**< \brief (AES) Interrupt Disable Register */
+#define REG_AES_IMR                (0x40004018U) /**< \brief (AES) Interrupt Mask Register */
+#define REG_AES_ISR                (0x4000401CU) /**< \brief (AES) Interrupt Status Register */
+#define REG_AES_KEYWR              (0x40004020U) /**< \brief (AES) Key Word Register */
+#define REG_AES_IDATAR             (0x40004040U) /**< \brief (AES) Input Data Register */
+#define REG_AES_ODATAR             (0x40004050U) /**< \brief (AES) Output Data Register */
+#define REG_AES_IVR                (0x40004060U) /**< \brief (AES) Initialization Vector Register */
+#else
+#define REG_AES_CR        (*(WoReg*)0x40004000U) /**< \brief (AES) Control Register */
+#define REG_AES_MR        (*(RwReg*)0x40004004U) /**< \brief (AES) Mode Register */
+#define REG_AES_IER       (*(WoReg*)0x40004010U) /**< \brief (AES) Interrupt Enable Register */
+#define REG_AES_IDR       (*(WoReg*)0x40004014U) /**< \brief (AES) Interrupt Disable Register */
+#define REG_AES_IMR       (*(RoReg*)0x40004018U) /**< \brief (AES) Interrupt Mask Register */
+#define REG_AES_ISR       (*(RoReg*)0x4000401CU) /**< \brief (AES) Interrupt Status Register */
+#define REG_AES_KEYWR     (*(WoReg*)0x40004020U) /**< \brief (AES) Key Word Register */
+#define REG_AES_IDATAR    (*(WoReg*)0x40004040U) /**< \brief (AES) Input Data Register */
+#define REG_AES_ODATAR    (*(RoReg*)0x40004050U) /**< \brief (AES) Output Data Register */
+#define REG_AES_IVR       (*(WoReg*)0x40004060U) /**< \brief (AES) Initialization Vector Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_AES_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/afec0.h
+++ b/asf/sam/include/sam4e/instance/afec0.h
@@ -1,0 +1,102 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_AFEC0_INSTANCE_
+#define _SAM4E_AFEC0_INSTANCE_
+
+/* ========== Register definition for AFEC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AFEC0_CR              (0x400B0000U) /**< \brief (AFEC0) Control Register */
+#define REG_AFEC0_MR              (0x400B0004U) /**< \brief (AFEC0) Mode Register */
+#define REG_AFEC0_EMR             (0x400B0008U) /**< \brief (AFEC0) Extended Mode Register */
+#define REG_AFEC0_SEQ1R           (0x400B000CU) /**< \brief (AFEC0) Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R           (0x400B0010U) /**< \brief (AFEC0) Channel Sequence 2 Register */
+#define REG_AFEC0_CHER            (0x400B0014U) /**< \brief (AFEC0) Channel Enable Register */
+#define REG_AFEC0_CHDR            (0x400B0018U) /**< \brief (AFEC0) Channel Disable Register */
+#define REG_AFEC0_CHSR            (0x400B001CU) /**< \brief (AFEC0) Channel Status Register */
+#define REG_AFEC0_LCDR            (0x400B0020U) /**< \brief (AFEC0) Last Converted Data Register */
+#define REG_AFEC0_IER             (0x400B0024U) /**< \brief (AFEC0) Interrupt Enable Register */
+#define REG_AFEC0_IDR             (0x400B0028U) /**< \brief (AFEC0) Interrupt Disable Register */
+#define REG_AFEC0_IMR             (0x400B002CU) /**< \brief (AFEC0) Interrupt Mask Register */
+#define REG_AFEC0_ISR             (0x400B0030U) /**< \brief (AFEC0) Interrupt Status Register */
+#define REG_AFEC0_OVER            (0x400B004CU) /**< \brief (AFEC0) Overrun Status Register */
+#define REG_AFEC0_CWR             (0x400B0050U) /**< \brief (AFEC0) Compare Window Register */
+#define REG_AFEC0_CGR             (0x400B0054U) /**< \brief (AFEC0) Channel Gain Register */
+#define REG_AFEC0_CDOR            (0x400B005CU) /**< \brief (AFEC0) Channel DC Offset Register */
+#define REG_AFEC0_DIFFR           (0x400B0060U) /**< \brief (AFEC0) Channel Differential Register */
+#define REG_AFEC0_CSELR           (0x400B0064U) /**< \brief (AFEC0) Channel Register Selection */
+#define REG_AFEC0_CDR             (0x400B0068U) /**< \brief (AFEC0) Channel Data Register */
+#define REG_AFEC0_COCR            (0x400B006CU) /**< \brief (AFEC0) Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR          (0x400B0070U) /**< \brief (AFEC0) Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR          (0x400B0074U) /**< \brief (AFEC0) Temperature Compare Window Register */
+#define REG_AFEC0_ACR             (0x400B0094U) /**< \brief (AFEC0) Analog Control Register */
+#define REG_AFEC0_WPMR            (0x400B00E4U) /**< \brief (AFEC0) Write Protect Mode Register */
+#define REG_AFEC0_WPSR            (0x400B00E8U) /**< \brief (AFEC0) Write Protect Status Register */
+#define REG_AFEC0_RPR             (0x400B0100U) /**< \brief (AFEC0) Receive Pointer Register */
+#define REG_AFEC0_RCR             (0x400B0104U) /**< \brief (AFEC0) Receive Counter Register */
+#define REG_AFEC0_RNPR            (0x400B0110U) /**< \brief (AFEC0) Receive Next Pointer Register */
+#define REG_AFEC0_RNCR            (0x400B0114U) /**< \brief (AFEC0) Receive Next Counter Register */
+#define REG_AFEC0_PTCR            (0x400B0120U) /**< \brief (AFEC0) Transfer Control Register */
+#define REG_AFEC0_PTSR            (0x400B0124U) /**< \brief (AFEC0) Transfer Status Register */
+#else
+#define REG_AFEC0_CR     (*(WoReg*)0x400B0000U) /**< \brief (AFEC0) Control Register */
+#define REG_AFEC0_MR     (*(RwReg*)0x400B0004U) /**< \brief (AFEC0) Mode Register */
+#define REG_AFEC0_EMR    (*(RwReg*)0x400B0008U) /**< \brief (AFEC0) Extended Mode Register */
+#define REG_AFEC0_SEQ1R  (*(RwReg*)0x400B000CU) /**< \brief (AFEC0) Channel Sequence 1 Register */
+#define REG_AFEC0_SEQ2R  (*(RwReg*)0x400B0010U) /**< \brief (AFEC0) Channel Sequence 2 Register */
+#define REG_AFEC0_CHER   (*(WoReg*)0x400B0014U) /**< \brief (AFEC0) Channel Enable Register */
+#define REG_AFEC0_CHDR   (*(WoReg*)0x400B0018U) /**< \brief (AFEC0) Channel Disable Register */
+#define REG_AFEC0_CHSR   (*(RoReg*)0x400B001CU) /**< \brief (AFEC0) Channel Status Register */
+#define REG_AFEC0_LCDR   (*(RoReg*)0x400B0020U) /**< \brief (AFEC0) Last Converted Data Register */
+#define REG_AFEC0_IER    (*(WoReg*)0x400B0024U) /**< \brief (AFEC0) Interrupt Enable Register */
+#define REG_AFEC0_IDR    (*(WoReg*)0x400B0028U) /**< \brief (AFEC0) Interrupt Disable Register */
+#define REG_AFEC0_IMR    (*(RoReg*)0x400B002CU) /**< \brief (AFEC0) Interrupt Mask Register */
+#define REG_AFEC0_ISR    (*(RoReg*)0x400B0030U) /**< \brief (AFEC0) Interrupt Status Register */
+#define REG_AFEC0_OVER   (*(RoReg*)0x400B004CU) /**< \brief (AFEC0) Overrun Status Register */
+#define REG_AFEC0_CWR    (*(RwReg*)0x400B0050U) /**< \brief (AFEC0) Compare Window Register */
+#define REG_AFEC0_CGR    (*(RwReg*)0x400B0054U) /**< \brief (AFEC0) Channel Gain Register */
+#define REG_AFEC0_CDOR   (*(RwReg*)0x400B005CU) /**< \brief (AFEC0) Channel DC Offset Register */
+#define REG_AFEC0_DIFFR  (*(RwReg*)0x400B0060U) /**< \brief (AFEC0) Channel Differential Register */
+#define REG_AFEC0_CSELR  (*(RoReg*)0x400B0064U) /**< \brief (AFEC0) Channel Register Selection */
+#define REG_AFEC0_CDR    (*(RoReg*)0x400B0068U) /**< \brief (AFEC0) Channel Data Register */
+#define REG_AFEC0_COCR   (*(RoReg*)0x400B006CU) /**< \brief (AFEC0) Channel Offset Compensation Register */
+#define REG_AFEC0_TEMPMR (*(RwReg*)0x400B0070U) /**< \brief (AFEC0) Temperature Sensor Mode Register */
+#define REG_AFEC0_TEMPCWR (*(RwReg*)0x400B0074U) /**< \brief (AFEC0) Temperature Compare Window Register */
+#define REG_AFEC0_ACR    (*(RwReg*)0x400B0094U) /**< \brief (AFEC0) Analog Control Register */
+#define REG_AFEC0_WPMR   (*(RwReg*)0x400B00E4U) /**< \brief (AFEC0) Write Protect Mode Register */
+#define REG_AFEC0_WPSR   (*(RoReg*)0x400B00E8U) /**< \brief (AFEC0) Write Protect Status Register */
+#define REG_AFEC0_RPR    (*(RwReg*)0x400B0100U) /**< \brief (AFEC0) Receive Pointer Register */
+#define REG_AFEC0_RCR    (*(RwReg*)0x400B0104U) /**< \brief (AFEC0) Receive Counter Register */
+#define REG_AFEC0_RNPR   (*(RwReg*)0x400B0110U) /**< \brief (AFEC0) Receive Next Pointer Register */
+#define REG_AFEC0_RNCR   (*(RwReg*)0x400B0114U) /**< \brief (AFEC0) Receive Next Counter Register */
+#define REG_AFEC0_PTCR   (*(WoReg*)0x400B0120U) /**< \brief (AFEC0) Transfer Control Register */
+#define REG_AFEC0_PTSR   (*(RoReg*)0x400B0124U) /**< \brief (AFEC0) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_AFEC0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/afec1.h
+++ b/asf/sam/include/sam4e/instance/afec1.h
@@ -1,0 +1,102 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_AFEC1_INSTANCE_
+#define _SAM4E_AFEC1_INSTANCE_
+
+/* ========== Register definition for AFEC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AFEC1_CR              (0x400B4000U) /**< \brief (AFEC1) Control Register */
+#define REG_AFEC1_MR              (0x400B4004U) /**< \brief (AFEC1) Mode Register */
+#define REG_AFEC1_EMR             (0x400B4008U) /**< \brief (AFEC1) Extended Mode Register */
+#define REG_AFEC1_SEQ1R           (0x400B400CU) /**< \brief (AFEC1) Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R           (0x400B4010U) /**< \brief (AFEC1) Channel Sequence 2 Register */
+#define REG_AFEC1_CHER            (0x400B4014U) /**< \brief (AFEC1) Channel Enable Register */
+#define REG_AFEC1_CHDR            (0x400B4018U) /**< \brief (AFEC1) Channel Disable Register */
+#define REG_AFEC1_CHSR            (0x400B401CU) /**< \brief (AFEC1) Channel Status Register */
+#define REG_AFEC1_LCDR            (0x400B4020U) /**< \brief (AFEC1) Last Converted Data Register */
+#define REG_AFEC1_IER             (0x400B4024U) /**< \brief (AFEC1) Interrupt Enable Register */
+#define REG_AFEC1_IDR             (0x400B4028U) /**< \brief (AFEC1) Interrupt Disable Register */
+#define REG_AFEC1_IMR             (0x400B402CU) /**< \brief (AFEC1) Interrupt Mask Register */
+#define REG_AFEC1_ISR             (0x400B4030U) /**< \brief (AFEC1) Interrupt Status Register */
+#define REG_AFEC1_OVER            (0x400B404CU) /**< \brief (AFEC1) Overrun Status Register */
+#define REG_AFEC1_CWR             (0x400B4050U) /**< \brief (AFEC1) Compare Window Register */
+#define REG_AFEC1_CGR             (0x400B4054U) /**< \brief (AFEC1) Channel Gain Register */
+#define REG_AFEC1_CDOR            (0x400B405CU) /**< \brief (AFEC1) Channel DC Offset Register */
+#define REG_AFEC1_DIFFR           (0x400B4060U) /**< \brief (AFEC1) Channel Differential Register */
+#define REG_AFEC1_CSELR           (0x400B4064U) /**< \brief (AFEC1) Channel Register Selection */
+#define REG_AFEC1_CDR             (0x400B4068U) /**< \brief (AFEC1) Channel Data Register */
+#define REG_AFEC1_COCR            (0x400B406CU) /**< \brief (AFEC1) Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR          (0x400B4070U) /**< \brief (AFEC1) Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR          (0x400B4074U) /**< \brief (AFEC1) Temperature Compare Window Register */
+#define REG_AFEC1_ACR             (0x400B4094U) /**< \brief (AFEC1) Analog Control Register */
+#define REG_AFEC1_WPMR            (0x400B40E4U) /**< \brief (AFEC1) Write Protect Mode Register */
+#define REG_AFEC1_WPSR            (0x400B40E8U) /**< \brief (AFEC1) Write Protect Status Register */
+#define REG_AFEC1_RPR             (0x400B4100U) /**< \brief (AFEC1) Receive Pointer Register */
+#define REG_AFEC1_RCR             (0x400B4104U) /**< \brief (AFEC1) Receive Counter Register */
+#define REG_AFEC1_RNPR            (0x400B4110U) /**< \brief (AFEC1) Receive Next Pointer Register */
+#define REG_AFEC1_RNCR            (0x400B4114U) /**< \brief (AFEC1) Receive Next Counter Register */
+#define REG_AFEC1_PTCR            (0x400B4120U) /**< \brief (AFEC1) Transfer Control Register */
+#define REG_AFEC1_PTSR            (0x400B4124U) /**< \brief (AFEC1) Transfer Status Register */
+#else
+#define REG_AFEC1_CR     (*(WoReg*)0x400B4000U) /**< \brief (AFEC1) Control Register */
+#define REG_AFEC1_MR     (*(RwReg*)0x400B4004U) /**< \brief (AFEC1) Mode Register */
+#define REG_AFEC1_EMR    (*(RwReg*)0x400B4008U) /**< \brief (AFEC1) Extended Mode Register */
+#define REG_AFEC1_SEQ1R  (*(RwReg*)0x400B400CU) /**< \brief (AFEC1) Channel Sequence 1 Register */
+#define REG_AFEC1_SEQ2R  (*(RwReg*)0x400B4010U) /**< \brief (AFEC1) Channel Sequence 2 Register */
+#define REG_AFEC1_CHER   (*(WoReg*)0x400B4014U) /**< \brief (AFEC1) Channel Enable Register */
+#define REG_AFEC1_CHDR   (*(WoReg*)0x400B4018U) /**< \brief (AFEC1) Channel Disable Register */
+#define REG_AFEC1_CHSR   (*(RoReg*)0x400B401CU) /**< \brief (AFEC1) Channel Status Register */
+#define REG_AFEC1_LCDR   (*(RoReg*)0x400B4020U) /**< \brief (AFEC1) Last Converted Data Register */
+#define REG_AFEC1_IER    (*(WoReg*)0x400B4024U) /**< \brief (AFEC1) Interrupt Enable Register */
+#define REG_AFEC1_IDR    (*(WoReg*)0x400B4028U) /**< \brief (AFEC1) Interrupt Disable Register */
+#define REG_AFEC1_IMR    (*(RoReg*)0x400B402CU) /**< \brief (AFEC1) Interrupt Mask Register */
+#define REG_AFEC1_ISR    (*(RoReg*)0x400B4030U) /**< \brief (AFEC1) Interrupt Status Register */
+#define REG_AFEC1_OVER   (*(RoReg*)0x400B404CU) /**< \brief (AFEC1) Overrun Status Register */
+#define REG_AFEC1_CWR    (*(RwReg*)0x400B4050U) /**< \brief (AFEC1) Compare Window Register */
+#define REG_AFEC1_CGR    (*(RwReg*)0x400B4054U) /**< \brief (AFEC1) Channel Gain Register */
+#define REG_AFEC1_CDOR   (*(RwReg*)0x400B405CU) /**< \brief (AFEC1) Channel DC Offset Register */
+#define REG_AFEC1_DIFFR  (*(RwReg*)0x400B4060U) /**< \brief (AFEC1) Channel Differential Register */
+#define REG_AFEC1_CSELR  (*(RoReg*)0x400B4064U) /**< \brief (AFEC1) Channel Register Selection */
+#define REG_AFEC1_CDR    (*(RoReg*)0x400B4068U) /**< \brief (AFEC1) Channel Data Register */
+#define REG_AFEC1_COCR   (*(RoReg*)0x400B406CU) /**< \brief (AFEC1) Channel Offset Compensation Register */
+#define REG_AFEC1_TEMPMR (*(RwReg*)0x400B4070U) /**< \brief (AFEC1) Temperature Sensor Mode Register */
+#define REG_AFEC1_TEMPCWR (*(RwReg*)0x400B4074U) /**< \brief (AFEC1) Temperature Compare Window Register */
+#define REG_AFEC1_ACR    (*(RwReg*)0x400B4094U) /**< \brief (AFEC1) Analog Control Register */
+#define REG_AFEC1_WPMR   (*(RwReg*)0x400B40E4U) /**< \brief (AFEC1) Write Protect Mode Register */
+#define REG_AFEC1_WPSR   (*(RoReg*)0x400B40E8U) /**< \brief (AFEC1) Write Protect Status Register */
+#define REG_AFEC1_RPR    (*(RwReg*)0x400B4100U) /**< \brief (AFEC1) Receive Pointer Register */
+#define REG_AFEC1_RCR    (*(RwReg*)0x400B4104U) /**< \brief (AFEC1) Receive Counter Register */
+#define REG_AFEC1_RNPR   (*(RwReg*)0x400B4110U) /**< \brief (AFEC1) Receive Next Pointer Register */
+#define REG_AFEC1_RNCR   (*(RwReg*)0x400B4114U) /**< \brief (AFEC1) Receive Next Counter Register */
+#define REG_AFEC1_PTCR   (*(WoReg*)0x400B4120U) /**< \brief (AFEC1) Transfer Control Register */
+#define REG_AFEC1_PTSR   (*(RoReg*)0x400B4124U) /**< \brief (AFEC1) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_AFEC1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/can0.h
+++ b/asf/sam/include/sam4e/instance/can0.h
@@ -1,0 +1,192 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CAN0_INSTANCE_
+#define _SAM4E_CAN0_INSTANCE_
+
+/* ========== Register definition for CAN0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CAN0_MR               (0x40010000U) /**< \brief (CAN0) Mode Register */
+#define REG_CAN0_IER              (0x40010004U) /**< \brief (CAN0) Interrupt Enable Register */
+#define REG_CAN0_IDR              (0x40010008U) /**< \brief (CAN0) Interrupt Disable Register */
+#define REG_CAN0_IMR              (0x4001000CU) /**< \brief (CAN0) Interrupt Mask Register */
+#define REG_CAN0_SR               (0x40010010U) /**< \brief (CAN0) Status Register */
+#define REG_CAN0_BR               (0x40010014U) /**< \brief (CAN0) Baudrate Register */
+#define REG_CAN0_TIM              (0x40010018U) /**< \brief (CAN0) Timer Register */
+#define REG_CAN0_TIMESTP          (0x4001001CU) /**< \brief (CAN0) Timestamp Register */
+#define REG_CAN0_ECR              (0x40010020U) /**< \brief (CAN0) Error Counter Register */
+#define REG_CAN0_TCR              (0x40010024U) /**< \brief (CAN0) Transfer Command Register */
+#define REG_CAN0_ACR              (0x40010028U) /**< \brief (CAN0) Abort Command Register */
+#define REG_CAN0_WPMR             (0x400100E4U) /**< \brief (CAN0) Write Protect Mode Register */
+#define REG_CAN0_WPSR             (0x400100E8U) /**< \brief (CAN0) Write Protect Status Register */
+#define REG_CAN0_MMR0             (0x40010200U) /**< \brief (CAN0) Mailbox Mode Register (MB = 0) */
+#define REG_CAN0_MAM0             (0x40010204U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 0) */
+#define REG_CAN0_MID0             (0x40010208U) /**< \brief (CAN0) Mailbox ID Register (MB = 0) */
+#define REG_CAN0_MFID0            (0x4001020CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 0) */
+#define REG_CAN0_MSR0             (0x40010210U) /**< \brief (CAN0) Mailbox Status Register (MB = 0) */
+#define REG_CAN0_MDL0             (0x40010214U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 0) */
+#define REG_CAN0_MDH0             (0x40010218U) /**< \brief (CAN0) Mailbox Data High Register (MB = 0) */
+#define REG_CAN0_MCR0             (0x4001021CU) /**< \brief (CAN0) Mailbox Control Register (MB = 0) */
+#define REG_CAN0_MMR1             (0x40010220U) /**< \brief (CAN0) Mailbox Mode Register (MB = 1) */
+#define REG_CAN0_MAM1             (0x40010224U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 1) */
+#define REG_CAN0_MID1             (0x40010228U) /**< \brief (CAN0) Mailbox ID Register (MB = 1) */
+#define REG_CAN0_MFID1            (0x4001022CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 1) */
+#define REG_CAN0_MSR1             (0x40010230U) /**< \brief (CAN0) Mailbox Status Register (MB = 1) */
+#define REG_CAN0_MDL1             (0x40010234U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 1) */
+#define REG_CAN0_MDH1             (0x40010238U) /**< \brief (CAN0) Mailbox Data High Register (MB = 1) */
+#define REG_CAN0_MCR1             (0x4001023CU) /**< \brief (CAN0) Mailbox Control Register (MB = 1) */
+#define REG_CAN0_MMR2             (0x40010240U) /**< \brief (CAN0) Mailbox Mode Register (MB = 2) */
+#define REG_CAN0_MAM2             (0x40010244U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 2) */
+#define REG_CAN0_MID2             (0x40010248U) /**< \brief (CAN0) Mailbox ID Register (MB = 2) */
+#define REG_CAN0_MFID2            (0x4001024CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 2) */
+#define REG_CAN0_MSR2             (0x40010250U) /**< \brief (CAN0) Mailbox Status Register (MB = 2) */
+#define REG_CAN0_MDL2             (0x40010254U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 2) */
+#define REG_CAN0_MDH2             (0x40010258U) /**< \brief (CAN0) Mailbox Data High Register (MB = 2) */
+#define REG_CAN0_MCR2             (0x4001025CU) /**< \brief (CAN0) Mailbox Control Register (MB = 2) */
+#define REG_CAN0_MMR3             (0x40010260U) /**< \brief (CAN0) Mailbox Mode Register (MB = 3) */
+#define REG_CAN0_MAM3             (0x40010264U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 3) */
+#define REG_CAN0_MID3             (0x40010268U) /**< \brief (CAN0) Mailbox ID Register (MB = 3) */
+#define REG_CAN0_MFID3            (0x4001026CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 3) */
+#define REG_CAN0_MSR3             (0x40010270U) /**< \brief (CAN0) Mailbox Status Register (MB = 3) */
+#define REG_CAN0_MDL3             (0x40010274U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 3) */
+#define REG_CAN0_MDH3             (0x40010278U) /**< \brief (CAN0) Mailbox Data High Register (MB = 3) */
+#define REG_CAN0_MCR3             (0x4001027CU) /**< \brief (CAN0) Mailbox Control Register (MB = 3) */
+#define REG_CAN0_MMR4             (0x40010280U) /**< \brief (CAN0) Mailbox Mode Register (MB = 4) */
+#define REG_CAN0_MAM4             (0x40010284U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 4) */
+#define REG_CAN0_MID4             (0x40010288U) /**< \brief (CAN0) Mailbox ID Register (MB = 4) */
+#define REG_CAN0_MFID4            (0x4001028CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 4) */
+#define REG_CAN0_MSR4             (0x40010290U) /**< \brief (CAN0) Mailbox Status Register (MB = 4) */
+#define REG_CAN0_MDL4             (0x40010294U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 4) */
+#define REG_CAN0_MDH4             (0x40010298U) /**< \brief (CAN0) Mailbox Data High Register (MB = 4) */
+#define REG_CAN0_MCR4             (0x4001029CU) /**< \brief (CAN0) Mailbox Control Register (MB = 4) */
+#define REG_CAN0_MMR5             (0x400102A0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 5) */
+#define REG_CAN0_MAM5             (0x400102A4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 5) */
+#define REG_CAN0_MID5             (0x400102A8U) /**< \brief (CAN0) Mailbox ID Register (MB = 5) */
+#define REG_CAN0_MFID5            (0x400102ACU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 5) */
+#define REG_CAN0_MSR5             (0x400102B0U) /**< \brief (CAN0) Mailbox Status Register (MB = 5) */
+#define REG_CAN0_MDL5             (0x400102B4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 5) */
+#define REG_CAN0_MDH5             (0x400102B8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 5) */
+#define REG_CAN0_MCR5             (0x400102BCU) /**< \brief (CAN0) Mailbox Control Register (MB = 5) */
+#define REG_CAN0_MMR6             (0x400102C0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 6) */
+#define REG_CAN0_MAM6             (0x400102C4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 6) */
+#define REG_CAN0_MID6             (0x400102C8U) /**< \brief (CAN0) Mailbox ID Register (MB = 6) */
+#define REG_CAN0_MFID6            (0x400102CCU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 6) */
+#define REG_CAN0_MSR6             (0x400102D0U) /**< \brief (CAN0) Mailbox Status Register (MB = 6) */
+#define REG_CAN0_MDL6             (0x400102D4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 6) */
+#define REG_CAN0_MDH6             (0x400102D8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 6) */
+#define REG_CAN0_MCR6             (0x400102DCU) /**< \brief (CAN0) Mailbox Control Register (MB = 6) */
+#define REG_CAN0_MMR7             (0x400102E0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 7) */
+#define REG_CAN0_MAM7             (0x400102E4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 7) */
+#define REG_CAN0_MID7             (0x400102E8U) /**< \brief (CAN0) Mailbox ID Register (MB = 7) */
+#define REG_CAN0_MFID7            (0x400102ECU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 7) */
+#define REG_CAN0_MSR7             (0x400102F0U) /**< \brief (CAN0) Mailbox Status Register (MB = 7) */
+#define REG_CAN0_MDL7             (0x400102F4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 7) */
+#define REG_CAN0_MDH7             (0x400102F8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 7) */
+#define REG_CAN0_MCR7             (0x400102FCU) /**< \brief (CAN0) Mailbox Control Register (MB = 7) */
+#else
+#define REG_CAN0_MR      (*(RwReg*)0x40010000U) /**< \brief (CAN0) Mode Register */
+#define REG_CAN0_IER     (*(WoReg*)0x40010004U) /**< \brief (CAN0) Interrupt Enable Register */
+#define REG_CAN0_IDR     (*(WoReg*)0x40010008U) /**< \brief (CAN0) Interrupt Disable Register */
+#define REG_CAN0_IMR     (*(RoReg*)0x4001000CU) /**< \brief (CAN0) Interrupt Mask Register */
+#define REG_CAN0_SR      (*(RoReg*)0x40010010U) /**< \brief (CAN0) Status Register */
+#define REG_CAN0_BR      (*(RwReg*)0x40010014U) /**< \brief (CAN0) Baudrate Register */
+#define REG_CAN0_TIM     (*(RoReg*)0x40010018U) /**< \brief (CAN0) Timer Register */
+#define REG_CAN0_TIMESTP (*(RoReg*)0x4001001CU) /**< \brief (CAN0) Timestamp Register */
+#define REG_CAN0_ECR     (*(RoReg*)0x40010020U) /**< \brief (CAN0) Error Counter Register */
+#define REG_CAN0_TCR     (*(WoReg*)0x40010024U) /**< \brief (CAN0) Transfer Command Register */
+#define REG_CAN0_ACR     (*(WoReg*)0x40010028U) /**< \brief (CAN0) Abort Command Register */
+#define REG_CAN0_WPMR    (*(RwReg*)0x400100E4U) /**< \brief (CAN0) Write Protect Mode Register */
+#define REG_CAN0_WPSR    (*(RoReg*)0x400100E8U) /**< \brief (CAN0) Write Protect Status Register */
+#define REG_CAN0_MMR0    (*(RwReg*)0x40010200U) /**< \brief (CAN0) Mailbox Mode Register (MB = 0) */
+#define REG_CAN0_MAM0    (*(RwReg*)0x40010204U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 0) */
+#define REG_CAN0_MID0    (*(RwReg*)0x40010208U) /**< \brief (CAN0) Mailbox ID Register (MB = 0) */
+#define REG_CAN0_MFID0   (*(RoReg*)0x4001020CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 0) */
+#define REG_CAN0_MSR0    (*(RoReg*)0x40010210U) /**< \brief (CAN0) Mailbox Status Register (MB = 0) */
+#define REG_CAN0_MDL0    (*(RwReg*)0x40010214U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 0) */
+#define REG_CAN0_MDH0    (*(RwReg*)0x40010218U) /**< \brief (CAN0) Mailbox Data High Register (MB = 0) */
+#define REG_CAN0_MCR0    (*(WoReg*)0x4001021CU) /**< \brief (CAN0) Mailbox Control Register (MB = 0) */
+#define REG_CAN0_MMR1    (*(RwReg*)0x40010220U) /**< \brief (CAN0) Mailbox Mode Register (MB = 1) */
+#define REG_CAN0_MAM1    (*(RwReg*)0x40010224U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 1) */
+#define REG_CAN0_MID1    (*(RwReg*)0x40010228U) /**< \brief (CAN0) Mailbox ID Register (MB = 1) */
+#define REG_CAN0_MFID1   (*(RoReg*)0x4001022CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 1) */
+#define REG_CAN0_MSR1    (*(RoReg*)0x40010230U) /**< \brief (CAN0) Mailbox Status Register (MB = 1) */
+#define REG_CAN0_MDL1    (*(RwReg*)0x40010234U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 1) */
+#define REG_CAN0_MDH1    (*(RwReg*)0x40010238U) /**< \brief (CAN0) Mailbox Data High Register (MB = 1) */
+#define REG_CAN0_MCR1    (*(WoReg*)0x4001023CU) /**< \brief (CAN0) Mailbox Control Register (MB = 1) */
+#define REG_CAN0_MMR2    (*(RwReg*)0x40010240U) /**< \brief (CAN0) Mailbox Mode Register (MB = 2) */
+#define REG_CAN0_MAM2    (*(RwReg*)0x40010244U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 2) */
+#define REG_CAN0_MID2    (*(RwReg*)0x40010248U) /**< \brief (CAN0) Mailbox ID Register (MB = 2) */
+#define REG_CAN0_MFID2   (*(RoReg*)0x4001024CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 2) */
+#define REG_CAN0_MSR2    (*(RoReg*)0x40010250U) /**< \brief (CAN0) Mailbox Status Register (MB = 2) */
+#define REG_CAN0_MDL2    (*(RwReg*)0x40010254U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 2) */
+#define REG_CAN0_MDH2    (*(RwReg*)0x40010258U) /**< \brief (CAN0) Mailbox Data High Register (MB = 2) */
+#define REG_CAN0_MCR2    (*(WoReg*)0x4001025CU) /**< \brief (CAN0) Mailbox Control Register (MB = 2) */
+#define REG_CAN0_MMR3    (*(RwReg*)0x40010260U) /**< \brief (CAN0) Mailbox Mode Register (MB = 3) */
+#define REG_CAN0_MAM3    (*(RwReg*)0x40010264U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 3) */
+#define REG_CAN0_MID3    (*(RwReg*)0x40010268U) /**< \brief (CAN0) Mailbox ID Register (MB = 3) */
+#define REG_CAN0_MFID3   (*(RoReg*)0x4001026CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 3) */
+#define REG_CAN0_MSR3    (*(RoReg*)0x40010270U) /**< \brief (CAN0) Mailbox Status Register (MB = 3) */
+#define REG_CAN0_MDL3    (*(RwReg*)0x40010274U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 3) */
+#define REG_CAN0_MDH3    (*(RwReg*)0x40010278U) /**< \brief (CAN0) Mailbox Data High Register (MB = 3) */
+#define REG_CAN0_MCR3    (*(WoReg*)0x4001027CU) /**< \brief (CAN0) Mailbox Control Register (MB = 3) */
+#define REG_CAN0_MMR4    (*(RwReg*)0x40010280U) /**< \brief (CAN0) Mailbox Mode Register (MB = 4) */
+#define REG_CAN0_MAM4    (*(RwReg*)0x40010284U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 4) */
+#define REG_CAN0_MID4    (*(RwReg*)0x40010288U) /**< \brief (CAN0) Mailbox ID Register (MB = 4) */
+#define REG_CAN0_MFID4   (*(RoReg*)0x4001028CU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 4) */
+#define REG_CAN0_MSR4    (*(RoReg*)0x40010290U) /**< \brief (CAN0) Mailbox Status Register (MB = 4) */
+#define REG_CAN0_MDL4    (*(RwReg*)0x40010294U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 4) */
+#define REG_CAN0_MDH4    (*(RwReg*)0x40010298U) /**< \brief (CAN0) Mailbox Data High Register (MB = 4) */
+#define REG_CAN0_MCR4    (*(WoReg*)0x4001029CU) /**< \brief (CAN0) Mailbox Control Register (MB = 4) */
+#define REG_CAN0_MMR5    (*(RwReg*)0x400102A0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 5) */
+#define REG_CAN0_MAM5    (*(RwReg*)0x400102A4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 5) */
+#define REG_CAN0_MID5    (*(RwReg*)0x400102A8U) /**< \brief (CAN0) Mailbox ID Register (MB = 5) */
+#define REG_CAN0_MFID5   (*(RoReg*)0x400102ACU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 5) */
+#define REG_CAN0_MSR5    (*(RoReg*)0x400102B0U) /**< \brief (CAN0) Mailbox Status Register (MB = 5) */
+#define REG_CAN0_MDL5    (*(RwReg*)0x400102B4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 5) */
+#define REG_CAN0_MDH5    (*(RwReg*)0x400102B8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 5) */
+#define REG_CAN0_MCR5    (*(WoReg*)0x400102BCU) /**< \brief (CAN0) Mailbox Control Register (MB = 5) */
+#define REG_CAN0_MMR6    (*(RwReg*)0x400102C0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 6) */
+#define REG_CAN0_MAM6    (*(RwReg*)0x400102C4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 6) */
+#define REG_CAN0_MID6    (*(RwReg*)0x400102C8U) /**< \brief (CAN0) Mailbox ID Register (MB = 6) */
+#define REG_CAN0_MFID6   (*(RoReg*)0x400102CCU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 6) */
+#define REG_CAN0_MSR6    (*(RoReg*)0x400102D0U) /**< \brief (CAN0) Mailbox Status Register (MB = 6) */
+#define REG_CAN0_MDL6    (*(RwReg*)0x400102D4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 6) */
+#define REG_CAN0_MDH6    (*(RwReg*)0x400102D8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 6) */
+#define REG_CAN0_MCR6    (*(WoReg*)0x400102DCU) /**< \brief (CAN0) Mailbox Control Register (MB = 6) */
+#define REG_CAN0_MMR7    (*(RwReg*)0x400102E0U) /**< \brief (CAN0) Mailbox Mode Register (MB = 7) */
+#define REG_CAN0_MAM7    (*(RwReg*)0x400102E4U) /**< \brief (CAN0) Mailbox Acceptance Mask Register (MB = 7) */
+#define REG_CAN0_MID7    (*(RwReg*)0x400102E8U) /**< \brief (CAN0) Mailbox ID Register (MB = 7) */
+#define REG_CAN0_MFID7   (*(RoReg*)0x400102ECU) /**< \brief (CAN0) Mailbox Family ID Register (MB = 7) */
+#define REG_CAN0_MSR7    (*(RoReg*)0x400102F0U) /**< \brief (CAN0) Mailbox Status Register (MB = 7) */
+#define REG_CAN0_MDL7    (*(RwReg*)0x400102F4U) /**< \brief (CAN0) Mailbox Data Low Register (MB = 7) */
+#define REG_CAN0_MDH7    (*(RwReg*)0x400102F8U) /**< \brief (CAN0) Mailbox Data High Register (MB = 7) */
+#define REG_CAN0_MCR7    (*(WoReg*)0x400102FCU) /**< \brief (CAN0) Mailbox Control Register (MB = 7) */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_CAN0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/can1.h
+++ b/asf/sam/include/sam4e/instance/can1.h
@@ -1,0 +1,192 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CAN1_INSTANCE_
+#define _SAM4E_CAN1_INSTANCE_
+
+/* ========== Register definition for CAN1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CAN1_MR               (0x40014000U) /**< \brief (CAN1) Mode Register */
+#define REG_CAN1_IER              (0x40014004U) /**< \brief (CAN1) Interrupt Enable Register */
+#define REG_CAN1_IDR              (0x40014008U) /**< \brief (CAN1) Interrupt Disable Register */
+#define REG_CAN1_IMR              (0x4001400CU) /**< \brief (CAN1) Interrupt Mask Register */
+#define REG_CAN1_SR               (0x40014010U) /**< \brief (CAN1) Status Register */
+#define REG_CAN1_BR               (0x40014014U) /**< \brief (CAN1) Baudrate Register */
+#define REG_CAN1_TIM              (0x40014018U) /**< \brief (CAN1) Timer Register */
+#define REG_CAN1_TIMESTP          (0x4001401CU) /**< \brief (CAN1) Timestamp Register */
+#define REG_CAN1_ECR              (0x40014020U) /**< \brief (CAN1) Error Counter Register */
+#define REG_CAN1_TCR              (0x40014024U) /**< \brief (CAN1) Transfer Command Register */
+#define REG_CAN1_ACR              (0x40014028U) /**< \brief (CAN1) Abort Command Register */
+#define REG_CAN1_WPMR             (0x400140E4U) /**< \brief (CAN1) Write Protect Mode Register */
+#define REG_CAN1_WPSR             (0x400140E8U) /**< \brief (CAN1) Write Protect Status Register */
+#define REG_CAN1_MMR0             (0x40014200U) /**< \brief (CAN1) Mailbox Mode Register (MB = 0) */
+#define REG_CAN1_MAM0             (0x40014204U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 0) */
+#define REG_CAN1_MID0             (0x40014208U) /**< \brief (CAN1) Mailbox ID Register (MB = 0) */
+#define REG_CAN1_MFID0            (0x4001420CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 0) */
+#define REG_CAN1_MSR0             (0x40014210U) /**< \brief (CAN1) Mailbox Status Register (MB = 0) */
+#define REG_CAN1_MDL0             (0x40014214U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 0) */
+#define REG_CAN1_MDH0             (0x40014218U) /**< \brief (CAN1) Mailbox Data High Register (MB = 0) */
+#define REG_CAN1_MCR0             (0x4001421CU) /**< \brief (CAN1) Mailbox Control Register (MB = 0) */
+#define REG_CAN1_MMR1             (0x40014220U) /**< \brief (CAN1) Mailbox Mode Register (MB = 1) */
+#define REG_CAN1_MAM1             (0x40014224U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 1) */
+#define REG_CAN1_MID1             (0x40014228U) /**< \brief (CAN1) Mailbox ID Register (MB = 1) */
+#define REG_CAN1_MFID1            (0x4001422CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 1) */
+#define REG_CAN1_MSR1             (0x40014230U) /**< \brief (CAN1) Mailbox Status Register (MB = 1) */
+#define REG_CAN1_MDL1             (0x40014234U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 1) */
+#define REG_CAN1_MDH1             (0x40014238U) /**< \brief (CAN1) Mailbox Data High Register (MB = 1) */
+#define REG_CAN1_MCR1             (0x4001423CU) /**< \brief (CAN1) Mailbox Control Register (MB = 1) */
+#define REG_CAN1_MMR2             (0x40014240U) /**< \brief (CAN1) Mailbox Mode Register (MB = 2) */
+#define REG_CAN1_MAM2             (0x40014244U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 2) */
+#define REG_CAN1_MID2             (0x40014248U) /**< \brief (CAN1) Mailbox ID Register (MB = 2) */
+#define REG_CAN1_MFID2            (0x4001424CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 2) */
+#define REG_CAN1_MSR2             (0x40014250U) /**< \brief (CAN1) Mailbox Status Register (MB = 2) */
+#define REG_CAN1_MDL2             (0x40014254U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 2) */
+#define REG_CAN1_MDH2             (0x40014258U) /**< \brief (CAN1) Mailbox Data High Register (MB = 2) */
+#define REG_CAN1_MCR2             (0x4001425CU) /**< \brief (CAN1) Mailbox Control Register (MB = 2) */
+#define REG_CAN1_MMR3             (0x40014260U) /**< \brief (CAN1) Mailbox Mode Register (MB = 3) */
+#define REG_CAN1_MAM3             (0x40014264U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 3) */
+#define REG_CAN1_MID3             (0x40014268U) /**< \brief (CAN1) Mailbox ID Register (MB = 3) */
+#define REG_CAN1_MFID3            (0x4001426CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 3) */
+#define REG_CAN1_MSR3             (0x40014270U) /**< \brief (CAN1) Mailbox Status Register (MB = 3) */
+#define REG_CAN1_MDL3             (0x40014274U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 3) */
+#define REG_CAN1_MDH3             (0x40014278U) /**< \brief (CAN1) Mailbox Data High Register (MB = 3) */
+#define REG_CAN1_MCR3             (0x4001427CU) /**< \brief (CAN1) Mailbox Control Register (MB = 3) */
+#define REG_CAN1_MMR4             (0x40014280U) /**< \brief (CAN1) Mailbox Mode Register (MB = 4) */
+#define REG_CAN1_MAM4             (0x40014284U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 4) */
+#define REG_CAN1_MID4             (0x40014288U) /**< \brief (CAN1) Mailbox ID Register (MB = 4) */
+#define REG_CAN1_MFID4            (0x4001428CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 4) */
+#define REG_CAN1_MSR4             (0x40014290U) /**< \brief (CAN1) Mailbox Status Register (MB = 4) */
+#define REG_CAN1_MDL4             (0x40014294U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 4) */
+#define REG_CAN1_MDH4             (0x40014298U) /**< \brief (CAN1) Mailbox Data High Register (MB = 4) */
+#define REG_CAN1_MCR4             (0x4001429CU) /**< \brief (CAN1) Mailbox Control Register (MB = 4) */
+#define REG_CAN1_MMR5             (0x400142A0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 5) */
+#define REG_CAN1_MAM5             (0x400142A4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 5) */
+#define REG_CAN1_MID5             (0x400142A8U) /**< \brief (CAN1) Mailbox ID Register (MB = 5) */
+#define REG_CAN1_MFID5            (0x400142ACU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 5) */
+#define REG_CAN1_MSR5             (0x400142B0U) /**< \brief (CAN1) Mailbox Status Register (MB = 5) */
+#define REG_CAN1_MDL5             (0x400142B4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 5) */
+#define REG_CAN1_MDH5             (0x400142B8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 5) */
+#define REG_CAN1_MCR5             (0x400142BCU) /**< \brief (CAN1) Mailbox Control Register (MB = 5) */
+#define REG_CAN1_MMR6             (0x400142C0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 6) */
+#define REG_CAN1_MAM6             (0x400142C4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 6) */
+#define REG_CAN1_MID6             (0x400142C8U) /**< \brief (CAN1) Mailbox ID Register (MB = 6) */
+#define REG_CAN1_MFID6            (0x400142CCU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 6) */
+#define REG_CAN1_MSR6             (0x400142D0U) /**< \brief (CAN1) Mailbox Status Register (MB = 6) */
+#define REG_CAN1_MDL6             (0x400142D4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 6) */
+#define REG_CAN1_MDH6             (0x400142D8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 6) */
+#define REG_CAN1_MCR6             (0x400142DCU) /**< \brief (CAN1) Mailbox Control Register (MB = 6) */
+#define REG_CAN1_MMR7             (0x400142E0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 7) */
+#define REG_CAN1_MAM7             (0x400142E4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 7) */
+#define REG_CAN1_MID7             (0x400142E8U) /**< \brief (CAN1) Mailbox ID Register (MB = 7) */
+#define REG_CAN1_MFID7            (0x400142ECU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 7) */
+#define REG_CAN1_MSR7             (0x400142F0U) /**< \brief (CAN1) Mailbox Status Register (MB = 7) */
+#define REG_CAN1_MDL7             (0x400142F4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 7) */
+#define REG_CAN1_MDH7             (0x400142F8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 7) */
+#define REG_CAN1_MCR7             (0x400142FCU) /**< \brief (CAN1) Mailbox Control Register (MB = 7) */
+#else
+#define REG_CAN1_MR      (*(RwReg*)0x40014000U) /**< \brief (CAN1) Mode Register */
+#define REG_CAN1_IER     (*(WoReg*)0x40014004U) /**< \brief (CAN1) Interrupt Enable Register */
+#define REG_CAN1_IDR     (*(WoReg*)0x40014008U) /**< \brief (CAN1) Interrupt Disable Register */
+#define REG_CAN1_IMR     (*(RoReg*)0x4001400CU) /**< \brief (CAN1) Interrupt Mask Register */
+#define REG_CAN1_SR      (*(RoReg*)0x40014010U) /**< \brief (CAN1) Status Register */
+#define REG_CAN1_BR      (*(RwReg*)0x40014014U) /**< \brief (CAN1) Baudrate Register */
+#define REG_CAN1_TIM     (*(RoReg*)0x40014018U) /**< \brief (CAN1) Timer Register */
+#define REG_CAN1_TIMESTP (*(RoReg*)0x4001401CU) /**< \brief (CAN1) Timestamp Register */
+#define REG_CAN1_ECR     (*(RoReg*)0x40014020U) /**< \brief (CAN1) Error Counter Register */
+#define REG_CAN1_TCR     (*(WoReg*)0x40014024U) /**< \brief (CAN1) Transfer Command Register */
+#define REG_CAN1_ACR     (*(WoReg*)0x40014028U) /**< \brief (CAN1) Abort Command Register */
+#define REG_CAN1_WPMR    (*(RwReg*)0x400140E4U) /**< \brief (CAN1) Write Protect Mode Register */
+#define REG_CAN1_WPSR    (*(RoReg*)0x400140E8U) /**< \brief (CAN1) Write Protect Status Register */
+#define REG_CAN1_MMR0    (*(RwReg*)0x40014200U) /**< \brief (CAN1) Mailbox Mode Register (MB = 0) */
+#define REG_CAN1_MAM0    (*(RwReg*)0x40014204U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 0) */
+#define REG_CAN1_MID0    (*(RwReg*)0x40014208U) /**< \brief (CAN1) Mailbox ID Register (MB = 0) */
+#define REG_CAN1_MFID0   (*(RoReg*)0x4001420CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 0) */
+#define REG_CAN1_MSR0    (*(RoReg*)0x40014210U) /**< \brief (CAN1) Mailbox Status Register (MB = 0) */
+#define REG_CAN1_MDL0    (*(RwReg*)0x40014214U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 0) */
+#define REG_CAN1_MDH0    (*(RwReg*)0x40014218U) /**< \brief (CAN1) Mailbox Data High Register (MB = 0) */
+#define REG_CAN1_MCR0    (*(WoReg*)0x4001421CU) /**< \brief (CAN1) Mailbox Control Register (MB = 0) */
+#define REG_CAN1_MMR1    (*(RwReg*)0x40014220U) /**< \brief (CAN1) Mailbox Mode Register (MB = 1) */
+#define REG_CAN1_MAM1    (*(RwReg*)0x40014224U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 1) */
+#define REG_CAN1_MID1    (*(RwReg*)0x40014228U) /**< \brief (CAN1) Mailbox ID Register (MB = 1) */
+#define REG_CAN1_MFID1   (*(RoReg*)0x4001422CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 1) */
+#define REG_CAN1_MSR1    (*(RoReg*)0x40014230U) /**< \brief (CAN1) Mailbox Status Register (MB = 1) */
+#define REG_CAN1_MDL1    (*(RwReg*)0x40014234U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 1) */
+#define REG_CAN1_MDH1    (*(RwReg*)0x40014238U) /**< \brief (CAN1) Mailbox Data High Register (MB = 1) */
+#define REG_CAN1_MCR1    (*(WoReg*)0x4001423CU) /**< \brief (CAN1) Mailbox Control Register (MB = 1) */
+#define REG_CAN1_MMR2    (*(RwReg*)0x40014240U) /**< \brief (CAN1) Mailbox Mode Register (MB = 2) */
+#define REG_CAN1_MAM2    (*(RwReg*)0x40014244U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 2) */
+#define REG_CAN1_MID2    (*(RwReg*)0x40014248U) /**< \brief (CAN1) Mailbox ID Register (MB = 2) */
+#define REG_CAN1_MFID2   (*(RoReg*)0x4001424CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 2) */
+#define REG_CAN1_MSR2    (*(RoReg*)0x40014250U) /**< \brief (CAN1) Mailbox Status Register (MB = 2) */
+#define REG_CAN1_MDL2    (*(RwReg*)0x40014254U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 2) */
+#define REG_CAN1_MDH2    (*(RwReg*)0x40014258U) /**< \brief (CAN1) Mailbox Data High Register (MB = 2) */
+#define REG_CAN1_MCR2    (*(WoReg*)0x4001425CU) /**< \brief (CAN1) Mailbox Control Register (MB = 2) */
+#define REG_CAN1_MMR3    (*(RwReg*)0x40014260U) /**< \brief (CAN1) Mailbox Mode Register (MB = 3) */
+#define REG_CAN1_MAM3    (*(RwReg*)0x40014264U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 3) */
+#define REG_CAN1_MID3    (*(RwReg*)0x40014268U) /**< \brief (CAN1) Mailbox ID Register (MB = 3) */
+#define REG_CAN1_MFID3   (*(RoReg*)0x4001426CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 3) */
+#define REG_CAN1_MSR3    (*(RoReg*)0x40014270U) /**< \brief (CAN1) Mailbox Status Register (MB = 3) */
+#define REG_CAN1_MDL3    (*(RwReg*)0x40014274U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 3) */
+#define REG_CAN1_MDH3    (*(RwReg*)0x40014278U) /**< \brief (CAN1) Mailbox Data High Register (MB = 3) */
+#define REG_CAN1_MCR3    (*(WoReg*)0x4001427CU) /**< \brief (CAN1) Mailbox Control Register (MB = 3) */
+#define REG_CAN1_MMR4    (*(RwReg*)0x40014280U) /**< \brief (CAN1) Mailbox Mode Register (MB = 4) */
+#define REG_CAN1_MAM4    (*(RwReg*)0x40014284U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 4) */
+#define REG_CAN1_MID4    (*(RwReg*)0x40014288U) /**< \brief (CAN1) Mailbox ID Register (MB = 4) */
+#define REG_CAN1_MFID4   (*(RoReg*)0x4001428CU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 4) */
+#define REG_CAN1_MSR4    (*(RoReg*)0x40014290U) /**< \brief (CAN1) Mailbox Status Register (MB = 4) */
+#define REG_CAN1_MDL4    (*(RwReg*)0x40014294U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 4) */
+#define REG_CAN1_MDH4    (*(RwReg*)0x40014298U) /**< \brief (CAN1) Mailbox Data High Register (MB = 4) */
+#define REG_CAN1_MCR4    (*(WoReg*)0x4001429CU) /**< \brief (CAN1) Mailbox Control Register (MB = 4) */
+#define REG_CAN1_MMR5    (*(RwReg*)0x400142A0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 5) */
+#define REG_CAN1_MAM5    (*(RwReg*)0x400142A4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 5) */
+#define REG_CAN1_MID5    (*(RwReg*)0x400142A8U) /**< \brief (CAN1) Mailbox ID Register (MB = 5) */
+#define REG_CAN1_MFID5   (*(RoReg*)0x400142ACU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 5) */
+#define REG_CAN1_MSR5    (*(RoReg*)0x400142B0U) /**< \brief (CAN1) Mailbox Status Register (MB = 5) */
+#define REG_CAN1_MDL5    (*(RwReg*)0x400142B4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 5) */
+#define REG_CAN1_MDH5    (*(RwReg*)0x400142B8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 5) */
+#define REG_CAN1_MCR5    (*(WoReg*)0x400142BCU) /**< \brief (CAN1) Mailbox Control Register (MB = 5) */
+#define REG_CAN1_MMR6    (*(RwReg*)0x400142C0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 6) */
+#define REG_CAN1_MAM6    (*(RwReg*)0x400142C4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 6) */
+#define REG_CAN1_MID6    (*(RwReg*)0x400142C8U) /**< \brief (CAN1) Mailbox ID Register (MB = 6) */
+#define REG_CAN1_MFID6   (*(RoReg*)0x400142CCU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 6) */
+#define REG_CAN1_MSR6    (*(RoReg*)0x400142D0U) /**< \brief (CAN1) Mailbox Status Register (MB = 6) */
+#define REG_CAN1_MDL6    (*(RwReg*)0x400142D4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 6) */
+#define REG_CAN1_MDH6    (*(RwReg*)0x400142D8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 6) */
+#define REG_CAN1_MCR6    (*(WoReg*)0x400142DCU) /**< \brief (CAN1) Mailbox Control Register (MB = 6) */
+#define REG_CAN1_MMR7    (*(RwReg*)0x400142E0U) /**< \brief (CAN1) Mailbox Mode Register (MB = 7) */
+#define REG_CAN1_MAM7    (*(RwReg*)0x400142E4U) /**< \brief (CAN1) Mailbox Acceptance Mask Register (MB = 7) */
+#define REG_CAN1_MID7    (*(RwReg*)0x400142E8U) /**< \brief (CAN1) Mailbox ID Register (MB = 7) */
+#define REG_CAN1_MFID7   (*(RoReg*)0x400142ECU) /**< \brief (CAN1) Mailbox Family ID Register (MB = 7) */
+#define REG_CAN1_MSR7    (*(RoReg*)0x400142F0U) /**< \brief (CAN1) Mailbox Status Register (MB = 7) */
+#define REG_CAN1_MDL7    (*(RwReg*)0x400142F4U) /**< \brief (CAN1) Mailbox Data Low Register (MB = 7) */
+#define REG_CAN1_MDH7    (*(RwReg*)0x400142F8U) /**< \brief (CAN1) Mailbox Data High Register (MB = 7) */
+#define REG_CAN1_MCR7    (*(WoReg*)0x400142FCU) /**< \brief (CAN1) Mailbox Control Register (MB = 7) */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_CAN1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/chipid.h
+++ b/asf/sam/include/sam4e/instance/chipid.h
@@ -1,0 +1,42 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CHIPID_INSTANCE_
+#define _SAM4E_CHIPID_INSTANCE_
+
+/* ========== Register definition for CHIPID peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CHIPID_CIDR          (0x400E0740U) /**< \brief (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID          (0x400E0744U) /**< \brief (CHIPID) Chip ID Extension Register */
+#else
+#define REG_CHIPID_CIDR (*(RoReg*)0x400E0740U) /**< \brief (CHIPID) Chip ID Register */
+#define REG_CHIPID_EXID (*(RoReg*)0x400E0744U) /**< \brief (CHIPID) Chip ID Extension Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_CHIPID_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/cmcc.h
+++ b/asf/sam/include/sam4e/instance/cmcc.h
@@ -1,0 +1,58 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CMCC_INSTANCE_
+#define _SAM4E_CMCC_INSTANCE_
+
+/* ========== Register definition for CMCC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CMCC_TYPE            (0x400C4000U) /**< \brief (CMCC) Cache Type Register */
+#define REG_CMCC_CFG             (0x400C4004U) /**< \brief (CMCC) Cache Configuration Register */
+#define REG_CMCC_CTRL            (0x400C4008U) /**< \brief (CMCC) Cache Control Register */
+#define REG_CMCC_SR              (0x400C400CU) /**< \brief (CMCC) Cache Status Register */
+#define REG_CMCC_MAINT0          (0x400C4020U) /**< \brief (CMCC) Cache Maintenance Register 0 */
+#define REG_CMCC_MAINT1          (0x400C4024U) /**< \brief (CMCC) Cache Maintenance Register 1 */
+#define REG_CMCC_MCFG            (0x400C4028U) /**< \brief (CMCC) Cache Monitor Configuration Register */
+#define REG_CMCC_MEN             (0x400C402CU) /**< \brief (CMCC) Cache Monitor Enable Register */
+#define REG_CMCC_MCTRL           (0x400C4030U) /**< \brief (CMCC) Cache Monitor Control Register */
+#define REG_CMCC_MSR             (0x400C4034U) /**< \brief (CMCC) Cache Monitor Status Register */
+#else
+#define REG_CMCC_TYPE   (*(RoReg*)0x400C4000U) /**< \brief (CMCC) Cache Type Register */
+#define REG_CMCC_CFG    (*(RwReg*)0x400C4004U) /**< \brief (CMCC) Cache Configuration Register */
+#define REG_CMCC_CTRL   (*(WoReg*)0x400C4008U) /**< \brief (CMCC) Cache Control Register */
+#define REG_CMCC_SR     (*(RoReg*)0x400C400CU) /**< \brief (CMCC) Cache Status Register */
+#define REG_CMCC_MAINT0 (*(WoReg*)0x400C4020U) /**< \brief (CMCC) Cache Maintenance Register 0 */
+#define REG_CMCC_MAINT1 (*(WoReg*)0x400C4024U) /**< \brief (CMCC) Cache Maintenance Register 1 */
+#define REG_CMCC_MCFG   (*(RwReg*)0x400C4028U) /**< \brief (CMCC) Cache Monitor Configuration Register */
+#define REG_CMCC_MEN    (*(RwReg*)0x400C402CU) /**< \brief (CMCC) Cache Monitor Enable Register */
+#define REG_CMCC_MCTRL  (*(WoReg*)0x400C4030U) /**< \brief (CMCC) Cache Monitor Control Register */
+#define REG_CMCC_MSR    (*(RoReg*)0x400C4034U) /**< \brief (CMCC) Cache Monitor Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_CMCC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/crccu.h
+++ b/asf/sam/include/sam4e/instance/crccu.h
@@ -1,0 +1,68 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_CRCCU_INSTANCE_
+#define _SAM4E_CRCCU_INSTANCE_
+
+/* ========== Register definition for CRCCU peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_CRCCU_DSCR             (0x40044000U) /**< \brief (CRCCU) CRCCU Descriptor Base Register */
+#define REG_CRCCU_DMA_EN           (0x40044008U) /**< \brief (CRCCU) CRCCU DMA Enable Register */
+#define REG_CRCCU_DMA_DIS          (0x4004400CU) /**< \brief (CRCCU) CRCCU DMA Disable Register */
+#define REG_CRCCU_DMA_SR           (0x40044010U) /**< \brief (CRCCU) CRCCU DMA Status Register */
+#define REG_CRCCU_DMA_IER          (0x40044014U) /**< \brief (CRCCU) CRCCU DMA Interrupt Enable Register */
+#define REG_CRCCU_DMA_IDR          (0x40044018U) /**< \brief (CRCCU) CRCCU DMA Interrupt Disable Register */
+#define REG_CRCCU_DMA_IMR          (0x4004401CU) /**< \brief (CRCCU) CRCCU DMA Interrupt Mask Register */
+#define REG_CRCCU_DMA_ISR          (0x40044020U) /**< \brief (CRCCU) CRCCU DMA Interrupt Status Register */
+#define REG_CRCCU_CR               (0x40044034U) /**< \brief (CRCCU) CRCCU Control Register */
+#define REG_CRCCU_MR               (0x40044038U) /**< \brief (CRCCU) CRCCU Mode Register */
+#define REG_CRCCU_SR               (0x4004403CU) /**< \brief (CRCCU) CRCCU Status Register */
+#define REG_CRCCU_IER              (0x40044040U) /**< \brief (CRCCU) CRCCU Interrupt Enable Register */
+#define REG_CRCCU_IDR              (0x40044044U) /**< \brief (CRCCU) CRCCU Interrupt Disable Register */
+#define REG_CRCCU_IMR              (0x40044048U) /**< \brief (CRCCU) CRCCU Interrupt Mask Register */
+#define REG_CRCCU_ISR              (0x4004404CU) /**< \brief (CRCCU) CRCCU Interrupt Status Register */
+#else
+#define REG_CRCCU_DSCR    (*(RwReg*)0x40044000U) /**< \brief (CRCCU) CRCCU Descriptor Base Register */
+#define REG_CRCCU_DMA_EN  (*(WoReg*)0x40044008U) /**< \brief (CRCCU) CRCCU DMA Enable Register */
+#define REG_CRCCU_DMA_DIS (*(WoReg*)0x4004400CU) /**< \brief (CRCCU) CRCCU DMA Disable Register */
+#define REG_CRCCU_DMA_SR  (*(RoReg*)0x40044010U) /**< \brief (CRCCU) CRCCU DMA Status Register */
+#define REG_CRCCU_DMA_IER (*(WoReg*)0x40044014U) /**< \brief (CRCCU) CRCCU DMA Interrupt Enable Register */
+#define REG_CRCCU_DMA_IDR (*(WoReg*)0x40044018U) /**< \brief (CRCCU) CRCCU DMA Interrupt Disable Register */
+#define REG_CRCCU_DMA_IMR (*(RoReg*)0x4004401CU) /**< \brief (CRCCU) CRCCU DMA Interrupt Mask Register */
+#define REG_CRCCU_DMA_ISR (*(RoReg*)0x40044020U) /**< \brief (CRCCU) CRCCU DMA Interrupt Status Register */
+#define REG_CRCCU_CR      (*(WoReg*)0x40044034U) /**< \brief (CRCCU) CRCCU Control Register */
+#define REG_CRCCU_MR      (*(RwReg*)0x40044038U) /**< \brief (CRCCU) CRCCU Mode Register */
+#define REG_CRCCU_SR      (*(RoReg*)0x4004403CU) /**< \brief (CRCCU) CRCCU Status Register */
+#define REG_CRCCU_IER     (*(WoReg*)0x40044040U) /**< \brief (CRCCU) CRCCU Interrupt Enable Register */
+#define REG_CRCCU_IDR     (*(WoReg*)0x40044044U) /**< \brief (CRCCU) CRCCU Interrupt Disable Register */
+#define REG_CRCCU_IMR     (*(RoReg*)0x40044048U) /**< \brief (CRCCU) CRCCU Interrupt Mask Register */
+#define REG_CRCCU_ISR     (*(RoReg*)0x4004404CU) /**< \brief (CRCCU) CRCCU Interrupt Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_CRCCU_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/dacc.h
+++ b/asf/sam/include/sam4e/instance/dacc.h
@@ -1,0 +1,76 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_DACC_INSTANCE_
+#define _SAM4E_DACC_INSTANCE_
+
+/* ========== Register definition for DACC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DACC_CR            (0x400B8000U) /**< \brief (DACC) Control Register */
+#define REG_DACC_MR            (0x400B8004U) /**< \brief (DACC) Mode Register */
+#define REG_DACC_CHER          (0x400B8010U) /**< \brief (DACC) Channel Enable Register */
+#define REG_DACC_CHDR          (0x400B8014U) /**< \brief (DACC) Channel Disable Register */
+#define REG_DACC_CHSR          (0x400B8018U) /**< \brief (DACC) Channel Status Register */
+#define REG_DACC_CDR           (0x400B8020U) /**< \brief (DACC) Conversion Data Register */
+#define REG_DACC_IER           (0x400B8024U) /**< \brief (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR           (0x400B8028U) /**< \brief (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR           (0x400B802CU) /**< \brief (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR           (0x400B8030U) /**< \brief (DACC) Interrupt Status Register */
+#define REG_DACC_ACR           (0x400B8094U) /**< \brief (DACC) Analog Current Register */
+#define REG_DACC_WPMR          (0x400B80E4U) /**< \brief (DACC) Write Protect Mode register */
+#define REG_DACC_WPSR          (0x400B80E8U) /**< \brief (DACC) Write Protect Status register */
+#define REG_DACC_TPR           (0x400B8108U) /**< \brief (DACC) Transmit Pointer Register */
+#define REG_DACC_TCR           (0x400B810CU) /**< \brief (DACC) Transmit Counter Register */
+#define REG_DACC_TNPR          (0x400B8118U) /**< \brief (DACC) Transmit Next Pointer Register */
+#define REG_DACC_TNCR          (0x400B811CU) /**< \brief (DACC) Transmit Next Counter Register */
+#define REG_DACC_PTCR          (0x400B8120U) /**< \brief (DACC) Transfer Control Register */
+#define REG_DACC_PTSR          (0x400B8124U) /**< \brief (DACC) Transfer Status Register */
+#else
+#define REG_DACC_CR   (*(WoReg*)0x400B8000U) /**< \brief (DACC) Control Register */
+#define REG_DACC_MR   (*(RwReg*)0x400B8004U) /**< \brief (DACC) Mode Register */
+#define REG_DACC_CHER (*(WoReg*)0x400B8010U) /**< \brief (DACC) Channel Enable Register */
+#define REG_DACC_CHDR (*(WoReg*)0x400B8014U) /**< \brief (DACC) Channel Disable Register */
+#define REG_DACC_CHSR (*(RoReg*)0x400B8018U) /**< \brief (DACC) Channel Status Register */
+#define REG_DACC_CDR  (*(WoReg*)0x400B8020U) /**< \brief (DACC) Conversion Data Register */
+#define REG_DACC_IER  (*(WoReg*)0x400B8024U) /**< \brief (DACC) Interrupt Enable Register */
+#define REG_DACC_IDR  (*(WoReg*)0x400B8028U) /**< \brief (DACC) Interrupt Disable Register */
+#define REG_DACC_IMR  (*(RoReg*)0x400B802CU) /**< \brief (DACC) Interrupt Mask Register */
+#define REG_DACC_ISR  (*(RoReg*)0x400B8030U) /**< \brief (DACC) Interrupt Status Register */
+#define REG_DACC_ACR  (*(RwReg*)0x400B8094U) /**< \brief (DACC) Analog Current Register */
+#define REG_DACC_WPMR (*(RwReg*)0x400B80E4U) /**< \brief (DACC) Write Protect Mode register */
+#define REG_DACC_WPSR (*(RoReg*)0x400B80E8U) /**< \brief (DACC) Write Protect Status register */
+#define REG_DACC_TPR  (*(RwReg*)0x400B8108U) /**< \brief (DACC) Transmit Pointer Register */
+#define REG_DACC_TCR  (*(RwReg*)0x400B810CU) /**< \brief (DACC) Transmit Counter Register */
+#define REG_DACC_TNPR (*(RwReg*)0x400B8118U) /**< \brief (DACC) Transmit Next Pointer Register */
+#define REG_DACC_TNCR (*(RwReg*)0x400B811CU) /**< \brief (DACC) Transmit Next Counter Register */
+#define REG_DACC_PTCR (*(WoReg*)0x400B8120U) /**< \brief (DACC) Transfer Control Register */
+#define REG_DACC_PTSR (*(RoReg*)0x400B8124U) /**< \brief (DACC) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_DACC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/dmac.h
+++ b/asf/sam/include/sam4e/instance/dmac.h
@@ -1,0 +1,114 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_DMAC_INSTANCE_
+#define _SAM4E_DMAC_INSTANCE_
+
+/* ========== Register definition for DMAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DMAC_GCFG            (0x400C0000U) /**< \brief (DMAC) DMAC Global Configuration Register */
+#define REG_DMAC_EN              (0x400C0004U) /**< \brief (DMAC) DMAC Enable Register */
+#define REG_DMAC_SREQ            (0x400C0008U) /**< \brief (DMAC) DMAC Software Single Request Register */
+#define REG_DMAC_CREQ            (0x400C000CU) /**< \brief (DMAC) DMAC Software Chunk Transfer Request Register */
+#define REG_DMAC_LAST            (0x400C0010U) /**< \brief (DMAC) DMAC Software Last Transfer Flag Register */
+#define REG_DMAC_EBCIER          (0x400C0018U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Enable register. */
+#define REG_DMAC_EBCIDR          (0x400C001CU) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Disable register. */
+#define REG_DMAC_EBCIMR          (0x400C0020U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Mask Register. */
+#define REG_DMAC_EBCISR          (0x400C0024U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Status Register. */
+#define REG_DMAC_CHER            (0x400C0028U) /**< \brief (DMAC) DMAC Channel Handler Enable Register */
+#define REG_DMAC_CHDR            (0x400C002CU) /**< \brief (DMAC) DMAC Channel Handler Disable Register */
+#define REG_DMAC_CHSR            (0x400C0030U) /**< \brief (DMAC) DMAC Channel Handler Status Register */
+#define REG_DMAC_SADDR0          (0x400C003CU) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 0) */
+#define REG_DMAC_DADDR0          (0x400C0040U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 0) */
+#define REG_DMAC_DSCR0           (0x400C0044U) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 0) */
+#define REG_DMAC_CTRLA0          (0x400C0048U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 0) */
+#define REG_DMAC_CTRLB0          (0x400C004CU) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 0) */
+#define REG_DMAC_CFG0            (0x400C0050U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 0) */
+#define REG_DMAC_SADDR1          (0x400C0064U) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 1) */
+#define REG_DMAC_DADDR1          (0x400C0068U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 1) */
+#define REG_DMAC_DSCR1           (0x400C006CU) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 1) */
+#define REG_DMAC_CTRLA1          (0x400C0070U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 1) */
+#define REG_DMAC_CTRLB1          (0x400C0074U) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 1) */
+#define REG_DMAC_CFG1            (0x400C0078U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 1) */
+#define REG_DMAC_SADDR2          (0x400C008CU) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 2) */
+#define REG_DMAC_DADDR2          (0x400C0090U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 2) */
+#define REG_DMAC_DSCR2           (0x400C0094U) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 2) */
+#define REG_DMAC_CTRLA2          (0x400C0098U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 2) */
+#define REG_DMAC_CTRLB2          (0x400C009CU) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 2) */
+#define REG_DMAC_CFG2            (0x400C00A0U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 2) */
+#define REG_DMAC_SADDR3          (0x400C00B4U) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 3) */
+#define REG_DMAC_DADDR3          (0x400C00B8U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 3) */
+#define REG_DMAC_DSCR3           (0x400C00BCU) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 3) */
+#define REG_DMAC_CTRLA3          (0x400C00C0U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 3) */
+#define REG_DMAC_CTRLB3          (0x400C00C4U) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 3) */
+#define REG_DMAC_CFG3            (0x400C00C8U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 3) */
+#define REG_DMAC_WPMR            (0x400C01E4U) /**< \brief (DMAC) DMAC Write Protect Mode Register */
+#define REG_DMAC_WPSR            (0x400C01E8U) /**< \brief (DMAC) DMAC Write Protect Status Register */
+#else
+#define REG_DMAC_GCFG   (*(RwReg*)0x400C0000U) /**< \brief (DMAC) DMAC Global Configuration Register */
+#define REG_DMAC_EN     (*(RwReg*)0x400C0004U) /**< \brief (DMAC) DMAC Enable Register */
+#define REG_DMAC_SREQ   (*(RwReg*)0x400C0008U) /**< \brief (DMAC) DMAC Software Single Request Register */
+#define REG_DMAC_CREQ   (*(RwReg*)0x400C000CU) /**< \brief (DMAC) DMAC Software Chunk Transfer Request Register */
+#define REG_DMAC_LAST   (*(RwReg*)0x400C0010U) /**< \brief (DMAC) DMAC Software Last Transfer Flag Register */
+#define REG_DMAC_EBCIER (*(WoReg*)0x400C0018U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Enable register. */
+#define REG_DMAC_EBCIDR (*(WoReg*)0x400C001CU) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer Transfer Completed Interrupt Disable register. */
+#define REG_DMAC_EBCIMR (*(RoReg*)0x400C0020U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Mask Register. */
+#define REG_DMAC_EBCISR (*(RoReg*)0x400C0024U) /**< \brief (DMAC) DMAC Error, Chained Buffer Transfer Completed Interrupt and Buffer transfer completed Status Register. */
+#define REG_DMAC_CHER   (*(WoReg*)0x400C0028U) /**< \brief (DMAC) DMAC Channel Handler Enable Register */
+#define REG_DMAC_CHDR   (*(WoReg*)0x400C002CU) /**< \brief (DMAC) DMAC Channel Handler Disable Register */
+#define REG_DMAC_CHSR   (*(RoReg*)0x400C0030U) /**< \brief (DMAC) DMAC Channel Handler Status Register */
+#define REG_DMAC_SADDR0 (*(RwReg*)0x400C003CU) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 0) */
+#define REG_DMAC_DADDR0 (*(RwReg*)0x400C0040U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 0) */
+#define REG_DMAC_DSCR0  (*(RwReg*)0x400C0044U) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 0) */
+#define REG_DMAC_CTRLA0 (*(RwReg*)0x400C0048U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 0) */
+#define REG_DMAC_CTRLB0 (*(RwReg*)0x400C004CU) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 0) */
+#define REG_DMAC_CFG0   (*(RwReg*)0x400C0050U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 0) */
+#define REG_DMAC_SADDR1 (*(RwReg*)0x400C0064U) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 1) */
+#define REG_DMAC_DADDR1 (*(RwReg*)0x400C0068U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 1) */
+#define REG_DMAC_DSCR1  (*(RwReg*)0x400C006CU) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 1) */
+#define REG_DMAC_CTRLA1 (*(RwReg*)0x400C0070U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 1) */
+#define REG_DMAC_CTRLB1 (*(RwReg*)0x400C0074U) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 1) */
+#define REG_DMAC_CFG1   (*(RwReg*)0x400C0078U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 1) */
+#define REG_DMAC_SADDR2 (*(RwReg*)0x400C008CU) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 2) */
+#define REG_DMAC_DADDR2 (*(RwReg*)0x400C0090U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 2) */
+#define REG_DMAC_DSCR2  (*(RwReg*)0x400C0094U) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 2) */
+#define REG_DMAC_CTRLA2 (*(RwReg*)0x400C0098U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 2) */
+#define REG_DMAC_CTRLB2 (*(RwReg*)0x400C009CU) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 2) */
+#define REG_DMAC_CFG2   (*(RwReg*)0x400C00A0U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 2) */
+#define REG_DMAC_SADDR3 (*(RwReg*)0x400C00B4U) /**< \brief (DMAC) DMAC Channel Source Address Register (ch_num = 3) */
+#define REG_DMAC_DADDR3 (*(RwReg*)0x400C00B8U) /**< \brief (DMAC) DMAC Channel Destination Address Register (ch_num = 3) */
+#define REG_DMAC_DSCR3  (*(RwReg*)0x400C00BCU) /**< \brief (DMAC) DMAC Channel Descriptor Address Register (ch_num = 3) */
+#define REG_DMAC_CTRLA3 (*(RwReg*)0x400C00C0U) /**< \brief (DMAC) DMAC Channel Control A Register (ch_num = 3) */
+#define REG_DMAC_CTRLB3 (*(RwReg*)0x400C00C4U) /**< \brief (DMAC) DMAC Channel Control B Register (ch_num = 3) */
+#define REG_DMAC_CFG3   (*(RwReg*)0x400C00C8U) /**< \brief (DMAC) DMAC Channel Configuration Register (ch_num = 3) */
+#define REG_DMAC_WPMR   (*(RwReg*)0x400C01E4U) /**< \brief (DMAC) DMAC Write Protect Mode Register */
+#define REG_DMAC_WPSR   (*(RoReg*)0x400C01E8U) /**< \brief (DMAC) DMAC Write Protect Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_DMAC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/efc.h
+++ b/asf/sam/include/sam4e/instance/efc.h
@@ -1,0 +1,46 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_EFC_INSTANCE_
+#define _SAM4E_EFC_INSTANCE_
+
+/* ========== Register definition for EFC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EFC_FMR           (0x400E0A00U) /**< \brief (EFC) EEFC Flash Mode Register */
+#define REG_EFC_FCR           (0x400E0A04U) /**< \brief (EFC) EEFC Flash Command Register */
+#define REG_EFC_FSR           (0x400E0A08U) /**< \brief (EFC) EEFC Flash Status Register */
+#define REG_EFC_FRR           (0x400E0A0CU) /**< \brief (EFC) EEFC Flash Result Register */
+#else
+#define REG_EFC_FMR  (*(RwReg*)0x400E0A00U) /**< \brief (EFC) EEFC Flash Mode Register */
+#define REG_EFC_FCR  (*(WoReg*)0x400E0A04U) /**< \brief (EFC) EEFC Flash Command Register */
+#define REG_EFC_FSR  (*(RoReg*)0x400E0A08U) /**< \brief (EFC) EEFC Flash Status Register */
+#define REG_EFC_FRR  (*(RoReg*)0x400E0A0CU) /**< \brief (EFC) EEFC Flash Result Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_EFC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/gmac.h
+++ b/asf/sam/include/sam4e/instance/gmac.h
@@ -1,0 +1,220 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_GMAC_INSTANCE_
+#define _SAM4E_GMAC_INSTANCE_
+
+/* ========== Register definition for GMAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GMAC_NCR                (0x40034000U) /**< \brief (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR              (0x40034004U) /**< \brief (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR                (0x40034008U) /**< \brief (GMAC) Network Status Register */
+#define REG_GMAC_UR                 (0x4003400CU) /**< \brief (GMAC) User Register */
+#define REG_GMAC_DCFGR              (0x40034010U) /**< \brief (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR                (0x40034014U) /**< \brief (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB               (0x40034018U) /**< \brief (GMAC) Receive Buffer Queue Base Address */
+#define REG_GMAC_TBQB               (0x4003401CU) /**< \brief (GMAC) Transmit Buffer Queue Base Address */
+#define REG_GMAC_RSR                (0x40034020U) /**< \brief (GMAC) Receive Status Register */
+#define REG_GMAC_ISR                (0x40034024U) /**< \brief (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER                (0x40034028U) /**< \brief (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR                (0x4003402CU) /**< \brief (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR                (0x40034030U) /**< \brief (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN                (0x40034034U) /**< \brief (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ                (0x40034038U) /**< \brief (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ                (0x4003403CU) /**< \brief (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_HRB                (0x40034080U) /**< \brief (GMAC) Hash Register Bottom [31:0] */
+#define REG_GMAC_HRT                (0x40034084U) /**< \brief (GMAC) Hash Register Top [63:32] */
+#define REG_GMAC_SAB1               (0x40034088U) /**< \brief (GMAC) Specific Address 1 Bottom [31:0] Register */
+#define REG_GMAC_SAT1               (0x4003408CU) /**< \brief (GMAC) Specific Address 1 Top [47:32] Register */
+#define REG_GMAC_SAB2               (0x40034090U) /**< \brief (GMAC) Specific Address 2 Bottom [31:0] Register */
+#define REG_GMAC_SAT2               (0x40034094U) /**< \brief (GMAC) Specific Address 2 Top [47:32] Register */
+#define REG_GMAC_SAB3               (0x40034098U) /**< \brief (GMAC) Specific Address 3 Bottom [31:0] Register */
+#define REG_GMAC_SAT3               (0x4003409CU) /**< \brief (GMAC) Specific Address 3 Top [47:32] Register */
+#define REG_GMAC_SAB4               (0x400340A0U) /**< \brief (GMAC) Specific Address 4 Bottom [31:0] Register */
+#define REG_GMAC_SAT4               (0x400340A4U) /**< \brief (GMAC) Specific Address 4 Top [47:32] Register */
+#define REG_GMAC_TIDM               (0x400340A8U) /**< \brief (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_IPGS               (0x400340BCU) /**< \brief (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN              (0x400340C0U) /**< \brief (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP              (0x400340C4U) /**< \brief (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1              (0x400340C8U) /**< \brief (GMAC) Specific Address 1 Mask Bottom [31:0] Register */
+#define REG_GMAC_SAMT1              (0x400340CCU) /**< \brief (GMAC) Specific Address 1 Mask Top [47:32] Register */
+#define REG_GMAC_OTLO               (0x40034100U) /**< \brief (GMAC) Octets Transmitted [31:0] Register */
+#define REG_GMAC_OTHI               (0x40034104U) /**< \brief (GMAC) Octets Transmitted [47:32] Register */
+#define REG_GMAC_FT                 (0x40034108U) /**< \brief (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT               (0x4003410CU) /**< \brief (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT                (0x40034110U) /**< \brief (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT                (0x40034114U) /**< \brief (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64              (0x40034118U) /**< \brief (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127            (0x4003411CU) /**< \brief (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255            (0x40034120U) /**< \brief (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511            (0x40034124U) /**< \brief (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023           (0x40034128U) /**< \brief (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518           (0x4003412CU) /**< \brief (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518          (0x40034130U) /**< \brief (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR                (0x40034134U) /**< \brief (GMAC) Transmit Under Runs Register */
+#define REG_GMAC_SCF                (0x40034138U) /**< \brief (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF                (0x4003413CU) /**< \brief (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC                 (0x40034140U) /**< \brief (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC                 (0x40034144U) /**< \brief (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF                (0x40034148U) /**< \brief (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE                (0x4003414CU) /**< \brief (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO               (0x40034150U) /**< \brief (GMAC) Octets Received [31:0] Received */
+#define REG_GMAC_ORHI               (0x40034154U) /**< \brief (GMAC) Octets Received [47:32] Received */
+#define REG_GMAC_FR                 (0x40034158U) /**< \brief (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR               (0x4003415CU) /**< \brief (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR                (0x40034160U) /**< \brief (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR                (0x40034164U) /**< \brief (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64              (0x40034168U) /**< \brief (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127            (0x4003416CU) /**< \brief (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255            (0x40034170U) /**< \brief (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511            (0x40034174U) /**< \brief (GMAC) 256 to 511Byte Frames Received Register */
+#define REG_GMAC_TBFR1023           (0x40034178U) /**< \brief (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518           (0x4003417CU) /**< \brief (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR             (0x40034180U) /**< \brief (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR                (0x40034184U) /**< \brief (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR                (0x40034188U) /**< \brief (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR                 (0x4003418CU) /**< \brief (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE               (0x40034190U) /**< \brief (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE               (0x40034194U) /**< \brief (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE                (0x40034198U) /**< \brief (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE                 (0x4003419CU) /**< \brief (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE                (0x400341A0U) /**< \brief (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE                (0x400341A4U) /**< \brief (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE               (0x400341A8U) /**< \brief (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE                (0x400341ACU) /**< \brief (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE                (0x400341B0U) /**< \brief (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TSSS               (0x400341C8U) /**< \brief (GMAC) 1588 Timer Sync Strobe Seconds Register */
+#define REG_GMAC_TSSN               (0x400341CCU) /**< \brief (GMAC) 1588 Timer Sync Strobe Nanoseconds Register */
+#define REG_GMAC_TS                 (0x400341D0U) /**< \brief (GMAC) 1588 Timer Seconds Register */
+#define REG_GMAC_TN                 (0x400341D4U) /**< \brief (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA                 (0x400341D8U) /**< \brief (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI                 (0x400341DCU) /**< \brief (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTS               (0x400341E0U) /**< \brief (GMAC) PTP Event Frame Transmitted Seconds */
+#define REG_GMAC_EFTN               (0x400341E4U) /**< \brief (GMAC) PTP Event Frame Transmitted Nanoseconds */
+#define REG_GMAC_EFRS               (0x400341E8U) /**< \brief (GMAC) PTP Event Frame Received Seconds */
+#define REG_GMAC_EFRN               (0x400341ECU) /**< \brief (GMAC) PTP Event Frame Received Nanoseconds */
+#define REG_GMAC_PEFTS              (0x400341F0U) /**< \brief (GMAC) PTP Peer Event Frame Transmitted Seconds */
+#define REG_GMAC_PEFTN              (0x400341F4U) /**< \brief (GMAC) PTP Peer Event Frame Transmitted Nanoseconds */
+#define REG_GMAC_PEFRS              (0x400341F8U) /**< \brief (GMAC) PTP Peer Event Frame Received Seconds */
+#define REG_GMAC_PEFRN              (0x400341FCU) /**< \brief (GMAC) PTP Peer Event Frame Received Nanoseconds */
+#else
+#define REG_GMAC_NCR       (*(RwReg*)0x40034000U) /**< \brief (GMAC) Network Control Register */
+#define REG_GMAC_NCFGR     (*(RwReg*)0x40034004U) /**< \brief (GMAC) Network Configuration Register */
+#define REG_GMAC_NSR       (*(RoReg*)0x40034008U) /**< \brief (GMAC) Network Status Register */
+#define REG_GMAC_UR        (*(RwReg*)0x4003400CU) /**< \brief (GMAC) User Register */
+#define REG_GMAC_DCFGR     (*(RwReg*)0x40034010U) /**< \brief (GMAC) DMA Configuration Register */
+#define REG_GMAC_TSR       (*(RwReg*)0x40034014U) /**< \brief (GMAC) Transmit Status Register */
+#define REG_GMAC_RBQB      (*(RwReg*)0x40034018U) /**< \brief (GMAC) Receive Buffer Queue Base Address */
+#define REG_GMAC_TBQB      (*(RwReg*)0x4003401CU) /**< \brief (GMAC) Transmit Buffer Queue Base Address */
+#define REG_GMAC_RSR       (*(RwReg*)0x40034020U) /**< \brief (GMAC) Receive Status Register */
+#define REG_GMAC_ISR       (*(RoReg*)0x40034024U) /**< \brief (GMAC) Interrupt Status Register */
+#define REG_GMAC_IER       (*(WoReg*)0x40034028U) /**< \brief (GMAC) Interrupt Enable Register */
+#define REG_GMAC_IDR       (*(WoReg*)0x4003402CU) /**< \brief (GMAC) Interrupt Disable Register */
+#define REG_GMAC_IMR       (*(RoReg*)0x40034030U) /**< \brief (GMAC) Interrupt Mask Register */
+#define REG_GMAC_MAN       (*(RwReg*)0x40034034U) /**< \brief (GMAC) PHY Maintenance Register */
+#define REG_GMAC_RPQ       (*(RoReg*)0x40034038U) /**< \brief (GMAC) Received Pause Quantum Register */
+#define REG_GMAC_TPQ       (*(RwReg*)0x4003403CU) /**< \brief (GMAC) Transmit Pause Quantum Register */
+#define REG_GMAC_HRB       (*(RwReg*)0x40034080U) /**< \brief (GMAC) Hash Register Bottom [31:0] */
+#define REG_GMAC_HRT       (*(RwReg*)0x40034084U) /**< \brief (GMAC) Hash Register Top [63:32] */
+#define REG_GMAC_SAB1      (*(RwReg*)0x40034088U) /**< \brief (GMAC) Specific Address 1 Bottom [31:0] Register */
+#define REG_GMAC_SAT1      (*(RwReg*)0x4003408CU) /**< \brief (GMAC) Specific Address 1 Top [47:32] Register */
+#define REG_GMAC_SAB2      (*(RwReg*)0x40034090U) /**< \brief (GMAC) Specific Address 2 Bottom [31:0] Register */
+#define REG_GMAC_SAT2      (*(RwReg*)0x40034094U) /**< \brief (GMAC) Specific Address 2 Top [47:32] Register */
+#define REG_GMAC_SAB3      (*(RwReg*)0x40034098U) /**< \brief (GMAC) Specific Address 3 Bottom [31:0] Register */
+#define REG_GMAC_SAT3      (*(RwReg*)0x4003409CU) /**< \brief (GMAC) Specific Address 3 Top [47:32] Register */
+#define REG_GMAC_SAB4      (*(RwReg*)0x400340A0U) /**< \brief (GMAC) Specific Address 4 Bottom [31:0] Register */
+#define REG_GMAC_SAT4      (*(RwReg*)0x400340A4U) /**< \brief (GMAC) Specific Address 4 Top [47:32] Register */
+#define REG_GMAC_TIDM      (*(RwReg*)0x400340A8U) /**< \brief (GMAC) Type ID Match 1 Register */
+#define REG_GMAC_IPGS      (*(RwReg*)0x400340BCU) /**< \brief (GMAC) IPG Stretch Register */
+#define REG_GMAC_SVLAN     (*(RwReg*)0x400340C0U) /**< \brief (GMAC) Stacked VLAN Register */
+#define REG_GMAC_TPFCP     (*(RwReg*)0x400340C4U) /**< \brief (GMAC) Transmit PFC Pause Register */
+#define REG_GMAC_SAMB1     (*(RwReg*)0x400340C8U) /**< \brief (GMAC) Specific Address 1 Mask Bottom [31:0] Register */
+#define REG_GMAC_SAMT1     (*(RwReg*)0x400340CCU) /**< \brief (GMAC) Specific Address 1 Mask Top [47:32] Register */
+#define REG_GMAC_OTLO      (*(RoReg*)0x40034100U) /**< \brief (GMAC) Octets Transmitted [31:0] Register */
+#define REG_GMAC_OTHI      (*(RoReg*)0x40034104U) /**< \brief (GMAC) Octets Transmitted [47:32] Register */
+#define REG_GMAC_FT        (*(RoReg*)0x40034108U) /**< \brief (GMAC) Frames Transmitted Register */
+#define REG_GMAC_BCFT      (*(RoReg*)0x4003410CU) /**< \brief (GMAC) Broadcast Frames Transmitted Register */
+#define REG_GMAC_MFT       (*(RoReg*)0x40034110U) /**< \brief (GMAC) Multicast Frames Transmitted Register */
+#define REG_GMAC_PFT       (*(RoReg*)0x40034114U) /**< \brief (GMAC) Pause Frames Transmitted Register */
+#define REG_GMAC_BFT64     (*(RoReg*)0x40034118U) /**< \brief (GMAC) 64 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT127   (*(RoReg*)0x4003411CU) /**< \brief (GMAC) 65 to 127 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT255   (*(RoReg*)0x40034120U) /**< \brief (GMAC) 128 to 255 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT511   (*(RoReg*)0x40034124U) /**< \brief (GMAC) 256 to 511 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1023  (*(RoReg*)0x40034128U) /**< \brief (GMAC) 512 to 1023 Byte Frames Transmitted Register */
+#define REG_GMAC_TBFT1518  (*(RoReg*)0x4003412CU) /**< \brief (GMAC) 1024 to 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_GTBFT1518 (*(RoReg*)0x40034130U) /**< \brief (GMAC) Greater Than 1518 Byte Frames Transmitted Register */
+#define REG_GMAC_TUR       (*(RoReg*)0x40034134U) /**< \brief (GMAC) Transmit Under Runs Register */
+#define REG_GMAC_SCF       (*(RoReg*)0x40034138U) /**< \brief (GMAC) Single Collision Frames Register */
+#define REG_GMAC_MCF       (*(RoReg*)0x4003413CU) /**< \brief (GMAC) Multiple Collision Frames Register */
+#define REG_GMAC_EC        (*(RoReg*)0x40034140U) /**< \brief (GMAC) Excessive Collisions Register */
+#define REG_GMAC_LC        (*(RoReg*)0x40034144U) /**< \brief (GMAC) Late Collisions Register */
+#define REG_GMAC_DTF       (*(RoReg*)0x40034148U) /**< \brief (GMAC) Deferred Transmission Frames Register */
+#define REG_GMAC_CSE       (*(RoReg*)0x4003414CU) /**< \brief (GMAC) Carrier Sense Errors Register */
+#define REG_GMAC_ORLO      (*(RoReg*)0x40034150U) /**< \brief (GMAC) Octets Received [31:0] Received */
+#define REG_GMAC_ORHI      (*(RoReg*)0x40034154U) /**< \brief (GMAC) Octets Received [47:32] Received */
+#define REG_GMAC_FR        (*(RoReg*)0x40034158U) /**< \brief (GMAC) Frames Received Register */
+#define REG_GMAC_BCFR      (*(RoReg*)0x4003415CU) /**< \brief (GMAC) Broadcast Frames Received Register */
+#define REG_GMAC_MFR       (*(RoReg*)0x40034160U) /**< \brief (GMAC) Multicast Frames Received Register */
+#define REG_GMAC_PFR       (*(RoReg*)0x40034164U) /**< \brief (GMAC) Pause Frames Received Register */
+#define REG_GMAC_BFR64     (*(RoReg*)0x40034168U) /**< \brief (GMAC) 64 Byte Frames Received Register */
+#define REG_GMAC_TBFR127   (*(RoReg*)0x4003416CU) /**< \brief (GMAC) 65 to 127 Byte Frames Received Register */
+#define REG_GMAC_TBFR255   (*(RoReg*)0x40034170U) /**< \brief (GMAC) 128 to 255 Byte Frames Received Register */
+#define REG_GMAC_TBFR511   (*(RoReg*)0x40034174U) /**< \brief (GMAC) 256 to 511Byte Frames Received Register */
+#define REG_GMAC_TBFR1023  (*(RoReg*)0x40034178U) /**< \brief (GMAC) 512 to 1023 Byte Frames Received Register */
+#define REG_GMAC_TBFR1518  (*(RoReg*)0x4003417CU) /**< \brief (GMAC) 1024 to 1518 Byte Frames Received Register */
+#define REG_GMAC_TMXBFR    (*(RoReg*)0x40034180U) /**< \brief (GMAC) 1519 to Maximum Byte Frames Received Register */
+#define REG_GMAC_UFR       (*(RoReg*)0x40034184U) /**< \brief (GMAC) Undersize Frames Received Register */
+#define REG_GMAC_OFR       (*(RoReg*)0x40034188U) /**< \brief (GMAC) Oversize Frames Received Register */
+#define REG_GMAC_JR        (*(RoReg*)0x4003418CU) /**< \brief (GMAC) Jabbers Received Register */
+#define REG_GMAC_FCSE      (*(RoReg*)0x40034190U) /**< \brief (GMAC) Frame Check Sequence Errors Register */
+#define REG_GMAC_LFFE      (*(RoReg*)0x40034194U) /**< \brief (GMAC) Length Field Frame Errors Register */
+#define REG_GMAC_RSE       (*(RoReg*)0x40034198U) /**< \brief (GMAC) Receive Symbol Errors Register */
+#define REG_GMAC_AE        (*(RoReg*)0x4003419CU) /**< \brief (GMAC) Alignment Errors Register */
+#define REG_GMAC_RRE       (*(RoReg*)0x400341A0U) /**< \brief (GMAC) Receive Resource Errors Register */
+#define REG_GMAC_ROE       (*(RoReg*)0x400341A4U) /**< \brief (GMAC) Receive Overrun Register */
+#define REG_GMAC_IHCE      (*(RoReg*)0x400341A8U) /**< \brief (GMAC) IP Header Checksum Errors Register */
+#define REG_GMAC_TCE       (*(RoReg*)0x400341ACU) /**< \brief (GMAC) TCP Checksum Errors Register */
+#define REG_GMAC_UCE       (*(RoReg*)0x400341B0U) /**< \brief (GMAC) UDP Checksum Errors Register */
+#define REG_GMAC_TSSS      (*(RwReg*)0x400341C8U) /**< \brief (GMAC) 1588 Timer Sync Strobe Seconds Register */
+#define REG_GMAC_TSSN      (*(RwReg*)0x400341CCU) /**< \brief (GMAC) 1588 Timer Sync Strobe Nanoseconds Register */
+#define REG_GMAC_TS        (*(RwReg*)0x400341D0U) /**< \brief (GMAC) 1588 Timer Seconds Register */
+#define REG_GMAC_TN        (*(RwReg*)0x400341D4U) /**< \brief (GMAC) 1588 Timer Nanoseconds Register */
+#define REG_GMAC_TA        (*(WoReg*)0x400341D8U) /**< \brief (GMAC) 1588 Timer Adjust Register */
+#define REG_GMAC_TI        (*(RwReg*)0x400341DCU) /**< \brief (GMAC) 1588 Timer Increment Register */
+#define REG_GMAC_EFTS      (*(RoReg*)0x400341E0U) /**< \brief (GMAC) PTP Event Frame Transmitted Seconds */
+#define REG_GMAC_EFTN      (*(RoReg*)0x400341E4U) /**< \brief (GMAC) PTP Event Frame Transmitted Nanoseconds */
+#define REG_GMAC_EFRS      (*(RoReg*)0x400341E8U) /**< \brief (GMAC) PTP Event Frame Received Seconds */
+#define REG_GMAC_EFRN      (*(RoReg*)0x400341ECU) /**< \brief (GMAC) PTP Event Frame Received Nanoseconds */
+#define REG_GMAC_PEFTS     (*(RoReg*)0x400341F0U) /**< \brief (GMAC) PTP Peer Event Frame Transmitted Seconds */
+#define REG_GMAC_PEFTN     (*(RoReg*)0x400341F4U) /**< \brief (GMAC) PTP Peer Event Frame Transmitted Nanoseconds */
+#define REG_GMAC_PEFRS     (*(RoReg*)0x400341F8U) /**< \brief (GMAC) PTP Peer Event Frame Received Seconds */
+#define REG_GMAC_PEFRN     (*(RoReg*)0x400341FCU) /**< \brief (GMAC) PTP Peer Event Frame Received Nanoseconds */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_GMAC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/gpbr.h
+++ b/asf/sam/include/sam4e/instance/gpbr.h
@@ -1,0 +1,40 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_GPBR_INSTANCE_
+#define _SAM4E_GPBR_INSTANCE_
+
+/* ========== Register definition for GPBR peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GPBR_GPBR             (0x400E1890U) /**< \brief (GPBR) General Purpose Backup Register */
+#else
+#define REG_GPBR_GPBR    (*(RwReg*)0x400E1890U) /**< \brief (GPBR) General Purpose Backup Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_GPBR_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/hsmci.h
+++ b/asf/sam/include/sam4e/instance/hsmci.h
@@ -1,0 +1,96 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_HSMCI_INSTANCE_
+#define _SAM4E_HSMCI_INSTANCE_
+
+/* ========== Register definition for HSMCI peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_HSMCI_CR                 (0x40080000U) /**< \brief (HSMCI) Control Register */
+#define REG_HSMCI_MR                 (0x40080004U) /**< \brief (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR               (0x40080008U) /**< \brief (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR               (0x4008000CU) /**< \brief (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR               (0x40080010U) /**< \brief (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR               (0x40080014U) /**< \brief (HSMCI) Command Register */
+#define REG_HSMCI_BLKR               (0x40080018U) /**< \brief (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR              (0x4008001CU) /**< \brief (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR               (0x40080020U) /**< \brief (HSMCI) Response Register */
+#define REG_HSMCI_RDR                (0x40080030U) /**< \brief (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR                (0x40080034U) /**< \brief (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR                 (0x40080040U) /**< \brief (HSMCI) Status Register */
+#define REG_HSMCI_IER                (0x40080044U) /**< \brief (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR                (0x40080048U) /**< \brief (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR                (0x4008004CU) /**< \brief (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_CFG                (0x40080054U) /**< \brief (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR               (0x400800E4U) /**< \brief (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR               (0x400800E8U) /**< \brief (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_RPR                (0x40080100U) /**< \brief (HSMCI) Receive Pointer Register */
+#define REG_HSMCI_RCR                (0x40080104U) /**< \brief (HSMCI) Receive Counter Register */
+#define REG_HSMCI_TPR                (0x40080108U) /**< \brief (HSMCI) Transmit Pointer Register */
+#define REG_HSMCI_TCR                (0x4008010CU) /**< \brief (HSMCI) Transmit Counter Register */
+#define REG_HSMCI_RNPR               (0x40080110U) /**< \brief (HSMCI) Receive Next Pointer Register */
+#define REG_HSMCI_RNCR               (0x40080114U) /**< \brief (HSMCI) Receive Next Counter Register */
+#define REG_HSMCI_TNPR               (0x40080118U) /**< \brief (HSMCI) Transmit Next Pointer Register */
+#define REG_HSMCI_TNCR               (0x4008011CU) /**< \brief (HSMCI) Transmit Next Counter Register */
+#define REG_HSMCI_PTCR               (0x40080120U) /**< \brief (HSMCI) Transfer Control Register */
+#define REG_HSMCI_PTSR               (0x40080124U) /**< \brief (HSMCI) Transfer Status Register */
+#define REG_HSMCI_FIFO               (0x40080200U) /**< \brief (HSMCI) FIFO Memory Aperture0 */
+#else
+#define REG_HSMCI_CR        (*(WoReg*)0x40080000U) /**< \brief (HSMCI) Control Register */
+#define REG_HSMCI_MR        (*(RwReg*)0x40080004U) /**< \brief (HSMCI) Mode Register */
+#define REG_HSMCI_DTOR      (*(RwReg*)0x40080008U) /**< \brief (HSMCI) Data Timeout Register */
+#define REG_HSMCI_SDCR      (*(RwReg*)0x4008000CU) /**< \brief (HSMCI) SD/SDIO Card Register */
+#define REG_HSMCI_ARGR      (*(RwReg*)0x40080010U) /**< \brief (HSMCI) Argument Register */
+#define REG_HSMCI_CMDR      (*(WoReg*)0x40080014U) /**< \brief (HSMCI) Command Register */
+#define REG_HSMCI_BLKR      (*(RwReg*)0x40080018U) /**< \brief (HSMCI) Block Register */
+#define REG_HSMCI_CSTOR     (*(RwReg*)0x4008001CU) /**< \brief (HSMCI) Completion Signal Timeout Register */
+#define REG_HSMCI_RSPR      (*(RoReg*)0x40080020U) /**< \brief (HSMCI) Response Register */
+#define REG_HSMCI_RDR       (*(RoReg*)0x40080030U) /**< \brief (HSMCI) Receive Data Register */
+#define REG_HSMCI_TDR       (*(WoReg*)0x40080034U) /**< \brief (HSMCI) Transmit Data Register */
+#define REG_HSMCI_SR        (*(RoReg*)0x40080040U) /**< \brief (HSMCI) Status Register */
+#define REG_HSMCI_IER       (*(WoReg*)0x40080044U) /**< \brief (HSMCI) Interrupt Enable Register */
+#define REG_HSMCI_IDR       (*(WoReg*)0x40080048U) /**< \brief (HSMCI) Interrupt Disable Register */
+#define REG_HSMCI_IMR       (*(RoReg*)0x4008004CU) /**< \brief (HSMCI) Interrupt Mask Register */
+#define REG_HSMCI_CFG       (*(RwReg*)0x40080054U) /**< \brief (HSMCI) Configuration Register */
+#define REG_HSMCI_WPMR      (*(RwReg*)0x400800E4U) /**< \brief (HSMCI) Write Protection Mode Register */
+#define REG_HSMCI_WPSR      (*(RoReg*)0x400800E8U) /**< \brief (HSMCI) Write Protection Status Register */
+#define REG_HSMCI_RPR       (*(RwReg*)0x40080100U) /**< \brief (HSMCI) Receive Pointer Register */
+#define REG_HSMCI_RCR       (*(RwReg*)0x40080104U) /**< \brief (HSMCI) Receive Counter Register */
+#define REG_HSMCI_TPR       (*(RwReg*)0x40080108U) /**< \brief (HSMCI) Transmit Pointer Register */
+#define REG_HSMCI_TCR       (*(RwReg*)0x4008010CU) /**< \brief (HSMCI) Transmit Counter Register */
+#define REG_HSMCI_RNPR      (*(RwReg*)0x40080110U) /**< \brief (HSMCI) Receive Next Pointer Register */
+#define REG_HSMCI_RNCR      (*(RwReg*)0x40080114U) /**< \brief (HSMCI) Receive Next Counter Register */
+#define REG_HSMCI_TNPR      (*(RwReg*)0x40080118U) /**< \brief (HSMCI) Transmit Next Pointer Register */
+#define REG_HSMCI_TNCR      (*(RwReg*)0x4008011CU) /**< \brief (HSMCI) Transmit Next Counter Register */
+#define REG_HSMCI_PTCR      (*(WoReg*)0x40080120U) /**< \brief (HSMCI) Transfer Control Register */
+#define REG_HSMCI_PTSR      (*(RoReg*)0x40080124U) /**< \brief (HSMCI) Transfer Status Register */
+#define REG_HSMCI_FIFO      (*(RwReg*)0x40080200U) /**< \brief (HSMCI) FIFO Memory Aperture0 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_HSMCI_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/matrix.h
+++ b/asf/sam/include/sam4e/instance/matrix.h
@@ -1,0 +1,114 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_MATRIX_INSTANCE_
+#define _SAM4E_MATRIX_INSTANCE_
+
+/* ========== Register definition for MATRIX peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_MATRIX_MCFG              (0x400E0200U) /**< \brief (MATRIX) Master Configuration Register */
+#define REG_MATRIX_SCFG              (0x400E0240U) /**< \brief (MATRIX) Slave Configuration Register */
+#define REG_MATRIX_PRAS0             (0x400E0280U) /**< \brief (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0             (0x400E0284U) /**< \brief (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1             (0x400E0288U) /**< \brief (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1             (0x400E028CU) /**< \brief (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2             (0x400E0290U) /**< \brief (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2             (0x400E0294U) /**< \brief (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3             (0x400E0298U) /**< \brief (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3             (0x400E029CU) /**< \brief (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4             (0x400E02A0U) /**< \brief (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4             (0x400E02A4U) /**< \brief (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5             (0x400E02A8U) /**< \brief (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5             (0x400E02ACU) /**< \brief (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6             (0x400E02B0U) /**< \brief (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6             (0x400E02B4U) /**< \brief (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7             (0x400E02B8U) /**< \brief (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7             (0x400E02BCU) /**< \brief (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8             (0x400E02C0U) /**< \brief (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8             (0x400E02C4U) /**< \brief (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_PRAS9             (0x400E02C8U) /**< \brief (MATRIX) Priority Register A for Slave 9 */
+#define REG_MATRIX_PRBS9             (0x400E02CCU) /**< \brief (MATRIX) Priority Register B for Slave 9 */
+#define REG_MATRIX_PRAS10            (0x400E02D0U) /**< \brief (MATRIX) Priority Register A for Slave 10 */
+#define REG_MATRIX_PRBS10            (0x400E02D4U) /**< \brief (MATRIX) Priority Register B for Slave 10 */
+#define REG_MATRIX_PRAS11            (0x400E02D8U) /**< \brief (MATRIX) Priority Register A for Slave 11 */
+#define REG_MATRIX_PRBS11            (0x400E02DCU) /**< \brief (MATRIX) Priority Register B for Slave 11 */
+#define REG_MATRIX_PRAS12            (0x400E02E0U) /**< \brief (MATRIX) Priority Register A for Slave 12 */
+#define REG_MATRIX_PRBS12            (0x400E02E4U) /**< \brief (MATRIX) Priority Register B for Slave 12 */
+#define REG_MATRIX_PRAS13            (0x400E02E8U) /**< \brief (MATRIX) Priority Register A for Slave 13 */
+#define REG_MATRIX_PRBS13            (0x400E02ECU) /**< \brief (MATRIX) Priority Register B for Slave 13 */
+#define REG_MATRIX_PRAS14            (0x400E02F0U) /**< \brief (MATRIX) Priority Register A for Slave 14 */
+#define REG_MATRIX_PRBS14            (0x400E02F4U) /**< \brief (MATRIX) Priority Register B for Slave 14 */
+#define REG_MATRIX_PRAS15            (0x400E02F8U) /**< \brief (MATRIX) Priority Register A for Slave 15 */
+#define REG_MATRIX_PRBS15            (0x400E02FCU) /**< \brief (MATRIX) Priority Register B for Slave 15 */
+#define REG_MATRIX_MRCR              (0x400E0300U) /**< \brief (MATRIX) Master Remap Control Register */
+#define REG_MATRIX_SFR               (0x400E0310U) /**< \brief (MATRIX) Special Function Register */
+#define REG_MATRIX_WPMR              (0x400E03E4U) /**< \brief (MATRIX) Write Protect Mode Register */
+#define REG_MATRIX_WPSR              (0x400E03E8U) /**< \brief (MATRIX) Write Protect Status Register */
+#else
+#define REG_MATRIX_MCFG     (*(RwReg*)0x400E0200U) /**< \brief (MATRIX) Master Configuration Register */
+#define REG_MATRIX_SCFG     (*(RwReg*)0x400E0240U) /**< \brief (MATRIX) Slave Configuration Register */
+#define REG_MATRIX_PRAS0    (*(RwReg*)0x400E0280U) /**< \brief (MATRIX) Priority Register A for Slave 0 */
+#define REG_MATRIX_PRBS0    (*(RwReg*)0x400E0284U) /**< \brief (MATRIX) Priority Register B for Slave 0 */
+#define REG_MATRIX_PRAS1    (*(RwReg*)0x400E0288U) /**< \brief (MATRIX) Priority Register A for Slave 1 */
+#define REG_MATRIX_PRBS1    (*(RwReg*)0x400E028CU) /**< \brief (MATRIX) Priority Register B for Slave 1 */
+#define REG_MATRIX_PRAS2    (*(RwReg*)0x400E0290U) /**< \brief (MATRIX) Priority Register A for Slave 2 */
+#define REG_MATRIX_PRBS2    (*(RwReg*)0x400E0294U) /**< \brief (MATRIX) Priority Register B for Slave 2 */
+#define REG_MATRIX_PRAS3    (*(RwReg*)0x400E0298U) /**< \brief (MATRIX) Priority Register A for Slave 3 */
+#define REG_MATRIX_PRBS3    (*(RwReg*)0x400E029CU) /**< \brief (MATRIX) Priority Register B for Slave 3 */
+#define REG_MATRIX_PRAS4    (*(RwReg*)0x400E02A0U) /**< \brief (MATRIX) Priority Register A for Slave 4 */
+#define REG_MATRIX_PRBS4    (*(RwReg*)0x400E02A4U) /**< \brief (MATRIX) Priority Register B for Slave 4 */
+#define REG_MATRIX_PRAS5    (*(RwReg*)0x400E02A8U) /**< \brief (MATRIX) Priority Register A for Slave 5 */
+#define REG_MATRIX_PRBS5    (*(RwReg*)0x400E02ACU) /**< \brief (MATRIX) Priority Register B for Slave 5 */
+#define REG_MATRIX_PRAS6    (*(RwReg*)0x400E02B0U) /**< \brief (MATRIX) Priority Register A for Slave 6 */
+#define REG_MATRIX_PRBS6    (*(RwReg*)0x400E02B4U) /**< \brief (MATRIX) Priority Register B for Slave 6 */
+#define REG_MATRIX_PRAS7    (*(RwReg*)0x400E02B8U) /**< \brief (MATRIX) Priority Register A for Slave 7 */
+#define REG_MATRIX_PRBS7    (*(RwReg*)0x400E02BCU) /**< \brief (MATRIX) Priority Register B for Slave 7 */
+#define REG_MATRIX_PRAS8    (*(RwReg*)0x400E02C0U) /**< \brief (MATRIX) Priority Register A for Slave 8 */
+#define REG_MATRIX_PRBS8    (*(RwReg*)0x400E02C4U) /**< \brief (MATRIX) Priority Register B for Slave 8 */
+#define REG_MATRIX_PRAS9    (*(RwReg*)0x400E02C8U) /**< \brief (MATRIX) Priority Register A for Slave 9 */
+#define REG_MATRIX_PRBS9    (*(RwReg*)0x400E02CCU) /**< \brief (MATRIX) Priority Register B for Slave 9 */
+#define REG_MATRIX_PRAS10   (*(RwReg*)0x400E02D0U) /**< \brief (MATRIX) Priority Register A for Slave 10 */
+#define REG_MATRIX_PRBS10   (*(RwReg*)0x400E02D4U) /**< \brief (MATRIX) Priority Register B for Slave 10 */
+#define REG_MATRIX_PRAS11   (*(RwReg*)0x400E02D8U) /**< \brief (MATRIX) Priority Register A for Slave 11 */
+#define REG_MATRIX_PRBS11   (*(RwReg*)0x400E02DCU) /**< \brief (MATRIX) Priority Register B for Slave 11 */
+#define REG_MATRIX_PRAS12   (*(RwReg*)0x400E02E0U) /**< \brief (MATRIX) Priority Register A for Slave 12 */
+#define REG_MATRIX_PRBS12   (*(RwReg*)0x400E02E4U) /**< \brief (MATRIX) Priority Register B for Slave 12 */
+#define REG_MATRIX_PRAS13   (*(RwReg*)0x400E02E8U) /**< \brief (MATRIX) Priority Register A for Slave 13 */
+#define REG_MATRIX_PRBS13   (*(RwReg*)0x400E02ECU) /**< \brief (MATRIX) Priority Register B for Slave 13 */
+#define REG_MATRIX_PRAS14   (*(RwReg*)0x400E02F0U) /**< \brief (MATRIX) Priority Register A for Slave 14 */
+#define REG_MATRIX_PRBS14   (*(RwReg*)0x400E02F4U) /**< \brief (MATRIX) Priority Register B for Slave 14 */
+#define REG_MATRIX_PRAS15   (*(RwReg*)0x400E02F8U) /**< \brief (MATRIX) Priority Register A for Slave 15 */
+#define REG_MATRIX_PRBS15   (*(RwReg*)0x400E02FCU) /**< \brief (MATRIX) Priority Register B for Slave 15 */
+#define REG_MATRIX_MRCR     (*(RwReg*)0x400E0300U) /**< \brief (MATRIX) Master Remap Control Register */
+#define REG_MATRIX_SFR      (*(RwReg*)0x400E0310U) /**< \brief (MATRIX) Special Function Register */
+#define REG_MATRIX_WPMR     (*(RwReg*)0x400E03E4U) /**< \brief (MATRIX) Write Protect Mode Register */
+#define REG_MATRIX_WPSR     (*(RoReg*)0x400E03E8U) /**< \brief (MATRIX) Write Protect Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_MATRIX_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/pioa.h
+++ b/asf/sam/include/sam4e/instance/pioa.h
@@ -1,0 +1,158 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIOA_INSTANCE_
+#define _SAM4E_PIOA_INSTANCE_
+
+/* ========== Register definition for PIOA peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PIOA_PER                (0x400E0E00U) /**< \brief (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR                (0x400E0E04U) /**< \brief (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR                (0x400E0E08U) /**< \brief (PIOA) PIO Status Register */
+#define REG_PIOA_OER                (0x400E0E10U) /**< \brief (PIOA) Output Enable Register */
+#define REG_PIOA_ODR                (0x400E0E14U) /**< \brief (PIOA) Output Disable Register */
+#define REG_PIOA_OSR                (0x400E0E18U) /**< \brief (PIOA) Output Status Register */
+#define REG_PIOA_IFER               (0x400E0E20U) /**< \brief (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR               (0x400E0E24U) /**< \brief (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR               (0x400E0E28U) /**< \brief (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR               (0x400E0E30U) /**< \brief (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR               (0x400E0E34U) /**< \brief (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR               (0x400E0E38U) /**< \brief (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR               (0x400E0E3CU) /**< \brief (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER                (0x400E0E40U) /**< \brief (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR                (0x400E0E44U) /**< \brief (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR                (0x400E0E48U) /**< \brief (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR                (0x400E0E4CU) /**< \brief (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER               (0x400E0E50U) /**< \brief (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR               (0x400E0E54U) /**< \brief (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR               (0x400E0E58U) /**< \brief (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR               (0x400E0E60U) /**< \brief (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER               (0x400E0E64U) /**< \brief (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR               (0x400E0E68U) /**< \brief (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR             (0x400E0E70U) /**< \brief (PIOA) Peripheral Select Register */
+#define REG_PIOA_IFSCDR             (0x400E0E80U) /**< \brief (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER             (0x400E0E84U) /**< \brief (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR             (0x400E0E88U) /**< \brief (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR               (0x400E0E8CU) /**< \brief (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR              (0x400E0E90U) /**< \brief (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER              (0x400E0E94U) /**< \brief (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR              (0x400E0E98U) /**< \brief (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER               (0x400E0EA0U) /**< \brief (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR               (0x400E0EA4U) /**< \brief (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR               (0x400E0EA8U) /**< \brief (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER              (0x400E0EB0U) /**< \brief (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR              (0x400E0EB4U) /**< \brief (PIOA) Additional Interrupt Modes Disables Register */
+#define REG_PIOA_AIMMR              (0x400E0EB8U) /**< \brief (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR                (0x400E0EC0U) /**< \brief (PIOA) Edge Select Register */
+#define REG_PIOA_LSR                (0x400E0EC4U) /**< \brief (PIOA) Level Select Register */
+#define REG_PIOA_ELSR               (0x400E0EC8U) /**< \brief (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR             (0x400E0ED0U) /**< \brief (PIOA) Falling Edge/Low Level Select Register */
+#define REG_PIOA_REHLSR             (0x400E0ED4U) /**< \brief (PIOA) Rising Edge/ High Level Select Register */
+#define REG_PIOA_FRLHSR             (0x400E0ED8U) /**< \brief (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR             (0x400E0EE0U) /**< \brief (PIOA) Lock Status */
+#define REG_PIOA_WPMR               (0x400E0EE4U) /**< \brief (PIOA) Write Protect Mode Register */
+#define REG_PIOA_WPSR               (0x400E0EE8U) /**< \brief (PIOA) Write Protect Status Register */
+#define REG_PIOA_SCHMITT            (0x400E0F00U) /**< \brief (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DELAYR             (0x400E0F10U) /**< \brief (PIOA) IO Delay Register */
+#define REG_PIOA_PCMR               (0x400E0F50U) /**< \brief (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER              (0x400E0F54U) /**< \brief (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR              (0x400E0F58U) /**< \brief (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR              (0x400E0F5CU) /**< \brief (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR              (0x400E0F60U) /**< \brief (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR              (0x400E0F64U) /**< \brief (PIOA) Parallel Capture Reception Holding Register */
+#define REG_PIOA_RPR                (0x400E0F68U) /**< \brief (PIOA) Receive Pointer Register */
+#define REG_PIOA_RCR                (0x400E0F6CU) /**< \brief (PIOA) Receive Counter Register */
+#define REG_PIOA_RNPR               (0x400E0F78U) /**< \brief (PIOA) Receive Next Pointer Register */
+#define REG_PIOA_RNCR               (0x400E0F7CU) /**< \brief (PIOA) Receive Next Counter Register */
+#define REG_PIOA_PTCR               (0x400E0F88U) /**< \brief (PIOA) Transfer Control Register */
+#define REG_PIOA_PTSR               (0x400E0F8CU) /**< \brief (PIOA) Transfer Status Register */
+#else
+#define REG_PIOA_PER       (*(WoReg*)0x400E0E00U) /**< \brief (PIOA) PIO Enable Register */
+#define REG_PIOA_PDR       (*(WoReg*)0x400E0E04U) /**< \brief (PIOA) PIO Disable Register */
+#define REG_PIOA_PSR       (*(RoReg*)0x400E0E08U) /**< \brief (PIOA) PIO Status Register */
+#define REG_PIOA_OER       (*(WoReg*)0x400E0E10U) /**< \brief (PIOA) Output Enable Register */
+#define REG_PIOA_ODR       (*(WoReg*)0x400E0E14U) /**< \brief (PIOA) Output Disable Register */
+#define REG_PIOA_OSR       (*(RoReg*)0x400E0E18U) /**< \brief (PIOA) Output Status Register */
+#define REG_PIOA_IFER      (*(WoReg*)0x400E0E20U) /**< \brief (PIOA) Glitch Input Filter Enable Register */
+#define REG_PIOA_IFDR      (*(WoReg*)0x400E0E24U) /**< \brief (PIOA) Glitch Input Filter Disable Register */
+#define REG_PIOA_IFSR      (*(RoReg*)0x400E0E28U) /**< \brief (PIOA) Glitch Input Filter Status Register */
+#define REG_PIOA_SODR      (*(WoReg*)0x400E0E30U) /**< \brief (PIOA) Set Output Data Register */
+#define REG_PIOA_CODR      (*(WoReg*)0x400E0E34U) /**< \brief (PIOA) Clear Output Data Register */
+#define REG_PIOA_ODSR      (*(RwReg*)0x400E0E38U) /**< \brief (PIOA) Output Data Status Register */
+#define REG_PIOA_PDSR      (*(RoReg*)0x400E0E3CU) /**< \brief (PIOA) Pin Data Status Register */
+#define REG_PIOA_IER       (*(WoReg*)0x400E0E40U) /**< \brief (PIOA) Interrupt Enable Register */
+#define REG_PIOA_IDR       (*(WoReg*)0x400E0E44U) /**< \brief (PIOA) Interrupt Disable Register */
+#define REG_PIOA_IMR       (*(RoReg*)0x400E0E48U) /**< \brief (PIOA) Interrupt Mask Register */
+#define REG_PIOA_ISR       (*(RoReg*)0x400E0E4CU) /**< \brief (PIOA) Interrupt Status Register */
+#define REG_PIOA_MDER      (*(WoReg*)0x400E0E50U) /**< \brief (PIOA) Multi-driver Enable Register */
+#define REG_PIOA_MDDR      (*(WoReg*)0x400E0E54U) /**< \brief (PIOA) Multi-driver Disable Register */
+#define REG_PIOA_MDSR      (*(RoReg*)0x400E0E58U) /**< \brief (PIOA) Multi-driver Status Register */
+#define REG_PIOA_PUDR      (*(WoReg*)0x400E0E60U) /**< \brief (PIOA) Pull-up Disable Register */
+#define REG_PIOA_PUER      (*(WoReg*)0x400E0E64U) /**< \brief (PIOA) Pull-up Enable Register */
+#define REG_PIOA_PUSR      (*(RoReg*)0x400E0E68U) /**< \brief (PIOA) Pad Pull-up Status Register */
+#define REG_PIOA_ABCDSR    (*(RwReg*)0x400E0E70U) /**< \brief (PIOA) Peripheral Select Register */
+#define REG_PIOA_IFSCDR    (*(WoReg*)0x400E0E80U) /**< \brief (PIOA) Input Filter Slow Clock Disable Register */
+#define REG_PIOA_IFSCER    (*(WoReg*)0x400E0E84U) /**< \brief (PIOA) Input Filter Slow Clock Enable Register */
+#define REG_PIOA_IFSCSR    (*(RoReg*)0x400E0E88U) /**< \brief (PIOA) Input Filter Slow Clock Status Register */
+#define REG_PIOA_SCDR      (*(RwReg*)0x400E0E8CU) /**< \brief (PIOA) Slow Clock Divider Debouncing Register */
+#define REG_PIOA_PPDDR     (*(WoReg*)0x400E0E90U) /**< \brief (PIOA) Pad Pull-down Disable Register */
+#define REG_PIOA_PPDER     (*(WoReg*)0x400E0E94U) /**< \brief (PIOA) Pad Pull-down Enable Register */
+#define REG_PIOA_PPDSR     (*(RoReg*)0x400E0E98U) /**< \brief (PIOA) Pad Pull-down Status Register */
+#define REG_PIOA_OWER      (*(WoReg*)0x400E0EA0U) /**< \brief (PIOA) Output Write Enable */
+#define REG_PIOA_OWDR      (*(WoReg*)0x400E0EA4U) /**< \brief (PIOA) Output Write Disable */
+#define REG_PIOA_OWSR      (*(RoReg*)0x400E0EA8U) /**< \brief (PIOA) Output Write Status Register */
+#define REG_PIOA_AIMER     (*(WoReg*)0x400E0EB0U) /**< \brief (PIOA) Additional Interrupt Modes Enable Register */
+#define REG_PIOA_AIMDR     (*(WoReg*)0x400E0EB4U) /**< \brief (PIOA) Additional Interrupt Modes Disables Register */
+#define REG_PIOA_AIMMR     (*(RoReg*)0x400E0EB8U) /**< \brief (PIOA) Additional Interrupt Modes Mask Register */
+#define REG_PIOA_ESR       (*(WoReg*)0x400E0EC0U) /**< \brief (PIOA) Edge Select Register */
+#define REG_PIOA_LSR       (*(WoReg*)0x400E0EC4U) /**< \brief (PIOA) Level Select Register */
+#define REG_PIOA_ELSR      (*(RoReg*)0x400E0EC8U) /**< \brief (PIOA) Edge/Level Status Register */
+#define REG_PIOA_FELLSR    (*(WoReg*)0x400E0ED0U) /**< \brief (PIOA) Falling Edge/Low Level Select Register */
+#define REG_PIOA_REHLSR    (*(WoReg*)0x400E0ED4U) /**< \brief (PIOA) Rising Edge/ High Level Select Register */
+#define REG_PIOA_FRLHSR    (*(RoReg*)0x400E0ED8U) /**< \brief (PIOA) Fall/Rise - Low/High Status Register */
+#define REG_PIOA_LOCKSR    (*(RoReg*)0x400E0EE0U) /**< \brief (PIOA) Lock Status */
+#define REG_PIOA_WPMR      (*(RwReg*)0x400E0EE4U) /**< \brief (PIOA) Write Protect Mode Register */
+#define REG_PIOA_WPSR      (*(RoReg*)0x400E0EE8U) /**< \brief (PIOA) Write Protect Status Register */
+#define REG_PIOA_SCHMITT   (*(RwReg*)0x400E0F00U) /**< \brief (PIOA) Schmitt Trigger Register */
+#define REG_PIOA_DELAYR    (*(RwReg*)0x400E0F10U) /**< \brief (PIOA) IO Delay Register */
+#define REG_PIOA_PCMR      (*(RwReg*)0x400E0F50U) /**< \brief (PIOA) Parallel Capture Mode Register */
+#define REG_PIOA_PCIER     (*(WoReg*)0x400E0F54U) /**< \brief (PIOA) Parallel Capture Interrupt Enable Register */
+#define REG_PIOA_PCIDR     (*(WoReg*)0x400E0F58U) /**< \brief (PIOA) Parallel Capture Interrupt Disable Register */
+#define REG_PIOA_PCIMR     (*(RoReg*)0x400E0F5CU) /**< \brief (PIOA) Parallel Capture Interrupt Mask Register */
+#define REG_PIOA_PCISR     (*(RoReg*)0x400E0F60U) /**< \brief (PIOA) Parallel Capture Interrupt Status Register */
+#define REG_PIOA_PCRHR     (*(RoReg*)0x400E0F64U) /**< \brief (PIOA) Parallel Capture Reception Holding Register */
+#define REG_PIOA_RPR       (*(RwReg*)0x400E0F68U) /**< \brief (PIOA) Receive Pointer Register */
+#define REG_PIOA_RCR       (*(RwReg*)0x400E0F6CU) /**< \brief (PIOA) Receive Counter Register */
+#define REG_PIOA_RNPR      (*(RwReg*)0x400E0F78U) /**< \brief (PIOA) Receive Next Pointer Register */
+#define REG_PIOA_RNCR      (*(RwReg*)0x400E0F7CU) /**< \brief (PIOA) Receive Next Counter Register */
+#define REG_PIOA_PTCR      (*(WoReg*)0x400E0F88U) /**< \brief (PIOA) Transfer Control Register */
+#define REG_PIOA_PTSR      (*(RoReg*)0x400E0F8CU) /**< \brief (PIOA) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PIOA_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/piob.h
+++ b/asf/sam/include/sam4e/instance/piob.h
@@ -1,0 +1,146 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIOB_INSTANCE_
+#define _SAM4E_PIOB_INSTANCE_
+
+/* ========== Register definition for PIOB peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PIOB_PER                (0x400E1000U) /**< \brief (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR                (0x400E1004U) /**< \brief (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR                (0x400E1008U) /**< \brief (PIOB) PIO Status Register */
+#define REG_PIOB_OER                (0x400E1010U) /**< \brief (PIOB) Output Enable Register */
+#define REG_PIOB_ODR                (0x400E1014U) /**< \brief (PIOB) Output Disable Register */
+#define REG_PIOB_OSR                (0x400E1018U) /**< \brief (PIOB) Output Status Register */
+#define REG_PIOB_IFER               (0x400E1020U) /**< \brief (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR               (0x400E1024U) /**< \brief (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR               (0x400E1028U) /**< \brief (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR               (0x400E1030U) /**< \brief (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR               (0x400E1034U) /**< \brief (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR               (0x400E1038U) /**< \brief (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR               (0x400E103CU) /**< \brief (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER                (0x400E1040U) /**< \brief (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR                (0x400E1044U) /**< \brief (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR                (0x400E1048U) /**< \brief (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR                (0x400E104CU) /**< \brief (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER               (0x400E1050U) /**< \brief (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR               (0x400E1054U) /**< \brief (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR               (0x400E1058U) /**< \brief (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR               (0x400E1060U) /**< \brief (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER               (0x400E1064U) /**< \brief (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR               (0x400E1068U) /**< \brief (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR             (0x400E1070U) /**< \brief (PIOB) Peripheral Select Register */
+#define REG_PIOB_IFSCDR             (0x400E1080U) /**< \brief (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER             (0x400E1084U) /**< \brief (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR             (0x400E1088U) /**< \brief (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR               (0x400E108CU) /**< \brief (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR              (0x400E1090U) /**< \brief (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER              (0x400E1094U) /**< \brief (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR              (0x400E1098U) /**< \brief (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER               (0x400E10A0U) /**< \brief (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR               (0x400E10A4U) /**< \brief (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR               (0x400E10A8U) /**< \brief (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER              (0x400E10B0U) /**< \brief (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR              (0x400E10B4U) /**< \brief (PIOB) Additional Interrupt Modes Disables Register */
+#define REG_PIOB_AIMMR              (0x400E10B8U) /**< \brief (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR                (0x400E10C0U) /**< \brief (PIOB) Edge Select Register */
+#define REG_PIOB_LSR                (0x400E10C4U) /**< \brief (PIOB) Level Select Register */
+#define REG_PIOB_ELSR               (0x400E10C8U) /**< \brief (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR             (0x400E10D0U) /**< \brief (PIOB) Falling Edge/Low Level Select Register */
+#define REG_PIOB_REHLSR             (0x400E10D4U) /**< \brief (PIOB) Rising Edge/ High Level Select Register */
+#define REG_PIOB_FRLHSR             (0x400E10D8U) /**< \brief (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR             (0x400E10E0U) /**< \brief (PIOB) Lock Status */
+#define REG_PIOB_WPMR               (0x400E10E4U) /**< \brief (PIOB) Write Protect Mode Register */
+#define REG_PIOB_WPSR               (0x400E10E8U) /**< \brief (PIOB) Write Protect Status Register */
+#define REG_PIOB_SCHMITT            (0x400E1100U) /**< \brief (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DELAYR             (0x400E1110U) /**< \brief (PIOB) IO Delay Register */
+#define REG_PIOB_PCMR               (0x400E1150U) /**< \brief (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER              (0x400E1154U) /**< \brief (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR              (0x400E1158U) /**< \brief (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR              (0x400E115CU) /**< \brief (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR              (0x400E1160U) /**< \brief (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR              (0x400E1164U) /**< \brief (PIOB) Parallel Capture Reception Holding Register */
+#else
+#define REG_PIOB_PER       (*(WoReg*)0x400E1000U) /**< \brief (PIOB) PIO Enable Register */
+#define REG_PIOB_PDR       (*(WoReg*)0x400E1004U) /**< \brief (PIOB) PIO Disable Register */
+#define REG_PIOB_PSR       (*(RoReg*)0x400E1008U) /**< \brief (PIOB) PIO Status Register */
+#define REG_PIOB_OER       (*(WoReg*)0x400E1010U) /**< \brief (PIOB) Output Enable Register */
+#define REG_PIOB_ODR       (*(WoReg*)0x400E1014U) /**< \brief (PIOB) Output Disable Register */
+#define REG_PIOB_OSR       (*(RoReg*)0x400E1018U) /**< \brief (PIOB) Output Status Register */
+#define REG_PIOB_IFER      (*(WoReg*)0x400E1020U) /**< \brief (PIOB) Glitch Input Filter Enable Register */
+#define REG_PIOB_IFDR      (*(WoReg*)0x400E1024U) /**< \brief (PIOB) Glitch Input Filter Disable Register */
+#define REG_PIOB_IFSR      (*(RoReg*)0x400E1028U) /**< \brief (PIOB) Glitch Input Filter Status Register */
+#define REG_PIOB_SODR      (*(WoReg*)0x400E1030U) /**< \brief (PIOB) Set Output Data Register */
+#define REG_PIOB_CODR      (*(WoReg*)0x400E1034U) /**< \brief (PIOB) Clear Output Data Register */
+#define REG_PIOB_ODSR      (*(RwReg*)0x400E1038U) /**< \brief (PIOB) Output Data Status Register */
+#define REG_PIOB_PDSR      (*(RoReg*)0x400E103CU) /**< \brief (PIOB) Pin Data Status Register */
+#define REG_PIOB_IER       (*(WoReg*)0x400E1040U) /**< \brief (PIOB) Interrupt Enable Register */
+#define REG_PIOB_IDR       (*(WoReg*)0x400E1044U) /**< \brief (PIOB) Interrupt Disable Register */
+#define REG_PIOB_IMR       (*(RoReg*)0x400E1048U) /**< \brief (PIOB) Interrupt Mask Register */
+#define REG_PIOB_ISR       (*(RoReg*)0x400E104CU) /**< \brief (PIOB) Interrupt Status Register */
+#define REG_PIOB_MDER      (*(WoReg*)0x400E1050U) /**< \brief (PIOB) Multi-driver Enable Register */
+#define REG_PIOB_MDDR      (*(WoReg*)0x400E1054U) /**< \brief (PIOB) Multi-driver Disable Register */
+#define REG_PIOB_MDSR      (*(RoReg*)0x400E1058U) /**< \brief (PIOB) Multi-driver Status Register */
+#define REG_PIOB_PUDR      (*(WoReg*)0x400E1060U) /**< \brief (PIOB) Pull-up Disable Register */
+#define REG_PIOB_PUER      (*(WoReg*)0x400E1064U) /**< \brief (PIOB) Pull-up Enable Register */
+#define REG_PIOB_PUSR      (*(RoReg*)0x400E1068U) /**< \brief (PIOB) Pad Pull-up Status Register */
+#define REG_PIOB_ABCDSR    (*(RwReg*)0x400E1070U) /**< \brief (PIOB) Peripheral Select Register */
+#define REG_PIOB_IFSCDR    (*(WoReg*)0x400E1080U) /**< \brief (PIOB) Input Filter Slow Clock Disable Register */
+#define REG_PIOB_IFSCER    (*(WoReg*)0x400E1084U) /**< \brief (PIOB) Input Filter Slow Clock Enable Register */
+#define REG_PIOB_IFSCSR    (*(RoReg*)0x400E1088U) /**< \brief (PIOB) Input Filter Slow Clock Status Register */
+#define REG_PIOB_SCDR      (*(RwReg*)0x400E108CU) /**< \brief (PIOB) Slow Clock Divider Debouncing Register */
+#define REG_PIOB_PPDDR     (*(WoReg*)0x400E1090U) /**< \brief (PIOB) Pad Pull-down Disable Register */
+#define REG_PIOB_PPDER     (*(WoReg*)0x400E1094U) /**< \brief (PIOB) Pad Pull-down Enable Register */
+#define REG_PIOB_PPDSR     (*(RoReg*)0x400E1098U) /**< \brief (PIOB) Pad Pull-down Status Register */
+#define REG_PIOB_OWER      (*(WoReg*)0x400E10A0U) /**< \brief (PIOB) Output Write Enable */
+#define REG_PIOB_OWDR      (*(WoReg*)0x400E10A4U) /**< \brief (PIOB) Output Write Disable */
+#define REG_PIOB_OWSR      (*(RoReg*)0x400E10A8U) /**< \brief (PIOB) Output Write Status Register */
+#define REG_PIOB_AIMER     (*(WoReg*)0x400E10B0U) /**< \brief (PIOB) Additional Interrupt Modes Enable Register */
+#define REG_PIOB_AIMDR     (*(WoReg*)0x400E10B4U) /**< \brief (PIOB) Additional Interrupt Modes Disables Register */
+#define REG_PIOB_AIMMR     (*(RoReg*)0x400E10B8U) /**< \brief (PIOB) Additional Interrupt Modes Mask Register */
+#define REG_PIOB_ESR       (*(WoReg*)0x400E10C0U) /**< \brief (PIOB) Edge Select Register */
+#define REG_PIOB_LSR       (*(WoReg*)0x400E10C4U) /**< \brief (PIOB) Level Select Register */
+#define REG_PIOB_ELSR      (*(RoReg*)0x400E10C8U) /**< \brief (PIOB) Edge/Level Status Register */
+#define REG_PIOB_FELLSR    (*(WoReg*)0x400E10D0U) /**< \brief (PIOB) Falling Edge/Low Level Select Register */
+#define REG_PIOB_REHLSR    (*(WoReg*)0x400E10D4U) /**< \brief (PIOB) Rising Edge/ High Level Select Register */
+#define REG_PIOB_FRLHSR    (*(RoReg*)0x400E10D8U) /**< \brief (PIOB) Fall/Rise - Low/High Status Register */
+#define REG_PIOB_LOCKSR    (*(RoReg*)0x400E10E0U) /**< \brief (PIOB) Lock Status */
+#define REG_PIOB_WPMR      (*(RwReg*)0x400E10E4U) /**< \brief (PIOB) Write Protect Mode Register */
+#define REG_PIOB_WPSR      (*(RoReg*)0x400E10E8U) /**< \brief (PIOB) Write Protect Status Register */
+#define REG_PIOB_SCHMITT   (*(RwReg*)0x400E1100U) /**< \brief (PIOB) Schmitt Trigger Register */
+#define REG_PIOB_DELAYR    (*(RwReg*)0x400E1110U) /**< \brief (PIOB) IO Delay Register */
+#define REG_PIOB_PCMR      (*(RwReg*)0x400E1150U) /**< \brief (PIOB) Parallel Capture Mode Register */
+#define REG_PIOB_PCIER     (*(WoReg*)0x400E1154U) /**< \brief (PIOB) Parallel Capture Interrupt Enable Register */
+#define REG_PIOB_PCIDR     (*(WoReg*)0x400E1158U) /**< \brief (PIOB) Parallel Capture Interrupt Disable Register */
+#define REG_PIOB_PCIMR     (*(RoReg*)0x400E115CU) /**< \brief (PIOB) Parallel Capture Interrupt Mask Register */
+#define REG_PIOB_PCISR     (*(RoReg*)0x400E1160U) /**< \brief (PIOB) Parallel Capture Interrupt Status Register */
+#define REG_PIOB_PCRHR     (*(RoReg*)0x400E1164U) /**< \brief (PIOB) Parallel Capture Reception Holding Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PIOB_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/pioc.h
+++ b/asf/sam/include/sam4e/instance/pioc.h
@@ -1,0 +1,146 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIOC_INSTANCE_
+#define _SAM4E_PIOC_INSTANCE_
+
+/* ========== Register definition for PIOC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PIOC_PER                (0x400E1200U) /**< \brief (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR                (0x400E1204U) /**< \brief (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR                (0x400E1208U) /**< \brief (PIOC) PIO Status Register */
+#define REG_PIOC_OER                (0x400E1210U) /**< \brief (PIOC) Output Enable Register */
+#define REG_PIOC_ODR                (0x400E1214U) /**< \brief (PIOC) Output Disable Register */
+#define REG_PIOC_OSR                (0x400E1218U) /**< \brief (PIOC) Output Status Register */
+#define REG_PIOC_IFER               (0x400E1220U) /**< \brief (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR               (0x400E1224U) /**< \brief (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR               (0x400E1228U) /**< \brief (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR               (0x400E1230U) /**< \brief (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR               (0x400E1234U) /**< \brief (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR               (0x400E1238U) /**< \brief (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR               (0x400E123CU) /**< \brief (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER                (0x400E1240U) /**< \brief (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR                (0x400E1244U) /**< \brief (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR                (0x400E1248U) /**< \brief (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR                (0x400E124CU) /**< \brief (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER               (0x400E1250U) /**< \brief (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR               (0x400E1254U) /**< \brief (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR               (0x400E1258U) /**< \brief (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR               (0x400E1260U) /**< \brief (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER               (0x400E1264U) /**< \brief (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR               (0x400E1268U) /**< \brief (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR             (0x400E1270U) /**< \brief (PIOC) Peripheral Select Register */
+#define REG_PIOC_IFSCDR             (0x400E1280U) /**< \brief (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER             (0x400E1284U) /**< \brief (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR             (0x400E1288U) /**< \brief (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR               (0x400E128CU) /**< \brief (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR              (0x400E1290U) /**< \brief (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER              (0x400E1294U) /**< \brief (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR              (0x400E1298U) /**< \brief (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER               (0x400E12A0U) /**< \brief (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR               (0x400E12A4U) /**< \brief (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR               (0x400E12A8U) /**< \brief (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER              (0x400E12B0U) /**< \brief (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR              (0x400E12B4U) /**< \brief (PIOC) Additional Interrupt Modes Disables Register */
+#define REG_PIOC_AIMMR              (0x400E12B8U) /**< \brief (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR                (0x400E12C0U) /**< \brief (PIOC) Edge Select Register */
+#define REG_PIOC_LSR                (0x400E12C4U) /**< \brief (PIOC) Level Select Register */
+#define REG_PIOC_ELSR               (0x400E12C8U) /**< \brief (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR             (0x400E12D0U) /**< \brief (PIOC) Falling Edge/Low Level Select Register */
+#define REG_PIOC_REHLSR             (0x400E12D4U) /**< \brief (PIOC) Rising Edge/ High Level Select Register */
+#define REG_PIOC_FRLHSR             (0x400E12D8U) /**< \brief (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR             (0x400E12E0U) /**< \brief (PIOC) Lock Status */
+#define REG_PIOC_WPMR               (0x400E12E4U) /**< \brief (PIOC) Write Protect Mode Register */
+#define REG_PIOC_WPSR               (0x400E12E8U) /**< \brief (PIOC) Write Protect Status Register */
+#define REG_PIOC_SCHMITT            (0x400E1300U) /**< \brief (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DELAYR             (0x400E1310U) /**< \brief (PIOC) IO Delay Register */
+#define REG_PIOC_PCMR               (0x400E1350U) /**< \brief (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER              (0x400E1354U) /**< \brief (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR              (0x400E1358U) /**< \brief (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR              (0x400E135CU) /**< \brief (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR              (0x400E1360U) /**< \brief (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR              (0x400E1364U) /**< \brief (PIOC) Parallel Capture Reception Holding Register */
+#else
+#define REG_PIOC_PER       (*(WoReg*)0x400E1200U) /**< \brief (PIOC) PIO Enable Register */
+#define REG_PIOC_PDR       (*(WoReg*)0x400E1204U) /**< \brief (PIOC) PIO Disable Register */
+#define REG_PIOC_PSR       (*(RoReg*)0x400E1208U) /**< \brief (PIOC) PIO Status Register */
+#define REG_PIOC_OER       (*(WoReg*)0x400E1210U) /**< \brief (PIOC) Output Enable Register */
+#define REG_PIOC_ODR       (*(WoReg*)0x400E1214U) /**< \brief (PIOC) Output Disable Register */
+#define REG_PIOC_OSR       (*(RoReg*)0x400E1218U) /**< \brief (PIOC) Output Status Register */
+#define REG_PIOC_IFER      (*(WoReg*)0x400E1220U) /**< \brief (PIOC) Glitch Input Filter Enable Register */
+#define REG_PIOC_IFDR      (*(WoReg*)0x400E1224U) /**< \brief (PIOC) Glitch Input Filter Disable Register */
+#define REG_PIOC_IFSR      (*(RoReg*)0x400E1228U) /**< \brief (PIOC) Glitch Input Filter Status Register */
+#define REG_PIOC_SODR      (*(WoReg*)0x400E1230U) /**< \brief (PIOC) Set Output Data Register */
+#define REG_PIOC_CODR      (*(WoReg*)0x400E1234U) /**< \brief (PIOC) Clear Output Data Register */
+#define REG_PIOC_ODSR      (*(RwReg*)0x400E1238U) /**< \brief (PIOC) Output Data Status Register */
+#define REG_PIOC_PDSR      (*(RoReg*)0x400E123CU) /**< \brief (PIOC) Pin Data Status Register */
+#define REG_PIOC_IER       (*(WoReg*)0x400E1240U) /**< \brief (PIOC) Interrupt Enable Register */
+#define REG_PIOC_IDR       (*(WoReg*)0x400E1244U) /**< \brief (PIOC) Interrupt Disable Register */
+#define REG_PIOC_IMR       (*(RoReg*)0x400E1248U) /**< \brief (PIOC) Interrupt Mask Register */
+#define REG_PIOC_ISR       (*(RoReg*)0x400E124CU) /**< \brief (PIOC) Interrupt Status Register */
+#define REG_PIOC_MDER      (*(WoReg*)0x400E1250U) /**< \brief (PIOC) Multi-driver Enable Register */
+#define REG_PIOC_MDDR      (*(WoReg*)0x400E1254U) /**< \brief (PIOC) Multi-driver Disable Register */
+#define REG_PIOC_MDSR      (*(RoReg*)0x400E1258U) /**< \brief (PIOC) Multi-driver Status Register */
+#define REG_PIOC_PUDR      (*(WoReg*)0x400E1260U) /**< \brief (PIOC) Pull-up Disable Register */
+#define REG_PIOC_PUER      (*(WoReg*)0x400E1264U) /**< \brief (PIOC) Pull-up Enable Register */
+#define REG_PIOC_PUSR      (*(RoReg*)0x400E1268U) /**< \brief (PIOC) Pad Pull-up Status Register */
+#define REG_PIOC_ABCDSR    (*(RwReg*)0x400E1270U) /**< \brief (PIOC) Peripheral Select Register */
+#define REG_PIOC_IFSCDR    (*(WoReg*)0x400E1280U) /**< \brief (PIOC) Input Filter Slow Clock Disable Register */
+#define REG_PIOC_IFSCER    (*(WoReg*)0x400E1284U) /**< \brief (PIOC) Input Filter Slow Clock Enable Register */
+#define REG_PIOC_IFSCSR    (*(RoReg*)0x400E1288U) /**< \brief (PIOC) Input Filter Slow Clock Status Register */
+#define REG_PIOC_SCDR      (*(RwReg*)0x400E128CU) /**< \brief (PIOC) Slow Clock Divider Debouncing Register */
+#define REG_PIOC_PPDDR     (*(WoReg*)0x400E1290U) /**< \brief (PIOC) Pad Pull-down Disable Register */
+#define REG_PIOC_PPDER     (*(WoReg*)0x400E1294U) /**< \brief (PIOC) Pad Pull-down Enable Register */
+#define REG_PIOC_PPDSR     (*(RoReg*)0x400E1298U) /**< \brief (PIOC) Pad Pull-down Status Register */
+#define REG_PIOC_OWER      (*(WoReg*)0x400E12A0U) /**< \brief (PIOC) Output Write Enable */
+#define REG_PIOC_OWDR      (*(WoReg*)0x400E12A4U) /**< \brief (PIOC) Output Write Disable */
+#define REG_PIOC_OWSR      (*(RoReg*)0x400E12A8U) /**< \brief (PIOC) Output Write Status Register */
+#define REG_PIOC_AIMER     (*(WoReg*)0x400E12B0U) /**< \brief (PIOC) Additional Interrupt Modes Enable Register */
+#define REG_PIOC_AIMDR     (*(WoReg*)0x400E12B4U) /**< \brief (PIOC) Additional Interrupt Modes Disables Register */
+#define REG_PIOC_AIMMR     (*(RoReg*)0x400E12B8U) /**< \brief (PIOC) Additional Interrupt Modes Mask Register */
+#define REG_PIOC_ESR       (*(WoReg*)0x400E12C0U) /**< \brief (PIOC) Edge Select Register */
+#define REG_PIOC_LSR       (*(WoReg*)0x400E12C4U) /**< \brief (PIOC) Level Select Register */
+#define REG_PIOC_ELSR      (*(RoReg*)0x400E12C8U) /**< \brief (PIOC) Edge/Level Status Register */
+#define REG_PIOC_FELLSR    (*(WoReg*)0x400E12D0U) /**< \brief (PIOC) Falling Edge/Low Level Select Register */
+#define REG_PIOC_REHLSR    (*(WoReg*)0x400E12D4U) /**< \brief (PIOC) Rising Edge/ High Level Select Register */
+#define REG_PIOC_FRLHSR    (*(RoReg*)0x400E12D8U) /**< \brief (PIOC) Fall/Rise - Low/High Status Register */
+#define REG_PIOC_LOCKSR    (*(RoReg*)0x400E12E0U) /**< \brief (PIOC) Lock Status */
+#define REG_PIOC_WPMR      (*(RwReg*)0x400E12E4U) /**< \brief (PIOC) Write Protect Mode Register */
+#define REG_PIOC_WPSR      (*(RoReg*)0x400E12E8U) /**< \brief (PIOC) Write Protect Status Register */
+#define REG_PIOC_SCHMITT   (*(RwReg*)0x400E1300U) /**< \brief (PIOC) Schmitt Trigger Register */
+#define REG_PIOC_DELAYR    (*(RwReg*)0x400E1310U) /**< \brief (PIOC) IO Delay Register */
+#define REG_PIOC_PCMR      (*(RwReg*)0x400E1350U) /**< \brief (PIOC) Parallel Capture Mode Register */
+#define REG_PIOC_PCIER     (*(WoReg*)0x400E1354U) /**< \brief (PIOC) Parallel Capture Interrupt Enable Register */
+#define REG_PIOC_PCIDR     (*(WoReg*)0x400E1358U) /**< \brief (PIOC) Parallel Capture Interrupt Disable Register */
+#define REG_PIOC_PCIMR     (*(RoReg*)0x400E135CU) /**< \brief (PIOC) Parallel Capture Interrupt Mask Register */
+#define REG_PIOC_PCISR     (*(RoReg*)0x400E1360U) /**< \brief (PIOC) Parallel Capture Interrupt Status Register */
+#define REG_PIOC_PCRHR     (*(RoReg*)0x400E1364U) /**< \brief (PIOC) Parallel Capture Reception Holding Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PIOC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/piod.h
+++ b/asf/sam/include/sam4e/instance/piod.h
@@ -1,0 +1,146 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIOD_INSTANCE_
+#define _SAM4E_PIOD_INSTANCE_
+
+/* ========== Register definition for PIOD peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PIOD_PER                (0x400E1400U) /**< \brief (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR                (0x400E1404U) /**< \brief (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR                (0x400E1408U) /**< \brief (PIOD) PIO Status Register */
+#define REG_PIOD_OER                (0x400E1410U) /**< \brief (PIOD) Output Enable Register */
+#define REG_PIOD_ODR                (0x400E1414U) /**< \brief (PIOD) Output Disable Register */
+#define REG_PIOD_OSR                (0x400E1418U) /**< \brief (PIOD) Output Status Register */
+#define REG_PIOD_IFER               (0x400E1420U) /**< \brief (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR               (0x400E1424U) /**< \brief (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR               (0x400E1428U) /**< \brief (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR               (0x400E1430U) /**< \brief (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR               (0x400E1434U) /**< \brief (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR               (0x400E1438U) /**< \brief (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR               (0x400E143CU) /**< \brief (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER                (0x400E1440U) /**< \brief (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR                (0x400E1444U) /**< \brief (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR                (0x400E1448U) /**< \brief (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR                (0x400E144CU) /**< \brief (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER               (0x400E1450U) /**< \brief (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR               (0x400E1454U) /**< \brief (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR               (0x400E1458U) /**< \brief (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR               (0x400E1460U) /**< \brief (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER               (0x400E1464U) /**< \brief (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR               (0x400E1468U) /**< \brief (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR             (0x400E1470U) /**< \brief (PIOD) Peripheral Select Register */
+#define REG_PIOD_IFSCDR             (0x400E1480U) /**< \brief (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER             (0x400E1484U) /**< \brief (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR             (0x400E1488U) /**< \brief (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR               (0x400E148CU) /**< \brief (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR              (0x400E1490U) /**< \brief (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER              (0x400E1494U) /**< \brief (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR              (0x400E1498U) /**< \brief (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER               (0x400E14A0U) /**< \brief (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR               (0x400E14A4U) /**< \brief (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR               (0x400E14A8U) /**< \brief (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER              (0x400E14B0U) /**< \brief (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR              (0x400E14B4U) /**< \brief (PIOD) Additional Interrupt Modes Disables Register */
+#define REG_PIOD_AIMMR              (0x400E14B8U) /**< \brief (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR                (0x400E14C0U) /**< \brief (PIOD) Edge Select Register */
+#define REG_PIOD_LSR                (0x400E14C4U) /**< \brief (PIOD) Level Select Register */
+#define REG_PIOD_ELSR               (0x400E14C8U) /**< \brief (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR             (0x400E14D0U) /**< \brief (PIOD) Falling Edge/Low Level Select Register */
+#define REG_PIOD_REHLSR             (0x400E14D4U) /**< \brief (PIOD) Rising Edge/ High Level Select Register */
+#define REG_PIOD_FRLHSR             (0x400E14D8U) /**< \brief (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR             (0x400E14E0U) /**< \brief (PIOD) Lock Status */
+#define REG_PIOD_WPMR               (0x400E14E4U) /**< \brief (PIOD) Write Protect Mode Register */
+#define REG_PIOD_WPSR               (0x400E14E8U) /**< \brief (PIOD) Write Protect Status Register */
+#define REG_PIOD_SCHMITT            (0x400E1500U) /**< \brief (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DELAYR             (0x400E1510U) /**< \brief (PIOD) IO Delay Register */
+#define REG_PIOD_PCMR               (0x400E1550U) /**< \brief (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER              (0x400E1554U) /**< \brief (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR              (0x400E1558U) /**< \brief (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR              (0x400E155CU) /**< \brief (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR              (0x400E1560U) /**< \brief (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR              (0x400E1564U) /**< \brief (PIOD) Parallel Capture Reception Holding Register */
+#else
+#define REG_PIOD_PER       (*(WoReg*)0x400E1400U) /**< \brief (PIOD) PIO Enable Register */
+#define REG_PIOD_PDR       (*(WoReg*)0x400E1404U) /**< \brief (PIOD) PIO Disable Register */
+#define REG_PIOD_PSR       (*(RoReg*)0x400E1408U) /**< \brief (PIOD) PIO Status Register */
+#define REG_PIOD_OER       (*(WoReg*)0x400E1410U) /**< \brief (PIOD) Output Enable Register */
+#define REG_PIOD_ODR       (*(WoReg*)0x400E1414U) /**< \brief (PIOD) Output Disable Register */
+#define REG_PIOD_OSR       (*(RoReg*)0x400E1418U) /**< \brief (PIOD) Output Status Register */
+#define REG_PIOD_IFER      (*(WoReg*)0x400E1420U) /**< \brief (PIOD) Glitch Input Filter Enable Register */
+#define REG_PIOD_IFDR      (*(WoReg*)0x400E1424U) /**< \brief (PIOD) Glitch Input Filter Disable Register */
+#define REG_PIOD_IFSR      (*(RoReg*)0x400E1428U) /**< \brief (PIOD) Glitch Input Filter Status Register */
+#define REG_PIOD_SODR      (*(WoReg*)0x400E1430U) /**< \brief (PIOD) Set Output Data Register */
+#define REG_PIOD_CODR      (*(WoReg*)0x400E1434U) /**< \brief (PIOD) Clear Output Data Register */
+#define REG_PIOD_ODSR      (*(RwReg*)0x400E1438U) /**< \brief (PIOD) Output Data Status Register */
+#define REG_PIOD_PDSR      (*(RoReg*)0x400E143CU) /**< \brief (PIOD) Pin Data Status Register */
+#define REG_PIOD_IER       (*(WoReg*)0x400E1440U) /**< \brief (PIOD) Interrupt Enable Register */
+#define REG_PIOD_IDR       (*(WoReg*)0x400E1444U) /**< \brief (PIOD) Interrupt Disable Register */
+#define REG_PIOD_IMR       (*(RoReg*)0x400E1448U) /**< \brief (PIOD) Interrupt Mask Register */
+#define REG_PIOD_ISR       (*(RoReg*)0x400E144CU) /**< \brief (PIOD) Interrupt Status Register */
+#define REG_PIOD_MDER      (*(WoReg*)0x400E1450U) /**< \brief (PIOD) Multi-driver Enable Register */
+#define REG_PIOD_MDDR      (*(WoReg*)0x400E1454U) /**< \brief (PIOD) Multi-driver Disable Register */
+#define REG_PIOD_MDSR      (*(RoReg*)0x400E1458U) /**< \brief (PIOD) Multi-driver Status Register */
+#define REG_PIOD_PUDR      (*(WoReg*)0x400E1460U) /**< \brief (PIOD) Pull-up Disable Register */
+#define REG_PIOD_PUER      (*(WoReg*)0x400E1464U) /**< \brief (PIOD) Pull-up Enable Register */
+#define REG_PIOD_PUSR      (*(RoReg*)0x400E1468U) /**< \brief (PIOD) Pad Pull-up Status Register */
+#define REG_PIOD_ABCDSR    (*(RwReg*)0x400E1470U) /**< \brief (PIOD) Peripheral Select Register */
+#define REG_PIOD_IFSCDR    (*(WoReg*)0x400E1480U) /**< \brief (PIOD) Input Filter Slow Clock Disable Register */
+#define REG_PIOD_IFSCER    (*(WoReg*)0x400E1484U) /**< \brief (PIOD) Input Filter Slow Clock Enable Register */
+#define REG_PIOD_IFSCSR    (*(RoReg*)0x400E1488U) /**< \brief (PIOD) Input Filter Slow Clock Status Register */
+#define REG_PIOD_SCDR      (*(RwReg*)0x400E148CU) /**< \brief (PIOD) Slow Clock Divider Debouncing Register */
+#define REG_PIOD_PPDDR     (*(WoReg*)0x400E1490U) /**< \brief (PIOD) Pad Pull-down Disable Register */
+#define REG_PIOD_PPDER     (*(WoReg*)0x400E1494U) /**< \brief (PIOD) Pad Pull-down Enable Register */
+#define REG_PIOD_PPDSR     (*(RoReg*)0x400E1498U) /**< \brief (PIOD) Pad Pull-down Status Register */
+#define REG_PIOD_OWER      (*(WoReg*)0x400E14A0U) /**< \brief (PIOD) Output Write Enable */
+#define REG_PIOD_OWDR      (*(WoReg*)0x400E14A4U) /**< \brief (PIOD) Output Write Disable */
+#define REG_PIOD_OWSR      (*(RoReg*)0x400E14A8U) /**< \brief (PIOD) Output Write Status Register */
+#define REG_PIOD_AIMER     (*(WoReg*)0x400E14B0U) /**< \brief (PIOD) Additional Interrupt Modes Enable Register */
+#define REG_PIOD_AIMDR     (*(WoReg*)0x400E14B4U) /**< \brief (PIOD) Additional Interrupt Modes Disables Register */
+#define REG_PIOD_AIMMR     (*(RoReg*)0x400E14B8U) /**< \brief (PIOD) Additional Interrupt Modes Mask Register */
+#define REG_PIOD_ESR       (*(WoReg*)0x400E14C0U) /**< \brief (PIOD) Edge Select Register */
+#define REG_PIOD_LSR       (*(WoReg*)0x400E14C4U) /**< \brief (PIOD) Level Select Register */
+#define REG_PIOD_ELSR      (*(RoReg*)0x400E14C8U) /**< \brief (PIOD) Edge/Level Status Register */
+#define REG_PIOD_FELLSR    (*(WoReg*)0x400E14D0U) /**< \brief (PIOD) Falling Edge/Low Level Select Register */
+#define REG_PIOD_REHLSR    (*(WoReg*)0x400E14D4U) /**< \brief (PIOD) Rising Edge/ High Level Select Register */
+#define REG_PIOD_FRLHSR    (*(RoReg*)0x400E14D8U) /**< \brief (PIOD) Fall/Rise - Low/High Status Register */
+#define REG_PIOD_LOCKSR    (*(RoReg*)0x400E14E0U) /**< \brief (PIOD) Lock Status */
+#define REG_PIOD_WPMR      (*(RwReg*)0x400E14E4U) /**< \brief (PIOD) Write Protect Mode Register */
+#define REG_PIOD_WPSR      (*(RoReg*)0x400E14E8U) /**< \brief (PIOD) Write Protect Status Register */
+#define REG_PIOD_SCHMITT   (*(RwReg*)0x400E1500U) /**< \brief (PIOD) Schmitt Trigger Register */
+#define REG_PIOD_DELAYR    (*(RwReg*)0x400E1510U) /**< \brief (PIOD) IO Delay Register */
+#define REG_PIOD_PCMR      (*(RwReg*)0x400E1550U) /**< \brief (PIOD) Parallel Capture Mode Register */
+#define REG_PIOD_PCIER     (*(WoReg*)0x400E1554U) /**< \brief (PIOD) Parallel Capture Interrupt Enable Register */
+#define REG_PIOD_PCIDR     (*(WoReg*)0x400E1558U) /**< \brief (PIOD) Parallel Capture Interrupt Disable Register */
+#define REG_PIOD_PCIMR     (*(RoReg*)0x400E155CU) /**< \brief (PIOD) Parallel Capture Interrupt Mask Register */
+#define REG_PIOD_PCISR     (*(RoReg*)0x400E1560U) /**< \brief (PIOD) Parallel Capture Interrupt Status Register */
+#define REG_PIOD_PCRHR     (*(RoReg*)0x400E1564U) /**< \brief (PIOD) Parallel Capture Reception Holding Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PIOD_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/pioe.h
+++ b/asf/sam/include/sam4e/instance/pioe.h
@@ -1,0 +1,146 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PIOE_INSTANCE_
+#define _SAM4E_PIOE_INSTANCE_
+
+/* ========== Register definition for PIOE peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PIOE_PER                (0x400E1600U) /**< \brief (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR                (0x400E1604U) /**< \brief (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR                (0x400E1608U) /**< \brief (PIOE) PIO Status Register */
+#define REG_PIOE_OER                (0x400E1610U) /**< \brief (PIOE) Output Enable Register */
+#define REG_PIOE_ODR                (0x400E1614U) /**< \brief (PIOE) Output Disable Register */
+#define REG_PIOE_OSR                (0x400E1618U) /**< \brief (PIOE) Output Status Register */
+#define REG_PIOE_IFER               (0x400E1620U) /**< \brief (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR               (0x400E1624U) /**< \brief (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR               (0x400E1628U) /**< \brief (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR               (0x400E1630U) /**< \brief (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR               (0x400E1634U) /**< \brief (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR               (0x400E1638U) /**< \brief (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR               (0x400E163CU) /**< \brief (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER                (0x400E1640U) /**< \brief (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR                (0x400E1644U) /**< \brief (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR                (0x400E1648U) /**< \brief (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR                (0x400E164CU) /**< \brief (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER               (0x400E1650U) /**< \brief (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR               (0x400E1654U) /**< \brief (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR               (0x400E1658U) /**< \brief (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR               (0x400E1660U) /**< \brief (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER               (0x400E1664U) /**< \brief (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR               (0x400E1668U) /**< \brief (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR             (0x400E1670U) /**< \brief (PIOE) Peripheral Select Register */
+#define REG_PIOE_IFSCDR             (0x400E1680U) /**< \brief (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER             (0x400E1684U) /**< \brief (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR             (0x400E1688U) /**< \brief (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR               (0x400E168CU) /**< \brief (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR              (0x400E1690U) /**< \brief (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER              (0x400E1694U) /**< \brief (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR              (0x400E1698U) /**< \brief (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER               (0x400E16A0U) /**< \brief (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR               (0x400E16A4U) /**< \brief (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR               (0x400E16A8U) /**< \brief (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER              (0x400E16B0U) /**< \brief (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR              (0x400E16B4U) /**< \brief (PIOE) Additional Interrupt Modes Disables Register */
+#define REG_PIOE_AIMMR              (0x400E16B8U) /**< \brief (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR                (0x400E16C0U) /**< \brief (PIOE) Edge Select Register */
+#define REG_PIOE_LSR                (0x400E16C4U) /**< \brief (PIOE) Level Select Register */
+#define REG_PIOE_ELSR               (0x400E16C8U) /**< \brief (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR             (0x400E16D0U) /**< \brief (PIOE) Falling Edge/Low Level Select Register */
+#define REG_PIOE_REHLSR             (0x400E16D4U) /**< \brief (PIOE) Rising Edge/ High Level Select Register */
+#define REG_PIOE_FRLHSR             (0x400E16D8U) /**< \brief (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR             (0x400E16E0U) /**< \brief (PIOE) Lock Status */
+#define REG_PIOE_WPMR               (0x400E16E4U) /**< \brief (PIOE) Write Protect Mode Register */
+#define REG_PIOE_WPSR               (0x400E16E8U) /**< \brief (PIOE) Write Protect Status Register */
+#define REG_PIOE_SCHMITT            (0x400E1700U) /**< \brief (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DELAYR             (0x400E1710U) /**< \brief (PIOE) IO Delay Register */
+#define REG_PIOE_PCMR               (0x400E1750U) /**< \brief (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER              (0x400E1754U) /**< \brief (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR              (0x400E1758U) /**< \brief (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR              (0x400E175CU) /**< \brief (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR              (0x400E1760U) /**< \brief (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR              (0x400E1764U) /**< \brief (PIOE) Parallel Capture Reception Holding Register */
+#else
+#define REG_PIOE_PER       (*(WoReg*)0x400E1600U) /**< \brief (PIOE) PIO Enable Register */
+#define REG_PIOE_PDR       (*(WoReg*)0x400E1604U) /**< \brief (PIOE) PIO Disable Register */
+#define REG_PIOE_PSR       (*(RoReg*)0x400E1608U) /**< \brief (PIOE) PIO Status Register */
+#define REG_PIOE_OER       (*(WoReg*)0x400E1610U) /**< \brief (PIOE) Output Enable Register */
+#define REG_PIOE_ODR       (*(WoReg*)0x400E1614U) /**< \brief (PIOE) Output Disable Register */
+#define REG_PIOE_OSR       (*(RoReg*)0x400E1618U) /**< \brief (PIOE) Output Status Register */
+#define REG_PIOE_IFER      (*(WoReg*)0x400E1620U) /**< \brief (PIOE) Glitch Input Filter Enable Register */
+#define REG_PIOE_IFDR      (*(WoReg*)0x400E1624U) /**< \brief (PIOE) Glitch Input Filter Disable Register */
+#define REG_PIOE_IFSR      (*(RoReg*)0x400E1628U) /**< \brief (PIOE) Glitch Input Filter Status Register */
+#define REG_PIOE_SODR      (*(WoReg*)0x400E1630U) /**< \brief (PIOE) Set Output Data Register */
+#define REG_PIOE_CODR      (*(WoReg*)0x400E1634U) /**< \brief (PIOE) Clear Output Data Register */
+#define REG_PIOE_ODSR      (*(RwReg*)0x400E1638U) /**< \brief (PIOE) Output Data Status Register */
+#define REG_PIOE_PDSR      (*(RoReg*)0x400E163CU) /**< \brief (PIOE) Pin Data Status Register */
+#define REG_PIOE_IER       (*(WoReg*)0x400E1640U) /**< \brief (PIOE) Interrupt Enable Register */
+#define REG_PIOE_IDR       (*(WoReg*)0x400E1644U) /**< \brief (PIOE) Interrupt Disable Register */
+#define REG_PIOE_IMR       (*(RoReg*)0x400E1648U) /**< \brief (PIOE) Interrupt Mask Register */
+#define REG_PIOE_ISR       (*(RoReg*)0x400E164CU) /**< \brief (PIOE) Interrupt Status Register */
+#define REG_PIOE_MDER      (*(WoReg*)0x400E1650U) /**< \brief (PIOE) Multi-driver Enable Register */
+#define REG_PIOE_MDDR      (*(WoReg*)0x400E1654U) /**< \brief (PIOE) Multi-driver Disable Register */
+#define REG_PIOE_MDSR      (*(RoReg*)0x400E1658U) /**< \brief (PIOE) Multi-driver Status Register */
+#define REG_PIOE_PUDR      (*(WoReg*)0x400E1660U) /**< \brief (PIOE) Pull-up Disable Register */
+#define REG_PIOE_PUER      (*(WoReg*)0x400E1664U) /**< \brief (PIOE) Pull-up Enable Register */
+#define REG_PIOE_PUSR      (*(RoReg*)0x400E1668U) /**< \brief (PIOE) Pad Pull-up Status Register */
+#define REG_PIOE_ABCDSR    (*(RwReg*)0x400E1670U) /**< \brief (PIOE) Peripheral Select Register */
+#define REG_PIOE_IFSCDR    (*(WoReg*)0x400E1680U) /**< \brief (PIOE) Input Filter Slow Clock Disable Register */
+#define REG_PIOE_IFSCER    (*(WoReg*)0x400E1684U) /**< \brief (PIOE) Input Filter Slow Clock Enable Register */
+#define REG_PIOE_IFSCSR    (*(RoReg*)0x400E1688U) /**< \brief (PIOE) Input Filter Slow Clock Status Register */
+#define REG_PIOE_SCDR      (*(RwReg*)0x400E168CU) /**< \brief (PIOE) Slow Clock Divider Debouncing Register */
+#define REG_PIOE_PPDDR     (*(WoReg*)0x400E1690U) /**< \brief (PIOE) Pad Pull-down Disable Register */
+#define REG_PIOE_PPDER     (*(WoReg*)0x400E1694U) /**< \brief (PIOE) Pad Pull-down Enable Register */
+#define REG_PIOE_PPDSR     (*(RoReg*)0x400E1698U) /**< \brief (PIOE) Pad Pull-down Status Register */
+#define REG_PIOE_OWER      (*(WoReg*)0x400E16A0U) /**< \brief (PIOE) Output Write Enable */
+#define REG_PIOE_OWDR      (*(WoReg*)0x400E16A4U) /**< \brief (PIOE) Output Write Disable */
+#define REG_PIOE_OWSR      (*(RoReg*)0x400E16A8U) /**< \brief (PIOE) Output Write Status Register */
+#define REG_PIOE_AIMER     (*(WoReg*)0x400E16B0U) /**< \brief (PIOE) Additional Interrupt Modes Enable Register */
+#define REG_PIOE_AIMDR     (*(WoReg*)0x400E16B4U) /**< \brief (PIOE) Additional Interrupt Modes Disables Register */
+#define REG_PIOE_AIMMR     (*(RoReg*)0x400E16B8U) /**< \brief (PIOE) Additional Interrupt Modes Mask Register */
+#define REG_PIOE_ESR       (*(WoReg*)0x400E16C0U) /**< \brief (PIOE) Edge Select Register */
+#define REG_PIOE_LSR       (*(WoReg*)0x400E16C4U) /**< \brief (PIOE) Level Select Register */
+#define REG_PIOE_ELSR      (*(RoReg*)0x400E16C8U) /**< \brief (PIOE) Edge/Level Status Register */
+#define REG_PIOE_FELLSR    (*(WoReg*)0x400E16D0U) /**< \brief (PIOE) Falling Edge/Low Level Select Register */
+#define REG_PIOE_REHLSR    (*(WoReg*)0x400E16D4U) /**< \brief (PIOE) Rising Edge/ High Level Select Register */
+#define REG_PIOE_FRLHSR    (*(RoReg*)0x400E16D8U) /**< \brief (PIOE) Fall/Rise - Low/High Status Register */
+#define REG_PIOE_LOCKSR    (*(RoReg*)0x400E16E0U) /**< \brief (PIOE) Lock Status */
+#define REG_PIOE_WPMR      (*(RwReg*)0x400E16E4U) /**< \brief (PIOE) Write Protect Mode Register */
+#define REG_PIOE_WPSR      (*(RoReg*)0x400E16E8U) /**< \brief (PIOE) Write Protect Status Register */
+#define REG_PIOE_SCHMITT   (*(RwReg*)0x400E1700U) /**< \brief (PIOE) Schmitt Trigger Register */
+#define REG_PIOE_DELAYR    (*(RwReg*)0x400E1710U) /**< \brief (PIOE) IO Delay Register */
+#define REG_PIOE_PCMR      (*(RwReg*)0x400E1750U) /**< \brief (PIOE) Parallel Capture Mode Register */
+#define REG_PIOE_PCIER     (*(WoReg*)0x400E1754U) /**< \brief (PIOE) Parallel Capture Interrupt Enable Register */
+#define REG_PIOE_PCIDR     (*(WoReg*)0x400E1758U) /**< \brief (PIOE) Parallel Capture Interrupt Disable Register */
+#define REG_PIOE_PCIMR     (*(RoReg*)0x400E175CU) /**< \brief (PIOE) Parallel Capture Interrupt Mask Register */
+#define REG_PIOE_PCISR     (*(RoReg*)0x400E1760U) /**< \brief (PIOE) Parallel Capture Interrupt Status Register */
+#define REG_PIOE_PCRHR     (*(RoReg*)0x400E1764U) /**< \brief (PIOE) Parallel Capture Reception Holding Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PIOE_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/pmc.h
+++ b/asf/sam/include/sam4e/instance/pmc.h
@@ -1,0 +1,88 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PMC_INSTANCE_
+#define _SAM4E_PMC_INSTANCE_
+
+/* ========== Register definition for PMC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PMC_SCER            (0x400E0400U) /**< \brief (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR            (0x400E0404U) /**< \brief (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR            (0x400E0408U) /**< \brief (PMC) System Clock Status Register */
+#define REG_PMC_PCER0           (0x400E0410U) /**< \brief (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0           (0x400E0414U) /**< \brief (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0           (0x400E0418U) /**< \brief (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_MOR            (0x400E0420U) /**< \brief (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR           (0x400E0424U) /**< \brief (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR          (0x400E0428U) /**< \brief (PMC) PLLA Register */
+#define REG_PMC_MCKR            (0x400E0430U) /**< \brief (PMC) Master Clock Register */
+#define REG_PMC_USB             (0x400E0438U) /**< \brief (PMC) USB Clock Register */
+#define REG_PMC_PCK             (0x400E0440U) /**< \brief (PMC) Programmable Clock 0 Register */
+#define REG_PMC_IER             (0x400E0460U) /**< \brief (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR             (0x400E0464U) /**< \brief (PMC) Interrupt Disable Register */
+#define REG_PMC_SR              (0x400E0468U) /**< \brief (PMC) Status Register */
+#define REG_PMC_IMR             (0x400E046CU) /**< \brief (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR            (0x400E0470U) /**< \brief (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR            (0x400E0474U) /**< \brief (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR            (0x400E0478U) /**< \brief (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR            (0x400E04E4U) /**< \brief (PMC) Write Protect Mode Register */
+#define REG_PMC_WPSR            (0x400E04E8U) /**< \brief (PMC) Write Protect Status Register */
+#define REG_PMC_PCER1           (0x400E0500U) /**< \brief (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1           (0x400E0504U) /**< \brief (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1           (0x400E0508U) /**< \brief (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_OCR             (0x400E0510U) /**< \brief (PMC) Oscillator Calibration Register */
+#else
+#define REG_PMC_SCER   (*(WoReg*)0x400E0400U) /**< \brief (PMC) System Clock Enable Register */
+#define REG_PMC_SCDR   (*(WoReg*)0x400E0404U) /**< \brief (PMC) System Clock Disable Register */
+#define REG_PMC_SCSR   (*(RoReg*)0x400E0408U) /**< \brief (PMC) System Clock Status Register */
+#define REG_PMC_PCER0  (*(WoReg*)0x400E0410U) /**< \brief (PMC) Peripheral Clock Enable Register 0 */
+#define REG_PMC_PCDR0  (*(WoReg*)0x400E0414U) /**< \brief (PMC) Peripheral Clock Disable Register 0 */
+#define REG_PMC_PCSR0  (*(RoReg*)0x400E0418U) /**< \brief (PMC) Peripheral Clock Status Register 0 */
+#define REG_CKGR_MOR   (*(RwReg*)0x400E0420U) /**< \brief (PMC) Main Oscillator Register */
+#define REG_CKGR_MCFR  (*(RwReg*)0x400E0424U) /**< \brief (PMC) Main Clock Frequency Register */
+#define REG_CKGR_PLLAR (*(RwReg*)0x400E0428U) /**< \brief (PMC) PLLA Register */
+#define REG_PMC_MCKR   (*(RwReg*)0x400E0430U) /**< \brief (PMC) Master Clock Register */
+#define REG_PMC_USB    (*(RwReg*)0x400E0438U) /**< \brief (PMC) USB Clock Register */
+#define REG_PMC_PCK    (*(RwReg*)0x400E0440U) /**< \brief (PMC) Programmable Clock 0 Register */
+#define REG_PMC_IER    (*(WoReg*)0x400E0460U) /**< \brief (PMC) Interrupt Enable Register */
+#define REG_PMC_IDR    (*(WoReg*)0x400E0464U) /**< \brief (PMC) Interrupt Disable Register */
+#define REG_PMC_SR     (*(RoReg*)0x400E0468U) /**< \brief (PMC) Status Register */
+#define REG_PMC_IMR    (*(RoReg*)0x400E046CU) /**< \brief (PMC) Interrupt Mask Register */
+#define REG_PMC_FSMR   (*(RwReg*)0x400E0470U) /**< \brief (PMC) Fast Startup Mode Register */
+#define REG_PMC_FSPR   (*(RwReg*)0x400E0474U) /**< \brief (PMC) Fast Startup Polarity Register */
+#define REG_PMC_FOCR   (*(WoReg*)0x400E0478U) /**< \brief (PMC) Fault Output Clear Register */
+#define REG_PMC_WPMR   (*(RwReg*)0x400E04E4U) /**< \brief (PMC) Write Protect Mode Register */
+#define REG_PMC_WPSR   (*(RoReg*)0x400E04E8U) /**< \brief (PMC) Write Protect Status Register */
+#define REG_PMC_PCER1  (*(WoReg*)0x400E0500U) /**< \brief (PMC) Peripheral Clock Enable Register 1 */
+#define REG_PMC_PCDR1  (*(WoReg*)0x400E0504U) /**< \brief (PMC) Peripheral Clock Disable Register 1 */
+#define REG_PMC_PCSR1  (*(RoReg*)0x400E0508U) /**< \brief (PMC) Peripheral Clock Status Register 1 */
+#define REG_PMC_OCR    (*(RwReg*)0x400E0510U) /**< \brief (PMC) Oscillator Calibration Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PMC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/pwm.h
+++ b/asf/sam/include/sam4e/instance/pwm.h
@@ -1,0 +1,270 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_PWM_INSTANCE_
+#define _SAM4E_PWM_INSTANCE_
+
+/* ========== Register definition for PWM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PWM_CLK               (0x40000000U) /**< \brief (PWM) PWM Clock Register */
+#define REG_PWM_ENA               (0x40000004U) /**< \brief (PWM) PWM Enable Register */
+#define REG_PWM_DIS               (0x40000008U) /**< \brief (PWM) PWM Disable Register */
+#define REG_PWM_SR                (0x4000000CU) /**< \brief (PWM) PWM Status Register */
+#define REG_PWM_IER1              (0x40000010U) /**< \brief (PWM) PWM Interrupt Enable Register 1 */
+#define REG_PWM_IDR1              (0x40000014U) /**< \brief (PWM) PWM Interrupt Disable Register 1 */
+#define REG_PWM_IMR1              (0x40000018U) /**< \brief (PWM) PWM Interrupt Mask Register 1 */
+#define REG_PWM_ISR1              (0x4000001CU) /**< \brief (PWM) PWM Interrupt Status Register 1 */
+#define REG_PWM_SCM               (0x40000020U) /**< \brief (PWM) PWM Sync Channels Mode Register */
+#define REG_PWM_SCUC              (0x40000028U) /**< \brief (PWM) PWM Sync Channels Update Control Register */
+#define REG_PWM_SCUP              (0x4000002CU) /**< \brief (PWM) PWM Sync Channels Update Period Register */
+#define REG_PWM_SCUPUPD           (0x40000030U) /**< \brief (PWM) PWM Sync Channels Update Period Update Register */
+#define REG_PWM_IER2              (0x40000034U) /**< \brief (PWM) PWM Interrupt Enable Register 2 */
+#define REG_PWM_IDR2              (0x40000038U) /**< \brief (PWM) PWM Interrupt Disable Register 2 */
+#define REG_PWM_IMR2              (0x4000003CU) /**< \brief (PWM) PWM Interrupt Mask Register 2 */
+#define REG_PWM_ISR2              (0x40000040U) /**< \brief (PWM) PWM Interrupt Status Register 2 */
+#define REG_PWM_OOV               (0x40000044U) /**< \brief (PWM) PWM Output Override Value Register */
+#define REG_PWM_OS                (0x40000048U) /**< \brief (PWM) PWM Output Selection Register */
+#define REG_PWM_OSS               (0x4000004CU) /**< \brief (PWM) PWM Output Selection Set Register */
+#define REG_PWM_OSC               (0x40000050U) /**< \brief (PWM) PWM Output Selection Clear Register */
+#define REG_PWM_OSSUPD            (0x40000054U) /**< \brief (PWM) PWM Output Selection Set Update Register */
+#define REG_PWM_OSCUPD            (0x40000058U) /**< \brief (PWM) PWM Output Selection Clear Update Register */
+#define REG_PWM_FMR               (0x4000005CU) /**< \brief (PWM) PWM Fault Mode Register */
+#define REG_PWM_FSR               (0x40000060U) /**< \brief (PWM) PWM Fault Status Register */
+#define REG_PWM_FCR               (0x40000064U) /**< \brief (PWM) PWM Fault Clear Register */
+#define REG_PWM_FPV1              (0x40000068U) /**< \brief (PWM) PWM Fault Protection Value Register 1 */
+#define REG_PWM_FPE               (0x4000006CU) /**< \brief (PWM) PWM Fault Protection Enable Register */
+#define REG_PWM_ELMR              (0x4000007CU) /**< \brief (PWM) PWM Event Line 0 Mode Register */
+#define REG_PWM_SSPR              (0x400000A0U) /**< \brief (PWM) PWM Spread Spectrum Register */
+#define REG_PWM_SSPUP             (0x400000A4U) /**< \brief (PWM) PWM Spread Spectrum Update Register */
+#define REG_PWM_SMMR              (0x400000B0U) /**< \brief (PWM) PWM Stepper Motor Mode Register */
+#define REG_PWM_FPV2              (0x400000C0U) /**< \brief (PWM) PWM Fault Protection Value 2 Register */
+#define REG_PWM_WPCR              (0x400000E4U) /**< \brief (PWM) PWM Write Protect Control Register */
+#define REG_PWM_WPSR              (0x400000E8U) /**< \brief (PWM) PWM Write Protect Status Register */
+#define REG_PWM_TPR               (0x40000108U) /**< \brief (PWM) Transmit Pointer Register */
+#define REG_PWM_TCR               (0x4000010CU) /**< \brief (PWM) Transmit Counter Register */
+#define REG_PWM_TNPR              (0x40000118U) /**< \brief (PWM) Transmit Next Pointer Register */
+#define REG_PWM_TNCR              (0x4000011CU) /**< \brief (PWM) Transmit Next Counter Register */
+#define REG_PWM_PTCR              (0x40000120U) /**< \brief (PWM) Transfer Control Register */
+#define REG_PWM_PTSR              (0x40000124U) /**< \brief (PWM) Transfer Status Register */
+#define REG_PWM_CMPV0             (0x40000130U) /**< \brief (PWM) PWM Comparison 0 Value Register */
+#define REG_PWM_CMPVUPD0          (0x40000134U) /**< \brief (PWM) PWM Comparison 0 Value Update Register */
+#define REG_PWM_CMPM0             (0x40000138U) /**< \brief (PWM) PWM Comparison 0 Mode Register */
+#define REG_PWM_CMPMUPD0          (0x4000013CU) /**< \brief (PWM) PWM Comparison 0 Mode Update Register */
+#define REG_PWM_CMPV1             (0x40000140U) /**< \brief (PWM) PWM Comparison 1 Value Register */
+#define REG_PWM_CMPVUPD1          (0x40000144U) /**< \brief (PWM) PWM Comparison 1 Value Update Register */
+#define REG_PWM_CMPM1             (0x40000148U) /**< \brief (PWM) PWM Comparison 1 Mode Register */
+#define REG_PWM_CMPMUPD1          (0x4000014CU) /**< \brief (PWM) PWM Comparison 1 Mode Update Register */
+#define REG_PWM_CMPV2             (0x40000150U) /**< \brief (PWM) PWM Comparison 2 Value Register */
+#define REG_PWM_CMPVUPD2          (0x40000154U) /**< \brief (PWM) PWM Comparison 2 Value Update Register */
+#define REG_PWM_CMPM2             (0x40000158U) /**< \brief (PWM) PWM Comparison 2 Mode Register */
+#define REG_PWM_CMPMUPD2          (0x4000015CU) /**< \brief (PWM) PWM Comparison 2 Mode Update Register */
+#define REG_PWM_CMPV3             (0x40000160U) /**< \brief (PWM) PWM Comparison 3 Value Register */
+#define REG_PWM_CMPVUPD3          (0x40000164U) /**< \brief (PWM) PWM Comparison 3 Value Update Register */
+#define REG_PWM_CMPM3             (0x40000168U) /**< \brief (PWM) PWM Comparison 3 Mode Register */
+#define REG_PWM_CMPMUPD3          (0x4000016CU) /**< \brief (PWM) PWM Comparison 3 Mode Update Register */
+#define REG_PWM_CMPV4             (0x40000170U) /**< \brief (PWM) PWM Comparison 4 Value Register */
+#define REG_PWM_CMPVUPD4          (0x40000174U) /**< \brief (PWM) PWM Comparison 4 Value Update Register */
+#define REG_PWM_CMPM4             (0x40000178U) /**< \brief (PWM) PWM Comparison 4 Mode Register */
+#define REG_PWM_CMPMUPD4          (0x4000017CU) /**< \brief (PWM) PWM Comparison 4 Mode Update Register */
+#define REG_PWM_CMPV5             (0x40000180U) /**< \brief (PWM) PWM Comparison 5 Value Register */
+#define REG_PWM_CMPVUPD5          (0x40000184U) /**< \brief (PWM) PWM Comparison 5 Value Update Register */
+#define REG_PWM_CMPM5             (0x40000188U) /**< \brief (PWM) PWM Comparison 5 Mode Register */
+#define REG_PWM_CMPMUPD5          (0x4000018CU) /**< \brief (PWM) PWM Comparison 5 Mode Update Register */
+#define REG_PWM_CMPV6             (0x40000190U) /**< \brief (PWM) PWM Comparison 6 Value Register */
+#define REG_PWM_CMPVUPD6          (0x40000194U) /**< \brief (PWM) PWM Comparison 6 Value Update Register */
+#define REG_PWM_CMPM6             (0x40000198U) /**< \brief (PWM) PWM Comparison 6 Mode Register */
+#define REG_PWM_CMPMUPD6          (0x4000019CU) /**< \brief (PWM) PWM Comparison 6 Mode Update Register */
+#define REG_PWM_CMPV7             (0x400001A0U) /**< \brief (PWM) PWM Comparison 7 Value Register */
+#define REG_PWM_CMPVUPD7          (0x400001A4U) /**< \brief (PWM) PWM Comparison 7 Value Update Register */
+#define REG_PWM_CMPM7             (0x400001A8U) /**< \brief (PWM) PWM Comparison 7 Mode Register */
+#define REG_PWM_CMPMUPD7          (0x400001ACU) /**< \brief (PWM) PWM Comparison 7 Mode Update Register */
+#define REG_PWM_CMR0              (0x40000200U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 0) */
+#define REG_PWM_CDTY0             (0x40000204U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 0) */
+#define REG_PWM_CDTYUPD0          (0x40000208U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 0) */
+#define REG_PWM_CPRD0             (0x4000020CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 0) */
+#define REG_PWM_CPRDUPD0          (0x40000210U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 0) */
+#define REG_PWM_CCNT0             (0x40000214U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 0) */
+#define REG_PWM_DT0               (0x40000218U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 0) */
+#define REG_PWM_DTUPD0            (0x4000021CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 0) */
+#define REG_PWM_CMR1              (0x40000220U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 1) */
+#define REG_PWM_CDTY1             (0x40000224U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 1) */
+#define REG_PWM_CDTYUPD1          (0x40000228U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 1) */
+#define REG_PWM_CPRD1             (0x4000022CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 1) */
+#define REG_PWM_CPRDUPD1          (0x40000230U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 1) */
+#define REG_PWM_CCNT1             (0x40000234U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 1) */
+#define REG_PWM_DT1               (0x40000238U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 1) */
+#define REG_PWM_DTUPD1            (0x4000023CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 1) */
+#define REG_PWM_CMR2              (0x40000240U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 2) */
+#define REG_PWM_CDTY2             (0x40000244U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 2) */
+#define REG_PWM_CDTYUPD2          (0x40000248U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 2) */
+#define REG_PWM_CPRD2             (0x4000024CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 2) */
+#define REG_PWM_CPRDUPD2          (0x40000250U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 2) */
+#define REG_PWM_CCNT2             (0x40000254U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 2) */
+#define REG_PWM_DT2               (0x40000258U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 2) */
+#define REG_PWM_DTUPD2            (0x4000025CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 2) */
+#define REG_PWM_CMR3              (0x40000260U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 3) */
+#define REG_PWM_CDTY3             (0x40000264U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 3) */
+#define REG_PWM_CDTYUPD3          (0x40000268U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 3) */
+#define REG_PWM_CPRD3             (0x4000026CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 3) */
+#define REG_PWM_CPRDUPD3          (0x40000270U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 3) */
+#define REG_PWM_CCNT3             (0x40000274U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 3) */
+#define REG_PWM_DT3               (0x40000278U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 3) */
+#define REG_PWM_DTUPD3            (0x4000027CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 3) */
+#define REG_PWM_CMUPD0            (0x40000400U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM_CAE0              (0x40000404U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 0) */
+#define REG_PWM_CAEUPD0           (0x40000408U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 0) */
+#define REG_PWM_CMUPD1            (0x40000420U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM_CAE1              (0x40000424U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 1) */
+#define REG_PWM_CAEUPD1           (0x40000428U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 1) */
+#define REG_PWM_CMUPD2            (0x40000440U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM_CAE2              (0x40000444U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 2) */
+#define REG_PWM_CAEUPD2           (0x40000448U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 2) */
+#define REG_PWM_CMUPD3            (0x40000460U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 3) */
+#define REG_PWM_CAE3              (0x40000464U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 3) */
+#define REG_PWM_CAEUPD3           (0x40000468U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 3) */
+#else
+#define REG_PWM_CLK      (*(RwReg*)0x40000000U) /**< \brief (PWM) PWM Clock Register */
+#define REG_PWM_ENA      (*(WoReg*)0x40000004U) /**< \brief (PWM) PWM Enable Register */
+#define REG_PWM_DIS      (*(WoReg*)0x40000008U) /**< \brief (PWM) PWM Disable Register */
+#define REG_PWM_SR       (*(RoReg*)0x4000000CU) /**< \brief (PWM) PWM Status Register */
+#define REG_PWM_IER1     (*(WoReg*)0x40000010U) /**< \brief (PWM) PWM Interrupt Enable Register 1 */
+#define REG_PWM_IDR1     (*(WoReg*)0x40000014U) /**< \brief (PWM) PWM Interrupt Disable Register 1 */
+#define REG_PWM_IMR1     (*(RoReg*)0x40000018U) /**< \brief (PWM) PWM Interrupt Mask Register 1 */
+#define REG_PWM_ISR1     (*(RoReg*)0x4000001CU) /**< \brief (PWM) PWM Interrupt Status Register 1 */
+#define REG_PWM_SCM      (*(RwReg*)0x40000020U) /**< \brief (PWM) PWM Sync Channels Mode Register */
+#define REG_PWM_SCUC     (*(RwReg*)0x40000028U) /**< \brief (PWM) PWM Sync Channels Update Control Register */
+#define REG_PWM_SCUP     (*(RwReg*)0x4000002CU) /**< \brief (PWM) PWM Sync Channels Update Period Register */
+#define REG_PWM_SCUPUPD  (*(WoReg*)0x40000030U) /**< \brief (PWM) PWM Sync Channels Update Period Update Register */
+#define REG_PWM_IER2     (*(WoReg*)0x40000034U) /**< \brief (PWM) PWM Interrupt Enable Register 2 */
+#define REG_PWM_IDR2     (*(WoReg*)0x40000038U) /**< \brief (PWM) PWM Interrupt Disable Register 2 */
+#define REG_PWM_IMR2     (*(RoReg*)0x4000003CU) /**< \brief (PWM) PWM Interrupt Mask Register 2 */
+#define REG_PWM_ISR2     (*(RoReg*)0x40000040U) /**< \brief (PWM) PWM Interrupt Status Register 2 */
+#define REG_PWM_OOV      (*(RwReg*)0x40000044U) /**< \brief (PWM) PWM Output Override Value Register */
+#define REG_PWM_OS       (*(RwReg*)0x40000048U) /**< \brief (PWM) PWM Output Selection Register */
+#define REG_PWM_OSS      (*(WoReg*)0x4000004CU) /**< \brief (PWM) PWM Output Selection Set Register */
+#define REG_PWM_OSC      (*(WoReg*)0x40000050U) /**< \brief (PWM) PWM Output Selection Clear Register */
+#define REG_PWM_OSSUPD   (*(WoReg*)0x40000054U) /**< \brief (PWM) PWM Output Selection Set Update Register */
+#define REG_PWM_OSCUPD   (*(WoReg*)0x40000058U) /**< \brief (PWM) PWM Output Selection Clear Update Register */
+#define REG_PWM_FMR      (*(RwReg*)0x4000005CU) /**< \brief (PWM) PWM Fault Mode Register */
+#define REG_PWM_FSR      (*(RoReg*)0x40000060U) /**< \brief (PWM) PWM Fault Status Register */
+#define REG_PWM_FCR      (*(WoReg*)0x40000064U) /**< \brief (PWM) PWM Fault Clear Register */
+#define REG_PWM_FPV1     (*(RwReg*)0x40000068U) /**< \brief (PWM) PWM Fault Protection Value Register 1 */
+#define REG_PWM_FPE      (*(RwReg*)0x4000006CU) /**< \brief (PWM) PWM Fault Protection Enable Register */
+#define REG_PWM_ELMR     (*(RwReg*)0x4000007CU) /**< \brief (PWM) PWM Event Line 0 Mode Register */
+#define REG_PWM_SSPR     (*(RwReg*)0x400000A0U) /**< \brief (PWM) PWM Spread Spectrum Register */
+#define REG_PWM_SSPUP    (*(WoReg*)0x400000A4U) /**< \brief (PWM) PWM Spread Spectrum Update Register */
+#define REG_PWM_SMMR     (*(RwReg*)0x400000B0U) /**< \brief (PWM) PWM Stepper Motor Mode Register */
+#define REG_PWM_FPV2     (*(RwReg*)0x400000C0U) /**< \brief (PWM) PWM Fault Protection Value 2 Register */
+#define REG_PWM_WPCR     (*(WoReg*)0x400000E4U) /**< \brief (PWM) PWM Write Protect Control Register */
+#define REG_PWM_WPSR     (*(RoReg*)0x400000E8U) /**< \brief (PWM) PWM Write Protect Status Register */
+#define REG_PWM_TPR      (*(RwReg*)0x40000108U) /**< \brief (PWM) Transmit Pointer Register */
+#define REG_PWM_TCR      (*(RwReg*)0x4000010CU) /**< \brief (PWM) Transmit Counter Register */
+#define REG_PWM_TNPR     (*(RwReg*)0x40000118U) /**< \brief (PWM) Transmit Next Pointer Register */
+#define REG_PWM_TNCR     (*(RwReg*)0x4000011CU) /**< \brief (PWM) Transmit Next Counter Register */
+#define REG_PWM_PTCR     (*(WoReg*)0x40000120U) /**< \brief (PWM) Transfer Control Register */
+#define REG_PWM_PTSR     (*(RoReg*)0x40000124U) /**< \brief (PWM) Transfer Status Register */
+#define REG_PWM_CMPV0    (*(RwReg*)0x40000130U) /**< \brief (PWM) PWM Comparison 0 Value Register */
+#define REG_PWM_CMPVUPD0 (*(WoReg*)0x40000134U) /**< \brief (PWM) PWM Comparison 0 Value Update Register */
+#define REG_PWM_CMPM0    (*(RwReg*)0x40000138U) /**< \brief (PWM) PWM Comparison 0 Mode Register */
+#define REG_PWM_CMPMUPD0 (*(WoReg*)0x4000013CU) /**< \brief (PWM) PWM Comparison 0 Mode Update Register */
+#define REG_PWM_CMPV1    (*(RwReg*)0x40000140U) /**< \brief (PWM) PWM Comparison 1 Value Register */
+#define REG_PWM_CMPVUPD1 (*(WoReg*)0x40000144U) /**< \brief (PWM) PWM Comparison 1 Value Update Register */
+#define REG_PWM_CMPM1    (*(RwReg*)0x40000148U) /**< \brief (PWM) PWM Comparison 1 Mode Register */
+#define REG_PWM_CMPMUPD1 (*(WoReg*)0x4000014CU) /**< \brief (PWM) PWM Comparison 1 Mode Update Register */
+#define REG_PWM_CMPV2    (*(RwReg*)0x40000150U) /**< \brief (PWM) PWM Comparison 2 Value Register */
+#define REG_PWM_CMPVUPD2 (*(WoReg*)0x40000154U) /**< \brief (PWM) PWM Comparison 2 Value Update Register */
+#define REG_PWM_CMPM2    (*(RwReg*)0x40000158U) /**< \brief (PWM) PWM Comparison 2 Mode Register */
+#define REG_PWM_CMPMUPD2 (*(WoReg*)0x4000015CU) /**< \brief (PWM) PWM Comparison 2 Mode Update Register */
+#define REG_PWM_CMPV3    (*(RwReg*)0x40000160U) /**< \brief (PWM) PWM Comparison 3 Value Register */
+#define REG_PWM_CMPVUPD3 (*(WoReg*)0x40000164U) /**< \brief (PWM) PWM Comparison 3 Value Update Register */
+#define REG_PWM_CMPM3    (*(RwReg*)0x40000168U) /**< \brief (PWM) PWM Comparison 3 Mode Register */
+#define REG_PWM_CMPMUPD3 (*(WoReg*)0x4000016CU) /**< \brief (PWM) PWM Comparison 3 Mode Update Register */
+#define REG_PWM_CMPV4    (*(RwReg*)0x40000170U) /**< \brief (PWM) PWM Comparison 4 Value Register */
+#define REG_PWM_CMPVUPD4 (*(WoReg*)0x40000174U) /**< \brief (PWM) PWM Comparison 4 Value Update Register */
+#define REG_PWM_CMPM4    (*(RwReg*)0x40000178U) /**< \brief (PWM) PWM Comparison 4 Mode Register */
+#define REG_PWM_CMPMUPD4 (*(WoReg*)0x4000017CU) /**< \brief (PWM) PWM Comparison 4 Mode Update Register */
+#define REG_PWM_CMPV5    (*(RwReg*)0x40000180U) /**< \brief (PWM) PWM Comparison 5 Value Register */
+#define REG_PWM_CMPVUPD5 (*(WoReg*)0x40000184U) /**< \brief (PWM) PWM Comparison 5 Value Update Register */
+#define REG_PWM_CMPM5    (*(RwReg*)0x40000188U) /**< \brief (PWM) PWM Comparison 5 Mode Register */
+#define REG_PWM_CMPMUPD5 (*(WoReg*)0x4000018CU) /**< \brief (PWM) PWM Comparison 5 Mode Update Register */
+#define REG_PWM_CMPV6    (*(RwReg*)0x40000190U) /**< \brief (PWM) PWM Comparison 6 Value Register */
+#define REG_PWM_CMPVUPD6 (*(WoReg*)0x40000194U) /**< \brief (PWM) PWM Comparison 6 Value Update Register */
+#define REG_PWM_CMPM6    (*(RwReg*)0x40000198U) /**< \brief (PWM) PWM Comparison 6 Mode Register */
+#define REG_PWM_CMPMUPD6 (*(WoReg*)0x4000019CU) /**< \brief (PWM) PWM Comparison 6 Mode Update Register */
+#define REG_PWM_CMPV7    (*(RwReg*)0x400001A0U) /**< \brief (PWM) PWM Comparison 7 Value Register */
+#define REG_PWM_CMPVUPD7 (*(WoReg*)0x400001A4U) /**< \brief (PWM) PWM Comparison 7 Value Update Register */
+#define REG_PWM_CMPM7    (*(RwReg*)0x400001A8U) /**< \brief (PWM) PWM Comparison 7 Mode Register */
+#define REG_PWM_CMPMUPD7 (*(WoReg*)0x400001ACU) /**< \brief (PWM) PWM Comparison 7 Mode Update Register */
+#define REG_PWM_CMR0     (*(RwReg*)0x40000200U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 0) */
+#define REG_PWM_CDTY0    (*(RwReg*)0x40000204U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 0) */
+#define REG_PWM_CDTYUPD0 (*(WoReg*)0x40000208U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 0) */
+#define REG_PWM_CPRD0    (*(RwReg*)0x4000020CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 0) */
+#define REG_PWM_CPRDUPD0 (*(WoReg*)0x40000210U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 0) */
+#define REG_PWM_CCNT0    (*(RoReg*)0x40000214U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 0) */
+#define REG_PWM_DT0      (*(RwReg*)0x40000218U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 0) */
+#define REG_PWM_DTUPD0   (*(WoReg*)0x4000021CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 0) */
+#define REG_PWM_CMR1     (*(RwReg*)0x40000220U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 1) */
+#define REG_PWM_CDTY1    (*(RwReg*)0x40000224U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 1) */
+#define REG_PWM_CDTYUPD1 (*(WoReg*)0x40000228U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 1) */
+#define REG_PWM_CPRD1    (*(RwReg*)0x4000022CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 1) */
+#define REG_PWM_CPRDUPD1 (*(WoReg*)0x40000230U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 1) */
+#define REG_PWM_CCNT1    (*(RoReg*)0x40000234U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 1) */
+#define REG_PWM_DT1      (*(RwReg*)0x40000238U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 1) */
+#define REG_PWM_DTUPD1   (*(WoReg*)0x4000023CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 1) */
+#define REG_PWM_CMR2     (*(RwReg*)0x40000240U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 2) */
+#define REG_PWM_CDTY2    (*(RwReg*)0x40000244U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 2) */
+#define REG_PWM_CDTYUPD2 (*(WoReg*)0x40000248U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 2) */
+#define REG_PWM_CPRD2    (*(RwReg*)0x4000024CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 2) */
+#define REG_PWM_CPRDUPD2 (*(WoReg*)0x40000250U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 2) */
+#define REG_PWM_CCNT2    (*(RoReg*)0x40000254U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 2) */
+#define REG_PWM_DT2      (*(RwReg*)0x40000258U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 2) */
+#define REG_PWM_DTUPD2   (*(WoReg*)0x4000025CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 2) */
+#define REG_PWM_CMR3     (*(RwReg*)0x40000260U) /**< \brief (PWM) PWM Channel Mode Register (ch_num = 3) */
+#define REG_PWM_CDTY3    (*(RwReg*)0x40000264U) /**< \brief (PWM) PWM Channel Duty Cycle Register (ch_num = 3) */
+#define REG_PWM_CDTYUPD3 (*(WoReg*)0x40000268U) /**< \brief (PWM) PWM Channel Duty Cycle Update Register (ch_num = 3) */
+#define REG_PWM_CPRD3    (*(RwReg*)0x4000026CU) /**< \brief (PWM) PWM Channel Period Register (ch_num = 3) */
+#define REG_PWM_CPRDUPD3 (*(WoReg*)0x40000270U) /**< \brief (PWM) PWM Channel Period Update Register (ch_num = 3) */
+#define REG_PWM_CCNT3    (*(RoReg*)0x40000274U) /**< \brief (PWM) PWM Channel Counter Register (ch_num = 3) */
+#define REG_PWM_DT3      (*(RwReg*)0x40000278U) /**< \brief (PWM) PWM Channel Dead Time Register (ch_num = 3) */
+#define REG_PWM_DTUPD3   (*(WoReg*)0x4000027CU) /**< \brief (PWM) PWM Channel Dead Time Update Register (ch_num = 3) */
+#define REG_PWM_CMUPD0   (*(WoReg*)0x40000400U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 0) */
+#define REG_PWM_CAE0     (*(RwReg*)0x40000404U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 0) */
+#define REG_PWM_CAEUPD0  (*(WoReg*)0x40000408U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 0) */
+#define REG_PWM_CMUPD1   (*(WoReg*)0x40000420U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 1) */
+#define REG_PWM_CAE1     (*(RwReg*)0x40000424U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 1) */
+#define REG_PWM_CAEUPD1  (*(WoReg*)0x40000428U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 1) */
+#define REG_PWM_CMUPD2   (*(WoReg*)0x40000440U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 2) */
+#define REG_PWM_CAE2     (*(RwReg*)0x40000444U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 2) */
+#define REG_PWM_CAEUPD2  (*(WoReg*)0x40000448U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 2) */
+#define REG_PWM_CMUPD3   (*(WoReg*)0x40000460U) /**< \brief (PWM) PWM Channel Mode Update Register (ch_num = 3) */
+#define REG_PWM_CAE3     (*(RwReg*)0x40000464U) /**< \brief (PWM) PWM Channel Additional Edge Register (ch_num = 3) */
+#define REG_PWM_CAEUPD3  (*(WoReg*)0x40000468U) /**< \brief (PWM) PWM Channel Additional Edge Update Register (ch_num = 3) */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_PWM_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/rstc.h
+++ b/asf/sam/include/sam4e/instance/rstc.h
@@ -1,0 +1,44 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RSTC_INSTANCE_
+#define _SAM4E_RSTC_INSTANCE_
+
+/* ========== Register definition for RSTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RSTC_CR          (0x400E1800U) /**< \brief (RSTC) Control Register */
+#define REG_RSTC_SR          (0x400E1804U) /**< \brief (RSTC) Status Register */
+#define REG_RSTC_MR          (0x400E1808U) /**< \brief (RSTC) Mode Register */
+#else
+#define REG_RSTC_CR (*(WoReg*)0x400E1800U) /**< \brief (RSTC) Control Register */
+#define REG_RSTC_SR (*(RoReg*)0x400E1804U) /**< \brief (RSTC) Status Register */
+#define REG_RSTC_MR (*(RwReg*)0x400E1808U) /**< \brief (RSTC) Mode Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_RSTC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/rtc.h
+++ b/asf/sam/include/sam4e/instance/rtc.h
@@ -1,0 +1,62 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RTC_INSTANCE_
+#define _SAM4E_RTC_INSTANCE_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RTC_CR              (0x400E1860U) /**< \brief (RTC) Control Register */
+#define REG_RTC_MR              (0x400E1864U) /**< \brief (RTC) Mode Register */
+#define REG_RTC_TIMR            (0x400E1868U) /**< \brief (RTC) Time Register */
+#define REG_RTC_CALR            (0x400E186CU) /**< \brief (RTC) Calendar Register */
+#define REG_RTC_TIMALR          (0x400E1870U) /**< \brief (RTC) Time Alarm Register */
+#define REG_RTC_CALALR          (0x400E1874U) /**< \brief (RTC) Calendar Alarm Register */
+#define REG_RTC_SR              (0x400E1878U) /**< \brief (RTC) Status Register */
+#define REG_RTC_SCCR            (0x400E187CU) /**< \brief (RTC) Status Clear Command Register */
+#define REG_RTC_IER             (0x400E1880U) /**< \brief (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR             (0x400E1884U) /**< \brief (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR             (0x400E1888U) /**< \brief (RTC) Interrupt Mask Register */
+#define REG_RTC_VER             (0x400E188CU) /**< \brief (RTC) Valid Entry Register */
+#else
+#define REG_RTC_CR     (*(RwReg*)0x400E1860U) /**< \brief (RTC) Control Register */
+#define REG_RTC_MR     (*(RwReg*)0x400E1864U) /**< \brief (RTC) Mode Register */
+#define REG_RTC_TIMR   (*(RwReg*)0x400E1868U) /**< \brief (RTC) Time Register */
+#define REG_RTC_CALR   (*(RwReg*)0x400E186CU) /**< \brief (RTC) Calendar Register */
+#define REG_RTC_TIMALR (*(RwReg*)0x400E1870U) /**< \brief (RTC) Time Alarm Register */
+#define REG_RTC_CALALR (*(RwReg*)0x400E1874U) /**< \brief (RTC) Calendar Alarm Register */
+#define REG_RTC_SR     (*(RoReg*)0x400E1878U) /**< \brief (RTC) Status Register */
+#define REG_RTC_SCCR   (*(WoReg*)0x400E187CU) /**< \brief (RTC) Status Clear Command Register */
+#define REG_RTC_IER    (*(WoReg*)0x400E1880U) /**< \brief (RTC) Interrupt Enable Register */
+#define REG_RTC_IDR    (*(WoReg*)0x400E1884U) /**< \brief (RTC) Interrupt Disable Register */
+#define REG_RTC_IMR    (*(RoReg*)0x400E1888U) /**< \brief (RTC) Interrupt Mask Register */
+#define REG_RTC_VER    (*(RoReg*)0x400E188CU) /**< \brief (RTC) Valid Entry Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_RTC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/rtt.h
+++ b/asf/sam/include/sam4e/instance/rtt.h
@@ -1,0 +1,46 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_RTT_INSTANCE_
+#define _SAM4E_RTT_INSTANCE_
+
+/* ========== Register definition for RTT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RTT_MR          (0x400E1830U) /**< \brief (RTT) Mode Register */
+#define REG_RTT_AR          (0x400E1834U) /**< \brief (RTT) Alarm Register */
+#define REG_RTT_VR          (0x400E1838U) /**< \brief (RTT) Value Register */
+#define REG_RTT_SR          (0x400E183CU) /**< \brief (RTT) Status Register */
+#else
+#define REG_RTT_MR (*(RwReg*)0x400E1830U) /**< \brief (RTT) Mode Register */
+#define REG_RTT_AR (*(RwReg*)0x400E1834U) /**< \brief (RTT) Alarm Register */
+#define REG_RTT_VR (*(RoReg*)0x400E1838U) /**< \brief (RTT) Value Register */
+#define REG_RTT_SR (*(RoReg*)0x400E183CU) /**< \brief (RTT) Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_RTT_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/smc.h
+++ b/asf/sam/include/sam4e/instance/smc.h
@@ -1,0 +1,80 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SMC_INSTANCE_
+#define _SAM4E_SMC_INSTANCE_
+
+/* ========== Register definition for SMC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SMC_SETUP0          (0x40060000U) /**< \brief (SMC) SMC Setup Register (CS_number = 0) */
+#define REG_SMC_PULSE0          (0x40060004U) /**< \brief (SMC) SMC Pulse Register (CS_number = 0) */
+#define REG_SMC_CYCLE0          (0x40060008U) /**< \brief (SMC) SMC Cycle Register (CS_number = 0) */
+#define REG_SMC_MODE0           (0x4006000CU) /**< \brief (SMC) SMC Mode Register (CS_number = 0) */
+#define REG_SMC_SETUP1          (0x40060010U) /**< \brief (SMC) SMC Setup Register (CS_number = 1) */
+#define REG_SMC_PULSE1          (0x40060014U) /**< \brief (SMC) SMC Pulse Register (CS_number = 1) */
+#define REG_SMC_CYCLE1          (0x40060018U) /**< \brief (SMC) SMC Cycle Register (CS_number = 1) */
+#define REG_SMC_MODE1           (0x4006001CU) /**< \brief (SMC) SMC Mode Register (CS_number = 1) */
+#define REG_SMC_SETUP2          (0x40060020U) /**< \brief (SMC) SMC Setup Register (CS_number = 2) */
+#define REG_SMC_PULSE2          (0x40060024U) /**< \brief (SMC) SMC Pulse Register (CS_number = 2) */
+#define REG_SMC_CYCLE2          (0x40060028U) /**< \brief (SMC) SMC Cycle Register (CS_number = 2) */
+#define REG_SMC_MODE2           (0x4006002CU) /**< \brief (SMC) SMC Mode Register (CS_number = 2) */
+#define REG_SMC_SETUP3          (0x40060030U) /**< \brief (SMC) SMC Setup Register (CS_number = 3) */
+#define REG_SMC_PULSE3          (0x40060034U) /**< \brief (SMC) SMC Pulse Register (CS_number = 3) */
+#define REG_SMC_CYCLE3          (0x40060038U) /**< \brief (SMC) SMC Cycle Register (CS_number = 3) */
+#define REG_SMC_MODE3           (0x4006003CU) /**< \brief (SMC) SMC Mode Register (CS_number = 3) */
+#define REG_SMC_OCMS            (0x40060080U) /**< \brief (SMC) SMC OCMS MODE Register */
+#define REG_SMC_KEY1            (0x40060084U) /**< \brief (SMC) SMC OCMS KEY1 Register */
+#define REG_SMC_KEY2            (0x40060088U) /**< \brief (SMC) SMC OCMS KEY2 Register */
+#define REG_SMC_WPMR            (0x400600E4U) /**< \brief (SMC) SMC Write Protect Mode Register */
+#define REG_SMC_WPSR            (0x400600E8U) /**< \brief (SMC) SMC Write Protect Status Register */
+#else
+#define REG_SMC_SETUP0 (*(RwReg*)0x40060000U) /**< \brief (SMC) SMC Setup Register (CS_number = 0) */
+#define REG_SMC_PULSE0 (*(RwReg*)0x40060004U) /**< \brief (SMC) SMC Pulse Register (CS_number = 0) */
+#define REG_SMC_CYCLE0 (*(RwReg*)0x40060008U) /**< \brief (SMC) SMC Cycle Register (CS_number = 0) */
+#define REG_SMC_MODE0  (*(RwReg*)0x4006000CU) /**< \brief (SMC) SMC Mode Register (CS_number = 0) */
+#define REG_SMC_SETUP1 (*(RwReg*)0x40060010U) /**< \brief (SMC) SMC Setup Register (CS_number = 1) */
+#define REG_SMC_PULSE1 (*(RwReg*)0x40060014U) /**< \brief (SMC) SMC Pulse Register (CS_number = 1) */
+#define REG_SMC_CYCLE1 (*(RwReg*)0x40060018U) /**< \brief (SMC) SMC Cycle Register (CS_number = 1) */
+#define REG_SMC_MODE1  (*(RwReg*)0x4006001CU) /**< \brief (SMC) SMC Mode Register (CS_number = 1) */
+#define REG_SMC_SETUP2 (*(RwReg*)0x40060020U) /**< \brief (SMC) SMC Setup Register (CS_number = 2) */
+#define REG_SMC_PULSE2 (*(RwReg*)0x40060024U) /**< \brief (SMC) SMC Pulse Register (CS_number = 2) */
+#define REG_SMC_CYCLE2 (*(RwReg*)0x40060028U) /**< \brief (SMC) SMC Cycle Register (CS_number = 2) */
+#define REG_SMC_MODE2  (*(RwReg*)0x4006002CU) /**< \brief (SMC) SMC Mode Register (CS_number = 2) */
+#define REG_SMC_SETUP3 (*(RwReg*)0x40060030U) /**< \brief (SMC) SMC Setup Register (CS_number = 3) */
+#define REG_SMC_PULSE3 (*(RwReg*)0x40060034U) /**< \brief (SMC) SMC Pulse Register (CS_number = 3) */
+#define REG_SMC_CYCLE3 (*(RwReg*)0x40060038U) /**< \brief (SMC) SMC Cycle Register (CS_number = 3) */
+#define REG_SMC_MODE3  (*(RwReg*)0x4006003CU) /**< \brief (SMC) SMC Mode Register (CS_number = 3) */
+#define REG_SMC_OCMS   (*(RwReg*)0x40060080U) /**< \brief (SMC) SMC OCMS MODE Register */
+#define REG_SMC_KEY1   (*(WoReg*)0x40060084U) /**< \brief (SMC) SMC OCMS KEY1 Register */
+#define REG_SMC_KEY2   (*(WoReg*)0x40060088U) /**< \brief (SMC) SMC OCMS KEY2 Register */
+#define REG_SMC_WPMR   (*(RwReg*)0x400600E4U) /**< \brief (SMC) SMC Write Protect Mode Register */
+#define REG_SMC_WPSR   (*(RoReg*)0x400600E8U) /**< \brief (SMC) SMC Write Protect Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_SMC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/spi.h
+++ b/asf/sam/include/sam4e/instance/spi.h
@@ -1,0 +1,80 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SPI_INSTANCE_
+#define _SAM4E_SPI_INSTANCE_
+
+/* ========== Register definition for SPI peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SPI_CR              (0x40088000U) /**< \brief (SPI) Control Register */
+#define REG_SPI_MR              (0x40088004U) /**< \brief (SPI) Mode Register */
+#define REG_SPI_RDR             (0x40088008U) /**< \brief (SPI) Receive Data Register */
+#define REG_SPI_TDR             (0x4008800CU) /**< \brief (SPI) Transmit Data Register */
+#define REG_SPI_SR              (0x40088010U) /**< \brief (SPI) Status Register */
+#define REG_SPI_IER             (0x40088014U) /**< \brief (SPI) Interrupt Enable Register */
+#define REG_SPI_IDR             (0x40088018U) /**< \brief (SPI) Interrupt Disable Register */
+#define REG_SPI_IMR             (0x4008801CU) /**< \brief (SPI) Interrupt Mask Register */
+#define REG_SPI_CSR             (0x40088030U) /**< \brief (SPI) Chip Select Register */
+#define REG_SPI_WPMR            (0x400880E4U) /**< \brief (SPI) Write Protection Control Register */
+#define REG_SPI_WPSR            (0x400880E8U) /**< \brief (SPI) Write Protection Status Register */
+#define REG_SPI_RPR             (0x40088100U) /**< \brief (SPI) Receive Pointer Register */
+#define REG_SPI_RCR             (0x40088104U) /**< \brief (SPI) Receive Counter Register */
+#define REG_SPI_TPR             (0x40088108U) /**< \brief (SPI) Transmit Pointer Register */
+#define REG_SPI_TCR             (0x4008810CU) /**< \brief (SPI) Transmit Counter Register */
+#define REG_SPI_RNPR            (0x40088110U) /**< \brief (SPI) Receive Next Pointer Register */
+#define REG_SPI_RNCR            (0x40088114U) /**< \brief (SPI) Receive Next Counter Register */
+#define REG_SPI_TNPR            (0x40088118U) /**< \brief (SPI) Transmit Next Pointer Register */
+#define REG_SPI_TNCR            (0x4008811CU) /**< \brief (SPI) Transmit Next Counter Register */
+#define REG_SPI_PTCR            (0x40088120U) /**< \brief (SPI) Transfer Control Register */
+#define REG_SPI_PTSR            (0x40088124U) /**< \brief (SPI) Transfer Status Register */
+#else
+#define REG_SPI_CR     (*(WoReg*)0x40088000U) /**< \brief (SPI) Control Register */
+#define REG_SPI_MR     (*(RwReg*)0x40088004U) /**< \brief (SPI) Mode Register */
+#define REG_SPI_RDR    (*(RoReg*)0x40088008U) /**< \brief (SPI) Receive Data Register */
+#define REG_SPI_TDR    (*(WoReg*)0x4008800CU) /**< \brief (SPI) Transmit Data Register */
+#define REG_SPI_SR     (*(RoReg*)0x40088010U) /**< \brief (SPI) Status Register */
+#define REG_SPI_IER    (*(WoReg*)0x40088014U) /**< \brief (SPI) Interrupt Enable Register */
+#define REG_SPI_IDR    (*(WoReg*)0x40088018U) /**< \brief (SPI) Interrupt Disable Register */
+#define REG_SPI_IMR    (*(RoReg*)0x4008801CU) /**< \brief (SPI) Interrupt Mask Register */
+#define REG_SPI_CSR    (*(RwReg*)0x40088030U) /**< \brief (SPI) Chip Select Register */
+#define REG_SPI_WPMR   (*(RwReg*)0x400880E4U) /**< \brief (SPI) Write Protection Control Register */
+#define REG_SPI_WPSR   (*(RoReg*)0x400880E8U) /**< \brief (SPI) Write Protection Status Register */
+#define REG_SPI_RPR    (*(RwReg*)0x40088100U) /**< \brief (SPI) Receive Pointer Register */
+#define REG_SPI_RCR    (*(RwReg*)0x40088104U) /**< \brief (SPI) Receive Counter Register */
+#define REG_SPI_TPR    (*(RwReg*)0x40088108U) /**< \brief (SPI) Transmit Pointer Register */
+#define REG_SPI_TCR    (*(RwReg*)0x4008810CU) /**< \brief (SPI) Transmit Counter Register */
+#define REG_SPI_RNPR   (*(RwReg*)0x40088110U) /**< \brief (SPI) Receive Next Pointer Register */
+#define REG_SPI_RNCR   (*(RwReg*)0x40088114U) /**< \brief (SPI) Receive Next Counter Register */
+#define REG_SPI_TNPR   (*(RwReg*)0x40088118U) /**< \brief (SPI) Transmit Next Pointer Register */
+#define REG_SPI_TNCR   (*(RwReg*)0x4008811CU) /**< \brief (SPI) Transmit Next Counter Register */
+#define REG_SPI_PTCR   (*(WoReg*)0x40088120U) /**< \brief (SPI) Transfer Control Register */
+#define REG_SPI_PTSR   (*(RoReg*)0x40088124U) /**< \brief (SPI) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_SPI_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/supc.h
+++ b/asf/sam/include/sam4e/instance/supc.h
@@ -1,0 +1,50 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_SUPC_INSTANCE_
+#define _SAM4E_SUPC_INSTANCE_
+
+/* ========== Register definition for SUPC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SUPC_CR            (0x400E1810U) /**< \brief (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR          (0x400E1814U) /**< \brief (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR            (0x400E1818U) /**< \brief (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR          (0x400E181CU) /**< \brief (SUPC) Supply Controller Wake Up Mode Register */
+#define REG_SUPC_WUIR          (0x400E1820U) /**< \brief (SUPC) Supply Controller Wake Up Inputs Register */
+#define REG_SUPC_SR            (0x400E1824U) /**< \brief (SUPC) Supply Controller Status Register */
+#else
+#define REG_SUPC_CR   (*(WoReg*)0x400E1810U) /**< \brief (SUPC) Supply Controller Control Register */
+#define REG_SUPC_SMMR (*(RwReg*)0x400E1814U) /**< \brief (SUPC) Supply Controller Supply Monitor Mode Register */
+#define REG_SUPC_MR   (*(RwReg*)0x400E1818U) /**< \brief (SUPC) Supply Controller Mode Register */
+#define REG_SUPC_WUMR (*(RwReg*)0x400E181CU) /**< \brief (SUPC) Supply Controller Wake Up Mode Register */
+#define REG_SUPC_WUIR (*(RwReg*)0x400E1820U) /**< \brief (SUPC) Supply Controller Wake Up Inputs Register */
+#define REG_SUPC_SR   (*(RoReg*)0x400E1824U) /**< \brief (SUPC) Supply Controller Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_SUPC_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/tc0.h
+++ b/asf/sam/include/sam4e/instance/tc0.h
@@ -1,0 +1,168 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TC0_INSTANCE_
+#define _SAM4E_TC0_INSTANCE_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC0_CCR0           (0x40090000U) /**< \brief (TC0) Channel Control Register (channel = 0) */
+#define REG_TC0_CMR0           (0x40090004U) /**< \brief (TC0) Channel Mode Register (channel = 0) */
+#define REG_TC0_SMMR0          (0x40090008U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC0_RAB0           (0x4009000CU) /**< \brief (TC0) Register AB (channel = 0) */
+#define REG_TC0_CV0            (0x40090010U) /**< \brief (TC0) Counter Value (channel = 0) */
+#define REG_TC0_RA0            (0x40090014U) /**< \brief (TC0) Register A (channel = 0) */
+#define REG_TC0_RB0            (0x40090018U) /**< \brief (TC0) Register B (channel = 0) */
+#define REG_TC0_RC0            (0x4009001CU) /**< \brief (TC0) Register C (channel = 0) */
+#define REG_TC0_SR0            (0x40090020U) /**< \brief (TC0) Status Register (channel = 0) */
+#define REG_TC0_IER0           (0x40090024U) /**< \brief (TC0) Interrupt Enable Register (channel = 0) */
+#define REG_TC0_IDR0           (0x40090028U) /**< \brief (TC0) Interrupt Disable Register (channel = 0) */
+#define REG_TC0_IMR0           (0x4009002CU) /**< \brief (TC0) Interrupt Mask Register (channel = 0) */
+#define REG_TC0_EMR0           (0x40090030U) /**< \brief (TC0) Extended Mode Register (channel = 0) */
+#define REG_TC0_CCR1           (0x40090040U) /**< \brief (TC0) Channel Control Register (channel = 1) */
+#define REG_TC0_CMR1           (0x40090044U) /**< \brief (TC0) Channel Mode Register (channel = 1) */
+#define REG_TC0_SMMR1          (0x40090048U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC0_RAB1           (0x4009004CU) /**< \brief (TC0) Register AB (channel = 1) */
+#define REG_TC0_CV1            (0x40090050U) /**< \brief (TC0) Counter Value (channel = 1) */
+#define REG_TC0_RA1            (0x40090054U) /**< \brief (TC0) Register A (channel = 1) */
+#define REG_TC0_RB1            (0x40090058U) /**< \brief (TC0) Register B (channel = 1) */
+#define REG_TC0_RC1            (0x4009005CU) /**< \brief (TC0) Register C (channel = 1) */
+#define REG_TC0_SR1            (0x40090060U) /**< \brief (TC0) Status Register (channel = 1) */
+#define REG_TC0_IER1           (0x40090064U) /**< \brief (TC0) Interrupt Enable Register (channel = 1) */
+#define REG_TC0_IDR1           (0x40090068U) /**< \brief (TC0) Interrupt Disable Register (channel = 1) */
+#define REG_TC0_IMR1           (0x4009006CU) /**< \brief (TC0) Interrupt Mask Register (channel = 1) */
+#define REG_TC0_EMR1           (0x40090070U) /**< \brief (TC0) Extended Mode Register (channel = 1) */
+#define REG_TC0_CCR2           (0x40090080U) /**< \brief (TC0) Channel Control Register (channel = 2) */
+#define REG_TC0_CMR2           (0x40090084U) /**< \brief (TC0) Channel Mode Register (channel = 2) */
+#define REG_TC0_SMMR2          (0x40090088U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC0_RAB2           (0x4009008CU) /**< \brief (TC0) Register AB (channel = 2) */
+#define REG_TC0_CV2            (0x40090090U) /**< \brief (TC0) Counter Value (channel = 2) */
+#define REG_TC0_RA2            (0x40090094U) /**< \brief (TC0) Register A (channel = 2) */
+#define REG_TC0_RB2            (0x40090098U) /**< \brief (TC0) Register B (channel = 2) */
+#define REG_TC0_RC2            (0x4009009CU) /**< \brief (TC0) Register C (channel = 2) */
+#define REG_TC0_SR2            (0x400900A0U) /**< \brief (TC0) Status Register (channel = 2) */
+#define REG_TC0_IER2           (0x400900A4U) /**< \brief (TC0) Interrupt Enable Register (channel = 2) */
+#define REG_TC0_IDR2           (0x400900A8U) /**< \brief (TC0) Interrupt Disable Register (channel = 2) */
+#define REG_TC0_IMR2           (0x400900ACU) /**< \brief (TC0) Interrupt Mask Register (channel = 2) */
+#define REG_TC0_EMR2           (0x400900B0U) /**< \brief (TC0) Extended Mode Register (channel = 2) */
+#define REG_TC0_BCR            (0x400900C0U) /**< \brief (TC0) Block Control Register */
+#define REG_TC0_BMR            (0x400900C4U) /**< \brief (TC0) Block Mode Register */
+#define REG_TC0_QIER           (0x400900C8U) /**< \brief (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR           (0x400900CCU) /**< \brief (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR           (0x400900D0U) /**< \brief (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR           (0x400900D4U) /**< \brief (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR            (0x400900D8U) /**< \brief (TC0) Fault Mode Register */
+#define REG_TC0_WPMR           (0x400900E4U) /**< \brief (TC0) Write Protect Mode Register */
+#define REG_TC0_RPR0           (0x40090100U) /**< \brief (TC0) Receive Pointer Register (pdc = 0) */
+#define REG_TC0_RCR0           (0x40090104U) /**< \brief (TC0) Receive Counter Register (pdc = 0) */
+#define REG_TC0_RNPR0          (0x40090110U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 0) */
+#define REG_TC0_RNCR0          (0x40090114U) /**< \brief (TC0) Receive Next Counter Register (pdc = 0) */
+#define REG_TC0_PTCR0          (0x40090120U) /**< \brief (TC0) Transfer Control Register (pdc = 0) */
+#define REG_TC0_PTSR0          (0x40090124U) /**< \brief (TC0) Transfer Status Register (pdc = 0) */
+#define REG_TC0_RPR1           (0x40090140U) /**< \brief (TC0) Receive Pointer Register (pdc = 1) */
+#define REG_TC0_RCR1           (0x40090144U) /**< \brief (TC0) Receive Counter Register (pdc = 1) */
+#define REG_TC0_RNPR1          (0x40090150U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 1) */
+#define REG_TC0_RNCR1          (0x40090154U) /**< \brief (TC0) Receive Next Counter Register (pdc = 1) */
+#define REG_TC0_PTCR1          (0x40090160U) /**< \brief (TC0) Transfer Control Register (pdc = 1) */
+#define REG_TC0_PTSR1          (0x40090164U) /**< \brief (TC0) Transfer Status Register (pdc = 1) */
+#define REG_TC0_RPR2           (0x40090180U) /**< \brief (TC0) Receive Pointer Register (pdc = 2) */
+#define REG_TC0_RCR2           (0x40090184U) /**< \brief (TC0) Receive Counter Register (pdc = 2) */
+#define REG_TC0_RNPR2          (0x40090190U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 2) */
+#define REG_TC0_RNCR2          (0x40090194U) /**< \brief (TC0) Receive Next Counter Register (pdc = 2) */
+#define REG_TC0_PTCR2          (0x400901A0U) /**< \brief (TC0) Transfer Control Register (pdc = 2) */
+#define REG_TC0_PTSR2          (0x400901A4U) /**< \brief (TC0) Transfer Status Register (pdc = 2) */
+#else
+#define REG_TC0_CCR0  (*(WoReg*)0x40090000U) /**< \brief (TC0) Channel Control Register (channel = 0) */
+#define REG_TC0_CMR0  (*(RwReg*)0x40090004U) /**< \brief (TC0) Channel Mode Register (channel = 0) */
+#define REG_TC0_SMMR0 (*(RwReg*)0x40090008U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC0_RAB0  (*(RoReg*)0x4009000CU) /**< \brief (TC0) Register AB (channel = 0) */
+#define REG_TC0_CV0   (*(RoReg*)0x40090010U) /**< \brief (TC0) Counter Value (channel = 0) */
+#define REG_TC0_RA0   (*(RwReg*)0x40090014U) /**< \brief (TC0) Register A (channel = 0) */
+#define REG_TC0_RB0   (*(RwReg*)0x40090018U) /**< \brief (TC0) Register B (channel = 0) */
+#define REG_TC0_RC0   (*(RwReg*)0x4009001CU) /**< \brief (TC0) Register C (channel = 0) */
+#define REG_TC0_SR0   (*(RoReg*)0x40090020U) /**< \brief (TC0) Status Register (channel = 0) */
+#define REG_TC0_IER0  (*(WoReg*)0x40090024U) /**< \brief (TC0) Interrupt Enable Register (channel = 0) */
+#define REG_TC0_IDR0  (*(WoReg*)0x40090028U) /**< \brief (TC0) Interrupt Disable Register (channel = 0) */
+#define REG_TC0_IMR0  (*(RoReg*)0x4009002CU) /**< \brief (TC0) Interrupt Mask Register (channel = 0) */
+#define REG_TC0_EMR0  (*(RwReg*)0x40090030U) /**< \brief (TC0) Extended Mode Register (channel = 0) */
+#define REG_TC0_CCR1  (*(WoReg*)0x40090040U) /**< \brief (TC0) Channel Control Register (channel = 1) */
+#define REG_TC0_CMR1  (*(RwReg*)0x40090044U) /**< \brief (TC0) Channel Mode Register (channel = 1) */
+#define REG_TC0_SMMR1 (*(RwReg*)0x40090048U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC0_RAB1  (*(RoReg*)0x4009004CU) /**< \brief (TC0) Register AB (channel = 1) */
+#define REG_TC0_CV1   (*(RoReg*)0x40090050U) /**< \brief (TC0) Counter Value (channel = 1) */
+#define REG_TC0_RA1   (*(RwReg*)0x40090054U) /**< \brief (TC0) Register A (channel = 1) */
+#define REG_TC0_RB1   (*(RwReg*)0x40090058U) /**< \brief (TC0) Register B (channel = 1) */
+#define REG_TC0_RC1   (*(RwReg*)0x4009005CU) /**< \brief (TC0) Register C (channel = 1) */
+#define REG_TC0_SR1   (*(RoReg*)0x40090060U) /**< \brief (TC0) Status Register (channel = 1) */
+#define REG_TC0_IER1  (*(WoReg*)0x40090064U) /**< \brief (TC0) Interrupt Enable Register (channel = 1) */
+#define REG_TC0_IDR1  (*(WoReg*)0x40090068U) /**< \brief (TC0) Interrupt Disable Register (channel = 1) */
+#define REG_TC0_IMR1  (*(RoReg*)0x4009006CU) /**< \brief (TC0) Interrupt Mask Register (channel = 1) */
+#define REG_TC0_EMR1  (*(RwReg*)0x40090070U) /**< \brief (TC0) Extended Mode Register (channel = 1) */
+#define REG_TC0_CCR2  (*(WoReg*)0x40090080U) /**< \brief (TC0) Channel Control Register (channel = 2) */
+#define REG_TC0_CMR2  (*(RwReg*)0x40090084U) /**< \brief (TC0) Channel Mode Register (channel = 2) */
+#define REG_TC0_SMMR2 (*(RwReg*)0x40090088U) /**< \brief (TC0) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC0_RAB2  (*(RoReg*)0x4009008CU) /**< \brief (TC0) Register AB (channel = 2) */
+#define REG_TC0_CV2   (*(RoReg*)0x40090090U) /**< \brief (TC0) Counter Value (channel = 2) */
+#define REG_TC0_RA2   (*(RwReg*)0x40090094U) /**< \brief (TC0) Register A (channel = 2) */
+#define REG_TC0_RB2   (*(RwReg*)0x40090098U) /**< \brief (TC0) Register B (channel = 2) */
+#define REG_TC0_RC2   (*(RwReg*)0x4009009CU) /**< \brief (TC0) Register C (channel = 2) */
+#define REG_TC0_SR2   (*(RoReg*)0x400900A0U) /**< \brief (TC0) Status Register (channel = 2) */
+#define REG_TC0_IER2  (*(WoReg*)0x400900A4U) /**< \brief (TC0) Interrupt Enable Register (channel = 2) */
+#define REG_TC0_IDR2  (*(WoReg*)0x400900A8U) /**< \brief (TC0) Interrupt Disable Register (channel = 2) */
+#define REG_TC0_IMR2  (*(RoReg*)0x400900ACU) /**< \brief (TC0) Interrupt Mask Register (channel = 2) */
+#define REG_TC0_EMR2  (*(RwReg*)0x400900B0U) /**< \brief (TC0) Extended Mode Register (channel = 2) */
+#define REG_TC0_BCR   (*(WoReg*)0x400900C0U) /**< \brief (TC0) Block Control Register */
+#define REG_TC0_BMR   (*(RwReg*)0x400900C4U) /**< \brief (TC0) Block Mode Register */
+#define REG_TC0_QIER  (*(WoReg*)0x400900C8U) /**< \brief (TC0) QDEC Interrupt Enable Register */
+#define REG_TC0_QIDR  (*(WoReg*)0x400900CCU) /**< \brief (TC0) QDEC Interrupt Disable Register */
+#define REG_TC0_QIMR  (*(RoReg*)0x400900D0U) /**< \brief (TC0) QDEC Interrupt Mask Register */
+#define REG_TC0_QISR  (*(RoReg*)0x400900D4U) /**< \brief (TC0) QDEC Interrupt Status Register */
+#define REG_TC0_FMR   (*(RwReg*)0x400900D8U) /**< \brief (TC0) Fault Mode Register */
+#define REG_TC0_WPMR  (*(RwReg*)0x400900E4U) /**< \brief (TC0) Write Protect Mode Register */
+#define REG_TC0_RPR0  (*(RwReg*)0x40090100U) /**< \brief (TC0) Receive Pointer Register (pdc = 0) */
+#define REG_TC0_RCR0  (*(RwReg*)0x40090104U) /**< \brief (TC0) Receive Counter Register (pdc = 0) */
+#define REG_TC0_RNPR0 (*(RwReg*)0x40090110U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 0) */
+#define REG_TC0_RNCR0 (*(RwReg*)0x40090114U) /**< \brief (TC0) Receive Next Counter Register (pdc = 0) */
+#define REG_TC0_PTCR0 (*(WoReg*)0x40090120U) /**< \brief (TC0) Transfer Control Register (pdc = 0) */
+#define REG_TC0_PTSR0 (*(RoReg*)0x40090124U) /**< \brief (TC0) Transfer Status Register (pdc = 0) */
+#define REG_TC0_RPR1  (*(RwReg*)0x40090140U) /**< \brief (TC0) Receive Pointer Register (pdc = 1) */
+#define REG_TC0_RCR1  (*(RwReg*)0x40090144U) /**< \brief (TC0) Receive Counter Register (pdc = 1) */
+#define REG_TC0_RNPR1 (*(RwReg*)0x40090150U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 1) */
+#define REG_TC0_RNCR1 (*(RwReg*)0x40090154U) /**< \brief (TC0) Receive Next Counter Register (pdc = 1) */
+#define REG_TC0_PTCR1 (*(WoReg*)0x40090160U) /**< \brief (TC0) Transfer Control Register (pdc = 1) */
+#define REG_TC0_PTSR1 (*(RoReg*)0x40090164U) /**< \brief (TC0) Transfer Status Register (pdc = 1) */
+#define REG_TC0_RPR2  (*(RwReg*)0x40090180U) /**< \brief (TC0) Receive Pointer Register (pdc = 2) */
+#define REG_TC0_RCR2  (*(RwReg*)0x40090184U) /**< \brief (TC0) Receive Counter Register (pdc = 2) */
+#define REG_TC0_RNPR2 (*(RwReg*)0x40090190U) /**< \brief (TC0) Receive Next Pointer Register (pdc = 2) */
+#define REG_TC0_RNCR2 (*(RwReg*)0x40090194U) /**< \brief (TC0) Receive Next Counter Register (pdc = 2) */
+#define REG_TC0_PTCR2 (*(WoReg*)0x400901A0U) /**< \brief (TC0) Transfer Control Register (pdc = 2) */
+#define REG_TC0_PTSR2 (*(RoReg*)0x400901A4U) /**< \brief (TC0) Transfer Status Register (pdc = 2) */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_TC0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/tc1.h
+++ b/asf/sam/include/sam4e/instance/tc1.h
@@ -1,0 +1,168 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TC1_INSTANCE_
+#define _SAM4E_TC1_INSTANCE_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC1_CCR0           (0x40094000U) /**< \brief (TC1) Channel Control Register (channel = 0) */
+#define REG_TC1_CMR0           (0x40094004U) /**< \brief (TC1) Channel Mode Register (channel = 0) */
+#define REG_TC1_SMMR0          (0x40094008U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC1_RAB0           (0x4009400CU) /**< \brief (TC1) Register AB (channel = 0) */
+#define REG_TC1_CV0            (0x40094010U) /**< \brief (TC1) Counter Value (channel = 0) */
+#define REG_TC1_RA0            (0x40094014U) /**< \brief (TC1) Register A (channel = 0) */
+#define REG_TC1_RB0            (0x40094018U) /**< \brief (TC1) Register B (channel = 0) */
+#define REG_TC1_RC0            (0x4009401CU) /**< \brief (TC1) Register C (channel = 0) */
+#define REG_TC1_SR0            (0x40094020U) /**< \brief (TC1) Status Register (channel = 0) */
+#define REG_TC1_IER0           (0x40094024U) /**< \brief (TC1) Interrupt Enable Register (channel = 0) */
+#define REG_TC1_IDR0           (0x40094028U) /**< \brief (TC1) Interrupt Disable Register (channel = 0) */
+#define REG_TC1_IMR0           (0x4009402CU) /**< \brief (TC1) Interrupt Mask Register (channel = 0) */
+#define REG_TC1_EMR0           (0x40094030U) /**< \brief (TC1) Extended Mode Register (channel = 0) */
+#define REG_TC1_CCR1           (0x40094040U) /**< \brief (TC1) Channel Control Register (channel = 1) */
+#define REG_TC1_CMR1           (0x40094044U) /**< \brief (TC1) Channel Mode Register (channel = 1) */
+#define REG_TC1_SMMR1          (0x40094048U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC1_RAB1           (0x4009404CU) /**< \brief (TC1) Register AB (channel = 1) */
+#define REG_TC1_CV1            (0x40094050U) /**< \brief (TC1) Counter Value (channel = 1) */
+#define REG_TC1_RA1            (0x40094054U) /**< \brief (TC1) Register A (channel = 1) */
+#define REG_TC1_RB1            (0x40094058U) /**< \brief (TC1) Register B (channel = 1) */
+#define REG_TC1_RC1            (0x4009405CU) /**< \brief (TC1) Register C (channel = 1) */
+#define REG_TC1_SR1            (0x40094060U) /**< \brief (TC1) Status Register (channel = 1) */
+#define REG_TC1_IER1           (0x40094064U) /**< \brief (TC1) Interrupt Enable Register (channel = 1) */
+#define REG_TC1_IDR1           (0x40094068U) /**< \brief (TC1) Interrupt Disable Register (channel = 1) */
+#define REG_TC1_IMR1           (0x4009406CU) /**< \brief (TC1) Interrupt Mask Register (channel = 1) */
+#define REG_TC1_EMR1           (0x40094070U) /**< \brief (TC1) Extended Mode Register (channel = 1) */
+#define REG_TC1_CCR2           (0x40094080U) /**< \brief (TC1) Channel Control Register (channel = 2) */
+#define REG_TC1_CMR2           (0x40094084U) /**< \brief (TC1) Channel Mode Register (channel = 2) */
+#define REG_TC1_SMMR2          (0x40094088U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC1_RAB2           (0x4009408CU) /**< \brief (TC1) Register AB (channel = 2) */
+#define REG_TC1_CV2            (0x40094090U) /**< \brief (TC1) Counter Value (channel = 2) */
+#define REG_TC1_RA2            (0x40094094U) /**< \brief (TC1) Register A (channel = 2) */
+#define REG_TC1_RB2            (0x40094098U) /**< \brief (TC1) Register B (channel = 2) */
+#define REG_TC1_RC2            (0x4009409CU) /**< \brief (TC1) Register C (channel = 2) */
+#define REG_TC1_SR2            (0x400940A0U) /**< \brief (TC1) Status Register (channel = 2) */
+#define REG_TC1_IER2           (0x400940A4U) /**< \brief (TC1) Interrupt Enable Register (channel = 2) */
+#define REG_TC1_IDR2           (0x400940A8U) /**< \brief (TC1) Interrupt Disable Register (channel = 2) */
+#define REG_TC1_IMR2           (0x400940ACU) /**< \brief (TC1) Interrupt Mask Register (channel = 2) */
+#define REG_TC1_EMR2           (0x400940B0U) /**< \brief (TC1) Extended Mode Register (channel = 2) */
+#define REG_TC1_BCR            (0x400940C0U) /**< \brief (TC1) Block Control Register */
+#define REG_TC1_BMR            (0x400940C4U) /**< \brief (TC1) Block Mode Register */
+#define REG_TC1_QIER           (0x400940C8U) /**< \brief (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR           (0x400940CCU) /**< \brief (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR           (0x400940D0U) /**< \brief (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR           (0x400940D4U) /**< \brief (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR            (0x400940D8U) /**< \brief (TC1) Fault Mode Register */
+#define REG_TC1_WPMR           (0x400940E4U) /**< \brief (TC1) Write Protect Mode Register */
+#define REG_TC1_RPR0           (0x40094100U) /**< \brief (TC1) Receive Pointer Register (pdc = 0) */
+#define REG_TC1_RCR0           (0x40094104U) /**< \brief (TC1) Receive Counter Register (pdc = 0) */
+#define REG_TC1_RNPR0          (0x40094110U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 0) */
+#define REG_TC1_RNCR0          (0x40094114U) /**< \brief (TC1) Receive Next Counter Register (pdc = 0) */
+#define REG_TC1_PTCR0          (0x40094120U) /**< \brief (TC1) Transfer Control Register (pdc = 0) */
+#define REG_TC1_PTSR0          (0x40094124U) /**< \brief (TC1) Transfer Status Register (pdc = 0) */
+#define REG_TC1_RPR1           (0x40094140U) /**< \brief (TC1) Receive Pointer Register (pdc = 1) */
+#define REG_TC1_RCR1           (0x40094144U) /**< \brief (TC1) Receive Counter Register (pdc = 1) */
+#define REG_TC1_RNPR1          (0x40094150U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 1) */
+#define REG_TC1_RNCR1          (0x40094154U) /**< \brief (TC1) Receive Next Counter Register (pdc = 1) */
+#define REG_TC1_PTCR1          (0x40094160U) /**< \brief (TC1) Transfer Control Register (pdc = 1) */
+#define REG_TC1_PTSR1          (0x40094164U) /**< \brief (TC1) Transfer Status Register (pdc = 1) */
+#define REG_TC1_RPR2           (0x40094180U) /**< \brief (TC1) Receive Pointer Register (pdc = 2) */
+#define REG_TC1_RCR2           (0x40094184U) /**< \brief (TC1) Receive Counter Register (pdc = 2) */
+#define REG_TC1_RNPR2          (0x40094190U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 2) */
+#define REG_TC1_RNCR2          (0x40094194U) /**< \brief (TC1) Receive Next Counter Register (pdc = 2) */
+#define REG_TC1_PTCR2          (0x400941A0U) /**< \brief (TC1) Transfer Control Register (pdc = 2) */
+#define REG_TC1_PTSR2          (0x400941A4U) /**< \brief (TC1) Transfer Status Register (pdc = 2) */
+#else
+#define REG_TC1_CCR0  (*(WoReg*)0x40094000U) /**< \brief (TC1) Channel Control Register (channel = 0) */
+#define REG_TC1_CMR0  (*(RwReg*)0x40094004U) /**< \brief (TC1) Channel Mode Register (channel = 0) */
+#define REG_TC1_SMMR0 (*(RwReg*)0x40094008U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC1_RAB0  (*(RoReg*)0x4009400CU) /**< \brief (TC1) Register AB (channel = 0) */
+#define REG_TC1_CV0   (*(RoReg*)0x40094010U) /**< \brief (TC1) Counter Value (channel = 0) */
+#define REG_TC1_RA0   (*(RwReg*)0x40094014U) /**< \brief (TC1) Register A (channel = 0) */
+#define REG_TC1_RB0   (*(RwReg*)0x40094018U) /**< \brief (TC1) Register B (channel = 0) */
+#define REG_TC1_RC0   (*(RwReg*)0x4009401CU) /**< \brief (TC1) Register C (channel = 0) */
+#define REG_TC1_SR0   (*(RoReg*)0x40094020U) /**< \brief (TC1) Status Register (channel = 0) */
+#define REG_TC1_IER0  (*(WoReg*)0x40094024U) /**< \brief (TC1) Interrupt Enable Register (channel = 0) */
+#define REG_TC1_IDR0  (*(WoReg*)0x40094028U) /**< \brief (TC1) Interrupt Disable Register (channel = 0) */
+#define REG_TC1_IMR0  (*(RoReg*)0x4009402CU) /**< \brief (TC1) Interrupt Mask Register (channel = 0) */
+#define REG_TC1_EMR0  (*(RwReg*)0x40094030U) /**< \brief (TC1) Extended Mode Register (channel = 0) */
+#define REG_TC1_CCR1  (*(WoReg*)0x40094040U) /**< \brief (TC1) Channel Control Register (channel = 1) */
+#define REG_TC1_CMR1  (*(RwReg*)0x40094044U) /**< \brief (TC1) Channel Mode Register (channel = 1) */
+#define REG_TC1_SMMR1 (*(RwReg*)0x40094048U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC1_RAB1  (*(RoReg*)0x4009404CU) /**< \brief (TC1) Register AB (channel = 1) */
+#define REG_TC1_CV1   (*(RoReg*)0x40094050U) /**< \brief (TC1) Counter Value (channel = 1) */
+#define REG_TC1_RA1   (*(RwReg*)0x40094054U) /**< \brief (TC1) Register A (channel = 1) */
+#define REG_TC1_RB1   (*(RwReg*)0x40094058U) /**< \brief (TC1) Register B (channel = 1) */
+#define REG_TC1_RC1   (*(RwReg*)0x4009405CU) /**< \brief (TC1) Register C (channel = 1) */
+#define REG_TC1_SR1   (*(RoReg*)0x40094060U) /**< \brief (TC1) Status Register (channel = 1) */
+#define REG_TC1_IER1  (*(WoReg*)0x40094064U) /**< \brief (TC1) Interrupt Enable Register (channel = 1) */
+#define REG_TC1_IDR1  (*(WoReg*)0x40094068U) /**< \brief (TC1) Interrupt Disable Register (channel = 1) */
+#define REG_TC1_IMR1  (*(RoReg*)0x4009406CU) /**< \brief (TC1) Interrupt Mask Register (channel = 1) */
+#define REG_TC1_EMR1  (*(RwReg*)0x40094070U) /**< \brief (TC1) Extended Mode Register (channel = 1) */
+#define REG_TC1_CCR2  (*(WoReg*)0x40094080U) /**< \brief (TC1) Channel Control Register (channel = 2) */
+#define REG_TC1_CMR2  (*(RwReg*)0x40094084U) /**< \brief (TC1) Channel Mode Register (channel = 2) */
+#define REG_TC1_SMMR2 (*(RwReg*)0x40094088U) /**< \brief (TC1) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC1_RAB2  (*(RoReg*)0x4009408CU) /**< \brief (TC1) Register AB (channel = 2) */
+#define REG_TC1_CV2   (*(RoReg*)0x40094090U) /**< \brief (TC1) Counter Value (channel = 2) */
+#define REG_TC1_RA2   (*(RwReg*)0x40094094U) /**< \brief (TC1) Register A (channel = 2) */
+#define REG_TC1_RB2   (*(RwReg*)0x40094098U) /**< \brief (TC1) Register B (channel = 2) */
+#define REG_TC1_RC2   (*(RwReg*)0x4009409CU) /**< \brief (TC1) Register C (channel = 2) */
+#define REG_TC1_SR2   (*(RoReg*)0x400940A0U) /**< \brief (TC1) Status Register (channel = 2) */
+#define REG_TC1_IER2  (*(WoReg*)0x400940A4U) /**< \brief (TC1) Interrupt Enable Register (channel = 2) */
+#define REG_TC1_IDR2  (*(WoReg*)0x400940A8U) /**< \brief (TC1) Interrupt Disable Register (channel = 2) */
+#define REG_TC1_IMR2  (*(RoReg*)0x400940ACU) /**< \brief (TC1) Interrupt Mask Register (channel = 2) */
+#define REG_TC1_EMR2  (*(RwReg*)0x400940B0U) /**< \brief (TC1) Extended Mode Register (channel = 2) */
+#define REG_TC1_BCR   (*(WoReg*)0x400940C0U) /**< \brief (TC1) Block Control Register */
+#define REG_TC1_BMR   (*(RwReg*)0x400940C4U) /**< \brief (TC1) Block Mode Register */
+#define REG_TC1_QIER  (*(WoReg*)0x400940C8U) /**< \brief (TC1) QDEC Interrupt Enable Register */
+#define REG_TC1_QIDR  (*(WoReg*)0x400940CCU) /**< \brief (TC1) QDEC Interrupt Disable Register */
+#define REG_TC1_QIMR  (*(RoReg*)0x400940D0U) /**< \brief (TC1) QDEC Interrupt Mask Register */
+#define REG_TC1_QISR  (*(RoReg*)0x400940D4U) /**< \brief (TC1) QDEC Interrupt Status Register */
+#define REG_TC1_FMR   (*(RwReg*)0x400940D8U) /**< \brief (TC1) Fault Mode Register */
+#define REG_TC1_WPMR  (*(RwReg*)0x400940E4U) /**< \brief (TC1) Write Protect Mode Register */
+#define REG_TC1_RPR0  (*(RwReg*)0x40094100U) /**< \brief (TC1) Receive Pointer Register (pdc = 0) */
+#define REG_TC1_RCR0  (*(RwReg*)0x40094104U) /**< \brief (TC1) Receive Counter Register (pdc = 0) */
+#define REG_TC1_RNPR0 (*(RwReg*)0x40094110U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 0) */
+#define REG_TC1_RNCR0 (*(RwReg*)0x40094114U) /**< \brief (TC1) Receive Next Counter Register (pdc = 0) */
+#define REG_TC1_PTCR0 (*(WoReg*)0x40094120U) /**< \brief (TC1) Transfer Control Register (pdc = 0) */
+#define REG_TC1_PTSR0 (*(RoReg*)0x40094124U) /**< \brief (TC1) Transfer Status Register (pdc = 0) */
+#define REG_TC1_RPR1  (*(RwReg*)0x40094140U) /**< \brief (TC1) Receive Pointer Register (pdc = 1) */
+#define REG_TC1_RCR1  (*(RwReg*)0x40094144U) /**< \brief (TC1) Receive Counter Register (pdc = 1) */
+#define REG_TC1_RNPR1 (*(RwReg*)0x40094150U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 1) */
+#define REG_TC1_RNCR1 (*(RwReg*)0x40094154U) /**< \brief (TC1) Receive Next Counter Register (pdc = 1) */
+#define REG_TC1_PTCR1 (*(WoReg*)0x40094160U) /**< \brief (TC1) Transfer Control Register (pdc = 1) */
+#define REG_TC1_PTSR1 (*(RoReg*)0x40094164U) /**< \brief (TC1) Transfer Status Register (pdc = 1) */
+#define REG_TC1_RPR2  (*(RwReg*)0x40094180U) /**< \brief (TC1) Receive Pointer Register (pdc = 2) */
+#define REG_TC1_RCR2  (*(RwReg*)0x40094184U) /**< \brief (TC1) Receive Counter Register (pdc = 2) */
+#define REG_TC1_RNPR2 (*(RwReg*)0x40094190U) /**< \brief (TC1) Receive Next Pointer Register (pdc = 2) */
+#define REG_TC1_RNCR2 (*(RwReg*)0x40094194U) /**< \brief (TC1) Receive Next Counter Register (pdc = 2) */
+#define REG_TC1_PTCR2 (*(WoReg*)0x400941A0U) /**< \brief (TC1) Transfer Control Register (pdc = 2) */
+#define REG_TC1_PTSR2 (*(RoReg*)0x400941A4U) /**< \brief (TC1) Transfer Status Register (pdc = 2) */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_TC1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/tc2.h
+++ b/asf/sam/include/sam4e/instance/tc2.h
@@ -1,0 +1,132 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TC2_INSTANCE_
+#define _SAM4E_TC2_INSTANCE_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC2_CCR0           (0x40098000U) /**< \brief (TC2) Channel Control Register (channel = 0) */
+#define REG_TC2_CMR0           (0x40098004U) /**< \brief (TC2) Channel Mode Register (channel = 0) */
+#define REG_TC2_SMMR0          (0x40098008U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC2_RAB0           (0x4009800CU) /**< \brief (TC2) Register AB (channel = 0) */
+#define REG_TC2_CV0            (0x40098010U) /**< \brief (TC2) Counter Value (channel = 0) */
+#define REG_TC2_RA0            (0x40098014U) /**< \brief (TC2) Register A (channel = 0) */
+#define REG_TC2_RB0            (0x40098018U) /**< \brief (TC2) Register B (channel = 0) */
+#define REG_TC2_RC0            (0x4009801CU) /**< \brief (TC2) Register C (channel = 0) */
+#define REG_TC2_SR0            (0x40098020U) /**< \brief (TC2) Status Register (channel = 0) */
+#define REG_TC2_IER0           (0x40098024U) /**< \brief (TC2) Interrupt Enable Register (channel = 0) */
+#define REG_TC2_IDR0           (0x40098028U) /**< \brief (TC2) Interrupt Disable Register (channel = 0) */
+#define REG_TC2_IMR0           (0x4009802CU) /**< \brief (TC2) Interrupt Mask Register (channel = 0) */
+#define REG_TC2_EMR0           (0x40098030U) /**< \brief (TC2) Extended Mode Register (channel = 0) */
+#define REG_TC2_CCR1           (0x40098040U) /**< \brief (TC2) Channel Control Register (channel = 1) */
+#define REG_TC2_CMR1           (0x40098044U) /**< \brief (TC2) Channel Mode Register (channel = 1) */
+#define REG_TC2_SMMR1          (0x40098048U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC2_RAB1           (0x4009804CU) /**< \brief (TC2) Register AB (channel = 1) */
+#define REG_TC2_CV1            (0x40098050U) /**< \brief (TC2) Counter Value (channel = 1) */
+#define REG_TC2_RA1            (0x40098054U) /**< \brief (TC2) Register A (channel = 1) */
+#define REG_TC2_RB1            (0x40098058U) /**< \brief (TC2) Register B (channel = 1) */
+#define REG_TC2_RC1            (0x4009805CU) /**< \brief (TC2) Register C (channel = 1) */
+#define REG_TC2_SR1            (0x40098060U) /**< \brief (TC2) Status Register (channel = 1) */
+#define REG_TC2_IER1           (0x40098064U) /**< \brief (TC2) Interrupt Enable Register (channel = 1) */
+#define REG_TC2_IDR1           (0x40098068U) /**< \brief (TC2) Interrupt Disable Register (channel = 1) */
+#define REG_TC2_IMR1           (0x4009806CU) /**< \brief (TC2) Interrupt Mask Register (channel = 1) */
+#define REG_TC2_EMR1           (0x40098070U) /**< \brief (TC2) Extended Mode Register (channel = 1) */
+#define REG_TC2_CCR2           (0x40098080U) /**< \brief (TC2) Channel Control Register (channel = 2) */
+#define REG_TC2_CMR2           (0x40098084U) /**< \brief (TC2) Channel Mode Register (channel = 2) */
+#define REG_TC2_SMMR2          (0x40098088U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC2_RAB2           (0x4009808CU) /**< \brief (TC2) Register AB (channel = 2) */
+#define REG_TC2_CV2            (0x40098090U) /**< \brief (TC2) Counter Value (channel = 2) */
+#define REG_TC2_RA2            (0x40098094U) /**< \brief (TC2) Register A (channel = 2) */
+#define REG_TC2_RB2            (0x40098098U) /**< \brief (TC2) Register B (channel = 2) */
+#define REG_TC2_RC2            (0x4009809CU) /**< \brief (TC2) Register C (channel = 2) */
+#define REG_TC2_SR2            (0x400980A0U) /**< \brief (TC2) Status Register (channel = 2) */
+#define REG_TC2_IER2           (0x400980A4U) /**< \brief (TC2) Interrupt Enable Register (channel = 2) */
+#define REG_TC2_IDR2           (0x400980A8U) /**< \brief (TC2) Interrupt Disable Register (channel = 2) */
+#define REG_TC2_IMR2           (0x400980ACU) /**< \brief (TC2) Interrupt Mask Register (channel = 2) */
+#define REG_TC2_EMR2           (0x400980B0U) /**< \brief (TC2) Extended Mode Register (channel = 2) */
+#define REG_TC2_BCR            (0x400980C0U) /**< \brief (TC2) Block Control Register */
+#define REG_TC2_BMR            (0x400980C4U) /**< \brief (TC2) Block Mode Register */
+#define REG_TC2_QIER           (0x400980C8U) /**< \brief (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR           (0x400980CCU) /**< \brief (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR           (0x400980D0U) /**< \brief (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR           (0x400980D4U) /**< \brief (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR            (0x400980D8U) /**< \brief (TC2) Fault Mode Register */
+#define REG_TC2_WPMR           (0x400980E4U) /**< \brief (TC2) Write Protect Mode Register */
+#else
+#define REG_TC2_CCR0  (*(WoReg*)0x40098000U) /**< \brief (TC2) Channel Control Register (channel = 0) */
+#define REG_TC2_CMR0  (*(RwReg*)0x40098004U) /**< \brief (TC2) Channel Mode Register (channel = 0) */
+#define REG_TC2_SMMR0 (*(RwReg*)0x40098008U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 0) */
+#define REG_TC2_RAB0  (*(RoReg*)0x4009800CU) /**< \brief (TC2) Register AB (channel = 0) */
+#define REG_TC2_CV0   (*(RoReg*)0x40098010U) /**< \brief (TC2) Counter Value (channel = 0) */
+#define REG_TC2_RA0   (*(RwReg*)0x40098014U) /**< \brief (TC2) Register A (channel = 0) */
+#define REG_TC2_RB0   (*(RwReg*)0x40098018U) /**< \brief (TC2) Register B (channel = 0) */
+#define REG_TC2_RC0   (*(RwReg*)0x4009801CU) /**< \brief (TC2) Register C (channel = 0) */
+#define REG_TC2_SR0   (*(RoReg*)0x40098020U) /**< \brief (TC2) Status Register (channel = 0) */
+#define REG_TC2_IER0  (*(WoReg*)0x40098024U) /**< \brief (TC2) Interrupt Enable Register (channel = 0) */
+#define REG_TC2_IDR0  (*(WoReg*)0x40098028U) /**< \brief (TC2) Interrupt Disable Register (channel = 0) */
+#define REG_TC2_IMR0  (*(RoReg*)0x4009802CU) /**< \brief (TC2) Interrupt Mask Register (channel = 0) */
+#define REG_TC2_EMR0  (*(RwReg*)0x40098030U) /**< \brief (TC2) Extended Mode Register (channel = 0) */
+#define REG_TC2_CCR1  (*(WoReg*)0x40098040U) /**< \brief (TC2) Channel Control Register (channel = 1) */
+#define REG_TC2_CMR1  (*(RwReg*)0x40098044U) /**< \brief (TC2) Channel Mode Register (channel = 1) */
+#define REG_TC2_SMMR1 (*(RwReg*)0x40098048U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 1) */
+#define REG_TC2_RAB1  (*(RoReg*)0x4009804CU) /**< \brief (TC2) Register AB (channel = 1) */
+#define REG_TC2_CV1   (*(RoReg*)0x40098050U) /**< \brief (TC2) Counter Value (channel = 1) */
+#define REG_TC2_RA1   (*(RwReg*)0x40098054U) /**< \brief (TC2) Register A (channel = 1) */
+#define REG_TC2_RB1   (*(RwReg*)0x40098058U) /**< \brief (TC2) Register B (channel = 1) */
+#define REG_TC2_RC1   (*(RwReg*)0x4009805CU) /**< \brief (TC2) Register C (channel = 1) */
+#define REG_TC2_SR1   (*(RoReg*)0x40098060U) /**< \brief (TC2) Status Register (channel = 1) */
+#define REG_TC2_IER1  (*(WoReg*)0x40098064U) /**< \brief (TC2) Interrupt Enable Register (channel = 1) */
+#define REG_TC2_IDR1  (*(WoReg*)0x40098068U) /**< \brief (TC2) Interrupt Disable Register (channel = 1) */
+#define REG_TC2_IMR1  (*(RoReg*)0x4009806CU) /**< \brief (TC2) Interrupt Mask Register (channel = 1) */
+#define REG_TC2_EMR1  (*(RwReg*)0x40098070U) /**< \brief (TC2) Extended Mode Register (channel = 1) */
+#define REG_TC2_CCR2  (*(WoReg*)0x40098080U) /**< \brief (TC2) Channel Control Register (channel = 2) */
+#define REG_TC2_CMR2  (*(RwReg*)0x40098084U) /**< \brief (TC2) Channel Mode Register (channel = 2) */
+#define REG_TC2_SMMR2 (*(RwReg*)0x40098088U) /**< \brief (TC2) Stepper Motor Mode Register (channel = 2) */
+#define REG_TC2_RAB2  (*(RoReg*)0x4009808CU) /**< \brief (TC2) Register AB (channel = 2) */
+#define REG_TC2_CV2   (*(RoReg*)0x40098090U) /**< \brief (TC2) Counter Value (channel = 2) */
+#define REG_TC2_RA2   (*(RwReg*)0x40098094U) /**< \brief (TC2) Register A (channel = 2) */
+#define REG_TC2_RB2   (*(RwReg*)0x40098098U) /**< \brief (TC2) Register B (channel = 2) */
+#define REG_TC2_RC2   (*(RwReg*)0x4009809CU) /**< \brief (TC2) Register C (channel = 2) */
+#define REG_TC2_SR2   (*(RoReg*)0x400980A0U) /**< \brief (TC2) Status Register (channel = 2) */
+#define REG_TC2_IER2  (*(WoReg*)0x400980A4U) /**< \brief (TC2) Interrupt Enable Register (channel = 2) */
+#define REG_TC2_IDR2  (*(WoReg*)0x400980A8U) /**< \brief (TC2) Interrupt Disable Register (channel = 2) */
+#define REG_TC2_IMR2  (*(RoReg*)0x400980ACU) /**< \brief (TC2) Interrupt Mask Register (channel = 2) */
+#define REG_TC2_EMR2  (*(RwReg*)0x400980B0U) /**< \brief (TC2) Extended Mode Register (channel = 2) */
+#define REG_TC2_BCR   (*(WoReg*)0x400980C0U) /**< \brief (TC2) Block Control Register */
+#define REG_TC2_BMR   (*(RwReg*)0x400980C4U) /**< \brief (TC2) Block Mode Register */
+#define REG_TC2_QIER  (*(WoReg*)0x400980C8U) /**< \brief (TC2) QDEC Interrupt Enable Register */
+#define REG_TC2_QIDR  (*(WoReg*)0x400980CCU) /**< \brief (TC2) QDEC Interrupt Disable Register */
+#define REG_TC2_QIMR  (*(RoReg*)0x400980D0U) /**< \brief (TC2) QDEC Interrupt Mask Register */
+#define REG_TC2_QISR  (*(RoReg*)0x400980D4U) /**< \brief (TC2) QDEC Interrupt Status Register */
+#define REG_TC2_FMR   (*(RwReg*)0x400980D8U) /**< \brief (TC2) Fault Mode Register */
+#define REG_TC2_WPMR  (*(RwReg*)0x400980E4U) /**< \brief (TC2) Write Protect Mode Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_TC2_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/twi0.h
+++ b/asf/sam/include/sam4e/instance/twi0.h
@@ -1,0 +1,84 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TWI0_INSTANCE_
+#define _SAM4E_TWI0_INSTANCE_
+
+/* ========== Register definition for TWI0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWI0_CR                    (0x400A8000U) /**< \brief (TWI0) Control Register */
+#define REG_TWI0_MMR                   (0x400A8004U) /**< \brief (TWI0) Master Mode Register */
+#define REG_TWI0_SMR                   (0x400A8008U) /**< \brief (TWI0) Slave Mode Register */
+#define REG_TWI0_IADR                  (0x400A800CU) /**< \brief (TWI0) Internal Address Register */
+#define REG_TWI0_CWGR                  (0x400A8010U) /**< \brief (TWI0) Clock Waveform Generator Register */
+#define REG_TWI0_SR                    (0x400A8020U) /**< \brief (TWI0) Status Register */
+#define REG_TWI0_IER                   (0x400A8024U) /**< \brief (TWI0) Interrupt Enable Register */
+#define REG_TWI0_IDR                   (0x400A8028U) /**< \brief (TWI0) Interrupt Disable Register */
+#define REG_TWI0_IMR                   (0x400A802CU) /**< \brief (TWI0) Interrupt Mask Register */
+#define REG_TWI0_RHR                   (0x400A8030U) /**< \brief (TWI0) Receive Holding Register */
+#define REG_TWI0_THR                   (0x400A8034U) /**< \brief (TWI0) Transmit Holding Register */
+#define REG_TWI0_WPROT_MODE            (0x400A80E4U) /**< \brief (TWI0) Protection Mode Register */
+#define REG_TWI0_WPROT_STATUS          (0x400A80E8U) /**< \brief (TWI0) Protection Status Register */
+#define REG_TWI0_RPR                   (0x400A8100U) /**< \brief (TWI0) Receive Pointer Register */
+#define REG_TWI0_RCR                   (0x400A8104U) /**< \brief (TWI0) Receive Counter Register */
+#define REG_TWI0_TPR                   (0x400A8108U) /**< \brief (TWI0) Transmit Pointer Register */
+#define REG_TWI0_TCR                   (0x400A810CU) /**< \brief (TWI0) Transmit Counter Register */
+#define REG_TWI0_RNPR                  (0x400A8110U) /**< \brief (TWI0) Receive Next Pointer Register */
+#define REG_TWI0_RNCR                  (0x400A8114U) /**< \brief (TWI0) Receive Next Counter Register */
+#define REG_TWI0_TNPR                  (0x400A8118U) /**< \brief (TWI0) Transmit Next Pointer Register */
+#define REG_TWI0_TNCR                  (0x400A811CU) /**< \brief (TWI0) Transmit Next Counter Register */
+#define REG_TWI0_PTCR                  (0x400A8120U) /**< \brief (TWI0) Transfer Control Register */
+#define REG_TWI0_PTSR                  (0x400A8124U) /**< \brief (TWI0) Transfer Status Register */
+#else
+#define REG_TWI0_CR           (*(WoReg*)0x400A8000U) /**< \brief (TWI0) Control Register */
+#define REG_TWI0_MMR          (*(RwReg*)0x400A8004U) /**< \brief (TWI0) Master Mode Register */
+#define REG_TWI0_SMR          (*(RwReg*)0x400A8008U) /**< \brief (TWI0) Slave Mode Register */
+#define REG_TWI0_IADR         (*(RwReg*)0x400A800CU) /**< \brief (TWI0) Internal Address Register */
+#define REG_TWI0_CWGR         (*(RwReg*)0x400A8010U) /**< \brief (TWI0) Clock Waveform Generator Register */
+#define REG_TWI0_SR           (*(RoReg*)0x400A8020U) /**< \brief (TWI0) Status Register */
+#define REG_TWI0_IER          (*(WoReg*)0x400A8024U) /**< \brief (TWI0) Interrupt Enable Register */
+#define REG_TWI0_IDR          (*(WoReg*)0x400A8028U) /**< \brief (TWI0) Interrupt Disable Register */
+#define REG_TWI0_IMR          (*(RoReg*)0x400A802CU) /**< \brief (TWI0) Interrupt Mask Register */
+#define REG_TWI0_RHR          (*(RoReg*)0x400A8030U) /**< \brief (TWI0) Receive Holding Register */
+#define REG_TWI0_THR          (*(WoReg*)0x400A8034U) /**< \brief (TWI0) Transmit Holding Register */
+#define REG_TWI0_WPROT_MODE   (*(RwReg*)0x400A80E4U) /**< \brief (TWI0) Protection Mode Register */
+#define REG_TWI0_WPROT_STATUS (*(RoReg*)0x400A80E8U) /**< \brief (TWI0) Protection Status Register */
+#define REG_TWI0_RPR          (*(RwReg*)0x400A8100U) /**< \brief (TWI0) Receive Pointer Register */
+#define REG_TWI0_RCR          (*(RwReg*)0x400A8104U) /**< \brief (TWI0) Receive Counter Register */
+#define REG_TWI0_TPR          (*(RwReg*)0x400A8108U) /**< \brief (TWI0) Transmit Pointer Register */
+#define REG_TWI0_TCR          (*(RwReg*)0x400A810CU) /**< \brief (TWI0) Transmit Counter Register */
+#define REG_TWI0_RNPR         (*(RwReg*)0x400A8110U) /**< \brief (TWI0) Receive Next Pointer Register */
+#define REG_TWI0_RNCR         (*(RwReg*)0x400A8114U) /**< \brief (TWI0) Receive Next Counter Register */
+#define REG_TWI0_TNPR         (*(RwReg*)0x400A8118U) /**< \brief (TWI0) Transmit Next Pointer Register */
+#define REG_TWI0_TNCR         (*(RwReg*)0x400A811CU) /**< \brief (TWI0) Transmit Next Counter Register */
+#define REG_TWI0_PTCR         (*(WoReg*)0x400A8120U) /**< \brief (TWI0) Transfer Control Register */
+#define REG_TWI0_PTSR         (*(RoReg*)0x400A8124U) /**< \brief (TWI0) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_TWI0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/twi1.h
+++ b/asf/sam/include/sam4e/instance/twi1.h
@@ -1,0 +1,84 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_TWI1_INSTANCE_
+#define _SAM4E_TWI1_INSTANCE_
+
+/* ========== Register definition for TWI1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TWI1_CR                    (0x400AC000U) /**< \brief (TWI1) Control Register */
+#define REG_TWI1_MMR                   (0x400AC004U) /**< \brief (TWI1) Master Mode Register */
+#define REG_TWI1_SMR                   (0x400AC008U) /**< \brief (TWI1) Slave Mode Register */
+#define REG_TWI1_IADR                  (0x400AC00CU) /**< \brief (TWI1) Internal Address Register */
+#define REG_TWI1_CWGR                  (0x400AC010U) /**< \brief (TWI1) Clock Waveform Generator Register */
+#define REG_TWI1_SR                    (0x400AC020U) /**< \brief (TWI1) Status Register */
+#define REG_TWI1_IER                   (0x400AC024U) /**< \brief (TWI1) Interrupt Enable Register */
+#define REG_TWI1_IDR                   (0x400AC028U) /**< \brief (TWI1) Interrupt Disable Register */
+#define REG_TWI1_IMR                   (0x400AC02CU) /**< \brief (TWI1) Interrupt Mask Register */
+#define REG_TWI1_RHR                   (0x400AC030U) /**< \brief (TWI1) Receive Holding Register */
+#define REG_TWI1_THR                   (0x400AC034U) /**< \brief (TWI1) Transmit Holding Register */
+#define REG_TWI1_WPROT_MODE            (0x400AC0E4U) /**< \brief (TWI1) Protection Mode Register */
+#define REG_TWI1_WPROT_STATUS          (0x400AC0E8U) /**< \brief (TWI1) Protection Status Register */
+#define REG_TWI1_RPR                   (0x400AC100U) /**< \brief (TWI1) Receive Pointer Register */
+#define REG_TWI1_RCR                   (0x400AC104U) /**< \brief (TWI1) Receive Counter Register */
+#define REG_TWI1_TPR                   (0x400AC108U) /**< \brief (TWI1) Transmit Pointer Register */
+#define REG_TWI1_TCR                   (0x400AC10CU) /**< \brief (TWI1) Transmit Counter Register */
+#define REG_TWI1_RNPR                  (0x400AC110U) /**< \brief (TWI1) Receive Next Pointer Register */
+#define REG_TWI1_RNCR                  (0x400AC114U) /**< \brief (TWI1) Receive Next Counter Register */
+#define REG_TWI1_TNPR                  (0x400AC118U) /**< \brief (TWI1) Transmit Next Pointer Register */
+#define REG_TWI1_TNCR                  (0x400AC11CU) /**< \brief (TWI1) Transmit Next Counter Register */
+#define REG_TWI1_PTCR                  (0x400AC120U) /**< \brief (TWI1) Transfer Control Register */
+#define REG_TWI1_PTSR                  (0x400AC124U) /**< \brief (TWI1) Transfer Status Register */
+#else
+#define REG_TWI1_CR           (*(WoReg*)0x400AC000U) /**< \brief (TWI1) Control Register */
+#define REG_TWI1_MMR          (*(RwReg*)0x400AC004U) /**< \brief (TWI1) Master Mode Register */
+#define REG_TWI1_SMR          (*(RwReg*)0x400AC008U) /**< \brief (TWI1) Slave Mode Register */
+#define REG_TWI1_IADR         (*(RwReg*)0x400AC00CU) /**< \brief (TWI1) Internal Address Register */
+#define REG_TWI1_CWGR         (*(RwReg*)0x400AC010U) /**< \brief (TWI1) Clock Waveform Generator Register */
+#define REG_TWI1_SR           (*(RoReg*)0x400AC020U) /**< \brief (TWI1) Status Register */
+#define REG_TWI1_IER          (*(WoReg*)0x400AC024U) /**< \brief (TWI1) Interrupt Enable Register */
+#define REG_TWI1_IDR          (*(WoReg*)0x400AC028U) /**< \brief (TWI1) Interrupt Disable Register */
+#define REG_TWI1_IMR          (*(RoReg*)0x400AC02CU) /**< \brief (TWI1) Interrupt Mask Register */
+#define REG_TWI1_RHR          (*(RoReg*)0x400AC030U) /**< \brief (TWI1) Receive Holding Register */
+#define REG_TWI1_THR          (*(WoReg*)0x400AC034U) /**< \brief (TWI1) Transmit Holding Register */
+#define REG_TWI1_WPROT_MODE   (*(RwReg*)0x400AC0E4U) /**< \brief (TWI1) Protection Mode Register */
+#define REG_TWI1_WPROT_STATUS (*(RoReg*)0x400AC0E8U) /**< \brief (TWI1) Protection Status Register */
+#define REG_TWI1_RPR          (*(RwReg*)0x400AC100U) /**< \brief (TWI1) Receive Pointer Register */
+#define REG_TWI1_RCR          (*(RwReg*)0x400AC104U) /**< \brief (TWI1) Receive Counter Register */
+#define REG_TWI1_TPR          (*(RwReg*)0x400AC108U) /**< \brief (TWI1) Transmit Pointer Register */
+#define REG_TWI1_TCR          (*(RwReg*)0x400AC10CU) /**< \brief (TWI1) Transmit Counter Register */
+#define REG_TWI1_RNPR         (*(RwReg*)0x400AC110U) /**< \brief (TWI1) Receive Next Pointer Register */
+#define REG_TWI1_RNCR         (*(RwReg*)0x400AC114U) /**< \brief (TWI1) Receive Next Counter Register */
+#define REG_TWI1_TNPR         (*(RwReg*)0x400AC118U) /**< \brief (TWI1) Transmit Next Pointer Register */
+#define REG_TWI1_TNCR         (*(RwReg*)0x400AC11CU) /**< \brief (TWI1) Transmit Next Counter Register */
+#define REG_TWI1_PTCR         (*(WoReg*)0x400AC120U) /**< \brief (TWI1) Transfer Control Register */
+#define REG_TWI1_PTSR         (*(RoReg*)0x400AC124U) /**< \brief (TWI1) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_TWI1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/uart0.h
+++ b/asf/sam/include/sam4e/instance/uart0.h
@@ -1,0 +1,76 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_UART0_INSTANCE_
+#define _SAM4E_UART0_INSTANCE_
+
+/* ========== Register definition for UART0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_UART0_CR            (0x400E0600U) /**< \brief (UART0) Control Register */
+#define REG_UART0_MR            (0x400E0604U) /**< \brief (UART0) Mode Register */
+#define REG_UART0_IER           (0x400E0608U) /**< \brief (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR           (0x400E060CU) /**< \brief (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR           (0x400E0610U) /**< \brief (UART0) Interrupt Mask Register */
+#define REG_UART0_SR            (0x400E0614U) /**< \brief (UART0) Status Register */
+#define REG_UART0_RHR           (0x400E0618U) /**< \brief (UART0) Receive Holding Register */
+#define REG_UART0_THR           (0x400E061CU) /**< \brief (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR          (0x400E0620U) /**< \brief (UART0) Baud Rate Generator Register */
+#define REG_UART0_RPR           (0x400E0700U) /**< \brief (UART0) Receive Pointer Register */
+#define REG_UART0_RCR           (0x400E0704U) /**< \brief (UART0) Receive Counter Register */
+#define REG_UART0_TPR           (0x400E0708U) /**< \brief (UART0) Transmit Pointer Register */
+#define REG_UART0_TCR           (0x400E070CU) /**< \brief (UART0) Transmit Counter Register */
+#define REG_UART0_RNPR          (0x400E0710U) /**< \brief (UART0) Receive Next Pointer Register */
+#define REG_UART0_RNCR          (0x400E0714U) /**< \brief (UART0) Receive Next Counter Register */
+#define REG_UART0_TNPR          (0x400E0718U) /**< \brief (UART0) Transmit Next Pointer Register */
+#define REG_UART0_TNCR          (0x400E071CU) /**< \brief (UART0) Transmit Next Counter Register */
+#define REG_UART0_PTCR          (0x400E0720U) /**< \brief (UART0) Transfer Control Register */
+#define REG_UART0_PTSR          (0x400E0724U) /**< \brief (UART0) Transfer Status Register */
+#else
+#define REG_UART0_CR   (*(WoReg*)0x400E0600U) /**< \brief (UART0) Control Register */
+#define REG_UART0_MR   (*(RwReg*)0x400E0604U) /**< \brief (UART0) Mode Register */
+#define REG_UART0_IER  (*(WoReg*)0x400E0608U) /**< \brief (UART0) Interrupt Enable Register */
+#define REG_UART0_IDR  (*(WoReg*)0x400E060CU) /**< \brief (UART0) Interrupt Disable Register */
+#define REG_UART0_IMR  (*(RoReg*)0x400E0610U) /**< \brief (UART0) Interrupt Mask Register */
+#define REG_UART0_SR   (*(RoReg*)0x400E0614U) /**< \brief (UART0) Status Register */
+#define REG_UART0_RHR  (*(RoReg*)0x400E0618U) /**< \brief (UART0) Receive Holding Register */
+#define REG_UART0_THR  (*(WoReg*)0x400E061CU) /**< \brief (UART0) Transmit Holding Register */
+#define REG_UART0_BRGR (*(RwReg*)0x400E0620U) /**< \brief (UART0) Baud Rate Generator Register */
+#define REG_UART0_RPR  (*(RwReg*)0x400E0700U) /**< \brief (UART0) Receive Pointer Register */
+#define REG_UART0_RCR  (*(RwReg*)0x400E0704U) /**< \brief (UART0) Receive Counter Register */
+#define REG_UART0_TPR  (*(RwReg*)0x400E0708U) /**< \brief (UART0) Transmit Pointer Register */
+#define REG_UART0_TCR  (*(RwReg*)0x400E070CU) /**< \brief (UART0) Transmit Counter Register */
+#define REG_UART0_RNPR (*(RwReg*)0x400E0710U) /**< \brief (UART0) Receive Next Pointer Register */
+#define REG_UART0_RNCR (*(RwReg*)0x400E0714U) /**< \brief (UART0) Receive Next Counter Register */
+#define REG_UART0_TNPR (*(RwReg*)0x400E0718U) /**< \brief (UART0) Transmit Next Pointer Register */
+#define REG_UART0_TNCR (*(RwReg*)0x400E071CU) /**< \brief (UART0) Transmit Next Counter Register */
+#define REG_UART0_PTCR (*(WoReg*)0x400E0720U) /**< \brief (UART0) Transfer Control Register */
+#define REG_UART0_PTSR (*(RoReg*)0x400E0724U) /**< \brief (UART0) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_UART0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/uart1.h
+++ b/asf/sam/include/sam4e/instance/uart1.h
@@ -1,0 +1,76 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_UART1_INSTANCE_
+#define _SAM4E_UART1_INSTANCE_
+
+/* ========== Register definition for UART1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_UART1_CR            (0x40060600U) /**< \brief (UART1) Control Register */
+#define REG_UART1_MR            (0x40060604U) /**< \brief (UART1) Mode Register */
+#define REG_UART1_IER           (0x40060608U) /**< \brief (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR           (0x4006060CU) /**< \brief (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR           (0x40060610U) /**< \brief (UART1) Interrupt Mask Register */
+#define REG_UART1_SR            (0x40060614U) /**< \brief (UART1) Status Register */
+#define REG_UART1_RHR           (0x40060618U) /**< \brief (UART1) Receive Holding Register */
+#define REG_UART1_THR           (0x4006061CU) /**< \brief (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR          (0x40060620U) /**< \brief (UART1) Baud Rate Generator Register */
+#define REG_UART1_RPR           (0x40060700U) /**< \brief (UART1) Receive Pointer Register */
+#define REG_UART1_RCR           (0x40060704U) /**< \brief (UART1) Receive Counter Register */
+#define REG_UART1_TPR           (0x40060708U) /**< \brief (UART1) Transmit Pointer Register */
+#define REG_UART1_TCR           (0x4006070CU) /**< \brief (UART1) Transmit Counter Register */
+#define REG_UART1_RNPR          (0x40060710U) /**< \brief (UART1) Receive Next Pointer Register */
+#define REG_UART1_RNCR          (0x40060714U) /**< \brief (UART1) Receive Next Counter Register */
+#define REG_UART1_TNPR          (0x40060718U) /**< \brief (UART1) Transmit Next Pointer Register */
+#define REG_UART1_TNCR          (0x4006071CU) /**< \brief (UART1) Transmit Next Counter Register */
+#define REG_UART1_PTCR          (0x40060720U) /**< \brief (UART1) Transfer Control Register */
+#define REG_UART1_PTSR          (0x40060724U) /**< \brief (UART1) Transfer Status Register */
+#else
+#define REG_UART1_CR   (*(WoReg*)0x40060600U) /**< \brief (UART1) Control Register */
+#define REG_UART1_MR   (*(RwReg*)0x40060604U) /**< \brief (UART1) Mode Register */
+#define REG_UART1_IER  (*(WoReg*)0x40060608U) /**< \brief (UART1) Interrupt Enable Register */
+#define REG_UART1_IDR  (*(WoReg*)0x4006060CU) /**< \brief (UART1) Interrupt Disable Register */
+#define REG_UART1_IMR  (*(RoReg*)0x40060610U) /**< \brief (UART1) Interrupt Mask Register */
+#define REG_UART1_SR   (*(RoReg*)0x40060614U) /**< \brief (UART1) Status Register */
+#define REG_UART1_RHR  (*(RoReg*)0x40060618U) /**< \brief (UART1) Receive Holding Register */
+#define REG_UART1_THR  (*(WoReg*)0x4006061CU) /**< \brief (UART1) Transmit Holding Register */
+#define REG_UART1_BRGR (*(RwReg*)0x40060620U) /**< \brief (UART1) Baud Rate Generator Register */
+#define REG_UART1_RPR  (*(RwReg*)0x40060700U) /**< \brief (UART1) Receive Pointer Register */
+#define REG_UART1_RCR  (*(RwReg*)0x40060704U) /**< \brief (UART1) Receive Counter Register */
+#define REG_UART1_TPR  (*(RwReg*)0x40060708U) /**< \brief (UART1) Transmit Pointer Register */
+#define REG_UART1_TCR  (*(RwReg*)0x4006070CU) /**< \brief (UART1) Transmit Counter Register */
+#define REG_UART1_RNPR (*(RwReg*)0x40060710U) /**< \brief (UART1) Receive Next Pointer Register */
+#define REG_UART1_RNCR (*(RwReg*)0x40060714U) /**< \brief (UART1) Receive Next Counter Register */
+#define REG_UART1_TNPR (*(RwReg*)0x40060718U) /**< \brief (UART1) Transmit Next Pointer Register */
+#define REG_UART1_TNCR (*(RwReg*)0x4006071CU) /**< \brief (UART1) Transmit Next Counter Register */
+#define REG_UART1_PTCR (*(WoReg*)0x40060720U) /**< \brief (UART1) Transfer Control Register */
+#define REG_UART1_PTSR (*(RoReg*)0x40060724U) /**< \brief (UART1) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_UART1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/udp.h
+++ b/asf/sam/include/sam4e/instance/udp.h
@@ -1,0 +1,62 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_UDP_INSTANCE_
+#define _SAM4E_UDP_INSTANCE_
+
+/* ========== Register definition for UDP peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_UDP_FRM_NUM           (0x40084000U) /**< \brief (UDP) Frame Number Register */
+#define REG_UDP_GLB_STAT          (0x40084004U) /**< \brief (UDP) Global State Register */
+#define REG_UDP_FADDR             (0x40084008U) /**< \brief (UDP) Function Address Register */
+#define REG_UDP_IER               (0x40084010U) /**< \brief (UDP) Interrupt Enable Register */
+#define REG_UDP_IDR               (0x40084014U) /**< \brief (UDP) Interrupt Disable Register */
+#define REG_UDP_IMR               (0x40084018U) /**< \brief (UDP) Interrupt Mask Register */
+#define REG_UDP_ISR               (0x4008401CU) /**< \brief (UDP) Interrupt Status Register */
+#define REG_UDP_ICR               (0x40084020U) /**< \brief (UDP) Interrupt Clear Register */
+#define REG_UDP_RST_EP            (0x40084028U) /**< \brief (UDP) Reset Endpoint Register */
+#define REG_UDP_CSR               (0x40084030U) /**< \brief (UDP) Endpoint Control and Status Register */
+#define REG_UDP_FDR               (0x40084050U) /**< \brief (UDP) Endpoint FIFO Data Register */
+#define REG_UDP_TXVC              (0x40084074U) /**< \brief (UDP) Transceiver Control Register */
+#else
+#define REG_UDP_FRM_NUM  (*(RoReg*)0x40084000U) /**< \brief (UDP) Frame Number Register */
+#define REG_UDP_GLB_STAT (*(RwReg*)0x40084004U) /**< \brief (UDP) Global State Register */
+#define REG_UDP_FADDR    (*(RwReg*)0x40084008U) /**< \brief (UDP) Function Address Register */
+#define REG_UDP_IER      (*(WoReg*)0x40084010U) /**< \brief (UDP) Interrupt Enable Register */
+#define REG_UDP_IDR      (*(WoReg*)0x40084014U) /**< \brief (UDP) Interrupt Disable Register */
+#define REG_UDP_IMR      (*(RoReg*)0x40084018U) /**< \brief (UDP) Interrupt Mask Register */
+#define REG_UDP_ISR      (*(RoReg*)0x4008401CU) /**< \brief (UDP) Interrupt Status Register */
+#define REG_UDP_ICR      (*(WoReg*)0x40084020U) /**< \brief (UDP) Interrupt Clear Register */
+#define REG_UDP_RST_EP   (*(RwReg*)0x40084028U) /**< \brief (UDP) Reset Endpoint Register */
+#define REG_UDP_CSR      (*(RwReg*)0x40084030U) /**< \brief (UDP) Endpoint Control and Status Register */
+#define REG_UDP_FDR      (*(RwReg*)0x40084050U) /**< \brief (UDP) Endpoint FIFO Data Register */
+#define REG_UDP_TXVC     (*(RwReg*)0x40084074U) /**< \brief (UDP) Transceiver Control Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_UDP_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/usart0.h
+++ b/asf/sam/include/sam4e/instance/usart0.h
@@ -1,0 +1,92 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_USART0_INSTANCE_
+#define _SAM4E_USART0_INSTANCE_
+
+/* ========== Register definition for USART0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART0_CR          (0x400A0000U) /**< \brief (USART0) Control Register */
+#define REG_USART0_MR          (0x400A0004U) /**< \brief (USART0) Mode Register */
+#define REG_USART0_IER          (0x400A0008U) /**< \brief (USART0) Interrupt Enable Register */
+#define REG_USART0_IDR          (0x400A000CU) /**< \brief (USART0) Interrupt Disable Register */
+#define REG_USART0_IMR          (0x400A0010U) /**< \brief (USART0) Interrupt Mask Register */
+#define REG_USART0_CSR          (0x400A0014U) /**< \brief (USART0) Channel Status Register */
+#define REG_USART0_RHR          (0x400A0018U) /**< \brief (USART0) Receiver Holding Register */
+#define REG_USART0_THR          (0x400A001CU) /**< \brief (USART0) Transmitter Holding Register */
+#define REG_USART0_BRGR          (0x400A0020U) /**< \brief (USART0) Baud Rate Generator Register */
+#define REG_USART0_RTOR          (0x400A0024U) /**< \brief (USART0) Receiver Time-out Register */
+#define REG_USART0_TTGR          (0x400A0028U) /**< \brief (USART0) Transmitter Timeguard Register */
+#define REG_USART0_FIDI          (0x400A0040U) /**< \brief (USART0) FI DI Ratio Register */
+#define REG_USART0_NER          (0x400A0044U) /**< \brief (USART0) Number of Errors Register */
+#define REG_USART0_IF          (0x400A004CU) /**< \brief (USART0) IrDA Filter Register */
+#define REG_USART0_MAN          (0x400A0050U) /**< \brief (USART0) Manchester Encoder Decoder Register */
+#define REG_USART0_WPMR          (0x400A00E4U) /**< \brief (USART0) Write Protect Mode Register */
+#define REG_USART0_WPSR          (0x400A00E8U) /**< \brief (USART0) Write Protect Status Register */
+#define REG_USART0_RPR          (0x400A0100U) /**< \brief (USART0) Receive Pointer Register */
+#define REG_USART0_RCR          (0x400A0104U) /**< \brief (USART0) Receive Counter Register */
+#define REG_USART0_TPR          (0x400A0108U) /**< \brief (USART0) Transmit Pointer Register */
+#define REG_USART0_TCR          (0x400A010CU) /**< \brief (USART0) Transmit Counter Register */
+#define REG_USART0_RNPR          (0x400A0110U) /**< \brief (USART0) Receive Next Pointer Register */
+#define REG_USART0_RNCR          (0x400A0114U) /**< \brief (USART0) Receive Next Counter Register */
+#define REG_USART0_TNPR          (0x400A0118U) /**< \brief (USART0) Transmit Next Pointer Register */
+#define REG_USART0_TNCR          (0x400A011CU) /**< \brief (USART0) Transmit Next Counter Register */
+#define REG_USART0_PTCR          (0x400A0120U) /**< \brief (USART0) Transfer Control Register */
+#define REG_USART0_PTSR          (0x400A0124U) /**< \brief (USART0) Transfer Status Register */
+#else
+#define REG_USART0_CR (*(WoReg*)0x400A0000U) /**< \brief (USART0) Control Register */
+#define REG_USART0_MR (*(RwReg*)0x400A0004U) /**< \brief (USART0) Mode Register */
+#define REG_USART0_IER (*(WoReg*)0x400A0008U) /**< \brief (USART0) Interrupt Enable Register */
+#define REG_USART0_IDR (*(WoReg*)0x400A000CU) /**< \brief (USART0) Interrupt Disable Register */
+#define REG_USART0_IMR (*(RoReg*)0x400A0010U) /**< \brief (USART0) Interrupt Mask Register */
+#define REG_USART0_CSR (*(RoReg*)0x400A0014U) /**< \brief (USART0) Channel Status Register */
+#define REG_USART0_RHR (*(RoReg*)0x400A0018U) /**< \brief (USART0) Receiver Holding Register */
+#define REG_USART0_THR (*(WoReg*)0x400A001CU) /**< \brief (USART0) Transmitter Holding Register */
+#define REG_USART0_BRGR (*(RwReg*)0x400A0020U) /**< \brief (USART0) Baud Rate Generator Register */
+#define REG_USART0_RTOR (*(RwReg*)0x400A0024U) /**< \brief (USART0) Receiver Time-out Register */
+#define REG_USART0_TTGR (*(RwReg*)0x400A0028U) /**< \brief (USART0) Transmitter Timeguard Register */
+#define REG_USART0_FIDI (*(RwReg*)0x400A0040U) /**< \brief (USART0) FI DI Ratio Register */
+#define REG_USART0_NER (*(RoReg*)0x400A0044U) /**< \brief (USART0) Number of Errors Register */
+#define REG_USART0_IF (*(RwReg*)0x400A004CU) /**< \brief (USART0) IrDA Filter Register */
+#define REG_USART0_MAN (*(RwReg*)0x400A0050U) /**< \brief (USART0) Manchester Encoder Decoder Register */
+#define REG_USART0_WPMR (*(RwReg*)0x400A00E4U) /**< \brief (USART0) Write Protect Mode Register */
+#define REG_USART0_WPSR (*(RoReg*)0x400A00E8U) /**< \brief (USART0) Write Protect Status Register */
+#define REG_USART0_RPR (*(RwReg*)0x400A0100U) /**< \brief (USART0) Receive Pointer Register */
+#define REG_USART0_RCR (*(RwReg*)0x400A0104U) /**< \brief (USART0) Receive Counter Register */
+#define REG_USART0_TPR (*(RwReg*)0x400A0108U) /**< \brief (USART0) Transmit Pointer Register */
+#define REG_USART0_TCR (*(RwReg*)0x400A010CU) /**< \brief (USART0) Transmit Counter Register */
+#define REG_USART0_RNPR (*(RwReg*)0x400A0110U) /**< \brief (USART0) Receive Next Pointer Register */
+#define REG_USART0_RNCR (*(RwReg*)0x400A0114U) /**< \brief (USART0) Receive Next Counter Register */
+#define REG_USART0_TNPR (*(RwReg*)0x400A0118U) /**< \brief (USART0) Transmit Next Pointer Register */
+#define REG_USART0_TNCR (*(RwReg*)0x400A011CU) /**< \brief (USART0) Transmit Next Counter Register */
+#define REG_USART0_PTCR (*(WoReg*)0x400A0120U) /**< \brief (USART0) Transfer Control Register */
+#define REG_USART0_PTSR (*(RoReg*)0x400A0124U) /**< \brief (USART0) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_USART0_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/usart1.h
+++ b/asf/sam/include/sam4e/instance/usart1.h
@@ -1,0 +1,92 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_USART1_INSTANCE_
+#define _SAM4E_USART1_INSTANCE_
+
+/* ========== Register definition for USART1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_USART1_CR          (0x400A4000U) /**< \brief (USART1) Control Register */
+#define REG_USART1_MR          (0x400A4004U) /**< \brief (USART1) Mode Register */
+#define REG_USART1_IER          (0x400A4008U) /**< \brief (USART1) Interrupt Enable Register */
+#define REG_USART1_IDR          (0x400A400CU) /**< \brief (USART1) Interrupt Disable Register */
+#define REG_USART1_IMR          (0x400A4010U) /**< \brief (USART1) Interrupt Mask Register */
+#define REG_USART1_CSR          (0x400A4014U) /**< \brief (USART1) Channel Status Register */
+#define REG_USART1_RHR          (0x400A4018U) /**< \brief (USART1) Receiver Holding Register */
+#define REG_USART1_THR          (0x400A401CU) /**< \brief (USART1) Transmitter Holding Register */
+#define REG_USART1_BRGR          (0x400A4020U) /**< \brief (USART1) Baud Rate Generator Register */
+#define REG_USART1_RTOR          (0x400A4024U) /**< \brief (USART1) Receiver Time-out Register */
+#define REG_USART1_TTGR          (0x400A4028U) /**< \brief (USART1) Transmitter Timeguard Register */
+#define REG_USART1_FIDI          (0x400A4040U) /**< \brief (USART1) FI DI Ratio Register */
+#define REG_USART1_NER          (0x400A4044U) /**< \brief (USART1) Number of Errors Register */
+#define REG_USART1_IF          (0x400A404CU) /**< \brief (USART1) IrDA Filter Register */
+#define REG_USART1_MAN          (0x400A4050U) /**< \brief (USART1) Manchester Encoder Decoder Register */
+#define REG_USART1_WPMR          (0x400A40E4U) /**< \brief (USART1) Write Protect Mode Register */
+#define REG_USART1_WPSR          (0x400A40E8U) /**< \brief (USART1) Write Protect Status Register */
+#define REG_USART1_RPR          (0x400A4100U) /**< \brief (USART1) Receive Pointer Register */
+#define REG_USART1_RCR          (0x400A4104U) /**< \brief (USART1) Receive Counter Register */
+#define REG_USART1_TPR          (0x400A4108U) /**< \brief (USART1) Transmit Pointer Register */
+#define REG_USART1_TCR          (0x400A410CU) /**< \brief (USART1) Transmit Counter Register */
+#define REG_USART1_RNPR          (0x400A4110U) /**< \brief (USART1) Receive Next Pointer Register */
+#define REG_USART1_RNCR          (0x400A4114U) /**< \brief (USART1) Receive Next Counter Register */
+#define REG_USART1_TNPR          (0x400A4118U) /**< \brief (USART1) Transmit Next Pointer Register */
+#define REG_USART1_TNCR          (0x400A411CU) /**< \brief (USART1) Transmit Next Counter Register */
+#define REG_USART1_PTCR          (0x400A4120U) /**< \brief (USART1) Transfer Control Register */
+#define REG_USART1_PTSR          (0x400A4124U) /**< \brief (USART1) Transfer Status Register */
+#else
+#define REG_USART1_CR (*(WoReg*)0x400A4000U) /**< \brief (USART1) Control Register */
+#define REG_USART1_MR (*(RwReg*)0x400A4004U) /**< \brief (USART1) Mode Register */
+#define REG_USART1_IER (*(WoReg*)0x400A4008U) /**< \brief (USART1) Interrupt Enable Register */
+#define REG_USART1_IDR (*(WoReg*)0x400A400CU) /**< \brief (USART1) Interrupt Disable Register */
+#define REG_USART1_IMR (*(RoReg*)0x400A4010U) /**< \brief (USART1) Interrupt Mask Register */
+#define REG_USART1_CSR (*(RoReg*)0x400A4014U) /**< \brief (USART1) Channel Status Register */
+#define REG_USART1_RHR (*(RoReg*)0x400A4018U) /**< \brief (USART1) Receiver Holding Register */
+#define REG_USART1_THR (*(WoReg*)0x400A401CU) /**< \brief (USART1) Transmitter Holding Register */
+#define REG_USART1_BRGR (*(RwReg*)0x400A4020U) /**< \brief (USART1) Baud Rate Generator Register */
+#define REG_USART1_RTOR (*(RwReg*)0x400A4024U) /**< \brief (USART1) Receiver Time-out Register */
+#define REG_USART1_TTGR (*(RwReg*)0x400A4028U) /**< \brief (USART1) Transmitter Timeguard Register */
+#define REG_USART1_FIDI (*(RwReg*)0x400A4040U) /**< \brief (USART1) FI DI Ratio Register */
+#define REG_USART1_NER (*(RoReg*)0x400A4044U) /**< \brief (USART1) Number of Errors Register */
+#define REG_USART1_IF (*(RwReg*)0x400A404CU) /**< \brief (USART1) IrDA Filter Register */
+#define REG_USART1_MAN (*(RwReg*)0x400A4050U) /**< \brief (USART1) Manchester Encoder Decoder Register */
+#define REG_USART1_WPMR (*(RwReg*)0x400A40E4U) /**< \brief (USART1) Write Protect Mode Register */
+#define REG_USART1_WPSR (*(RoReg*)0x400A40E8U) /**< \brief (USART1) Write Protect Status Register */
+#define REG_USART1_RPR (*(RwReg*)0x400A4100U) /**< \brief (USART1) Receive Pointer Register */
+#define REG_USART1_RCR (*(RwReg*)0x400A4104U) /**< \brief (USART1) Receive Counter Register */
+#define REG_USART1_TPR (*(RwReg*)0x400A4108U) /**< \brief (USART1) Transmit Pointer Register */
+#define REG_USART1_TCR (*(RwReg*)0x400A410CU) /**< \brief (USART1) Transmit Counter Register */
+#define REG_USART1_RNPR (*(RwReg*)0x400A4110U) /**< \brief (USART1) Receive Next Pointer Register */
+#define REG_USART1_RNCR (*(RwReg*)0x400A4114U) /**< \brief (USART1) Receive Next Counter Register */
+#define REG_USART1_TNPR (*(RwReg*)0x400A4118U) /**< \brief (USART1) Transmit Next Pointer Register */
+#define REG_USART1_TNCR (*(RwReg*)0x400A411CU) /**< \brief (USART1) Transmit Next Counter Register */
+#define REG_USART1_PTCR (*(WoReg*)0x400A4120U) /**< \brief (USART1) Transfer Control Register */
+#define REG_USART1_PTSR (*(RoReg*)0x400A4124U) /**< \brief (USART1) Transfer Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_USART1_INSTANCE_ */

--- a/asf/sam/include/sam4e/instance/wdt.h
+++ b/asf/sam/include/sam4e/instance/wdt.h
@@ -1,0 +1,44 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E_WDT_INSTANCE_
+#define _SAM4E_WDT_INSTANCE_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_WDT_CR          (0x400E1850U) /**< \brief (WDT) Control Register */
+#define REG_WDT_MR          (0x400E1854U) /**< \brief (WDT) Mode Register */
+#define REG_WDT_SR          (0x400E1858U) /**< \brief (WDT) Status Register */
+#else
+#define REG_WDT_CR (*(WoReg*)0x400E1850U) /**< \brief (WDT) Control Register */
+#define REG_WDT_MR (*(RwReg*)0x400E1854U) /**< \brief (WDT) Mode Register */
+#define REG_WDT_SR (*(RoReg*)0x400E1858U) /**< \brief (WDT) Status Register */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#endif /* _SAM4E_WDT_INSTANCE_ */

--- a/asf/sam/include/sam4e/pio/sam4e16c.h
+++ b/asf/sam/include/sam4e/pio/sam4e16c.h
@@ -1,0 +1,479 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E16C_PIO_
+#define _SAM4E16C_PIO_
+
+#define PIO_PA0              (1u << 0)  /**< \brief Pin Controlled by PA0 */
+#define PIO_PA1              (1u << 1)  /**< \brief Pin Controlled by PA1 */
+#define PIO_PA2              (1u << 2)  /**< \brief Pin Controlled by PA2 */
+#define PIO_PA3              (1u << 3)  /**< \brief Pin Controlled by PA3 */
+#define PIO_PA4              (1u << 4)  /**< \brief Pin Controlled by PA4 */
+#define PIO_PA5              (1u << 5)  /**< \brief Pin Controlled by PA5 */
+#define PIO_PA6              (1u << 6)  /**< \brief Pin Controlled by PA6 */
+#define PIO_PA7              (1u << 7)  /**< \brief Pin Controlled by PA7 */
+#define PIO_PA8              (1u << 8)  /**< \brief Pin Controlled by PA8 */
+#define PIO_PA9              (1u << 9)  /**< \brief Pin Controlled by PA9 */
+#define PIO_PA10             (1u << 10) /**< \brief Pin Controlled by PA10 */
+#define PIO_PA11             (1u << 11) /**< \brief Pin Controlled by PA11 */
+#define PIO_PA12             (1u << 12) /**< \brief Pin Controlled by PA12 */
+#define PIO_PA13             (1u << 13) /**< \brief Pin Controlled by PA13 */
+#define PIO_PA14             (1u << 14) /**< \brief Pin Controlled by PA14 */
+#define PIO_PA15             (1u << 15) /**< \brief Pin Controlled by PA15 */
+#define PIO_PA16             (1u << 16) /**< \brief Pin Controlled by PA16 */
+#define PIO_PA17             (1u << 17) /**< \brief Pin Controlled by PA17 */
+#define PIO_PA18             (1u << 18) /**< \brief Pin Controlled by PA18 */
+#define PIO_PA19             (1u << 19) /**< \brief Pin Controlled by PA19 */
+#define PIO_PA20             (1u << 20) /**< \brief Pin Controlled by PA20 */
+#define PIO_PA21             (1u << 21) /**< \brief Pin Controlled by PA21 */
+#define PIO_PA22             (1u << 22) /**< \brief Pin Controlled by PA22 */
+#define PIO_PA23             (1u << 23) /**< \brief Pin Controlled by PA23 */
+#define PIO_PA24             (1u << 24) /**< \brief Pin Controlled by PA24 */
+#define PIO_PA25             (1u << 25) /**< \brief Pin Controlled by PA25 */
+#define PIO_PA26             (1u << 26) /**< \brief Pin Controlled by PA26 */
+#define PIO_PA27             (1u << 27) /**< \brief Pin Controlled by PA27 */
+#define PIO_PA28             (1u << 28) /**< \brief Pin Controlled by PA28 */
+#define PIO_PA29             (1u << 29) /**< \brief Pin Controlled by PA29 */
+#define PIO_PA30             (1u << 30) /**< \brief Pin Controlled by PA30 */
+#define PIO_PA31             (1u << 31) /**< \brief Pin Controlled by PA31 */
+#define PIO_PB0              (1u << 0)  /**< \brief Pin Controlled by PB0 */
+#define PIO_PB1              (1u << 1)  /**< \brief Pin Controlled by PB1 */
+#define PIO_PB2              (1u << 2)  /**< \brief Pin Controlled by PB2 */
+#define PIO_PB3              (1u << 3)  /**< \brief Pin Controlled by PB3 */
+#define PIO_PB4              (1u << 4)  /**< \brief Pin Controlled by PB4 */
+#define PIO_PB5              (1u << 5)  /**< \brief Pin Controlled by PB5 */
+#define PIO_PB6              (1u << 6)  /**< \brief Pin Controlled by PB6 */
+#define PIO_PB7              (1u << 7)  /**< \brief Pin Controlled by PB7 */
+#define PIO_PB8              (1u << 8)  /**< \brief Pin Controlled by PB8 */
+#define PIO_PB9              (1u << 9)  /**< \brief Pin Controlled by PB9 */
+#define PIO_PB10             (1u << 10) /**< \brief Pin Controlled by PB10 */
+#define PIO_PB11             (1u << 11) /**< \brief Pin Controlled by PB11 */
+#define PIO_PB12             (1u << 12) /**< \brief Pin Controlled by PB12 */
+#define PIO_PB13             (1u << 13) /**< \brief Pin Controlled by PB13 */
+#define PIO_PB14             (1u << 14) /**< \brief Pin Controlled by PB14 */
+#define PIO_PC0              (1u << 0)  /**< \brief Pin Controlled by PC0 */
+#define PIO_PC1              (1u << 1)  /**< \brief Pin Controlled by PC1 */
+#define PIO_PC2              (1u << 2)  /**< \brief Pin Controlled by PC2 */
+#define PIO_PC3              (1u << 3)  /**< \brief Pin Controlled by PC3 */
+#define PIO_PC4              (1u << 4)  /**< \brief Pin Controlled by PC4 */
+#define PIO_PC5              (1u << 5)  /**< \brief Pin Controlled by PC5 */
+#define PIO_PC6              (1u << 6)  /**< \brief Pin Controlled by PC6 */
+#define PIO_PC7              (1u << 7)  /**< \brief Pin Controlled by PC7 */
+#define PIO_PC8              (1u << 8)  /**< \brief Pin Controlled by PC8 */
+#define PIO_PC9              (1u << 9)  /**< \brief Pin Controlled by PC9 */
+#define PIO_PC10             (1u << 10) /**< \brief Pin Controlled by PC10 */
+#define PIO_PC11             (1u << 11) /**< \brief Pin Controlled by PC11 */
+#define PIO_PC12             (1u << 12) /**< \brief Pin Controlled by PC12 */
+#define PIO_PC13             (1u << 13) /**< \brief Pin Controlled by PC13 */
+#define PIO_PC14             (1u << 14) /**< \brief Pin Controlled by PC14 */
+#define PIO_PC15             (1u << 15) /**< \brief Pin Controlled by PC15 */
+#define PIO_PC16             (1u << 16) /**< \brief Pin Controlled by PC16 */
+#define PIO_PC17             (1u << 17) /**< \brief Pin Controlled by PC17 */
+#define PIO_PC18             (1u << 18) /**< \brief Pin Controlled by PC18 */
+#define PIO_PC19             (1u << 19) /**< \brief Pin Controlled by PC19 */
+#define PIO_PC20             (1u << 20) /**< \brief Pin Controlled by PC20 */
+#define PIO_PC21             (1u << 21) /**< \brief Pin Controlled by PC21 */
+#define PIO_PC22             (1u << 22) /**< \brief Pin Controlled by PC22 */
+#define PIO_PC23             (1u << 23) /**< \brief Pin Controlled by PC23 */
+#define PIO_PC24             (1u << 24) /**< \brief Pin Controlled by PC24 */
+#define PIO_PC25             (1u << 25) /**< \brief Pin Controlled by PC25 */
+#define PIO_PC26             (1u << 26) /**< \brief Pin Controlled by PC26 */
+#define PIO_PC27             (1u << 27) /**< \brief Pin Controlled by PC27 */
+#define PIO_PC28             (1u << 28) /**< \brief Pin Controlled by PC28 */
+#define PIO_PC29             (1u << 29) /**< \brief Pin Controlled by PC29 */
+#define PIO_PC30             (1u << 30) /**< \brief Pin Controlled by PC30 */
+#define PIO_PC31             (1u << 31) /**< \brief Pin Controlled by PC31 */
+#define PIO_PD0              (1u << 0)  /**< \brief Pin Controlled by PD0 */
+#define PIO_PD1              (1u << 1)  /**< \brief Pin Controlled by PD1 */
+#define PIO_PD2              (1u << 2)  /**< \brief Pin Controlled by PD2 */
+#define PIO_PD3              (1u << 3)  /**< \brief Pin Controlled by PD3 */
+#define PIO_PD4              (1u << 4)  /**< \brief Pin Controlled by PD4 */
+#define PIO_PD5              (1u << 5)  /**< \brief Pin Controlled by PD5 */
+#define PIO_PD6              (1u << 6)  /**< \brief Pin Controlled by PD6 */
+#define PIO_PD7              (1u << 7)  /**< \brief Pin Controlled by PD7 */
+#define PIO_PD8              (1u << 8)  /**< \brief Pin Controlled by PD8 */
+#define PIO_PD9              (1u << 9)  /**< \brief Pin Controlled by PD9 */
+#define PIO_PD10             (1u << 10) /**< \brief Pin Controlled by PD10 */
+#define PIO_PD11             (1u << 11) /**< \brief Pin Controlled by PD11 */
+#define PIO_PD12             (1u << 12) /**< \brief Pin Controlled by PD12 */
+#define PIO_PD13             (1u << 13) /**< \brief Pin Controlled by PD13 */
+#define PIO_PD14             (1u << 14) /**< \brief Pin Controlled by PD14 */
+#define PIO_PD15             (1u << 15) /**< \brief Pin Controlled by PD15 */
+#define PIO_PD16             (1u << 16) /**< \brief Pin Controlled by PD16 */
+#define PIO_PD17             (1u << 17) /**< \brief Pin Controlled by PD17 */
+#define PIO_PD18             (1u << 18) /**< \brief Pin Controlled by PD18 */
+#define PIO_PD19             (1u << 19) /**< \brief Pin Controlled by PD19 */
+#define PIO_PD20             (1u << 20) /**< \brief Pin Controlled by PD20 */
+#define PIO_PD21             (1u << 21) /**< \brief Pin Controlled by PD21 */
+#define PIO_PD22             (1u << 22) /**< \brief Pin Controlled by PD22 */
+#define PIO_PD23             (1u << 23) /**< \brief Pin Controlled by PD23 */
+#define PIO_PD24             (1u << 24) /**< \brief Pin Controlled by PD24 */
+#define PIO_PD25             (1u << 25) /**< \brief Pin Controlled by PD25 */
+#define PIO_PD26             (1u << 26) /**< \brief Pin Controlled by PD26 */
+#define PIO_PD27             (1u << 27) /**< \brief Pin Controlled by PD27 */
+#define PIO_PD28             (1u << 28) /**< \brief Pin Controlled by PD28 */
+#define PIO_PD29             (1u << 29) /**< \brief Pin Controlled by PD29 */
+#define PIO_PD30             (1u << 30) /**< \brief Pin Controlled by PD30 */
+#define PIO_PD31             (1u << 31) /**< \brief Pin Controlled by PD31 */
+#define PIO_PE0              (1u << 0)  /**< \brief Pin Controlled by PE0 */
+#define PIO_PE1              (1u << 1)  /**< \brief Pin Controlled by PE1 */
+#define PIO_PE2              (1u << 2)  /**< \brief Pin Controlled by PE2 */
+#define PIO_PE3              (1u << 3)  /**< \brief Pin Controlled by PE3 */
+#define PIO_PE4              (1u << 4)  /**< \brief Pin Controlled by PE4 */
+#define PIO_PE5              (1u << 5)  /**< \brief Pin Controlled by PE5 */
+/* ========== Pio definition for AFEC0 peripheral ========== */
+#define PIO_PA17X1_AFE0_AD0  (1u << 17) /**< \brief Afec0 signal: AFE0_AD0 */
+#define PIO_PA18X1_AFE0_AD1  (1u << 18) /**< \brief Afec0 signal: AFE0_AD1 */
+#define PIO_PC30X1_AFE0_AD10 (1u << 30) /**< \brief Afec0 signal: AFE0_AD10 */
+#define PIO_PC31X1_AFE0_AD11 (1u << 31) /**< \brief Afec0 signal: AFE0_AD11 */
+#define PIO_PC26X1_AFE0_AD12 (1u << 26) /**< \brief Afec0 signal: AFE0_AD12 */
+#define PIO_PC27X1_AFE0_AD13 (1u << 27) /**< \brief Afec0 signal: AFE0_AD13 */
+#define PIO_PC0X1_AFE0_AD14  (1u << 0)  /**< \brief Afec0 signal: AFE0_AD14 */
+#define PIO_PA19X1_AFE0_AD2  (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA19X1_WKUP9     (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA20X1_AFE0_AD3  (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PA20X1_WKUP10    (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PB0X1_AFE0_AD4   (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB0X1_RTCOUT0    (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB1X1_AFE0_AD5   (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PB1X1_RTCOUT1    (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PC13X1_AFE0_AD6  (1u << 13) /**< \brief Afec0 signal: AFE0_AD6 */
+#define PIO_PC15X1_AFE0_AD7  (1u << 15) /**< \brief Afec0 signal: AFE0_AD7 */
+#define PIO_PC12X1_AFE0_AD8  (1u << 12) /**< \brief Afec0 signal: AFE0_AD8 */
+#define PIO_PC29X1_AFE0_AD9  (1u << 29) /**< \brief Afec0 signal: AFE0_AD9 */
+#define PIO_PA8B_AFE0_ADTRG  (1u << 8)  /**< \brief Afec0 signal: AFE0_ADTRG */
+/* ========== Pio definition for AFEC1 peripheral ========== */
+#define PIO_PB2X1_AFE1_AD0   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB2X1_WKUP12     (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB3X1_AFE1_AD1   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD1 */
+#define PIO_PA21X1_AFE1_AD2  (1u << 21) /**< \brief Afec1 signal: AFE1_AD2 */
+#define PIO_PA22X1_AFE1_AD3  (1u << 22) /**< \brief Afec1 signal: AFE1_AD3 */
+#define PIO_PC1X1_AFE1_AD4   (1u << 1)  /**< \brief Afec1 signal: AFE1_AD4 */
+#define PIO_PC2X1_AFE1_AD5   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD5 */
+#define PIO_PC3X1_AFE1_AD6   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD6 */
+#define PIO_PC4X1_AFE1_AD7   (1u << 4)  /**< \brief Afec1 signal: AFE1_AD7 */
+/* ========== Pio definition for CAN0 peripheral ========== */
+#define PIO_PB3A_CANRX0      (1u << 3)  /**< \brief Can0 signal: CANRX0 */
+#define PIO_PB2A_CANTX0      (1u << 2)  /**< \brief Can0 signal: CANTX0 */
+/* ========== Pio definition for CAN1 peripheral ========== */
+#define PIO_PC12C_CANRX1     (1u << 12) /**< \brief Can1 signal: CANRX1 */
+#define PIO_PC15C_CANTX1     (1u << 15) /**< \brief Can1 signal: CANTX1 */
+/* ========== Pio definition for DACC peripheral ========== */
+#define PIO_PB13X1_DAC0      (1u << 13) /**< \brief Dacc signal: DAC0 */
+#define PIO_PB14X1_DAC1      (1u << 14) /**< \brief Dacc signal: DAC1 */
+#define PIO_PA2C_DATRG       (1u << 2)  /**< \brief Dacc signal: DATRG */
+/* ========== Pio definition for GMAC peripheral ========== */
+#define PIO_PD13A_GCOL       (1u << 13) /**< \brief Gmac signal: GCOL */
+#define PIO_PD10A_GCRS       (1u << 10) /**< \brief Gmac signal: GCRS */
+#define PIO_PD4A_GCRSDV      (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD4A_GRXDV       (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
+#define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
+#define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
+#define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
+#define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */
+#define PIO_PD7A_GRXER       (1u << 7)  /**< \brief Gmac signal: GRXER */
+#define PIO_PD2A_GTX0        (1u << 2)  /**< \brief Gmac signal: GTX0 */
+#define PIO_PD3A_GTX1        (1u << 3)  /**< \brief Gmac signal: GTX1 */
+#define PIO_PD15A_GTX2       (1u << 15) /**< \brief Gmac signal: GTX2 */
+#define PIO_PD16A_GTX3       (1u << 16) /**< \brief Gmac signal: GTX3 */
+#define PIO_PD0A_GTXCK       (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD0A_GREFCK      (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD1A_GTXEN       (1u << 1)  /**< \brief Gmac signal: GTXEN */
+#define PIO_PD17A_GTXER      (1u << 17) /**< \brief Gmac signal: GTXER */
+/* ========== Pio definition for HSMCI peripheral ========== */
+#define PIO_PA28C_MCCDA      (1u << 28) /**< \brief Hsmci signal: MCCDA */
+#define PIO_PA29C_MCCK       (1u << 29) /**< \brief Hsmci signal: MCCK */
+#define PIO_PA30C_MCDA0      (1u << 30) /**< \brief Hsmci signal: MCDA0 */
+#define PIO_PA31C_MCDA1      (1u << 31) /**< \brief Hsmci signal: MCDA1 */
+#define PIO_PA26C_MCDA2      (1u << 26) /**< \brief Hsmci signal: MCDA2 */
+#define PIO_PA27C_MCDA3      (1u << 27) /**< \brief Hsmci signal: MCDA3 */
+/* ========== Pio definition for PIOA peripheral ========== */
+#define PIO_PA24X1_PIODC0    (1u << 24) /**< \brief Pioa signal: PIODC0 */
+#define PIO_PA25X1_PIODC1    (1u << 25) /**< \brief Pioa signal: PIODC1 */
+#define PIO_PA26X1_PIODC2    (1u << 26) /**< \brief Pioa signal: PIODC2 */
+#define PIO_PA27X1_PIODC3    (1u << 27) /**< \brief Pioa signal: PIODC3 */
+#define PIO_PA28X1_PIODC4    (1u << 28) /**< \brief Pioa signal: PIODC4 */
+#define PIO_PA29X1_PIODC5    (1u << 29) /**< \brief Pioa signal: PIODC5 */
+#define PIO_PA31X1_PIODC7    (1u << 31) /**< \brief Pioa signal: PIODC7 */
+#define PIO_PA23X1_PIODCCLK  (1u << 23) /**< \brief Pioa signal: PIODCCLK */
+#define PIO_PA30X1_WKUP11    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA30X1_PIODC6    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA15X1_WKUP14    (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA15X1_PIODCEN1  (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA16X1_WKUP15    (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+#define PIO_PA16X1_PIODCEN2  (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+/* ========== Pio definition for PMC peripheral ========== */
+#define PIO_PA6B_PCK0        (1u << 6)  /**< \brief Pmc signal: PCK0 */
+#define PIO_PB13B_PCK0       (1u << 13) /**< \brief Pmc signal: PCK0 */
+#define PIO_PA17B_PCK1       (1u << 17) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA21B_PCK1       (1u << 21) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA18B_PCK2       (1u << 18) /**< \brief Pmc signal: PCK2 */
+#define PIO_PA31B_PCK2       (1u << 31) /**< \brief Pmc signal: PCK2 */
+#define PIO_PB3B_PCK2        (1u << 3)  /**< \brief Pmc signal: PCK2 */
+/* ========== Pio definition for PWM peripheral ========== */
+#define PIO_PA9C_PWMFI0      (1u << 9)  /**< \brief Pwm signal: PWMFI0 */
+#define PIO_PA0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA11B_PWMH0      (1u << 11) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA23B_PWMH0      (1u << 23) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PB0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PC18B_PWMH0      (1u << 18) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PD20A_PWMH0      (1u << 20) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA12B_PWMH1      (1u << 12) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA24B_PWMH1      (1u << 24) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PB1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PC19B_PWMH1      (1u << 19) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PD21A_PWMH1      (1u << 21) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA2A_PWMH2       (1u << 2)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA13B_PWMH2      (1u << 13) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA25B_PWMH2      (1u << 25) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PB4B_PWMH2       (1u << 4)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PC20B_PWMH2      (1u << 20) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PD22A_PWMH2      (1u << 22) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA7B_PWMH3       (1u << 7)  /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA17C_PWMH3      (1u << 17) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PB14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PC21B_PWMH3      (1u << 21) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PD23A_PWMH3      (1u << 23) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA19B_PWML0      (1u << 19) /**< \brief Pwm signal: PWML0 */
+#define PIO_PB5B_PWML0       (1u << 5)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC0B_PWML0       (1u << 0)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC13B_PWML0      (1u << 13) /**< \brief Pwm signal: PWML0 */
+#define PIO_PD24A_PWML0      (1u << 24) /**< \brief Pwm signal: PWML0 */
+#define PIO_PA20B_PWML1      (1u << 20) /**< \brief Pwm signal: PWML1 */
+#define PIO_PB12A_PWML1      (1u << 12) /**< \brief Pwm signal: PWML1 */
+#define PIO_PC1B_PWML1       (1u << 1)  /**< \brief Pwm signal: PWML1 */
+#define PIO_PC15B_PWML1      (1u << 15) /**< \brief Pwm signal: PWML1 */
+#define PIO_PD25A_PWML1      (1u << 25) /**< \brief Pwm signal: PWML1 */
+#define PIO_PA16C_PWML2      (1u << 16) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA30A_PWML2      (1u << 30) /**< \brief Pwm signal: PWML2 */
+#define PIO_PB13A_PWML2      (1u << 13) /**< \brief Pwm signal: PWML2 */
+#define PIO_PC2B_PWML2       (1u << 2)  /**< \brief Pwm signal: PWML2 */
+#define PIO_PD26A_PWML2      (1u << 26) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA15C_PWML3      (1u << 15) /**< \brief Pwm signal: PWML3 */
+#define PIO_PC3B_PWML3       (1u << 3)  /**< \brief Pwm signal: PWML3 */
+#define PIO_PC22B_PWML3      (1u << 22) /**< \brief Pwm signal: PWML3 */
+#define PIO_PD27A_PWML3      (1u << 27) /**< \brief Pwm signal: PWML3 */
+/* ========== Pio definition for SPI peripheral ========== */
+#define PIO_PA12A_MISO       (1u << 12) /**< \brief Spi signal: MISO */
+#define PIO_PA13A_MOSI       (1u << 13) /**< \brief Spi signal: MOSI */
+#define PIO_PA11A_NPCS0      (1u << 11) /**< \brief Spi signal: NPCS0 */
+#define PIO_PA9B_NPCS1       (1u << 9)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA31A_NPCS1      (1u << 31) /**< \brief Spi signal: NPCS1 */
+#define PIO_PB14A_NPCS1      (1u << 14) /**< \brief Spi signal: NPCS1 */
+#define PIO_PC4B_NPCS1       (1u << 4)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA10B_NPCS2      (1u << 10) /**< \brief Spi signal: NPCS2 */
+#define PIO_PA30B_NPCS2      (1u << 30) /**< \brief Spi signal: NPCS2 */
+#define PIO_PB2B_NPCS2       (1u << 2)  /**< \brief Spi signal: NPCS2 */
+#define PIO_PA3B_NPCS3       (1u << 3)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA5B_NPCS3       (1u << 5)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA22B_NPCS3      (1u << 22) /**< \brief Spi signal: NPCS3 */
+#define PIO_PA14A_SPCK       (1u << 14) /**< \brief Spi signal: SPCK */
+/* ========== Pio definition for TC0 peripheral ========== */
+#define PIO_PA4B_TCLK0       (1u << 4)  /**< \brief Tc0 signal: TCLK0 */
+#define PIO_PA28B_TCLK1      (1u << 28) /**< \brief Tc0 signal: TCLK1 */
+#define PIO_PA29B_TCLK2      (1u << 29) /**< \brief Tc0 signal: TCLK2 */
+#define PIO_PA0B_TIOA0       (1u << 0)  /**< \brief Tc0 signal: TIOA0 */
+#define PIO_PA15B_TIOA1      (1u << 15) /**< \brief Tc0 signal: TIOA1 */
+#define PIO_PA26B_TIOA2      (1u << 26) /**< \brief Tc0 signal: TIOA2 */
+#define PIO_PA1B_TIOB0       (1u << 1)  /**< \brief Tc0 signal: TIOB0 */
+#define PIO_PA16B_TIOB1      (1u << 16) /**< \brief Tc0 signal: TIOB1 */
+#define PIO_PA27B_TIOB2      (1u << 27) /**< \brief Tc0 signal: TIOB2 */
+/* ========== Pio definition for TC1 peripheral ========== */
+#define PIO_PC25B_TCLK3      (1u << 25) /**< \brief Tc1 signal: TCLK3 */
+#define PIO_PC28B_TCLK4      (1u << 28) /**< \brief Tc1 signal: TCLK4 */
+#define PIO_PC31B_TCLK5      (1u << 31) /**< \brief Tc1 signal: TCLK5 */
+#define PIO_PC23B_TIOA3      (1u << 23) /**< \brief Tc1 signal: TIOA3 */
+#define PIO_PC26B_TIOA4      (1u << 26) /**< \brief Tc1 signal: TIOA4 */
+#define PIO_PC29B_TIOA5      (1u << 29) /**< \brief Tc1 signal: TIOA5 */
+#define PIO_PC24B_TIOB3      (1u << 24) /**< \brief Tc1 signal: TIOB3 */
+#define PIO_PC27B_TIOB4      (1u << 27) /**< \brief Tc1 signal: TIOB4 */
+#define PIO_PC30B_TIOB5      (1u << 30) /**< \brief Tc1 signal: TIOB5 */
+/* ========== Pio definition for TC2 peripheral ========== */
+#define PIO_PC7B_TCLK6       (1u << 7)  /**< \brief Tc2 signal: TCLK6 */
+#define PIO_PC10B_TCLK7      (1u << 10) /**< \brief Tc2 signal: TCLK7 */
+#define PIO_PC14B_TCLK8      (1u << 14) /**< \brief Tc2 signal: TCLK8 */
+#define PIO_PC5B_TIOA6       (1u << 5)  /**< \brief Tc2 signal: TIOA6 */
+#define PIO_PC8B_TIOA7       (1u << 8)  /**< \brief Tc2 signal: TIOA7 */
+#define PIO_PC11B_TIOA8      (1u << 11) /**< \brief Tc2 signal: TIOA8 */
+#define PIO_PC6B_TIOB6       (1u << 6)  /**< \brief Tc2 signal: TIOB6 */
+#define PIO_PC9B_TIOB7       (1u << 9)  /**< \brief Tc2 signal: TIOB7 */
+#define PIO_PC12B_TIOB8      (1u << 12) /**< \brief Tc2 signal: TIOB8 */
+/* ========== Pio definition for TWI0 peripheral ========== */
+#define PIO_PA4A_TWCK0       (1u << 4)  /**< \brief Twi0 signal: TWCK0 */
+#define PIO_PA3A_TWD0        (1u << 3)  /**< \brief Twi0 signal: TWD0 */
+/* ========== Pio definition for TWI1 peripheral ========== */
+#define PIO_PB5A_TWCK1       (1u << 5)  /**< \brief Twi1 signal: TWCK1 */
+#define PIO_PB4A_TWD1        (1u << 4)  /**< \brief Twi1 signal: TWD1 */
+/* ========== Pio definition for UART0 peripheral ========== */
+#define PIO_PA9A_URXD0       (1u << 9)  /**< \brief Uart0 signal: URXD0 */
+#define PIO_PA10A_UTXD0      (1u << 10) /**< \brief Uart0 signal: UTXD0 */
+/* ========== Pio definition for UART1 peripheral ========== */
+#define PIO_PA5C_URXD1       (1u << 5)  /**< \brief Uart1 signal: URXD1 */
+#define PIO_PA6C_UTXD1       (1u << 6)  /**< \brief Uart1 signal: UTXD1 */
+/* ========== Pio definition for USART0 peripheral ========== */
+#define PIO_PB2C_CTS0        (1u << 2)  /**< \brief Usart0 signal: CTS0 */
+#define PIO_PB3C_RTS0        (1u << 3)  /**< \brief Usart0 signal: RTS0 */
+#define PIO_PB0C_RXD0        (1u << 0)  /**< \brief Usart0 signal: RXD0 */
+#define PIO_PB13C_SCK0       (1u << 13) /**< \brief Usart0 signal: SCK0 */
+#define PIO_PB1C_TXD0        (1u << 1)  /**< \brief Usart0 signal: TXD0 */
+/* ========== Pio definition for USART1 peripheral ========== */
+#define PIO_PA25A_CTS1       (1u << 25) /**< \brief Usart1 signal: CTS1 */
+#define PIO_PA26A_DCD1       (1u << 26) /**< \brief Usart1 signal: DCD1 */
+#define PIO_PA28A_DSR1       (1u << 28) /**< \brief Usart1 signal: DSR1 */
+#define PIO_PA27A_DTR1       (1u << 27) /**< \brief Usart1 signal: DTR1 */
+#define PIO_PA29A_RI1        (1u << 29) /**< \brief Usart1 signal: RI1 */
+#define PIO_PA24A_RTS1       (1u << 24) /**< \brief Usart1 signal: RTS1 */
+#define PIO_PA21A_RXD1       (1u << 21) /**< \brief Usart1 signal: RXD1 */
+#define PIO_PA23A_SCK1       (1u << 23) /**< \brief Usart1 signal: SCK1 */
+#define PIO_PA22A_TXD1       (1u << 22) /**< \brief Usart1 signal: TXD1 */
+/* ========== Pio indexes ========== */
+#define PIO_PA0_IDX          0
+#define PIO_PA1_IDX          1
+#define PIO_PA2_IDX          2
+#define PIO_PA3_IDX          3
+#define PIO_PA4_IDX          4
+#define PIO_PA5_IDX          5
+#define PIO_PA6_IDX          6
+#define PIO_PA7_IDX          7
+#define PIO_PA8_IDX          8
+#define PIO_PA9_IDX          9
+#define PIO_PA10_IDX         10
+#define PIO_PA11_IDX         11
+#define PIO_PA12_IDX         12
+#define PIO_PA13_IDX         13
+#define PIO_PA14_IDX         14
+#define PIO_PA15_IDX         15
+#define PIO_PA16_IDX         16
+#define PIO_PA17_IDX         17
+#define PIO_PA18_IDX         18
+#define PIO_PA19_IDX         19
+#define PIO_PA20_IDX         20
+#define PIO_PA21_IDX         21
+#define PIO_PA22_IDX         22
+#define PIO_PA23_IDX         23
+#define PIO_PA24_IDX         24
+#define PIO_PA25_IDX         25
+#define PIO_PA26_IDX         26
+#define PIO_PA27_IDX         27
+#define PIO_PA28_IDX         28
+#define PIO_PA29_IDX         29
+#define PIO_PA30_IDX         30
+#define PIO_PA31_IDX         31
+#define PIO_PB0_IDX          32
+#define PIO_PB1_IDX          33
+#define PIO_PB2_IDX          34
+#define PIO_PB3_IDX          35
+#define PIO_PB4_IDX          36
+#define PIO_PB5_IDX          37
+#define PIO_PB6_IDX          38
+#define PIO_PB7_IDX          39
+#define PIO_PB8_IDX          40
+#define PIO_PB9_IDX          41
+#define PIO_PB10_IDX         42
+#define PIO_PB11_IDX         43
+#define PIO_PB12_IDX         44
+#define PIO_PB13_IDX         45
+#define PIO_PB14_IDX         46
+#define PIO_PC0_IDX          64
+#define PIO_PC1_IDX          65
+#define PIO_PC2_IDX          66
+#define PIO_PC3_IDX          67
+#define PIO_PC4_IDX          68
+#define PIO_PC5_IDX          69
+#define PIO_PC6_IDX          70
+#define PIO_PC7_IDX          71
+#define PIO_PC8_IDX          72
+#define PIO_PC9_IDX          73
+#define PIO_PC10_IDX         74
+#define PIO_PC11_IDX         75
+#define PIO_PC12_IDX         76
+#define PIO_PC13_IDX         77
+#define PIO_PC14_IDX         78
+#define PIO_PC15_IDX         79
+#define PIO_PC16_IDX         80
+#define PIO_PC17_IDX         81
+#define PIO_PC18_IDX         82
+#define PIO_PC19_IDX         83
+#define PIO_PC20_IDX         84
+#define PIO_PC21_IDX         85
+#define PIO_PC22_IDX         86
+#define PIO_PC23_IDX         87
+#define PIO_PC24_IDX         88
+#define PIO_PC25_IDX         89
+#define PIO_PC26_IDX         90
+#define PIO_PC27_IDX         91
+#define PIO_PC28_IDX         92
+#define PIO_PC29_IDX         93
+#define PIO_PC30_IDX         94
+#define PIO_PC31_IDX         95
+#define PIO_PD0_IDX          96
+#define PIO_PD1_IDX          97
+#define PIO_PD2_IDX          98
+#define PIO_PD3_IDX          99
+#define PIO_PD4_IDX          100
+#define PIO_PD5_IDX          101
+#define PIO_PD6_IDX          102
+#define PIO_PD7_IDX          103
+#define PIO_PD8_IDX          104
+#define PIO_PD9_IDX          105
+#define PIO_PD10_IDX         106
+#define PIO_PD11_IDX         107
+#define PIO_PD12_IDX         108
+#define PIO_PD13_IDX         109
+#define PIO_PD14_IDX         110
+#define PIO_PD15_IDX         111
+#define PIO_PD16_IDX         112
+#define PIO_PD17_IDX         113
+#define PIO_PD18_IDX         114
+#define PIO_PD19_IDX         115
+#define PIO_PD20_IDX         116
+#define PIO_PD21_IDX         117
+#define PIO_PD22_IDX         118
+#define PIO_PD23_IDX         119
+#define PIO_PD24_IDX         120
+#define PIO_PD25_IDX         121
+#define PIO_PD26_IDX         122
+#define PIO_PD27_IDX         123
+#define PIO_PD28_IDX         124
+#define PIO_PD29_IDX         125
+#define PIO_PD30_IDX         126
+#define PIO_PD31_IDX         127
+#define PIO_PE0_IDX          128
+#define PIO_PE1_IDX          129
+#define PIO_PE2_IDX          130
+#define PIO_PE3_IDX          131
+#define PIO_PE4_IDX          132
+#define PIO_PE5_IDX          133
+
+#endif /* _SAM4E16C_PIO_ */

--- a/asf/sam/include/sam4e/pio/sam4e16c.h
+++ b/asf/sam/include/sam4e/pio/sam4e16c.h
@@ -196,7 +196,7 @@
 #define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
 #define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
 #define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
-#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX1        (1u << 6)  /**< \brief Gmac signal: GRX1 */
 #define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
 #define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
 #define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */

--- a/asf/sam/include/sam4e/pio/sam4e16e.h
+++ b/asf/sam/include/sam4e/pio/sam4e16e.h
@@ -1,0 +1,525 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E16E_PIO_
+#define _SAM4E16E_PIO_
+
+#define PIO_PA0              (1u << 0)  /**< \brief Pin Controlled by PA0 */
+#define PIO_PA1              (1u << 1)  /**< \brief Pin Controlled by PA1 */
+#define PIO_PA2              (1u << 2)  /**< \brief Pin Controlled by PA2 */
+#define PIO_PA3              (1u << 3)  /**< \brief Pin Controlled by PA3 */
+#define PIO_PA4              (1u << 4)  /**< \brief Pin Controlled by PA4 */
+#define PIO_PA5              (1u << 5)  /**< \brief Pin Controlled by PA5 */
+#define PIO_PA6              (1u << 6)  /**< \brief Pin Controlled by PA6 */
+#define PIO_PA7              (1u << 7)  /**< \brief Pin Controlled by PA7 */
+#define PIO_PA8              (1u << 8)  /**< \brief Pin Controlled by PA8 */
+#define PIO_PA9              (1u << 9)  /**< \brief Pin Controlled by PA9 */
+#define PIO_PA10             (1u << 10) /**< \brief Pin Controlled by PA10 */
+#define PIO_PA11             (1u << 11) /**< \brief Pin Controlled by PA11 */
+#define PIO_PA12             (1u << 12) /**< \brief Pin Controlled by PA12 */
+#define PIO_PA13             (1u << 13) /**< \brief Pin Controlled by PA13 */
+#define PIO_PA14             (1u << 14) /**< \brief Pin Controlled by PA14 */
+#define PIO_PA15             (1u << 15) /**< \brief Pin Controlled by PA15 */
+#define PIO_PA16             (1u << 16) /**< \brief Pin Controlled by PA16 */
+#define PIO_PA17             (1u << 17) /**< \brief Pin Controlled by PA17 */
+#define PIO_PA18             (1u << 18) /**< \brief Pin Controlled by PA18 */
+#define PIO_PA19             (1u << 19) /**< \brief Pin Controlled by PA19 */
+#define PIO_PA20             (1u << 20) /**< \brief Pin Controlled by PA20 */
+#define PIO_PA21             (1u << 21) /**< \brief Pin Controlled by PA21 */
+#define PIO_PA22             (1u << 22) /**< \brief Pin Controlled by PA22 */
+#define PIO_PA23             (1u << 23) /**< \brief Pin Controlled by PA23 */
+#define PIO_PA24             (1u << 24) /**< \brief Pin Controlled by PA24 */
+#define PIO_PA25             (1u << 25) /**< \brief Pin Controlled by PA25 */
+#define PIO_PA26             (1u << 26) /**< \brief Pin Controlled by PA26 */
+#define PIO_PA27             (1u << 27) /**< \brief Pin Controlled by PA27 */
+#define PIO_PA28             (1u << 28) /**< \brief Pin Controlled by PA28 */
+#define PIO_PA29             (1u << 29) /**< \brief Pin Controlled by PA29 */
+#define PIO_PA30             (1u << 30) /**< \brief Pin Controlled by PA30 */
+#define PIO_PA31             (1u << 31) /**< \brief Pin Controlled by PA31 */
+#define PIO_PB0              (1u << 0)  /**< \brief Pin Controlled by PB0 */
+#define PIO_PB1              (1u << 1)  /**< \brief Pin Controlled by PB1 */
+#define PIO_PB2              (1u << 2)  /**< \brief Pin Controlled by PB2 */
+#define PIO_PB3              (1u << 3)  /**< \brief Pin Controlled by PB3 */
+#define PIO_PB4              (1u << 4)  /**< \brief Pin Controlled by PB4 */
+#define PIO_PB5              (1u << 5)  /**< \brief Pin Controlled by PB5 */
+#define PIO_PB6              (1u << 6)  /**< \brief Pin Controlled by PB6 */
+#define PIO_PB7              (1u << 7)  /**< \brief Pin Controlled by PB7 */
+#define PIO_PB8              (1u << 8)  /**< \brief Pin Controlled by PB8 */
+#define PIO_PB9              (1u << 9)  /**< \brief Pin Controlled by PB9 */
+#define PIO_PB10             (1u << 10) /**< \brief Pin Controlled by PB10 */
+#define PIO_PB11             (1u << 11) /**< \brief Pin Controlled by PB11 */
+#define PIO_PB12             (1u << 12) /**< \brief Pin Controlled by PB12 */
+#define PIO_PB13             (1u << 13) /**< \brief Pin Controlled by PB13 */
+#define PIO_PB14             (1u << 14) /**< \brief Pin Controlled by PB14 */
+#define PIO_PC0              (1u << 0)  /**< \brief Pin Controlled by PC0 */
+#define PIO_PC1              (1u << 1)  /**< \brief Pin Controlled by PC1 */
+#define PIO_PC2              (1u << 2)  /**< \brief Pin Controlled by PC2 */
+#define PIO_PC3              (1u << 3)  /**< \brief Pin Controlled by PC3 */
+#define PIO_PC4              (1u << 4)  /**< \brief Pin Controlled by PC4 */
+#define PIO_PC5              (1u << 5)  /**< \brief Pin Controlled by PC5 */
+#define PIO_PC6              (1u << 6)  /**< \brief Pin Controlled by PC6 */
+#define PIO_PC7              (1u << 7)  /**< \brief Pin Controlled by PC7 */
+#define PIO_PC8              (1u << 8)  /**< \brief Pin Controlled by PC8 */
+#define PIO_PC9              (1u << 9)  /**< \brief Pin Controlled by PC9 */
+#define PIO_PC10             (1u << 10) /**< \brief Pin Controlled by PC10 */
+#define PIO_PC11             (1u << 11) /**< \brief Pin Controlled by PC11 */
+#define PIO_PC12             (1u << 12) /**< \brief Pin Controlled by PC12 */
+#define PIO_PC13             (1u << 13) /**< \brief Pin Controlled by PC13 */
+#define PIO_PC14             (1u << 14) /**< \brief Pin Controlled by PC14 */
+#define PIO_PC15             (1u << 15) /**< \brief Pin Controlled by PC15 */
+#define PIO_PC16             (1u << 16) /**< \brief Pin Controlled by PC16 */
+#define PIO_PC17             (1u << 17) /**< \brief Pin Controlled by PC17 */
+#define PIO_PC18             (1u << 18) /**< \brief Pin Controlled by PC18 */
+#define PIO_PC19             (1u << 19) /**< \brief Pin Controlled by PC19 */
+#define PIO_PC20             (1u << 20) /**< \brief Pin Controlled by PC20 */
+#define PIO_PC21             (1u << 21) /**< \brief Pin Controlled by PC21 */
+#define PIO_PC22             (1u << 22) /**< \brief Pin Controlled by PC22 */
+#define PIO_PC23             (1u << 23) /**< \brief Pin Controlled by PC23 */
+#define PIO_PC24             (1u << 24) /**< \brief Pin Controlled by PC24 */
+#define PIO_PC25             (1u << 25) /**< \brief Pin Controlled by PC25 */
+#define PIO_PC26             (1u << 26) /**< \brief Pin Controlled by PC26 */
+#define PIO_PC27             (1u << 27) /**< \brief Pin Controlled by PC27 */
+#define PIO_PC28             (1u << 28) /**< \brief Pin Controlled by PC28 */
+#define PIO_PC29             (1u << 29) /**< \brief Pin Controlled by PC29 */
+#define PIO_PC30             (1u << 30) /**< \brief Pin Controlled by PC30 */
+#define PIO_PC31             (1u << 31) /**< \brief Pin Controlled by PC31 */
+#define PIO_PD0              (1u << 0)  /**< \brief Pin Controlled by PD0 */
+#define PIO_PD1              (1u << 1)  /**< \brief Pin Controlled by PD1 */
+#define PIO_PD2              (1u << 2)  /**< \brief Pin Controlled by PD2 */
+#define PIO_PD3              (1u << 3)  /**< \brief Pin Controlled by PD3 */
+#define PIO_PD4              (1u << 4)  /**< \brief Pin Controlled by PD4 */
+#define PIO_PD5              (1u << 5)  /**< \brief Pin Controlled by PD5 */
+#define PIO_PD6              (1u << 6)  /**< \brief Pin Controlled by PD6 */
+#define PIO_PD7              (1u << 7)  /**< \brief Pin Controlled by PD7 */
+#define PIO_PD8              (1u << 8)  /**< \brief Pin Controlled by PD8 */
+#define PIO_PD9              (1u << 9)  /**< \brief Pin Controlled by PD9 */
+#define PIO_PD10             (1u << 10) /**< \brief Pin Controlled by PD10 */
+#define PIO_PD11             (1u << 11) /**< \brief Pin Controlled by PD11 */
+#define PIO_PD12             (1u << 12) /**< \brief Pin Controlled by PD12 */
+#define PIO_PD13             (1u << 13) /**< \brief Pin Controlled by PD13 */
+#define PIO_PD14             (1u << 14) /**< \brief Pin Controlled by PD14 */
+#define PIO_PD15             (1u << 15) /**< \brief Pin Controlled by PD15 */
+#define PIO_PD16             (1u << 16) /**< \brief Pin Controlled by PD16 */
+#define PIO_PD17             (1u << 17) /**< \brief Pin Controlled by PD17 */
+#define PIO_PD18             (1u << 18) /**< \brief Pin Controlled by PD18 */
+#define PIO_PD19             (1u << 19) /**< \brief Pin Controlled by PD19 */
+#define PIO_PD20             (1u << 20) /**< \brief Pin Controlled by PD20 */
+#define PIO_PD21             (1u << 21) /**< \brief Pin Controlled by PD21 */
+#define PIO_PD22             (1u << 22) /**< \brief Pin Controlled by PD22 */
+#define PIO_PD23             (1u << 23) /**< \brief Pin Controlled by PD23 */
+#define PIO_PD24             (1u << 24) /**< \brief Pin Controlled by PD24 */
+#define PIO_PD25             (1u << 25) /**< \brief Pin Controlled by PD25 */
+#define PIO_PD26             (1u << 26) /**< \brief Pin Controlled by PD26 */
+#define PIO_PD27             (1u << 27) /**< \brief Pin Controlled by PD27 */
+#define PIO_PD28             (1u << 28) /**< \brief Pin Controlled by PD28 */
+#define PIO_PD29             (1u << 29) /**< \brief Pin Controlled by PD29 */
+#define PIO_PD30             (1u << 30) /**< \brief Pin Controlled by PD30 */
+#define PIO_PD31             (1u << 31) /**< \brief Pin Controlled by PD31 */
+#define PIO_PE0              (1u << 0)  /**< \brief Pin Controlled by PE0 */
+#define PIO_PE1              (1u << 1)  /**< \brief Pin Controlled by PE1 */
+#define PIO_PE2              (1u << 2)  /**< \brief Pin Controlled by PE2 */
+#define PIO_PE3              (1u << 3)  /**< \brief Pin Controlled by PE3 */
+#define PIO_PE4              (1u << 4)  /**< \brief Pin Controlled by PE4 */
+#define PIO_PE5              (1u << 5)  /**< \brief Pin Controlled by PE5 */
+/* ========== Pio definition for AFEC0 peripheral ========== */
+#define PIO_PA17X1_AFE0_AD0  (1u << 17) /**< \brief Afec0 signal: AFE0_AD0 */
+#define PIO_PA18X1_AFE0_AD1  (1u << 18) /**< \brief Afec0 signal: AFE0_AD1 */
+#define PIO_PC30X1_AFE0_AD10 (1u << 30) /**< \brief Afec0 signal: AFE0_AD10 */
+#define PIO_PC31X1_AFE0_AD11 (1u << 31) /**< \brief Afec0 signal: AFE0_AD11 */
+#define PIO_PC26X1_AFE0_AD12 (1u << 26) /**< \brief Afec0 signal: AFE0_AD12 */
+#define PIO_PC27X1_AFE0_AD13 (1u << 27) /**< \brief Afec0 signal: AFE0_AD13 */
+#define PIO_PC0X1_AFE0_AD14  (1u << 0)  /**< \brief Afec0 signal: AFE0_AD14 */
+#define PIO_PA19X1_AFE0_AD2  (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA19X1_WKUP9     (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA20X1_AFE0_AD3  (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PA20X1_WKUP10    (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PB0X1_AFE0_AD4   (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB0X1_RTCOUT0    (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB1X1_AFE0_AD5   (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PB1X1_RTCOUT1    (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PC13X1_AFE0_AD6  (1u << 13) /**< \brief Afec0 signal: AFE0_AD6 */
+#define PIO_PC15X1_AFE0_AD7  (1u << 15) /**< \brief Afec0 signal: AFE0_AD7 */
+#define PIO_PC12X1_AFE0_AD8  (1u << 12) /**< \brief Afec0 signal: AFE0_AD8 */
+#define PIO_PC29X1_AFE0_AD9  (1u << 29) /**< \brief Afec0 signal: AFE0_AD9 */
+#define PIO_PA8B_AFE0_ADTRG  (1u << 8)  /**< \brief Afec0 signal: AFE0_ADTRG */
+/* ========== Pio definition for AFEC1 peripheral ========== */
+#define PIO_PB2X1_AFE1_AD0   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB2X1_WKUP12     (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB3X1_AFE1_AD1   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD1 */
+#define PIO_PA21X1_AFE1_AD2  (1u << 21) /**< \brief Afec1 signal: AFE1_AD2 */
+#define PIO_PA22X1_AFE1_AD3  (1u << 22) /**< \brief Afec1 signal: AFE1_AD3 */
+#define PIO_PC1X1_AFE1_AD4   (1u << 1)  /**< \brief Afec1 signal: AFE1_AD4 */
+#define PIO_PC2X1_AFE1_AD5   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD5 */
+#define PIO_PC3X1_AFE1_AD6   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD6 */
+#define PIO_PC4X1_AFE1_AD7   (1u << 4)  /**< \brief Afec1 signal: AFE1_AD7 */
+/* ========== Pio definition for CAN0 peripheral ========== */
+#define PIO_PB3A_CANRX0      (1u << 3)  /**< \brief Can0 signal: CANRX0 */
+#define PIO_PB2A_CANTX0      (1u << 2)  /**< \brief Can0 signal: CANTX0 */
+/* ========== Pio definition for CAN1 peripheral ========== */
+#define PIO_PC12C_CANRX1     (1u << 12) /**< \brief Can1 signal: CANRX1 */
+#define PIO_PC15C_CANTX1     (1u << 15) /**< \brief Can1 signal: CANTX1 */
+/* ========== Pio definition for DACC peripheral ========== */
+#define PIO_PB13X1_DAC0      (1u << 13) /**< \brief Dacc signal: DAC0 */
+#define PIO_PB14X1_DAC1      (1u << 14) /**< \brief Dacc signal: DAC1 */
+#define PIO_PA2C_DATRG       (1u << 2)  /**< \brief Dacc signal: DATRG */
+/* ========== Pio definition for EBI peripheral ========== */
+#define PIO_PC18A_A0         (1u << 18) /**< \brief Ebi signal: A0 */
+#define PIO_PC19A_A1         (1u << 19) /**< \brief Ebi signal: A1 */
+#define PIO_PC28A_A10        (1u << 28) /**< \brief Ebi signal: A10 */
+#define PIO_PC29A_A11        (1u << 29) /**< \brief Ebi signal: A11 */
+#define PIO_PC30A_A12        (1u << 30) /**< \brief Ebi signal: A12 */
+#define PIO_PC31A_A13        (1u << 31) /**< \brief Ebi signal: A13 */
+#define PIO_PA18C_A14        (1u << 18) /**< \brief Ebi signal: A14 */
+#define PIO_PA19C_A15        (1u << 19) /**< \brief Ebi signal: A15 */
+#define PIO_PA20C_A16        (1u << 20) /**< \brief Ebi signal: A16 */
+#define PIO_PA0C_A17         (1u << 0)  /**< \brief Ebi signal: A17 */
+#define PIO_PA1C_A18         (1u << 1)  /**< \brief Ebi signal: A18 */
+#define PIO_PA23C_A19        (1u << 23) /**< \brief Ebi signal: A19 */
+#define PIO_PC20A_A2         (1u << 20) /**< \brief Ebi signal: A2 */
+#define PIO_PA24C_A20        (1u << 24) /**< \brief Ebi signal: A20 */
+#define PIO_PC16A_A21        (1u << 16) /**< \brief Ebi signal: A21/NANDALE */
+#define PIO_PC16A_NANDALE    (1u << 16) /**< \brief Ebi signal: A21/NANDALE */
+#define PIO_PC17A_A22        (1u << 17) /**< \brief Ebi signal: A22/NANDCLE */
+#define PIO_PC17A_NANDCLE    (1u << 17) /**< \brief Ebi signal: A22/NANDCLE */
+#define PIO_PA25C_A23        (1u << 25) /**< \brief Ebi signal: A23 */
+#define PIO_PC21A_A3         (1u << 21) /**< \brief Ebi signal: A3 */
+#define PIO_PC22A_A4         (1u << 22) /**< \brief Ebi signal: A4 */
+#define PIO_PC23A_A5         (1u << 23) /**< \brief Ebi signal: A5 */
+#define PIO_PC24A_A6         (1u << 24) /**< \brief Ebi signal: A6 */
+#define PIO_PC25A_A7         (1u << 25) /**< \brief Ebi signal: A7 */
+#define PIO_PC26A_A8         (1u << 26) /**< \brief Ebi signal: A8 */
+#define PIO_PC27A_A9         (1u << 27) /**< \brief Ebi signal: A9 */
+#define PIO_PC0A_D0          (1u << 0)  /**< \brief Ebi signal: D0 */
+#define PIO_PC1A_D1          (1u << 1)  /**< \brief Ebi signal: D1 */
+#define PIO_PC2A_D2          (1u << 2)  /**< \brief Ebi signal: D2 */
+#define PIO_PC3A_D3          (1u << 3)  /**< \brief Ebi signal: D3 */
+#define PIO_PC4A_D4          (1u << 4)  /**< \brief Ebi signal: D4 */
+#define PIO_PC5A_D5          (1u << 5)  /**< \brief Ebi signal: D5 */
+#define PIO_PC6A_D6          (1u << 6)  /**< \brief Ebi signal: D6 */
+#define PIO_PC7A_D7          (1u << 7)  /**< \brief Ebi signal: D7 */
+#define PIO_PC9A_NANDOE      (1u << 9)  /**< \brief Ebi signal: NANDOE */
+#define PIO_PC10A_NANDWE     (1u << 10) /**< \brief Ebi signal: NANDWE */
+#define PIO_PC14A_NCS0       (1u << 14) /**< \brief Ebi signal: NCS0 */
+#define PIO_PC15A_NCS1       (1u << 15) /**< \brief Ebi signal: NCS1 */
+#define PIO_PD18A_NCS1       (1u << 18) /**< \brief Ebi signal: NCS1 */
+#define PIO_PA22C_NCS2       (1u << 22) /**< \brief Ebi signal: NCS2 */
+#define PIO_PC12A_NCS3       (1u << 12) /**< \brief Ebi signal: NCS3 */
+#define PIO_PD19A_NCS3       (1u << 19) /**< \brief Ebi signal: NCS3 */
+#define PIO_PC11A_NRD        (1u << 11) /**< \brief Ebi signal: NRD */
+#define PIO_PC13A_NWAIT      (1u << 13) /**< \brief Ebi signal: NWAIT */
+#define PIO_PC8A_NWE         (1u << 8)  /**< \brief Ebi signal: NWE */
+/* ========== Pio definition for GMAC peripheral ========== */
+#define PIO_PD13A_GCOL       (1u << 13) /**< \brief Gmac signal: GCOL */
+#define PIO_PD10A_GCRS       (1u << 10) /**< \brief Gmac signal: GCRS */
+#define PIO_PD4A_GCRSDV      (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD4A_GRXDV       (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
+#define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
+#define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
+#define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
+#define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */
+#define PIO_PD7A_GRXER       (1u << 7)  /**< \brief Gmac signal: GRXER */
+#define PIO_PD2A_GTX0        (1u << 2)  /**< \brief Gmac signal: GTX0 */
+#define PIO_PD3A_GTX1        (1u << 3)  /**< \brief Gmac signal: GTX1 */
+#define PIO_PD15A_GTX2       (1u << 15) /**< \brief Gmac signal: GTX2 */
+#define PIO_PD16A_GTX3       (1u << 16) /**< \brief Gmac signal: GTX3 */
+#define PIO_PD0A_GTXCK       (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD0A_GREFCK      (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD1A_GTXEN       (1u << 1)  /**< \brief Gmac signal: GTXEN */
+#define PIO_PD17A_GTXER      (1u << 17) /**< \brief Gmac signal: GTXER */
+/* ========== Pio definition for HSMCI peripheral ========== */
+#define PIO_PA28C_MCCDA      (1u << 28) /**< \brief Hsmci signal: MCCDA */
+#define PIO_PA29C_MCCK       (1u << 29) /**< \brief Hsmci signal: MCCK */
+#define PIO_PA30C_MCDA0      (1u << 30) /**< \brief Hsmci signal: MCDA0 */
+#define PIO_PA31C_MCDA1      (1u << 31) /**< \brief Hsmci signal: MCDA1 */
+#define PIO_PA26C_MCDA2      (1u << 26) /**< \brief Hsmci signal: MCDA2 */
+#define PIO_PA27C_MCDA3      (1u << 27) /**< \brief Hsmci signal: MCDA3 */
+/* ========== Pio definition for PIOA peripheral ========== */
+#define PIO_PA24X1_PIODC0    (1u << 24) /**< \brief Pioa signal: PIODC0 */
+#define PIO_PA25X1_PIODC1    (1u << 25) /**< \brief Pioa signal: PIODC1 */
+#define PIO_PA26X1_PIODC2    (1u << 26) /**< \brief Pioa signal: PIODC2 */
+#define PIO_PA27X1_PIODC3    (1u << 27) /**< \brief Pioa signal: PIODC3 */
+#define PIO_PA28X1_PIODC4    (1u << 28) /**< \brief Pioa signal: PIODC4 */
+#define PIO_PA29X1_PIODC5    (1u << 29) /**< \brief Pioa signal: PIODC5 */
+#define PIO_PA31X1_PIODC7    (1u << 31) /**< \brief Pioa signal: PIODC7 */
+#define PIO_PA23X1_PIODCCLK  (1u << 23) /**< \brief Pioa signal: PIODCCLK */
+#define PIO_PA30X1_WKUP11    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA30X1_PIODC6    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA15X1_WKUP14    (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA15X1_PIODCEN1  (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA16X1_WKUP15    (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+#define PIO_PA16X1_PIODCEN2  (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+/* ========== Pio definition for PMC peripheral ========== */
+#define PIO_PA6B_PCK0        (1u << 6)  /**< \brief Pmc signal: PCK0 */
+#define PIO_PB13B_PCK0       (1u << 13) /**< \brief Pmc signal: PCK0 */
+#define PIO_PA17B_PCK1       (1u << 17) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA21B_PCK1       (1u << 21) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA18B_PCK2       (1u << 18) /**< \brief Pmc signal: PCK2 */
+#define PIO_PA31B_PCK2       (1u << 31) /**< \brief Pmc signal: PCK2 */
+#define PIO_PB3B_PCK2        (1u << 3)  /**< \brief Pmc signal: PCK2 */
+/* ========== Pio definition for PWM peripheral ========== */
+#define PIO_PA9C_PWMFI0      (1u << 9)  /**< \brief Pwm signal: PWMFI0 */
+#define PIO_PA0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA11B_PWMH0      (1u << 11) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA23B_PWMH0      (1u << 23) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PB0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PC18B_PWMH0      (1u << 18) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PD20A_PWMH0      (1u << 20) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA12B_PWMH1      (1u << 12) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA24B_PWMH1      (1u << 24) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PB1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PC19B_PWMH1      (1u << 19) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PD21A_PWMH1      (1u << 21) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA2A_PWMH2       (1u << 2)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA13B_PWMH2      (1u << 13) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA25B_PWMH2      (1u << 25) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PB4B_PWMH2       (1u << 4)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PC20B_PWMH2      (1u << 20) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PD22A_PWMH2      (1u << 22) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA7B_PWMH3       (1u << 7)  /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA17C_PWMH3      (1u << 17) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PB14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PC21B_PWMH3      (1u << 21) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PD23A_PWMH3      (1u << 23) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA19B_PWML0      (1u << 19) /**< \brief Pwm signal: PWML0 */
+#define PIO_PB5B_PWML0       (1u << 5)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC0B_PWML0       (1u << 0)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC13B_PWML0      (1u << 13) /**< \brief Pwm signal: PWML0 */
+#define PIO_PD24A_PWML0      (1u << 24) /**< \brief Pwm signal: PWML0 */
+#define PIO_PA20B_PWML1      (1u << 20) /**< \brief Pwm signal: PWML1 */
+#define PIO_PB12A_PWML1      (1u << 12) /**< \brief Pwm signal: PWML1 */
+#define PIO_PC1B_PWML1       (1u << 1)  /**< \brief Pwm signal: PWML1 */
+#define PIO_PC15B_PWML1      (1u << 15) /**< \brief Pwm signal: PWML1 */
+#define PIO_PD25A_PWML1      (1u << 25) /**< \brief Pwm signal: PWML1 */
+#define PIO_PA16C_PWML2      (1u << 16) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA30A_PWML2      (1u << 30) /**< \brief Pwm signal: PWML2 */
+#define PIO_PB13A_PWML2      (1u << 13) /**< \brief Pwm signal: PWML2 */
+#define PIO_PC2B_PWML2       (1u << 2)  /**< \brief Pwm signal: PWML2 */
+#define PIO_PD26A_PWML2      (1u << 26) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA15C_PWML3      (1u << 15) /**< \brief Pwm signal: PWML3 */
+#define PIO_PC3B_PWML3       (1u << 3)  /**< \brief Pwm signal: PWML3 */
+#define PIO_PC22B_PWML3      (1u << 22) /**< \brief Pwm signal: PWML3 */
+#define PIO_PD27A_PWML3      (1u << 27) /**< \brief Pwm signal: PWML3 */
+/* ========== Pio definition for SPI peripheral ========== */
+#define PIO_PA12A_MISO       (1u << 12) /**< \brief Spi signal: MISO */
+#define PIO_PA13A_MOSI       (1u << 13) /**< \brief Spi signal: MOSI */
+#define PIO_PA11A_NPCS0      (1u << 11) /**< \brief Spi signal: NPCS0 */
+#define PIO_PA9B_NPCS1       (1u << 9)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA31A_NPCS1      (1u << 31) /**< \brief Spi signal: NPCS1 */
+#define PIO_PB14A_NPCS1      (1u << 14) /**< \brief Spi signal: NPCS1 */
+#define PIO_PC4B_NPCS1       (1u << 4)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA10B_NPCS2      (1u << 10) /**< \brief Spi signal: NPCS2 */
+#define PIO_PA30B_NPCS2      (1u << 30) /**< \brief Spi signal: NPCS2 */
+#define PIO_PB2B_NPCS2       (1u << 2)  /**< \brief Spi signal: NPCS2 */
+#define PIO_PA3B_NPCS3       (1u << 3)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA5B_NPCS3       (1u << 5)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA22B_NPCS3      (1u << 22) /**< \brief Spi signal: NPCS3 */
+#define PIO_PA14A_SPCK       (1u << 14) /**< \brief Spi signal: SPCK */
+/* ========== Pio definition for TC0 peripheral ========== */
+#define PIO_PA4B_TCLK0       (1u << 4)  /**< \brief Tc0 signal: TCLK0 */
+#define PIO_PA28B_TCLK1      (1u << 28) /**< \brief Tc0 signal: TCLK1 */
+#define PIO_PA29B_TCLK2      (1u << 29) /**< \brief Tc0 signal: TCLK2 */
+#define PIO_PA0B_TIOA0       (1u << 0)  /**< \brief Tc0 signal: TIOA0 */
+#define PIO_PA15B_TIOA1      (1u << 15) /**< \brief Tc0 signal: TIOA1 */
+#define PIO_PA26B_TIOA2      (1u << 26) /**< \brief Tc0 signal: TIOA2 */
+#define PIO_PA1B_TIOB0       (1u << 1)  /**< \brief Tc0 signal: TIOB0 */
+#define PIO_PA16B_TIOB1      (1u << 16) /**< \brief Tc0 signal: TIOB1 */
+#define PIO_PA27B_TIOB2      (1u << 27) /**< \brief Tc0 signal: TIOB2 */
+/* ========== Pio definition for TC1 peripheral ========== */
+#define PIO_PC25B_TCLK3      (1u << 25) /**< \brief Tc1 signal: TCLK3 */
+#define PIO_PC28B_TCLK4      (1u << 28) /**< \brief Tc1 signal: TCLK4 */
+#define PIO_PC31B_TCLK5      (1u << 31) /**< \brief Tc1 signal: TCLK5 */
+#define PIO_PC23B_TIOA3      (1u << 23) /**< \brief Tc1 signal: TIOA3 */
+#define PIO_PC26B_TIOA4      (1u << 26) /**< \brief Tc1 signal: TIOA4 */
+#define PIO_PC29B_TIOA5      (1u << 29) /**< \brief Tc1 signal: TIOA5 */
+#define PIO_PC24B_TIOB3      (1u << 24) /**< \brief Tc1 signal: TIOB3 */
+#define PIO_PC27B_TIOB4      (1u << 27) /**< \brief Tc1 signal: TIOB4 */
+#define PIO_PC30B_TIOB5      (1u << 30) /**< \brief Tc1 signal: TIOB5 */
+/* ========== Pio definition for TC2 peripheral ========== */
+#define PIO_PC7B_TCLK6       (1u << 7)  /**< \brief Tc2 signal: TCLK6 */
+#define PIO_PC10B_TCLK7      (1u << 10) /**< \brief Tc2 signal: TCLK7 */
+#define PIO_PC14B_TCLK8      (1u << 14) /**< \brief Tc2 signal: TCLK8 */
+#define PIO_PC5B_TIOA6       (1u << 5)  /**< \brief Tc2 signal: TIOA6 */
+#define PIO_PC8B_TIOA7       (1u << 8)  /**< \brief Tc2 signal: TIOA7 */
+#define PIO_PC11B_TIOA8      (1u << 11) /**< \brief Tc2 signal: TIOA8 */
+#define PIO_PC6B_TIOB6       (1u << 6)  /**< \brief Tc2 signal: TIOB6 */
+#define PIO_PC9B_TIOB7       (1u << 9)  /**< \brief Tc2 signal: TIOB7 */
+#define PIO_PC12B_TIOB8      (1u << 12) /**< \brief Tc2 signal: TIOB8 */
+/* ========== Pio definition for TWI0 peripheral ========== */
+#define PIO_PA4A_TWCK0       (1u << 4)  /**< \brief Twi0 signal: TWCK0 */
+#define PIO_PA3A_TWD0        (1u << 3)  /**< \brief Twi0 signal: TWD0 */
+/* ========== Pio definition for TWI1 peripheral ========== */
+#define PIO_PB5A_TWCK1       (1u << 5)  /**< \brief Twi1 signal: TWCK1 */
+#define PIO_PB4A_TWD1        (1u << 4)  /**< \brief Twi1 signal: TWD1 */
+/* ========== Pio definition for UART0 peripheral ========== */
+#define PIO_PA9A_URXD0       (1u << 9)  /**< \brief Uart0 signal: URXD0 */
+#define PIO_PA10A_UTXD0      (1u << 10) /**< \brief Uart0 signal: UTXD0 */
+/* ========== Pio definition for UART1 peripheral ========== */
+#define PIO_PA5C_URXD1       (1u << 5)  /**< \brief Uart1 signal: URXD1 */
+#define PIO_PA6C_UTXD1       (1u << 6)  /**< \brief Uart1 signal: UTXD1 */
+/* ========== Pio definition for USART0 peripheral ========== */
+#define PIO_PB2C_CTS0        (1u << 2)  /**< \brief Usart0 signal: CTS0 */
+#define PIO_PB3C_RTS0        (1u << 3)  /**< \brief Usart0 signal: RTS0 */
+#define PIO_PB0C_RXD0        (1u << 0)  /**< \brief Usart0 signal: RXD0 */
+#define PIO_PB13C_SCK0       (1u << 13) /**< \brief Usart0 signal: SCK0 */
+#define PIO_PB1C_TXD0        (1u << 1)  /**< \brief Usart0 signal: TXD0 */
+/* ========== Pio definition for USART1 peripheral ========== */
+#define PIO_PA25A_CTS1       (1u << 25) /**< \brief Usart1 signal: CTS1 */
+#define PIO_PA26A_DCD1       (1u << 26) /**< \brief Usart1 signal: DCD1 */
+#define PIO_PA28A_DSR1       (1u << 28) /**< \brief Usart1 signal: DSR1 */
+#define PIO_PA27A_DTR1       (1u << 27) /**< \brief Usart1 signal: DTR1 */
+#define PIO_PA29A_RI1        (1u << 29) /**< \brief Usart1 signal: RI1 */
+#define PIO_PA24A_RTS1       (1u << 24) /**< \brief Usart1 signal: RTS1 */
+#define PIO_PA21A_RXD1       (1u << 21) /**< \brief Usart1 signal: RXD1 */
+#define PIO_PA23A_SCK1       (1u << 23) /**< \brief Usart1 signal: SCK1 */
+#define PIO_PA22A_TXD1       (1u << 22) /**< \brief Usart1 signal: TXD1 */
+/* ========== Pio indexes ========== */
+#define PIO_PA0_IDX          0
+#define PIO_PA1_IDX          1
+#define PIO_PA2_IDX          2
+#define PIO_PA3_IDX          3
+#define PIO_PA4_IDX          4
+#define PIO_PA5_IDX          5
+#define PIO_PA6_IDX          6
+#define PIO_PA7_IDX          7
+#define PIO_PA8_IDX          8
+#define PIO_PA9_IDX          9
+#define PIO_PA10_IDX         10
+#define PIO_PA11_IDX         11
+#define PIO_PA12_IDX         12
+#define PIO_PA13_IDX         13
+#define PIO_PA14_IDX         14
+#define PIO_PA15_IDX         15
+#define PIO_PA16_IDX         16
+#define PIO_PA17_IDX         17
+#define PIO_PA18_IDX         18
+#define PIO_PA19_IDX         19
+#define PIO_PA20_IDX         20
+#define PIO_PA21_IDX         21
+#define PIO_PA22_IDX         22
+#define PIO_PA23_IDX         23
+#define PIO_PA24_IDX         24
+#define PIO_PA25_IDX         25
+#define PIO_PA26_IDX         26
+#define PIO_PA27_IDX         27
+#define PIO_PA28_IDX         28
+#define PIO_PA29_IDX         29
+#define PIO_PA30_IDX         30
+#define PIO_PA31_IDX         31
+#define PIO_PB0_IDX          32
+#define PIO_PB1_IDX          33
+#define PIO_PB2_IDX          34
+#define PIO_PB3_IDX          35
+#define PIO_PB4_IDX          36
+#define PIO_PB5_IDX          37
+#define PIO_PB6_IDX          38
+#define PIO_PB7_IDX          39
+#define PIO_PB8_IDX          40
+#define PIO_PB9_IDX          41
+#define PIO_PB10_IDX         42
+#define PIO_PB11_IDX         43
+#define PIO_PB12_IDX         44
+#define PIO_PB13_IDX         45
+#define PIO_PB14_IDX         46
+#define PIO_PC0_IDX          64
+#define PIO_PC1_IDX          65
+#define PIO_PC2_IDX          66
+#define PIO_PC3_IDX          67
+#define PIO_PC4_IDX          68
+#define PIO_PC5_IDX          69
+#define PIO_PC6_IDX          70
+#define PIO_PC7_IDX          71
+#define PIO_PC8_IDX          72
+#define PIO_PC9_IDX          73
+#define PIO_PC10_IDX         74
+#define PIO_PC11_IDX         75
+#define PIO_PC12_IDX         76
+#define PIO_PC13_IDX         77
+#define PIO_PC14_IDX         78
+#define PIO_PC15_IDX         79
+#define PIO_PC16_IDX         80
+#define PIO_PC17_IDX         81
+#define PIO_PC18_IDX         82
+#define PIO_PC19_IDX         83
+#define PIO_PC20_IDX         84
+#define PIO_PC21_IDX         85
+#define PIO_PC22_IDX         86
+#define PIO_PC23_IDX         87
+#define PIO_PC24_IDX         88
+#define PIO_PC25_IDX         89
+#define PIO_PC26_IDX         90
+#define PIO_PC27_IDX         91
+#define PIO_PC28_IDX         92
+#define PIO_PC29_IDX         93
+#define PIO_PC30_IDX         94
+#define PIO_PC31_IDX         95
+#define PIO_PD0_IDX          96
+#define PIO_PD1_IDX          97
+#define PIO_PD2_IDX          98
+#define PIO_PD3_IDX          99
+#define PIO_PD4_IDX          100
+#define PIO_PD5_IDX          101
+#define PIO_PD6_IDX          102
+#define PIO_PD7_IDX          103
+#define PIO_PD8_IDX          104
+#define PIO_PD9_IDX          105
+#define PIO_PD10_IDX         106
+#define PIO_PD11_IDX         107
+#define PIO_PD12_IDX         108
+#define PIO_PD13_IDX         109
+#define PIO_PD14_IDX         110
+#define PIO_PD15_IDX         111
+#define PIO_PD16_IDX         112
+#define PIO_PD17_IDX         113
+#define PIO_PD18_IDX         114
+#define PIO_PD19_IDX         115
+#define PIO_PD20_IDX         116
+#define PIO_PD21_IDX         117
+#define PIO_PD22_IDX         118
+#define PIO_PD23_IDX         119
+#define PIO_PD24_IDX         120
+#define PIO_PD25_IDX         121
+#define PIO_PD26_IDX         122
+#define PIO_PD27_IDX         123
+#define PIO_PD28_IDX         124
+#define PIO_PD29_IDX         125
+#define PIO_PD30_IDX         126
+#define PIO_PD31_IDX         127
+#define PIO_PE0_IDX          128
+#define PIO_PE1_IDX          129
+#define PIO_PE2_IDX          130
+#define PIO_PE3_IDX          131
+#define PIO_PE4_IDX          132
+#define PIO_PE5_IDX          133
+
+#endif /* _SAM4E16E_PIO_ */

--- a/asf/sam/include/sam4e/pio/sam4e16e.h
+++ b/asf/sam/include/sam4e/pio/sam4e16e.h
@@ -242,7 +242,7 @@
 #define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
 #define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
 #define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
-#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX1        (1u << 6)  /**< \brief Gmac signal: GRX1 */
 #define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
 #define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
 #define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */

--- a/asf/sam/include/sam4e/pio/sam4e8c.h
+++ b/asf/sam/include/sam4e/pio/sam4e8c.h
@@ -1,0 +1,479 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E8C_PIO_
+#define _SAM4E8C_PIO_
+
+#define PIO_PA0              (1u << 0)  /**< \brief Pin Controlled by PA0 */
+#define PIO_PA1              (1u << 1)  /**< \brief Pin Controlled by PA1 */
+#define PIO_PA2              (1u << 2)  /**< \brief Pin Controlled by PA2 */
+#define PIO_PA3              (1u << 3)  /**< \brief Pin Controlled by PA3 */
+#define PIO_PA4              (1u << 4)  /**< \brief Pin Controlled by PA4 */
+#define PIO_PA5              (1u << 5)  /**< \brief Pin Controlled by PA5 */
+#define PIO_PA6              (1u << 6)  /**< \brief Pin Controlled by PA6 */
+#define PIO_PA7              (1u << 7)  /**< \brief Pin Controlled by PA7 */
+#define PIO_PA8              (1u << 8)  /**< \brief Pin Controlled by PA8 */
+#define PIO_PA9              (1u << 9)  /**< \brief Pin Controlled by PA9 */
+#define PIO_PA10             (1u << 10) /**< \brief Pin Controlled by PA10 */
+#define PIO_PA11             (1u << 11) /**< \brief Pin Controlled by PA11 */
+#define PIO_PA12             (1u << 12) /**< \brief Pin Controlled by PA12 */
+#define PIO_PA13             (1u << 13) /**< \brief Pin Controlled by PA13 */
+#define PIO_PA14             (1u << 14) /**< \brief Pin Controlled by PA14 */
+#define PIO_PA15             (1u << 15) /**< \brief Pin Controlled by PA15 */
+#define PIO_PA16             (1u << 16) /**< \brief Pin Controlled by PA16 */
+#define PIO_PA17             (1u << 17) /**< \brief Pin Controlled by PA17 */
+#define PIO_PA18             (1u << 18) /**< \brief Pin Controlled by PA18 */
+#define PIO_PA19             (1u << 19) /**< \brief Pin Controlled by PA19 */
+#define PIO_PA20             (1u << 20) /**< \brief Pin Controlled by PA20 */
+#define PIO_PA21             (1u << 21) /**< \brief Pin Controlled by PA21 */
+#define PIO_PA22             (1u << 22) /**< \brief Pin Controlled by PA22 */
+#define PIO_PA23             (1u << 23) /**< \brief Pin Controlled by PA23 */
+#define PIO_PA24             (1u << 24) /**< \brief Pin Controlled by PA24 */
+#define PIO_PA25             (1u << 25) /**< \brief Pin Controlled by PA25 */
+#define PIO_PA26             (1u << 26) /**< \brief Pin Controlled by PA26 */
+#define PIO_PA27             (1u << 27) /**< \brief Pin Controlled by PA27 */
+#define PIO_PA28             (1u << 28) /**< \brief Pin Controlled by PA28 */
+#define PIO_PA29             (1u << 29) /**< \brief Pin Controlled by PA29 */
+#define PIO_PA30             (1u << 30) /**< \brief Pin Controlled by PA30 */
+#define PIO_PA31             (1u << 31) /**< \brief Pin Controlled by PA31 */
+#define PIO_PB0              (1u << 0)  /**< \brief Pin Controlled by PB0 */
+#define PIO_PB1              (1u << 1)  /**< \brief Pin Controlled by PB1 */
+#define PIO_PB2              (1u << 2)  /**< \brief Pin Controlled by PB2 */
+#define PIO_PB3              (1u << 3)  /**< \brief Pin Controlled by PB3 */
+#define PIO_PB4              (1u << 4)  /**< \brief Pin Controlled by PB4 */
+#define PIO_PB5              (1u << 5)  /**< \brief Pin Controlled by PB5 */
+#define PIO_PB6              (1u << 6)  /**< \brief Pin Controlled by PB6 */
+#define PIO_PB7              (1u << 7)  /**< \brief Pin Controlled by PB7 */
+#define PIO_PB8              (1u << 8)  /**< \brief Pin Controlled by PB8 */
+#define PIO_PB9              (1u << 9)  /**< \brief Pin Controlled by PB9 */
+#define PIO_PB10             (1u << 10) /**< \brief Pin Controlled by PB10 */
+#define PIO_PB11             (1u << 11) /**< \brief Pin Controlled by PB11 */
+#define PIO_PB12             (1u << 12) /**< \brief Pin Controlled by PB12 */
+#define PIO_PB13             (1u << 13) /**< \brief Pin Controlled by PB13 */
+#define PIO_PB14             (1u << 14) /**< \brief Pin Controlled by PB14 */
+#define PIO_PC0              (1u << 0)  /**< \brief Pin Controlled by PC0 */
+#define PIO_PC1              (1u << 1)  /**< \brief Pin Controlled by PC1 */
+#define PIO_PC2              (1u << 2)  /**< \brief Pin Controlled by PC2 */
+#define PIO_PC3              (1u << 3)  /**< \brief Pin Controlled by PC3 */
+#define PIO_PC4              (1u << 4)  /**< \brief Pin Controlled by PC4 */
+#define PIO_PC5              (1u << 5)  /**< \brief Pin Controlled by PC5 */
+#define PIO_PC6              (1u << 6)  /**< \brief Pin Controlled by PC6 */
+#define PIO_PC7              (1u << 7)  /**< \brief Pin Controlled by PC7 */
+#define PIO_PC8              (1u << 8)  /**< \brief Pin Controlled by PC8 */
+#define PIO_PC9              (1u << 9)  /**< \brief Pin Controlled by PC9 */
+#define PIO_PC10             (1u << 10) /**< \brief Pin Controlled by PC10 */
+#define PIO_PC11             (1u << 11) /**< \brief Pin Controlled by PC11 */
+#define PIO_PC12             (1u << 12) /**< \brief Pin Controlled by PC12 */
+#define PIO_PC13             (1u << 13) /**< \brief Pin Controlled by PC13 */
+#define PIO_PC14             (1u << 14) /**< \brief Pin Controlled by PC14 */
+#define PIO_PC15             (1u << 15) /**< \brief Pin Controlled by PC15 */
+#define PIO_PC16             (1u << 16) /**< \brief Pin Controlled by PC16 */
+#define PIO_PC17             (1u << 17) /**< \brief Pin Controlled by PC17 */
+#define PIO_PC18             (1u << 18) /**< \brief Pin Controlled by PC18 */
+#define PIO_PC19             (1u << 19) /**< \brief Pin Controlled by PC19 */
+#define PIO_PC20             (1u << 20) /**< \brief Pin Controlled by PC20 */
+#define PIO_PC21             (1u << 21) /**< \brief Pin Controlled by PC21 */
+#define PIO_PC22             (1u << 22) /**< \brief Pin Controlled by PC22 */
+#define PIO_PC23             (1u << 23) /**< \brief Pin Controlled by PC23 */
+#define PIO_PC24             (1u << 24) /**< \brief Pin Controlled by PC24 */
+#define PIO_PC25             (1u << 25) /**< \brief Pin Controlled by PC25 */
+#define PIO_PC26             (1u << 26) /**< \brief Pin Controlled by PC26 */
+#define PIO_PC27             (1u << 27) /**< \brief Pin Controlled by PC27 */
+#define PIO_PC28             (1u << 28) /**< \brief Pin Controlled by PC28 */
+#define PIO_PC29             (1u << 29) /**< \brief Pin Controlled by PC29 */
+#define PIO_PC30             (1u << 30) /**< \brief Pin Controlled by PC30 */
+#define PIO_PC31             (1u << 31) /**< \brief Pin Controlled by PC31 */
+#define PIO_PD0              (1u << 0)  /**< \brief Pin Controlled by PD0 */
+#define PIO_PD1              (1u << 1)  /**< \brief Pin Controlled by PD1 */
+#define PIO_PD2              (1u << 2)  /**< \brief Pin Controlled by PD2 */
+#define PIO_PD3              (1u << 3)  /**< \brief Pin Controlled by PD3 */
+#define PIO_PD4              (1u << 4)  /**< \brief Pin Controlled by PD4 */
+#define PIO_PD5              (1u << 5)  /**< \brief Pin Controlled by PD5 */
+#define PIO_PD6              (1u << 6)  /**< \brief Pin Controlled by PD6 */
+#define PIO_PD7              (1u << 7)  /**< \brief Pin Controlled by PD7 */
+#define PIO_PD8              (1u << 8)  /**< \brief Pin Controlled by PD8 */
+#define PIO_PD9              (1u << 9)  /**< \brief Pin Controlled by PD9 */
+#define PIO_PD10             (1u << 10) /**< \brief Pin Controlled by PD10 */
+#define PIO_PD11             (1u << 11) /**< \brief Pin Controlled by PD11 */
+#define PIO_PD12             (1u << 12) /**< \brief Pin Controlled by PD12 */
+#define PIO_PD13             (1u << 13) /**< \brief Pin Controlled by PD13 */
+#define PIO_PD14             (1u << 14) /**< \brief Pin Controlled by PD14 */
+#define PIO_PD15             (1u << 15) /**< \brief Pin Controlled by PD15 */
+#define PIO_PD16             (1u << 16) /**< \brief Pin Controlled by PD16 */
+#define PIO_PD17             (1u << 17) /**< \brief Pin Controlled by PD17 */
+#define PIO_PD18             (1u << 18) /**< \brief Pin Controlled by PD18 */
+#define PIO_PD19             (1u << 19) /**< \brief Pin Controlled by PD19 */
+#define PIO_PD20             (1u << 20) /**< \brief Pin Controlled by PD20 */
+#define PIO_PD21             (1u << 21) /**< \brief Pin Controlled by PD21 */
+#define PIO_PD22             (1u << 22) /**< \brief Pin Controlled by PD22 */
+#define PIO_PD23             (1u << 23) /**< \brief Pin Controlled by PD23 */
+#define PIO_PD24             (1u << 24) /**< \brief Pin Controlled by PD24 */
+#define PIO_PD25             (1u << 25) /**< \brief Pin Controlled by PD25 */
+#define PIO_PD26             (1u << 26) /**< \brief Pin Controlled by PD26 */
+#define PIO_PD27             (1u << 27) /**< \brief Pin Controlled by PD27 */
+#define PIO_PD28             (1u << 28) /**< \brief Pin Controlled by PD28 */
+#define PIO_PD29             (1u << 29) /**< \brief Pin Controlled by PD29 */
+#define PIO_PD30             (1u << 30) /**< \brief Pin Controlled by PD30 */
+#define PIO_PD31             (1u << 31) /**< \brief Pin Controlled by PD31 */
+#define PIO_PE0              (1u << 0)  /**< \brief Pin Controlled by PE0 */
+#define PIO_PE1              (1u << 1)  /**< \brief Pin Controlled by PE1 */
+#define PIO_PE2              (1u << 2)  /**< \brief Pin Controlled by PE2 */
+#define PIO_PE3              (1u << 3)  /**< \brief Pin Controlled by PE3 */
+#define PIO_PE4              (1u << 4)  /**< \brief Pin Controlled by PE4 */
+#define PIO_PE5              (1u << 5)  /**< \brief Pin Controlled by PE5 */
+/* ========== Pio definition for AFEC0 peripheral ========== */
+#define PIO_PA17X1_AFE0_AD0  (1u << 17) /**< \brief Afec0 signal: AFE0_AD0 */
+#define PIO_PA18X1_AFE0_AD1  (1u << 18) /**< \brief Afec0 signal: AFE0_AD1 */
+#define PIO_PC30X1_AFE0_AD10 (1u << 30) /**< \brief Afec0 signal: AFE0_AD10 */
+#define PIO_PC31X1_AFE0_AD11 (1u << 31) /**< \brief Afec0 signal: AFE0_AD11 */
+#define PIO_PC26X1_AFE0_AD12 (1u << 26) /**< \brief Afec0 signal: AFE0_AD12 */
+#define PIO_PC27X1_AFE0_AD13 (1u << 27) /**< \brief Afec0 signal: AFE0_AD13 */
+#define PIO_PC0X1_AFE0_AD14  (1u << 0)  /**< \brief Afec0 signal: AFE0_AD14 */
+#define PIO_PA19X1_AFE0_AD2  (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA19X1_WKUP9     (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA20X1_AFE0_AD3  (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PA20X1_WKUP10    (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PB0X1_AFE0_AD4   (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB0X1_RTCOUT0    (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB1X1_AFE0_AD5   (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PB1X1_RTCOUT1    (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PC13X1_AFE0_AD6  (1u << 13) /**< \brief Afec0 signal: AFE0_AD6 */
+#define PIO_PC15X1_AFE0_AD7  (1u << 15) /**< \brief Afec0 signal: AFE0_AD7 */
+#define PIO_PC12X1_AFE0_AD8  (1u << 12) /**< \brief Afec0 signal: AFE0_AD8 */
+#define PIO_PC29X1_AFE0_AD9  (1u << 29) /**< \brief Afec0 signal: AFE0_AD9 */
+#define PIO_PA8B_AFE0_ADTRG  (1u << 8)  /**< \brief Afec0 signal: AFE0_ADTRG */
+/* ========== Pio definition for AFEC1 peripheral ========== */
+#define PIO_PB2X1_AFE1_AD0   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB2X1_WKUP12     (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB3X1_AFE1_AD1   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD1 */
+#define PIO_PA21X1_AFE1_AD2  (1u << 21) /**< \brief Afec1 signal: AFE1_AD2 */
+#define PIO_PA22X1_AFE1_AD3  (1u << 22) /**< \brief Afec1 signal: AFE1_AD3 */
+#define PIO_PC1X1_AFE1_AD4   (1u << 1)  /**< \brief Afec1 signal: AFE1_AD4 */
+#define PIO_PC2X1_AFE1_AD5   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD5 */
+#define PIO_PC3X1_AFE1_AD6   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD6 */
+#define PIO_PC4X1_AFE1_AD7   (1u << 4)  /**< \brief Afec1 signal: AFE1_AD7 */
+/* ========== Pio definition for CAN0 peripheral ========== */
+#define PIO_PB3A_CANRX0      (1u << 3)  /**< \brief Can0 signal: CANRX0 */
+#define PIO_PB2A_CANTX0      (1u << 2)  /**< \brief Can0 signal: CANTX0 */
+/* ========== Pio definition for CAN1 peripheral ========== */
+#define PIO_PC12C_CANRX1     (1u << 12) /**< \brief Can1 signal: CANRX1 */
+#define PIO_PC15C_CANTX1     (1u << 15) /**< \brief Can1 signal: CANTX1 */
+/* ========== Pio definition for DACC peripheral ========== */
+#define PIO_PB13X1_DAC0      (1u << 13) /**< \brief Dacc signal: DAC0 */
+#define PIO_PB14X1_DAC1      (1u << 14) /**< \brief Dacc signal: DAC1 */
+#define PIO_PA2C_DATRG       (1u << 2)  /**< \brief Dacc signal: DATRG */
+/* ========== Pio definition for GMAC peripheral ========== */
+#define PIO_PD13A_GCOL       (1u << 13) /**< \brief Gmac signal: GCOL */
+#define PIO_PD10A_GCRS       (1u << 10) /**< \brief Gmac signal: GCRS */
+#define PIO_PD4A_GCRSDV      (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD4A_GRXDV       (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
+#define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
+#define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
+#define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
+#define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */
+#define PIO_PD7A_GRXER       (1u << 7)  /**< \brief Gmac signal: GRXER */
+#define PIO_PD2A_GTX0        (1u << 2)  /**< \brief Gmac signal: GTX0 */
+#define PIO_PD3A_GTX1        (1u << 3)  /**< \brief Gmac signal: GTX1 */
+#define PIO_PD15A_GTX2       (1u << 15) /**< \brief Gmac signal: GTX2 */
+#define PIO_PD16A_GTX3       (1u << 16) /**< \brief Gmac signal: GTX3 */
+#define PIO_PD0A_GTXCK       (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD0A_GREFCK      (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD1A_GTXEN       (1u << 1)  /**< \brief Gmac signal: GTXEN */
+#define PIO_PD17A_GTXER      (1u << 17) /**< \brief Gmac signal: GTXER */
+/* ========== Pio definition for HSMCI peripheral ========== */
+#define PIO_PA28C_MCCDA      (1u << 28) /**< \brief Hsmci signal: MCCDA */
+#define PIO_PA29C_MCCK       (1u << 29) /**< \brief Hsmci signal: MCCK */
+#define PIO_PA30C_MCDA0      (1u << 30) /**< \brief Hsmci signal: MCDA0 */
+#define PIO_PA31C_MCDA1      (1u << 31) /**< \brief Hsmci signal: MCDA1 */
+#define PIO_PA26C_MCDA2      (1u << 26) /**< \brief Hsmci signal: MCDA2 */
+#define PIO_PA27C_MCDA3      (1u << 27) /**< \brief Hsmci signal: MCDA3 */
+/* ========== Pio definition for PIOA peripheral ========== */
+#define PIO_PA24X1_PIODC0    (1u << 24) /**< \brief Pioa signal: PIODC0 */
+#define PIO_PA25X1_PIODC1    (1u << 25) /**< \brief Pioa signal: PIODC1 */
+#define PIO_PA26X1_PIODC2    (1u << 26) /**< \brief Pioa signal: PIODC2 */
+#define PIO_PA27X1_PIODC3    (1u << 27) /**< \brief Pioa signal: PIODC3 */
+#define PIO_PA28X1_PIODC4    (1u << 28) /**< \brief Pioa signal: PIODC4 */
+#define PIO_PA29X1_PIODC5    (1u << 29) /**< \brief Pioa signal: PIODC5 */
+#define PIO_PA31X1_PIODC7    (1u << 31) /**< \brief Pioa signal: PIODC7 */
+#define PIO_PA23X1_PIODCCLK  (1u << 23) /**< \brief Pioa signal: PIODCCLK */
+#define PIO_PA30X1_WKUP11    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA30X1_PIODC6    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA15X1_WKUP14    (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA15X1_PIODCEN1  (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA16X1_WKUP15    (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+#define PIO_PA16X1_PIODCEN2  (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+/* ========== Pio definition for PMC peripheral ========== */
+#define PIO_PA6B_PCK0        (1u << 6)  /**< \brief Pmc signal: PCK0 */
+#define PIO_PB13B_PCK0       (1u << 13) /**< \brief Pmc signal: PCK0 */
+#define PIO_PA17B_PCK1       (1u << 17) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA21B_PCK1       (1u << 21) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA18B_PCK2       (1u << 18) /**< \brief Pmc signal: PCK2 */
+#define PIO_PA31B_PCK2       (1u << 31) /**< \brief Pmc signal: PCK2 */
+#define PIO_PB3B_PCK2        (1u << 3)  /**< \brief Pmc signal: PCK2 */
+/* ========== Pio definition for PWM peripheral ========== */
+#define PIO_PA9C_PWMFI0      (1u << 9)  /**< \brief Pwm signal: PWMFI0 */
+#define PIO_PA0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA11B_PWMH0      (1u << 11) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA23B_PWMH0      (1u << 23) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PB0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PC18B_PWMH0      (1u << 18) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PD20A_PWMH0      (1u << 20) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA12B_PWMH1      (1u << 12) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA24B_PWMH1      (1u << 24) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PB1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PC19B_PWMH1      (1u << 19) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PD21A_PWMH1      (1u << 21) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA2A_PWMH2       (1u << 2)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA13B_PWMH2      (1u << 13) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA25B_PWMH2      (1u << 25) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PB4B_PWMH2       (1u << 4)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PC20B_PWMH2      (1u << 20) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PD22A_PWMH2      (1u << 22) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA7B_PWMH3       (1u << 7)  /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA17C_PWMH3      (1u << 17) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PB14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PC21B_PWMH3      (1u << 21) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PD23A_PWMH3      (1u << 23) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA19B_PWML0      (1u << 19) /**< \brief Pwm signal: PWML0 */
+#define PIO_PB5B_PWML0       (1u << 5)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC0B_PWML0       (1u << 0)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC13B_PWML0      (1u << 13) /**< \brief Pwm signal: PWML0 */
+#define PIO_PD24A_PWML0      (1u << 24) /**< \brief Pwm signal: PWML0 */
+#define PIO_PA20B_PWML1      (1u << 20) /**< \brief Pwm signal: PWML1 */
+#define PIO_PB12A_PWML1      (1u << 12) /**< \brief Pwm signal: PWML1 */
+#define PIO_PC1B_PWML1       (1u << 1)  /**< \brief Pwm signal: PWML1 */
+#define PIO_PC15B_PWML1      (1u << 15) /**< \brief Pwm signal: PWML1 */
+#define PIO_PD25A_PWML1      (1u << 25) /**< \brief Pwm signal: PWML1 */
+#define PIO_PA16C_PWML2      (1u << 16) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA30A_PWML2      (1u << 30) /**< \brief Pwm signal: PWML2 */
+#define PIO_PB13A_PWML2      (1u << 13) /**< \brief Pwm signal: PWML2 */
+#define PIO_PC2B_PWML2       (1u << 2)  /**< \brief Pwm signal: PWML2 */
+#define PIO_PD26A_PWML2      (1u << 26) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA15C_PWML3      (1u << 15) /**< \brief Pwm signal: PWML3 */
+#define PIO_PC3B_PWML3       (1u << 3)  /**< \brief Pwm signal: PWML3 */
+#define PIO_PC22B_PWML3      (1u << 22) /**< \brief Pwm signal: PWML3 */
+#define PIO_PD27A_PWML3      (1u << 27) /**< \brief Pwm signal: PWML3 */
+/* ========== Pio definition for SPI peripheral ========== */
+#define PIO_PA12A_MISO       (1u << 12) /**< \brief Spi signal: MISO */
+#define PIO_PA13A_MOSI       (1u << 13) /**< \brief Spi signal: MOSI */
+#define PIO_PA11A_NPCS0      (1u << 11) /**< \brief Spi signal: NPCS0 */
+#define PIO_PA9B_NPCS1       (1u << 9)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA31A_NPCS1      (1u << 31) /**< \brief Spi signal: NPCS1 */
+#define PIO_PB14A_NPCS1      (1u << 14) /**< \brief Spi signal: NPCS1 */
+#define PIO_PC4B_NPCS1       (1u << 4)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA10B_NPCS2      (1u << 10) /**< \brief Spi signal: NPCS2 */
+#define PIO_PA30B_NPCS2      (1u << 30) /**< \brief Spi signal: NPCS2 */
+#define PIO_PB2B_NPCS2       (1u << 2)  /**< \brief Spi signal: NPCS2 */
+#define PIO_PA3B_NPCS3       (1u << 3)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA5B_NPCS3       (1u << 5)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA22B_NPCS3      (1u << 22) /**< \brief Spi signal: NPCS3 */
+#define PIO_PA14A_SPCK       (1u << 14) /**< \brief Spi signal: SPCK */
+/* ========== Pio definition for TC0 peripheral ========== */
+#define PIO_PA4B_TCLK0       (1u << 4)  /**< \brief Tc0 signal: TCLK0 */
+#define PIO_PA28B_TCLK1      (1u << 28) /**< \brief Tc0 signal: TCLK1 */
+#define PIO_PA29B_TCLK2      (1u << 29) /**< \brief Tc0 signal: TCLK2 */
+#define PIO_PA0B_TIOA0       (1u << 0)  /**< \brief Tc0 signal: TIOA0 */
+#define PIO_PA15B_TIOA1      (1u << 15) /**< \brief Tc0 signal: TIOA1 */
+#define PIO_PA26B_TIOA2      (1u << 26) /**< \brief Tc0 signal: TIOA2 */
+#define PIO_PA1B_TIOB0       (1u << 1)  /**< \brief Tc0 signal: TIOB0 */
+#define PIO_PA16B_TIOB1      (1u << 16) /**< \brief Tc0 signal: TIOB1 */
+#define PIO_PA27B_TIOB2      (1u << 27) /**< \brief Tc0 signal: TIOB2 */
+/* ========== Pio definition for TC1 peripheral ========== */
+#define PIO_PC25B_TCLK3      (1u << 25) /**< \brief Tc1 signal: TCLK3 */
+#define PIO_PC28B_TCLK4      (1u << 28) /**< \brief Tc1 signal: TCLK4 */
+#define PIO_PC31B_TCLK5      (1u << 31) /**< \brief Tc1 signal: TCLK5 */
+#define PIO_PC23B_TIOA3      (1u << 23) /**< \brief Tc1 signal: TIOA3 */
+#define PIO_PC26B_TIOA4      (1u << 26) /**< \brief Tc1 signal: TIOA4 */
+#define PIO_PC29B_TIOA5      (1u << 29) /**< \brief Tc1 signal: TIOA5 */
+#define PIO_PC24B_TIOB3      (1u << 24) /**< \brief Tc1 signal: TIOB3 */
+#define PIO_PC27B_TIOB4      (1u << 27) /**< \brief Tc1 signal: TIOB4 */
+#define PIO_PC30B_TIOB5      (1u << 30) /**< \brief Tc1 signal: TIOB5 */
+/* ========== Pio definition for TC2 peripheral ========== */
+#define PIO_PC7B_TCLK6       (1u << 7)  /**< \brief Tc2 signal: TCLK6 */
+#define PIO_PC10B_TCLK7      (1u << 10) /**< \brief Tc2 signal: TCLK7 */
+#define PIO_PC14B_TCLK8      (1u << 14) /**< \brief Tc2 signal: TCLK8 */
+#define PIO_PC5B_TIOA6       (1u << 5)  /**< \brief Tc2 signal: TIOA6 */
+#define PIO_PC8B_TIOA7       (1u << 8)  /**< \brief Tc2 signal: TIOA7 */
+#define PIO_PC11B_TIOA8      (1u << 11) /**< \brief Tc2 signal: TIOA8 */
+#define PIO_PC6B_TIOB6       (1u << 6)  /**< \brief Tc2 signal: TIOB6 */
+#define PIO_PC9B_TIOB7       (1u << 9)  /**< \brief Tc2 signal: TIOB7 */
+#define PIO_PC12B_TIOB8      (1u << 12) /**< \brief Tc2 signal: TIOB8 */
+/* ========== Pio definition for TWI0 peripheral ========== */
+#define PIO_PA4A_TWCK0       (1u << 4)  /**< \brief Twi0 signal: TWCK0 */
+#define PIO_PA3A_TWD0        (1u << 3)  /**< \brief Twi0 signal: TWD0 */
+/* ========== Pio definition for TWI1 peripheral ========== */
+#define PIO_PB5A_TWCK1       (1u << 5)  /**< \brief Twi1 signal: TWCK1 */
+#define PIO_PB4A_TWD1        (1u << 4)  /**< \brief Twi1 signal: TWD1 */
+/* ========== Pio definition for UART0 peripheral ========== */
+#define PIO_PA9A_URXD0       (1u << 9)  /**< \brief Uart0 signal: URXD0 */
+#define PIO_PA10A_UTXD0      (1u << 10) /**< \brief Uart0 signal: UTXD0 */
+/* ========== Pio definition for UART1 peripheral ========== */
+#define PIO_PA5C_URXD1       (1u << 5)  /**< \brief Uart1 signal: URXD1 */
+#define PIO_PA6C_UTXD1       (1u << 6)  /**< \brief Uart1 signal: UTXD1 */
+/* ========== Pio definition for USART0 peripheral ========== */
+#define PIO_PB2C_CTS0        (1u << 2)  /**< \brief Usart0 signal: CTS0 */
+#define PIO_PB3C_RTS0        (1u << 3)  /**< \brief Usart0 signal: RTS0 */
+#define PIO_PB0C_RXD0        (1u << 0)  /**< \brief Usart0 signal: RXD0 */
+#define PIO_PB13C_SCK0       (1u << 13) /**< \brief Usart0 signal: SCK0 */
+#define PIO_PB1C_TXD0        (1u << 1)  /**< \brief Usart0 signal: TXD0 */
+/* ========== Pio definition for USART1 peripheral ========== */
+#define PIO_PA25A_CTS1       (1u << 25) /**< \brief Usart1 signal: CTS1 */
+#define PIO_PA26A_DCD1       (1u << 26) /**< \brief Usart1 signal: DCD1 */
+#define PIO_PA28A_DSR1       (1u << 28) /**< \brief Usart1 signal: DSR1 */
+#define PIO_PA27A_DTR1       (1u << 27) /**< \brief Usart1 signal: DTR1 */
+#define PIO_PA29A_RI1        (1u << 29) /**< \brief Usart1 signal: RI1 */
+#define PIO_PA24A_RTS1       (1u << 24) /**< \brief Usart1 signal: RTS1 */
+#define PIO_PA21A_RXD1       (1u << 21) /**< \brief Usart1 signal: RXD1 */
+#define PIO_PA23A_SCK1       (1u << 23) /**< \brief Usart1 signal: SCK1 */
+#define PIO_PA22A_TXD1       (1u << 22) /**< \brief Usart1 signal: TXD1 */
+/* ========== Pio indexes ========== */
+#define PIO_PA0_IDX          0
+#define PIO_PA1_IDX          1
+#define PIO_PA2_IDX          2
+#define PIO_PA3_IDX          3
+#define PIO_PA4_IDX          4
+#define PIO_PA5_IDX          5
+#define PIO_PA6_IDX          6
+#define PIO_PA7_IDX          7
+#define PIO_PA8_IDX          8
+#define PIO_PA9_IDX          9
+#define PIO_PA10_IDX         10
+#define PIO_PA11_IDX         11
+#define PIO_PA12_IDX         12
+#define PIO_PA13_IDX         13
+#define PIO_PA14_IDX         14
+#define PIO_PA15_IDX         15
+#define PIO_PA16_IDX         16
+#define PIO_PA17_IDX         17
+#define PIO_PA18_IDX         18
+#define PIO_PA19_IDX         19
+#define PIO_PA20_IDX         20
+#define PIO_PA21_IDX         21
+#define PIO_PA22_IDX         22
+#define PIO_PA23_IDX         23
+#define PIO_PA24_IDX         24
+#define PIO_PA25_IDX         25
+#define PIO_PA26_IDX         26
+#define PIO_PA27_IDX         27
+#define PIO_PA28_IDX         28
+#define PIO_PA29_IDX         29
+#define PIO_PA30_IDX         30
+#define PIO_PA31_IDX         31
+#define PIO_PB0_IDX          32
+#define PIO_PB1_IDX          33
+#define PIO_PB2_IDX          34
+#define PIO_PB3_IDX          35
+#define PIO_PB4_IDX          36
+#define PIO_PB5_IDX          37
+#define PIO_PB6_IDX          38
+#define PIO_PB7_IDX          39
+#define PIO_PB8_IDX          40
+#define PIO_PB9_IDX          41
+#define PIO_PB10_IDX         42
+#define PIO_PB11_IDX         43
+#define PIO_PB12_IDX         44
+#define PIO_PB13_IDX         45
+#define PIO_PB14_IDX         46
+#define PIO_PC0_IDX          64
+#define PIO_PC1_IDX          65
+#define PIO_PC2_IDX          66
+#define PIO_PC3_IDX          67
+#define PIO_PC4_IDX          68
+#define PIO_PC5_IDX          69
+#define PIO_PC6_IDX          70
+#define PIO_PC7_IDX          71
+#define PIO_PC8_IDX          72
+#define PIO_PC9_IDX          73
+#define PIO_PC10_IDX         74
+#define PIO_PC11_IDX         75
+#define PIO_PC12_IDX         76
+#define PIO_PC13_IDX         77
+#define PIO_PC14_IDX         78
+#define PIO_PC15_IDX         79
+#define PIO_PC16_IDX         80
+#define PIO_PC17_IDX         81
+#define PIO_PC18_IDX         82
+#define PIO_PC19_IDX         83
+#define PIO_PC20_IDX         84
+#define PIO_PC21_IDX         85
+#define PIO_PC22_IDX         86
+#define PIO_PC23_IDX         87
+#define PIO_PC24_IDX         88
+#define PIO_PC25_IDX         89
+#define PIO_PC26_IDX         90
+#define PIO_PC27_IDX         91
+#define PIO_PC28_IDX         92
+#define PIO_PC29_IDX         93
+#define PIO_PC30_IDX         94
+#define PIO_PC31_IDX         95
+#define PIO_PD0_IDX          96
+#define PIO_PD1_IDX          97
+#define PIO_PD2_IDX          98
+#define PIO_PD3_IDX          99
+#define PIO_PD4_IDX          100
+#define PIO_PD5_IDX          101
+#define PIO_PD6_IDX          102
+#define PIO_PD7_IDX          103
+#define PIO_PD8_IDX          104
+#define PIO_PD9_IDX          105
+#define PIO_PD10_IDX         106
+#define PIO_PD11_IDX         107
+#define PIO_PD12_IDX         108
+#define PIO_PD13_IDX         109
+#define PIO_PD14_IDX         110
+#define PIO_PD15_IDX         111
+#define PIO_PD16_IDX         112
+#define PIO_PD17_IDX         113
+#define PIO_PD18_IDX         114
+#define PIO_PD19_IDX         115
+#define PIO_PD20_IDX         116
+#define PIO_PD21_IDX         117
+#define PIO_PD22_IDX         118
+#define PIO_PD23_IDX         119
+#define PIO_PD24_IDX         120
+#define PIO_PD25_IDX         121
+#define PIO_PD26_IDX         122
+#define PIO_PD27_IDX         123
+#define PIO_PD28_IDX         124
+#define PIO_PD29_IDX         125
+#define PIO_PD30_IDX         126
+#define PIO_PD31_IDX         127
+#define PIO_PE0_IDX          128
+#define PIO_PE1_IDX          129
+#define PIO_PE2_IDX          130
+#define PIO_PE3_IDX          131
+#define PIO_PE4_IDX          132
+#define PIO_PE5_IDX          133
+
+#endif /* _SAM4E8C_PIO_ */

--- a/asf/sam/include/sam4e/pio/sam4e8c.h
+++ b/asf/sam/include/sam4e/pio/sam4e8c.h
@@ -196,7 +196,7 @@
 #define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
 #define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
 #define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
-#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX1        (1u << 6)  /**< \brief Gmac signal: GRX1 */
 #define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
 #define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
 #define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */

--- a/asf/sam/include/sam4e/pio/sam4e8e.h
+++ b/asf/sam/include/sam4e/pio/sam4e8e.h
@@ -1,0 +1,525 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E8E_PIO_
+#define _SAM4E8E_PIO_
+
+#define PIO_PA0              (1u << 0)  /**< \brief Pin Controlled by PA0 */
+#define PIO_PA1              (1u << 1)  /**< \brief Pin Controlled by PA1 */
+#define PIO_PA2              (1u << 2)  /**< \brief Pin Controlled by PA2 */
+#define PIO_PA3              (1u << 3)  /**< \brief Pin Controlled by PA3 */
+#define PIO_PA4              (1u << 4)  /**< \brief Pin Controlled by PA4 */
+#define PIO_PA5              (1u << 5)  /**< \brief Pin Controlled by PA5 */
+#define PIO_PA6              (1u << 6)  /**< \brief Pin Controlled by PA6 */
+#define PIO_PA7              (1u << 7)  /**< \brief Pin Controlled by PA7 */
+#define PIO_PA8              (1u << 8)  /**< \brief Pin Controlled by PA8 */
+#define PIO_PA9              (1u << 9)  /**< \brief Pin Controlled by PA9 */
+#define PIO_PA10             (1u << 10) /**< \brief Pin Controlled by PA10 */
+#define PIO_PA11             (1u << 11) /**< \brief Pin Controlled by PA11 */
+#define PIO_PA12             (1u << 12) /**< \brief Pin Controlled by PA12 */
+#define PIO_PA13             (1u << 13) /**< \brief Pin Controlled by PA13 */
+#define PIO_PA14             (1u << 14) /**< \brief Pin Controlled by PA14 */
+#define PIO_PA15             (1u << 15) /**< \brief Pin Controlled by PA15 */
+#define PIO_PA16             (1u << 16) /**< \brief Pin Controlled by PA16 */
+#define PIO_PA17             (1u << 17) /**< \brief Pin Controlled by PA17 */
+#define PIO_PA18             (1u << 18) /**< \brief Pin Controlled by PA18 */
+#define PIO_PA19             (1u << 19) /**< \brief Pin Controlled by PA19 */
+#define PIO_PA20             (1u << 20) /**< \brief Pin Controlled by PA20 */
+#define PIO_PA21             (1u << 21) /**< \brief Pin Controlled by PA21 */
+#define PIO_PA22             (1u << 22) /**< \brief Pin Controlled by PA22 */
+#define PIO_PA23             (1u << 23) /**< \brief Pin Controlled by PA23 */
+#define PIO_PA24             (1u << 24) /**< \brief Pin Controlled by PA24 */
+#define PIO_PA25             (1u << 25) /**< \brief Pin Controlled by PA25 */
+#define PIO_PA26             (1u << 26) /**< \brief Pin Controlled by PA26 */
+#define PIO_PA27             (1u << 27) /**< \brief Pin Controlled by PA27 */
+#define PIO_PA28             (1u << 28) /**< \brief Pin Controlled by PA28 */
+#define PIO_PA29             (1u << 29) /**< \brief Pin Controlled by PA29 */
+#define PIO_PA30             (1u << 30) /**< \brief Pin Controlled by PA30 */
+#define PIO_PA31             (1u << 31) /**< \brief Pin Controlled by PA31 */
+#define PIO_PB0              (1u << 0)  /**< \brief Pin Controlled by PB0 */
+#define PIO_PB1              (1u << 1)  /**< \brief Pin Controlled by PB1 */
+#define PIO_PB2              (1u << 2)  /**< \brief Pin Controlled by PB2 */
+#define PIO_PB3              (1u << 3)  /**< \brief Pin Controlled by PB3 */
+#define PIO_PB4              (1u << 4)  /**< \brief Pin Controlled by PB4 */
+#define PIO_PB5              (1u << 5)  /**< \brief Pin Controlled by PB5 */
+#define PIO_PB6              (1u << 6)  /**< \brief Pin Controlled by PB6 */
+#define PIO_PB7              (1u << 7)  /**< \brief Pin Controlled by PB7 */
+#define PIO_PB8              (1u << 8)  /**< \brief Pin Controlled by PB8 */
+#define PIO_PB9              (1u << 9)  /**< \brief Pin Controlled by PB9 */
+#define PIO_PB10             (1u << 10) /**< \brief Pin Controlled by PB10 */
+#define PIO_PB11             (1u << 11) /**< \brief Pin Controlled by PB11 */
+#define PIO_PB12             (1u << 12) /**< \brief Pin Controlled by PB12 */
+#define PIO_PB13             (1u << 13) /**< \brief Pin Controlled by PB13 */
+#define PIO_PB14             (1u << 14) /**< \brief Pin Controlled by PB14 */
+#define PIO_PC0              (1u << 0)  /**< \brief Pin Controlled by PC0 */
+#define PIO_PC1              (1u << 1)  /**< \brief Pin Controlled by PC1 */
+#define PIO_PC2              (1u << 2)  /**< \brief Pin Controlled by PC2 */
+#define PIO_PC3              (1u << 3)  /**< \brief Pin Controlled by PC3 */
+#define PIO_PC4              (1u << 4)  /**< \brief Pin Controlled by PC4 */
+#define PIO_PC5              (1u << 5)  /**< \brief Pin Controlled by PC5 */
+#define PIO_PC6              (1u << 6)  /**< \brief Pin Controlled by PC6 */
+#define PIO_PC7              (1u << 7)  /**< \brief Pin Controlled by PC7 */
+#define PIO_PC8              (1u << 8)  /**< \brief Pin Controlled by PC8 */
+#define PIO_PC9              (1u << 9)  /**< \brief Pin Controlled by PC9 */
+#define PIO_PC10             (1u << 10) /**< \brief Pin Controlled by PC10 */
+#define PIO_PC11             (1u << 11) /**< \brief Pin Controlled by PC11 */
+#define PIO_PC12             (1u << 12) /**< \brief Pin Controlled by PC12 */
+#define PIO_PC13             (1u << 13) /**< \brief Pin Controlled by PC13 */
+#define PIO_PC14             (1u << 14) /**< \brief Pin Controlled by PC14 */
+#define PIO_PC15             (1u << 15) /**< \brief Pin Controlled by PC15 */
+#define PIO_PC16             (1u << 16) /**< \brief Pin Controlled by PC16 */
+#define PIO_PC17             (1u << 17) /**< \brief Pin Controlled by PC17 */
+#define PIO_PC18             (1u << 18) /**< \brief Pin Controlled by PC18 */
+#define PIO_PC19             (1u << 19) /**< \brief Pin Controlled by PC19 */
+#define PIO_PC20             (1u << 20) /**< \brief Pin Controlled by PC20 */
+#define PIO_PC21             (1u << 21) /**< \brief Pin Controlled by PC21 */
+#define PIO_PC22             (1u << 22) /**< \brief Pin Controlled by PC22 */
+#define PIO_PC23             (1u << 23) /**< \brief Pin Controlled by PC23 */
+#define PIO_PC24             (1u << 24) /**< \brief Pin Controlled by PC24 */
+#define PIO_PC25             (1u << 25) /**< \brief Pin Controlled by PC25 */
+#define PIO_PC26             (1u << 26) /**< \brief Pin Controlled by PC26 */
+#define PIO_PC27             (1u << 27) /**< \brief Pin Controlled by PC27 */
+#define PIO_PC28             (1u << 28) /**< \brief Pin Controlled by PC28 */
+#define PIO_PC29             (1u << 29) /**< \brief Pin Controlled by PC29 */
+#define PIO_PC30             (1u << 30) /**< \brief Pin Controlled by PC30 */
+#define PIO_PC31             (1u << 31) /**< \brief Pin Controlled by PC31 */
+#define PIO_PD0              (1u << 0)  /**< \brief Pin Controlled by PD0 */
+#define PIO_PD1              (1u << 1)  /**< \brief Pin Controlled by PD1 */
+#define PIO_PD2              (1u << 2)  /**< \brief Pin Controlled by PD2 */
+#define PIO_PD3              (1u << 3)  /**< \brief Pin Controlled by PD3 */
+#define PIO_PD4              (1u << 4)  /**< \brief Pin Controlled by PD4 */
+#define PIO_PD5              (1u << 5)  /**< \brief Pin Controlled by PD5 */
+#define PIO_PD6              (1u << 6)  /**< \brief Pin Controlled by PD6 */
+#define PIO_PD7              (1u << 7)  /**< \brief Pin Controlled by PD7 */
+#define PIO_PD8              (1u << 8)  /**< \brief Pin Controlled by PD8 */
+#define PIO_PD9              (1u << 9)  /**< \brief Pin Controlled by PD9 */
+#define PIO_PD10             (1u << 10) /**< \brief Pin Controlled by PD10 */
+#define PIO_PD11             (1u << 11) /**< \brief Pin Controlled by PD11 */
+#define PIO_PD12             (1u << 12) /**< \brief Pin Controlled by PD12 */
+#define PIO_PD13             (1u << 13) /**< \brief Pin Controlled by PD13 */
+#define PIO_PD14             (1u << 14) /**< \brief Pin Controlled by PD14 */
+#define PIO_PD15             (1u << 15) /**< \brief Pin Controlled by PD15 */
+#define PIO_PD16             (1u << 16) /**< \brief Pin Controlled by PD16 */
+#define PIO_PD17             (1u << 17) /**< \brief Pin Controlled by PD17 */
+#define PIO_PD18             (1u << 18) /**< \brief Pin Controlled by PD18 */
+#define PIO_PD19             (1u << 19) /**< \brief Pin Controlled by PD19 */
+#define PIO_PD20             (1u << 20) /**< \brief Pin Controlled by PD20 */
+#define PIO_PD21             (1u << 21) /**< \brief Pin Controlled by PD21 */
+#define PIO_PD22             (1u << 22) /**< \brief Pin Controlled by PD22 */
+#define PIO_PD23             (1u << 23) /**< \brief Pin Controlled by PD23 */
+#define PIO_PD24             (1u << 24) /**< \brief Pin Controlled by PD24 */
+#define PIO_PD25             (1u << 25) /**< \brief Pin Controlled by PD25 */
+#define PIO_PD26             (1u << 26) /**< \brief Pin Controlled by PD26 */
+#define PIO_PD27             (1u << 27) /**< \brief Pin Controlled by PD27 */
+#define PIO_PD28             (1u << 28) /**< \brief Pin Controlled by PD28 */
+#define PIO_PD29             (1u << 29) /**< \brief Pin Controlled by PD29 */
+#define PIO_PD30             (1u << 30) /**< \brief Pin Controlled by PD30 */
+#define PIO_PD31             (1u << 31) /**< \brief Pin Controlled by PD31 */
+#define PIO_PE0              (1u << 0)  /**< \brief Pin Controlled by PE0 */
+#define PIO_PE1              (1u << 1)  /**< \brief Pin Controlled by PE1 */
+#define PIO_PE2              (1u << 2)  /**< \brief Pin Controlled by PE2 */
+#define PIO_PE3              (1u << 3)  /**< \brief Pin Controlled by PE3 */
+#define PIO_PE4              (1u << 4)  /**< \brief Pin Controlled by PE4 */
+#define PIO_PE5              (1u << 5)  /**< \brief Pin Controlled by PE5 */
+/* ========== Pio definition for AFEC0 peripheral ========== */
+#define PIO_PA17X1_AFE0_AD0  (1u << 17) /**< \brief Afec0 signal: AFE0_AD0 */
+#define PIO_PA18X1_AFE0_AD1  (1u << 18) /**< \brief Afec0 signal: AFE0_AD1 */
+#define PIO_PC30X1_AFE0_AD10 (1u << 30) /**< \brief Afec0 signal: AFE0_AD10 */
+#define PIO_PC31X1_AFE0_AD11 (1u << 31) /**< \brief Afec0 signal: AFE0_AD11 */
+#define PIO_PC26X1_AFE0_AD12 (1u << 26) /**< \brief Afec0 signal: AFE0_AD12 */
+#define PIO_PC27X1_AFE0_AD13 (1u << 27) /**< \brief Afec0 signal: AFE0_AD13 */
+#define PIO_PC0X1_AFE0_AD14  (1u << 0)  /**< \brief Afec0 signal: AFE0_AD14 */
+#define PIO_PA19X1_AFE0_AD2  (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA19X1_WKUP9     (1u << 19) /**< \brief Afec0 signal: AFE0_AD2/WKUP9 */
+#define PIO_PA20X1_AFE0_AD3  (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PA20X1_WKUP10    (1u << 20) /**< \brief Afec0 signal: AFE0_AD3/WKUP10 */
+#define PIO_PB0X1_AFE0_AD4   (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB0X1_RTCOUT0    (1u << 0)  /**< \brief Afec0 signal: AFE0_AD4/RTCOUT0 */
+#define PIO_PB1X1_AFE0_AD5   (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PB1X1_RTCOUT1    (1u << 1)  /**< \brief Afec0 signal: AFE0_AD5/RTCOUT1 */
+#define PIO_PC13X1_AFE0_AD6  (1u << 13) /**< \brief Afec0 signal: AFE0_AD6 */
+#define PIO_PC15X1_AFE0_AD7  (1u << 15) /**< \brief Afec0 signal: AFE0_AD7 */
+#define PIO_PC12X1_AFE0_AD8  (1u << 12) /**< \brief Afec0 signal: AFE0_AD8 */
+#define PIO_PC29X1_AFE0_AD9  (1u << 29) /**< \brief Afec0 signal: AFE0_AD9 */
+#define PIO_PA8B_AFE0_ADTRG  (1u << 8)  /**< \brief Afec0 signal: AFE0_ADTRG */
+/* ========== Pio definition for AFEC1 peripheral ========== */
+#define PIO_PB2X1_AFE1_AD0   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB2X1_WKUP12     (1u << 2)  /**< \brief Afec1 signal: AFE1_AD0/WKUP12 */
+#define PIO_PB3X1_AFE1_AD1   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD1 */
+#define PIO_PA21X1_AFE1_AD2  (1u << 21) /**< \brief Afec1 signal: AFE1_AD2 */
+#define PIO_PA22X1_AFE1_AD3  (1u << 22) /**< \brief Afec1 signal: AFE1_AD3 */
+#define PIO_PC1X1_AFE1_AD4   (1u << 1)  /**< \brief Afec1 signal: AFE1_AD4 */
+#define PIO_PC2X1_AFE1_AD5   (1u << 2)  /**< \brief Afec1 signal: AFE1_AD5 */
+#define PIO_PC3X1_AFE1_AD6   (1u << 3)  /**< \brief Afec1 signal: AFE1_AD6 */
+#define PIO_PC4X1_AFE1_AD7   (1u << 4)  /**< \brief Afec1 signal: AFE1_AD7 */
+/* ========== Pio definition for CAN0 peripheral ========== */
+#define PIO_PB3A_CANRX0      (1u << 3)  /**< \brief Can0 signal: CANRX0 */
+#define PIO_PB2A_CANTX0      (1u << 2)  /**< \brief Can0 signal: CANTX0 */
+/* ========== Pio definition for CAN1 peripheral ========== */
+#define PIO_PC12C_CANRX1     (1u << 12) /**< \brief Can1 signal: CANRX1 */
+#define PIO_PC15C_CANTX1     (1u << 15) /**< \brief Can1 signal: CANTX1 */
+/* ========== Pio definition for DACC peripheral ========== */
+#define PIO_PB13X1_DAC0      (1u << 13) /**< \brief Dacc signal: DAC0 */
+#define PIO_PB14X1_DAC1      (1u << 14) /**< \brief Dacc signal: DAC1 */
+#define PIO_PA2C_DATRG       (1u << 2)  /**< \brief Dacc signal: DATRG */
+/* ========== Pio definition for EBI peripheral ========== */
+#define PIO_PC18A_A0         (1u << 18) /**< \brief Ebi signal: A0 */
+#define PIO_PC19A_A1         (1u << 19) /**< \brief Ebi signal: A1 */
+#define PIO_PC28A_A10        (1u << 28) /**< \brief Ebi signal: A10 */
+#define PIO_PC29A_A11        (1u << 29) /**< \brief Ebi signal: A11 */
+#define PIO_PC30A_A12        (1u << 30) /**< \brief Ebi signal: A12 */
+#define PIO_PC31A_A13        (1u << 31) /**< \brief Ebi signal: A13 */
+#define PIO_PA18C_A14        (1u << 18) /**< \brief Ebi signal: A14 */
+#define PIO_PA19C_A15        (1u << 19) /**< \brief Ebi signal: A15 */
+#define PIO_PA20C_A16        (1u << 20) /**< \brief Ebi signal: A16 */
+#define PIO_PA0C_A17         (1u << 0)  /**< \brief Ebi signal: A17 */
+#define PIO_PA1C_A18         (1u << 1)  /**< \brief Ebi signal: A18 */
+#define PIO_PA23C_A19        (1u << 23) /**< \brief Ebi signal: A19 */
+#define PIO_PC20A_A2         (1u << 20) /**< \brief Ebi signal: A2 */
+#define PIO_PA24C_A20        (1u << 24) /**< \brief Ebi signal: A20 */
+#define PIO_PC16A_A21        (1u << 16) /**< \brief Ebi signal: A21/NANDALE */
+#define PIO_PC16A_NANDALE    (1u << 16) /**< \brief Ebi signal: A21/NANDALE */
+#define PIO_PC17A_A22        (1u << 17) /**< \brief Ebi signal: A22/NANDCLE */
+#define PIO_PC17A_NANDCLE    (1u << 17) /**< \brief Ebi signal: A22/NANDCLE */
+#define PIO_PA25C_A23        (1u << 25) /**< \brief Ebi signal: A23 */
+#define PIO_PC21A_A3         (1u << 21) /**< \brief Ebi signal: A3 */
+#define PIO_PC22A_A4         (1u << 22) /**< \brief Ebi signal: A4 */
+#define PIO_PC23A_A5         (1u << 23) /**< \brief Ebi signal: A5 */
+#define PIO_PC24A_A6         (1u << 24) /**< \brief Ebi signal: A6 */
+#define PIO_PC25A_A7         (1u << 25) /**< \brief Ebi signal: A7 */
+#define PIO_PC26A_A8         (1u << 26) /**< \brief Ebi signal: A8 */
+#define PIO_PC27A_A9         (1u << 27) /**< \brief Ebi signal: A9 */
+#define PIO_PC0A_D0          (1u << 0)  /**< \brief Ebi signal: D0 */
+#define PIO_PC1A_D1          (1u << 1)  /**< \brief Ebi signal: D1 */
+#define PIO_PC2A_D2          (1u << 2)  /**< \brief Ebi signal: D2 */
+#define PIO_PC3A_D3          (1u << 3)  /**< \brief Ebi signal: D3 */
+#define PIO_PC4A_D4          (1u << 4)  /**< \brief Ebi signal: D4 */
+#define PIO_PC5A_D5          (1u << 5)  /**< \brief Ebi signal: D5 */
+#define PIO_PC6A_D6          (1u << 6)  /**< \brief Ebi signal: D6 */
+#define PIO_PC7A_D7          (1u << 7)  /**< \brief Ebi signal: D7 */
+#define PIO_PC9A_NANDOE      (1u << 9)  /**< \brief Ebi signal: NANDOE */
+#define PIO_PC10A_NANDWE     (1u << 10) /**< \brief Ebi signal: NANDWE */
+#define PIO_PC14A_NCS0       (1u << 14) /**< \brief Ebi signal: NCS0 */
+#define PIO_PC15A_NCS1       (1u << 15) /**< \brief Ebi signal: NCS1 */
+#define PIO_PD18A_NCS1       (1u << 18) /**< \brief Ebi signal: NCS1 */
+#define PIO_PA22C_NCS2       (1u << 22) /**< \brief Ebi signal: NCS2 */
+#define PIO_PC12A_NCS3       (1u << 12) /**< \brief Ebi signal: NCS3 */
+#define PIO_PD19A_NCS3       (1u << 19) /**< \brief Ebi signal: NCS3 */
+#define PIO_PC11A_NRD        (1u << 11) /**< \brief Ebi signal: NRD */
+#define PIO_PC13A_NWAIT      (1u << 13) /**< \brief Ebi signal: NWAIT */
+#define PIO_PC8A_NWE         (1u << 8)  /**< \brief Ebi signal: NWE */
+/* ========== Pio definition for GMAC peripheral ========== */
+#define PIO_PD13A_GCOL       (1u << 13) /**< \brief Gmac signal: GCOL */
+#define PIO_PD10A_GCRS       (1u << 10) /**< \brief Gmac signal: GCRS */
+#define PIO_PD4A_GCRSDV      (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD4A_GRXDV       (1u << 4)  /**< \brief Gmac signal: GCRSDV/GRXDV */
+#define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
+#define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
+#define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
+#define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
+#define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */
+#define PIO_PD7A_GRXER       (1u << 7)  /**< \brief Gmac signal: GRXER */
+#define PIO_PD2A_GTX0        (1u << 2)  /**< \brief Gmac signal: GTX0 */
+#define PIO_PD3A_GTX1        (1u << 3)  /**< \brief Gmac signal: GTX1 */
+#define PIO_PD15A_GTX2       (1u << 15) /**< \brief Gmac signal: GTX2 */
+#define PIO_PD16A_GTX3       (1u << 16) /**< \brief Gmac signal: GTX3 */
+#define PIO_PD0A_GTXCK       (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD0A_GREFCK      (1u << 0)  /**< \brief Gmac signal: GTXCK/GREFCK */
+#define PIO_PD1A_GTXEN       (1u << 1)  /**< \brief Gmac signal: GTXEN */
+#define PIO_PD17A_GTXER      (1u << 17) /**< \brief Gmac signal: GTXER */
+/* ========== Pio definition for HSMCI peripheral ========== */
+#define PIO_PA28C_MCCDA      (1u << 28) /**< \brief Hsmci signal: MCCDA */
+#define PIO_PA29C_MCCK       (1u << 29) /**< \brief Hsmci signal: MCCK */
+#define PIO_PA30C_MCDA0      (1u << 30) /**< \brief Hsmci signal: MCDA0 */
+#define PIO_PA31C_MCDA1      (1u << 31) /**< \brief Hsmci signal: MCDA1 */
+#define PIO_PA26C_MCDA2      (1u << 26) /**< \brief Hsmci signal: MCDA2 */
+#define PIO_PA27C_MCDA3      (1u << 27) /**< \brief Hsmci signal: MCDA3 */
+/* ========== Pio definition for PIOA peripheral ========== */
+#define PIO_PA24X1_PIODC0    (1u << 24) /**< \brief Pioa signal: PIODC0 */
+#define PIO_PA25X1_PIODC1    (1u << 25) /**< \brief Pioa signal: PIODC1 */
+#define PIO_PA26X1_PIODC2    (1u << 26) /**< \brief Pioa signal: PIODC2 */
+#define PIO_PA27X1_PIODC3    (1u << 27) /**< \brief Pioa signal: PIODC3 */
+#define PIO_PA28X1_PIODC4    (1u << 28) /**< \brief Pioa signal: PIODC4 */
+#define PIO_PA29X1_PIODC5    (1u << 29) /**< \brief Pioa signal: PIODC5 */
+#define PIO_PA31X1_PIODC7    (1u << 31) /**< \brief Pioa signal: PIODC7 */
+#define PIO_PA23X1_PIODCCLK  (1u << 23) /**< \brief Pioa signal: PIODCCLK */
+#define PIO_PA30X1_WKUP11    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA30X1_PIODC6    (1u << 30) /**< \brief Pioa signal: WKUP11/PIODC6 */
+#define PIO_PA15X1_WKUP14    (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA15X1_PIODCEN1  (1u << 15) /**< \brief Pioa signal: WKUP14/PIODCEN1 */
+#define PIO_PA16X1_WKUP15    (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+#define PIO_PA16X1_PIODCEN2  (1u << 16) /**< \brief Pioa signal: WKUP15/PIODCEN2 */
+/* ========== Pio definition for PMC peripheral ========== */
+#define PIO_PA6B_PCK0        (1u << 6)  /**< \brief Pmc signal: PCK0 */
+#define PIO_PB13B_PCK0       (1u << 13) /**< \brief Pmc signal: PCK0 */
+#define PIO_PA17B_PCK1       (1u << 17) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA21B_PCK1       (1u << 21) /**< \brief Pmc signal: PCK1 */
+#define PIO_PA18B_PCK2       (1u << 18) /**< \brief Pmc signal: PCK2 */
+#define PIO_PA31B_PCK2       (1u << 31) /**< \brief Pmc signal: PCK2 */
+#define PIO_PB3B_PCK2        (1u << 3)  /**< \brief Pmc signal: PCK2 */
+/* ========== Pio definition for PWM peripheral ========== */
+#define PIO_PA9C_PWMFI0      (1u << 9)  /**< \brief Pwm signal: PWMFI0 */
+#define PIO_PA0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA11B_PWMH0      (1u << 11) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA23B_PWMH0      (1u << 23) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PB0A_PWMH0       (1u << 0)  /**< \brief Pwm signal: PWMH0 */
+#define PIO_PC18B_PWMH0      (1u << 18) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PD20A_PWMH0      (1u << 20) /**< \brief Pwm signal: PWMH0 */
+#define PIO_PA1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA12B_PWMH1      (1u << 12) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA24B_PWMH1      (1u << 24) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PB1A_PWMH1       (1u << 1)  /**< \brief Pwm signal: PWMH1 */
+#define PIO_PC19B_PWMH1      (1u << 19) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PD21A_PWMH1      (1u << 21) /**< \brief Pwm signal: PWMH1 */
+#define PIO_PA2A_PWMH2       (1u << 2)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA13B_PWMH2      (1u << 13) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA25B_PWMH2      (1u << 25) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PB4B_PWMH2       (1u << 4)  /**< \brief Pwm signal: PWMH2 */
+#define PIO_PC20B_PWMH2      (1u << 20) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PD22A_PWMH2      (1u << 22) /**< \brief Pwm signal: PWMH2 */
+#define PIO_PA7B_PWMH3       (1u << 7)  /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA17C_PWMH3      (1u << 17) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PB14B_PWMH3      (1u << 14) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PC21B_PWMH3      (1u << 21) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PD23A_PWMH3      (1u << 23) /**< \brief Pwm signal: PWMH3 */
+#define PIO_PA19B_PWML0      (1u << 19) /**< \brief Pwm signal: PWML0 */
+#define PIO_PB5B_PWML0       (1u << 5)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC0B_PWML0       (1u << 0)  /**< \brief Pwm signal: PWML0 */
+#define PIO_PC13B_PWML0      (1u << 13) /**< \brief Pwm signal: PWML0 */
+#define PIO_PD24A_PWML0      (1u << 24) /**< \brief Pwm signal: PWML0 */
+#define PIO_PA20B_PWML1      (1u << 20) /**< \brief Pwm signal: PWML1 */
+#define PIO_PB12A_PWML1      (1u << 12) /**< \brief Pwm signal: PWML1 */
+#define PIO_PC1B_PWML1       (1u << 1)  /**< \brief Pwm signal: PWML1 */
+#define PIO_PC15B_PWML1      (1u << 15) /**< \brief Pwm signal: PWML1 */
+#define PIO_PD25A_PWML1      (1u << 25) /**< \brief Pwm signal: PWML1 */
+#define PIO_PA16C_PWML2      (1u << 16) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA30A_PWML2      (1u << 30) /**< \brief Pwm signal: PWML2 */
+#define PIO_PB13A_PWML2      (1u << 13) /**< \brief Pwm signal: PWML2 */
+#define PIO_PC2B_PWML2       (1u << 2)  /**< \brief Pwm signal: PWML2 */
+#define PIO_PD26A_PWML2      (1u << 26) /**< \brief Pwm signal: PWML2 */
+#define PIO_PA15C_PWML3      (1u << 15) /**< \brief Pwm signal: PWML3 */
+#define PIO_PC3B_PWML3       (1u << 3)  /**< \brief Pwm signal: PWML3 */
+#define PIO_PC22B_PWML3      (1u << 22) /**< \brief Pwm signal: PWML3 */
+#define PIO_PD27A_PWML3      (1u << 27) /**< \brief Pwm signal: PWML3 */
+/* ========== Pio definition for SPI peripheral ========== */
+#define PIO_PA12A_MISO       (1u << 12) /**< \brief Spi signal: MISO */
+#define PIO_PA13A_MOSI       (1u << 13) /**< \brief Spi signal: MOSI */
+#define PIO_PA11A_NPCS0      (1u << 11) /**< \brief Spi signal: NPCS0 */
+#define PIO_PA9B_NPCS1       (1u << 9)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA31A_NPCS1      (1u << 31) /**< \brief Spi signal: NPCS1 */
+#define PIO_PB14A_NPCS1      (1u << 14) /**< \brief Spi signal: NPCS1 */
+#define PIO_PC4B_NPCS1       (1u << 4)  /**< \brief Spi signal: NPCS1 */
+#define PIO_PA10B_NPCS2      (1u << 10) /**< \brief Spi signal: NPCS2 */
+#define PIO_PA30B_NPCS2      (1u << 30) /**< \brief Spi signal: NPCS2 */
+#define PIO_PB2B_NPCS2       (1u << 2)  /**< \brief Spi signal: NPCS2 */
+#define PIO_PA3B_NPCS3       (1u << 3)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA5B_NPCS3       (1u << 5)  /**< \brief Spi signal: NPCS3 */
+#define PIO_PA22B_NPCS3      (1u << 22) /**< \brief Spi signal: NPCS3 */
+#define PIO_PA14A_SPCK       (1u << 14) /**< \brief Spi signal: SPCK */
+/* ========== Pio definition for TC0 peripheral ========== */
+#define PIO_PA4B_TCLK0       (1u << 4)  /**< \brief Tc0 signal: TCLK0 */
+#define PIO_PA28B_TCLK1      (1u << 28) /**< \brief Tc0 signal: TCLK1 */
+#define PIO_PA29B_TCLK2      (1u << 29) /**< \brief Tc0 signal: TCLK2 */
+#define PIO_PA0B_TIOA0       (1u << 0)  /**< \brief Tc0 signal: TIOA0 */
+#define PIO_PA15B_TIOA1      (1u << 15) /**< \brief Tc0 signal: TIOA1 */
+#define PIO_PA26B_TIOA2      (1u << 26) /**< \brief Tc0 signal: TIOA2 */
+#define PIO_PA1B_TIOB0       (1u << 1)  /**< \brief Tc0 signal: TIOB0 */
+#define PIO_PA16B_TIOB1      (1u << 16) /**< \brief Tc0 signal: TIOB1 */
+#define PIO_PA27B_TIOB2      (1u << 27) /**< \brief Tc0 signal: TIOB2 */
+/* ========== Pio definition for TC1 peripheral ========== */
+#define PIO_PC25B_TCLK3      (1u << 25) /**< \brief Tc1 signal: TCLK3 */
+#define PIO_PC28B_TCLK4      (1u << 28) /**< \brief Tc1 signal: TCLK4 */
+#define PIO_PC31B_TCLK5      (1u << 31) /**< \brief Tc1 signal: TCLK5 */
+#define PIO_PC23B_TIOA3      (1u << 23) /**< \brief Tc1 signal: TIOA3 */
+#define PIO_PC26B_TIOA4      (1u << 26) /**< \brief Tc1 signal: TIOA4 */
+#define PIO_PC29B_TIOA5      (1u << 29) /**< \brief Tc1 signal: TIOA5 */
+#define PIO_PC24B_TIOB3      (1u << 24) /**< \brief Tc1 signal: TIOB3 */
+#define PIO_PC27B_TIOB4      (1u << 27) /**< \brief Tc1 signal: TIOB4 */
+#define PIO_PC30B_TIOB5      (1u << 30) /**< \brief Tc1 signal: TIOB5 */
+/* ========== Pio definition for TC2 peripheral ========== */
+#define PIO_PC7B_TCLK6       (1u << 7)  /**< \brief Tc2 signal: TCLK6 */
+#define PIO_PC10B_TCLK7      (1u << 10) /**< \brief Tc2 signal: TCLK7 */
+#define PIO_PC14B_TCLK8      (1u << 14) /**< \brief Tc2 signal: TCLK8 */
+#define PIO_PC5B_TIOA6       (1u << 5)  /**< \brief Tc2 signal: TIOA6 */
+#define PIO_PC8B_TIOA7       (1u << 8)  /**< \brief Tc2 signal: TIOA7 */
+#define PIO_PC11B_TIOA8      (1u << 11) /**< \brief Tc2 signal: TIOA8 */
+#define PIO_PC6B_TIOB6       (1u << 6)  /**< \brief Tc2 signal: TIOB6 */
+#define PIO_PC9B_TIOB7       (1u << 9)  /**< \brief Tc2 signal: TIOB7 */
+#define PIO_PC12B_TIOB8      (1u << 12) /**< \brief Tc2 signal: TIOB8 */
+/* ========== Pio definition for TWI0 peripheral ========== */
+#define PIO_PA4A_TWCK0       (1u << 4)  /**< \brief Twi0 signal: TWCK0 */
+#define PIO_PA3A_TWD0        (1u << 3)  /**< \brief Twi0 signal: TWD0 */
+/* ========== Pio definition for TWI1 peripheral ========== */
+#define PIO_PB5A_TWCK1       (1u << 5)  /**< \brief Twi1 signal: TWCK1 */
+#define PIO_PB4A_TWD1        (1u << 4)  /**< \brief Twi1 signal: TWD1 */
+/* ========== Pio definition for UART0 peripheral ========== */
+#define PIO_PA9A_URXD0       (1u << 9)  /**< \brief Uart0 signal: URXD0 */
+#define PIO_PA10A_UTXD0      (1u << 10) /**< \brief Uart0 signal: UTXD0 */
+/* ========== Pio definition for UART1 peripheral ========== */
+#define PIO_PA5C_URXD1       (1u << 5)  /**< \brief Uart1 signal: URXD1 */
+#define PIO_PA6C_UTXD1       (1u << 6)  /**< \brief Uart1 signal: UTXD1 */
+/* ========== Pio definition for USART0 peripheral ========== */
+#define PIO_PB2C_CTS0        (1u << 2)  /**< \brief Usart0 signal: CTS0 */
+#define PIO_PB3C_RTS0        (1u << 3)  /**< \brief Usart0 signal: RTS0 */
+#define PIO_PB0C_RXD0        (1u << 0)  /**< \brief Usart0 signal: RXD0 */
+#define PIO_PB13C_SCK0       (1u << 13) /**< \brief Usart0 signal: SCK0 */
+#define PIO_PB1C_TXD0        (1u << 1)  /**< \brief Usart0 signal: TXD0 */
+/* ========== Pio definition for USART1 peripheral ========== */
+#define PIO_PA25A_CTS1       (1u << 25) /**< \brief Usart1 signal: CTS1 */
+#define PIO_PA26A_DCD1       (1u << 26) /**< \brief Usart1 signal: DCD1 */
+#define PIO_PA28A_DSR1       (1u << 28) /**< \brief Usart1 signal: DSR1 */
+#define PIO_PA27A_DTR1       (1u << 27) /**< \brief Usart1 signal: DTR1 */
+#define PIO_PA29A_RI1        (1u << 29) /**< \brief Usart1 signal: RI1 */
+#define PIO_PA24A_RTS1       (1u << 24) /**< \brief Usart1 signal: RTS1 */
+#define PIO_PA21A_RXD1       (1u << 21) /**< \brief Usart1 signal: RXD1 */
+#define PIO_PA23A_SCK1       (1u << 23) /**< \brief Usart1 signal: SCK1 */
+#define PIO_PA22A_TXD1       (1u << 22) /**< \brief Usart1 signal: TXD1 */
+/* ========== Pio indexes ========== */
+#define PIO_PA0_IDX          0
+#define PIO_PA1_IDX          1
+#define PIO_PA2_IDX          2
+#define PIO_PA3_IDX          3
+#define PIO_PA4_IDX          4
+#define PIO_PA5_IDX          5
+#define PIO_PA6_IDX          6
+#define PIO_PA7_IDX          7
+#define PIO_PA8_IDX          8
+#define PIO_PA9_IDX          9
+#define PIO_PA10_IDX         10
+#define PIO_PA11_IDX         11
+#define PIO_PA12_IDX         12
+#define PIO_PA13_IDX         13
+#define PIO_PA14_IDX         14
+#define PIO_PA15_IDX         15
+#define PIO_PA16_IDX         16
+#define PIO_PA17_IDX         17
+#define PIO_PA18_IDX         18
+#define PIO_PA19_IDX         19
+#define PIO_PA20_IDX         20
+#define PIO_PA21_IDX         21
+#define PIO_PA22_IDX         22
+#define PIO_PA23_IDX         23
+#define PIO_PA24_IDX         24
+#define PIO_PA25_IDX         25
+#define PIO_PA26_IDX         26
+#define PIO_PA27_IDX         27
+#define PIO_PA28_IDX         28
+#define PIO_PA29_IDX         29
+#define PIO_PA30_IDX         30
+#define PIO_PA31_IDX         31
+#define PIO_PB0_IDX          32
+#define PIO_PB1_IDX          33
+#define PIO_PB2_IDX          34
+#define PIO_PB3_IDX          35
+#define PIO_PB4_IDX          36
+#define PIO_PB5_IDX          37
+#define PIO_PB6_IDX          38
+#define PIO_PB7_IDX          39
+#define PIO_PB8_IDX          40
+#define PIO_PB9_IDX          41
+#define PIO_PB10_IDX         42
+#define PIO_PB11_IDX         43
+#define PIO_PB12_IDX         44
+#define PIO_PB13_IDX         45
+#define PIO_PB14_IDX         46
+#define PIO_PC0_IDX          64
+#define PIO_PC1_IDX          65
+#define PIO_PC2_IDX          66
+#define PIO_PC3_IDX          67
+#define PIO_PC4_IDX          68
+#define PIO_PC5_IDX          69
+#define PIO_PC6_IDX          70
+#define PIO_PC7_IDX          71
+#define PIO_PC8_IDX          72
+#define PIO_PC9_IDX          73
+#define PIO_PC10_IDX         74
+#define PIO_PC11_IDX         75
+#define PIO_PC12_IDX         76
+#define PIO_PC13_IDX         77
+#define PIO_PC14_IDX         78
+#define PIO_PC15_IDX         79
+#define PIO_PC16_IDX         80
+#define PIO_PC17_IDX         81
+#define PIO_PC18_IDX         82
+#define PIO_PC19_IDX         83
+#define PIO_PC20_IDX         84
+#define PIO_PC21_IDX         85
+#define PIO_PC22_IDX         86
+#define PIO_PC23_IDX         87
+#define PIO_PC24_IDX         88
+#define PIO_PC25_IDX         89
+#define PIO_PC26_IDX         90
+#define PIO_PC27_IDX         91
+#define PIO_PC28_IDX         92
+#define PIO_PC29_IDX         93
+#define PIO_PC30_IDX         94
+#define PIO_PC31_IDX         95
+#define PIO_PD0_IDX          96
+#define PIO_PD1_IDX          97
+#define PIO_PD2_IDX          98
+#define PIO_PD3_IDX          99
+#define PIO_PD4_IDX          100
+#define PIO_PD5_IDX          101
+#define PIO_PD6_IDX          102
+#define PIO_PD7_IDX          103
+#define PIO_PD8_IDX          104
+#define PIO_PD9_IDX          105
+#define PIO_PD10_IDX         106
+#define PIO_PD11_IDX         107
+#define PIO_PD12_IDX         108
+#define PIO_PD13_IDX         109
+#define PIO_PD14_IDX         110
+#define PIO_PD15_IDX         111
+#define PIO_PD16_IDX         112
+#define PIO_PD17_IDX         113
+#define PIO_PD18_IDX         114
+#define PIO_PD19_IDX         115
+#define PIO_PD20_IDX         116
+#define PIO_PD21_IDX         117
+#define PIO_PD22_IDX         118
+#define PIO_PD23_IDX         119
+#define PIO_PD24_IDX         120
+#define PIO_PD25_IDX         121
+#define PIO_PD26_IDX         122
+#define PIO_PD27_IDX         123
+#define PIO_PD28_IDX         124
+#define PIO_PD29_IDX         125
+#define PIO_PD30_IDX         126
+#define PIO_PD31_IDX         127
+#define PIO_PE0_IDX          128
+#define PIO_PE1_IDX          129
+#define PIO_PE2_IDX          130
+#define PIO_PE3_IDX          131
+#define PIO_PE4_IDX          132
+#define PIO_PE5_IDX          133
+
+#endif /* _SAM4E8E_PIO_ */

--- a/asf/sam/include/sam4e/pio/sam4e8e.h
+++ b/asf/sam/include/sam4e/pio/sam4e8e.h
@@ -242,7 +242,7 @@
 #define PIO_PD8A_GMDC        (1u << 8)  /**< \brief Gmac signal: GMDC */
 #define PIO_PD9A_GMDIO       (1u << 9)  /**< \brief Gmac signal: GMDIO */
 #define PIO_PD5A_GRX0        (1u << 5)  /**< \brief Gmac signal: GRX0 */
-#define PIO_PD6A_GRX0        (1u << 6)  /**< \brief Gmac signal: GRX0 */
+#define PIO_PD6A_GRX1        (1u << 6)  /**< \brief Gmac signal: GRX1 */
 #define PIO_PD11A_GRX2       (1u << 11) /**< \brief Gmac signal: GRX2 */
 #define PIO_PD12A_GRX3       (1u << 12) /**< \brief Gmac signal: GRX3 */
 #define PIO_PD14A_GRXCK      (1u << 14) /**< \brief Gmac signal: GRXCK */

--- a/asf/sam/include/sam4e/sam4e16c.h
+++ b/asf/sam/include/sam4e/sam4e16c.h
@@ -1,0 +1,591 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E16C_
+#define _SAM4E16C_
+
+/** \addtogroup SAM4E16C_definitions SAM4E16C definitions
+  This file defines all structures and symbols for SAM4E16C:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg; /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg; /**< Read-Write 32-bit register (volatile unsigned int) */
+#endif
+
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_cmsis CMSIS Definitions */
+/*@{*/
+
+/**< Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,  /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,  /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
+/******  SAM4E16C specific Interrupt Numbers *********************************/
+  
+  SUPC_IRQn            =  0, /**<  0 SAM4E16C Supply Controller (SUPC) */
+  RSTC_IRQn            =  1, /**<  1 SAM4E16C Reset Controller (RSTC) */
+  RTC_IRQn             =  2, /**<  2 SAM4E16C Real Time Clock (RTC) */
+  RTT_IRQn             =  3, /**<  3 SAM4E16C Real Time Timer (RTT) */
+  WDT_IRQn             =  4, /**<  4 SAM4E16C Watchdog/Dual Watchdog Timer (WDT) */
+  PMC_IRQn             =  5, /**<  5 SAM4E16C Power Management Controller (PMC) */
+  EFC_IRQn             =  6, /**<  6 SAM4E16C Enhanced Embedded Flash Controller (EFC) */
+  UART0_IRQn           =  7, /**<  7 SAM4E16C UART 0 (UART0) */
+  PIOA_IRQn            =  9, /**<  9 SAM4E16C Parallel I/O Controller A (PIOA) */
+  PIOB_IRQn            = 10, /**< 10 SAM4E16C Parallel I/O Controller B (PIOB) */
+  PIOC_IRQn            = 11, /**< 11 SAM4E16C Parallel I/O Controller C (PIOC) */
+  PIOD_IRQn            = 12, /**< 12 SAM4E16C Parallel I/O Controller D (PIOD) */
+  PIOE_IRQn            = 13, /**< 13 SAM4E16C Parallel I/O Controller E (PIOE) */
+  USART0_IRQn          = 14, /**< 14 SAM4E16C USART 0 (USART0) */
+  USART1_IRQn          = 15, /**< 15 SAM4E16C USART 1 (USART1) */
+  HSMCI_IRQn           = 16, /**< 16 SAM4E16C Multimedia Card Interface (HSMCI) */
+  TWI0_IRQn            = 17, /**< 17 SAM4E16C Two Wire Interface 0 (TWI0) */
+  TWI1_IRQn            = 18, /**< 18 SAM4E16C Two Wire Interface 1 (TWI1) */
+  SPI_IRQn             = 19, /**< 19 SAM4E16C Serial Peripheral Interface (SPI) */
+  DMAC_IRQn            = 20, /**< 20 SAM4E16C DMAC (DMAC) */
+  TC0_IRQn             = 21, /**< 21 SAM4E16C Timer/Counter 0 (TC0) */
+  TC1_IRQn             = 22, /**< 22 SAM4E16C Timer/Counter 1 (TC1) */
+  TC2_IRQn             = 23, /**< 23 SAM4E16C Timer/Counter 2 (TC2) */
+  TC3_IRQn             = 24, /**< 24 SAM4E16C Timer/Counter 3 (TC3) */
+  TC4_IRQn             = 25, /**< 25 SAM4E16C Timer/Counter 4 (TC4) */
+  TC5_IRQn             = 26, /**< 26 SAM4E16C Timer/Counter 5 (TC5) */
+  TC6_IRQn             = 27, /**< 27 SAM4E16C Timer/Counter 6 (TC6) */
+  TC7_IRQn             = 28, /**< 28 SAM4E16C Timer/Counter 7 (TC7) */
+  TC8_IRQn             = 29, /**< 29 SAM4E16C Timer/Counter 8 (TC8) */
+  AFEC0_IRQn           = 30, /**< 30 SAM4E16C Analog Front End 0 (AFEC0) */
+  AFEC1_IRQn           = 31, /**< 31 SAM4E16C Analog Front End 1 (AFEC1) */
+  DACC_IRQn            = 32, /**< 32 SAM4E16C Digital To Analog Converter (DACC) */
+  ACC_IRQn             = 33, /**< 33 SAM4E16C Analog Comparator (ACC) */
+  ARM_IRQn             = 34, /**< 34 SAM4E16C FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+  UDP_IRQn             = 35, /**< 35 SAM4E16C USB DEVICE (UDP) */
+  PWM_IRQn             = 36, /**< 36 SAM4E16C PWM (PWM) */
+  CAN0_IRQn            = 37, /**< 37 SAM4E16C CAN0 (CAN0) */
+  CAN1_IRQn            = 38, /**< 38 SAM4E16C CAN1 (CAN1) */
+  AES_IRQn             = 39, /**< 39 SAM4E16C AES (AES) */
+  GMAC_IRQn            = 44, /**< 44 SAM4E16C EMAC (GMAC) */
+  UART1_IRQn           = 45, /**< 45 SAM4E16C UART (UART1) */
+
+  PERIPH_COUNT_IRQn    = 46  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pfnReserved1_Handler;
+  void* pfnReserved2_Handler;
+  void* pfnReserved3_Handler;
+  void* pfnReserved4_Handler;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pfnReserved5_Handler;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;   /*  0 Supply Controller */
+  void* pfnRSTC_Handler;   /*  1 Reset Controller */
+  void* pfnRTC_Handler;    /*  2 Real Time Clock */
+  void* pfnRTT_Handler;    /*  3 Real Time Timer */
+  void* pfnWDT_Handler;    /*  4 Watchdog/Dual Watchdog Timer */
+  void* pfnPMC_Handler;    /*  5 Power Management Controller */
+  void* pfnEFC_Handler;    /*  6 Enhanced Embedded Flash Controller */
+  void* pfnUART0_Handler;  /*  7 UART 0 */
+  void* pvReserved8;
+  void* pfnPIOA_Handler;   /*  9 Parallel I/O Controller A */
+  void* pfnPIOB_Handler;   /* 10 Parallel I/O Controller B */
+  void* pfnPIOC_Handler;   /* 11 Parallel I/O Controller C */
+  void* pfnPIOD_Handler;   /* 12 Parallel I/O Controller D */
+  void* pfnPIOE_Handler;   /* 13 Parallel I/O Controller E */
+  void* pfnUSART0_Handler; /* 14 USART 0 */
+  void* pfnUSART1_Handler; /* 15 USART 1 */
+  void* pfnHSMCI_Handler;  /* 16 Multimedia Card Interface */
+  void* pfnTWI0_Handler;   /* 17 Two Wire Interface 0 */
+  void* pfnTWI1_Handler;   /* 18 Two Wire Interface 1 */
+  void* pfnSPI_Handler;    /* 19 Serial Peripheral Interface */
+  void* pfnDMAC_Handler;   /* 20 DMAC */
+  void* pfnTC0_Handler;    /* 21 Timer/Counter 0 */
+  void* pfnTC1_Handler;    /* 22 Timer/Counter 1 */
+  void* pfnTC2_Handler;    /* 23 Timer/Counter 2 */
+  void* pfnTC3_Handler;    /* 24 Timer/Counter 3 */
+  void* pfnTC4_Handler;    /* 25 Timer/Counter 4 */
+  void* pfnTC5_Handler;    /* 26 Timer/Counter 5 */
+  void* pfnTC6_Handler;    /* 27 Timer/Counter 6 */
+  void* pfnTC7_Handler;    /* 28 Timer/Counter 7 */
+  void* pfnTC8_Handler;    /* 29 Timer/Counter 8 */
+  void* pfnAFEC0_Handler;  /* 30 Analog Front End 0 */
+  void* pfnAFEC1_Handler;  /* 31 Analog Front End 1 */
+  void* pfnDACC_Handler;   /* 32 Digital To Analog Converter */
+  void* pfnACC_Handler;    /* 33 Analog Comparator */
+  void* pfnARM_Handler;    /* 34 FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC */
+  void* pfnUDP_Handler;    /* 35 USB DEVICE */
+  void* pfnPWM_Handler;    /* 36 PWM */
+  void* pfnCAN0_Handler;   /* 37 CAN0 */
+  void* pfnCAN1_Handler;   /* 38 CAN1 */
+  void* pfnAES_Handler;    /* 39 AES */
+  void* pvReserved40;
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pvReserved43;
+  void* pfnGMAC_Handler;   /* 44 EMAC */
+  void* pfnUART1_Handler;  /* 45 UART */
+} DeviceVectors;
+
+/* Cortex-M4 core handlers */
+void Reset_Handler      ( void );
+void NMI_Handler        ( void );
+void HardFault_Handler  ( void );
+void MemManage_Handler  ( void );
+void BusFault_Handler   ( void );
+void UsageFault_Handler ( void );
+void SVC_Handler        ( void );
+void DebugMon_Handler   ( void );
+void PendSV_Handler     ( void );
+void SysTick_Handler    ( void );
+
+/* Peripherals handlers */
+void ACC_Handler        ( void );
+void AES_Handler        ( void );
+void AFEC0_Handler      ( void );
+void AFEC1_Handler      ( void );
+void ARM_Handler        ( void );
+void CAN0_Handler       ( void );
+void CAN1_Handler       ( void );
+void DACC_Handler       ( void );
+void DMAC_Handler       ( void );
+void EFC_Handler        ( void );
+void GMAC_Handler       ( void );
+void HSMCI_Handler      ( void );
+void PIOA_Handler       ( void );
+void PIOB_Handler       ( void );
+void PIOC_Handler       ( void );
+void PIOD_Handler       ( void );
+void PIOE_Handler       ( void );
+void PMC_Handler        ( void );
+void PWM_Handler        ( void );
+void RSTC_Handler       ( void );
+void RTC_Handler        ( void );
+void RTT_Handler        ( void );
+void SPI_Handler        ( void );
+void SUPC_Handler       ( void );
+void TC0_Handler        ( void );
+void TC1_Handler        ( void );
+void TC2_Handler        ( void );
+void TC3_Handler        ( void );
+void TC4_Handler        ( void );
+void TC5_Handler        ( void );
+void TC6_Handler        ( void );
+void TC7_Handler        ( void );
+void TC8_Handler        ( void );
+void TWI0_Handler       ( void );
+void TWI1_Handler       ( void );
+void UART0_Handler      ( void );
+void UART1_Handler      ( void );
+void UDP_Handler        ( void );
+void USART0_Handler     ( void );
+void USART1_Handler     ( void );
+void WDT_Handler        ( void );
+
+/**
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ */
+
+#define __CM4_REV              0x0000 /**< SAM4E16C core revision number ([15:8] revision number, [7:0] patch number) */
+#define __MPU_PRESENT          0      /**< SAM4E16C does not provide a MPU */
+#define __FPU_PRESENT          1      /**< SAM4E16C does provide a FPU */
+#define __NVIC_PRIO_BITS       4      /**< SAM4E16C uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */
+
+/*
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4e.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_api Peripheral Software API */
+/*@{*/
+
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/can.h"
+#include "component/chipid.h"
+#include "component/cmcc.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/dmac.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/matrix.h"
+#include "component/pdc.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/twi.h"
+#include "component/uart.h"
+#include "component/udp.h"
+#include "component/usart.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/pwm.h"
+#include "instance/aes.h"
+#include "instance/can0.h"
+#include "instance/can1.h"
+#include "instance/gmac.h"
+#include "instance/crccu.h"
+#include "instance/uart1.h"
+#include "instance/hsmci.h"
+#include "instance/udp.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/twi0.h"
+#include "instance/twi1.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/dacc.h"
+#include "instance/acc.h"
+#include "instance/dmac.h"
+#include "instance/cmcc.h"
+#include "instance/matrix.h"
+#include "instance/pmc.h"
+#include "instance/uart0.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/rstc.h"
+#include "instance/supc.h"
+#include "instance/rtt.h"
+#include "instance/wdt.h"
+#include "instance/rtc.h"
+#include "instance/gpbr.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   PERIPHERAL ID DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_id Peripheral Ids Definitions */
+/*@{*/
+
+#define ID_SUPC   ( 0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC   ( 1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC    ( 2) /**< \brief Real Time Clock (RTC) */
+#define ID_RTT    ( 3) /**< \brief Real Time Timer (RTT) */
+#define ID_WDT    ( 4) /**< \brief Watchdog/Dual Watchdog Timer (WDT) */
+#define ID_PMC    ( 5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC    ( 6) /**< \brief Enhanced Embedded Flash Controller (EFC) */
+#define ID_UART0  ( 7) /**< \brief UART 0 (UART0) */
+#define ID_PIOA   ( 9) /**< \brief Parallel I/O Controller A (PIOA) */
+#define ID_PIOB   (10) /**< \brief Parallel I/O Controller B (PIOB) */
+#define ID_PIOC   (11) /**< \brief Parallel I/O Controller C (PIOC) */
+#define ID_PIOD   (12) /**< \brief Parallel I/O Controller D (PIOD) */
+#define ID_PIOE   (13) /**< \brief Parallel I/O Controller E (PIOE) */
+#define ID_USART0 (14) /**< \brief USART 0 (USART0) */
+#define ID_USART1 (15) /**< \brief USART 1 (USART1) */
+#define ID_HSMCI  (16) /**< \brief Multimedia Card Interface (HSMCI) */
+#define ID_TWI0   (17) /**< \brief Two Wire Interface 0 (TWI0) */
+#define ID_TWI1   (18) /**< \brief Two Wire Interface 1 (TWI1) */
+#define ID_SPI    (19) /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_DMAC   (20) /**< \brief DMAC (DMAC) */
+#define ID_TC0    (21) /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1    (22) /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TC2    (23) /**< \brief Timer/Counter 2 (TC2) */
+#define ID_TC3    (24) /**< \brief Timer/Counter 3 (TC3) */
+#define ID_TC4    (25) /**< \brief Timer/Counter 4 (TC4) */
+#define ID_TC5    (26) /**< \brief Timer/Counter 5 (TC5) */
+#define ID_TC6    (27) /**< \brief Timer/Counter 6 (TC6) */
+#define ID_TC7    (28) /**< \brief Timer/Counter 7 (TC7) */
+#define ID_TC8    (29) /**< \brief Timer/Counter 8 (TC8) */
+#define ID_AFEC0  (30) /**< \brief Analog Front End 0 (AFEC0) */
+#define ID_AFEC1  (31) /**< \brief Analog Front End 1 (AFEC1) */
+#define ID_DACC   (32) /**< \brief Digital To Analog Converter (DACC) */
+#define ID_ACC    (33) /**< \brief Analog Comparator (ACC) */
+#define ID_ARM    (34) /**< \brief FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+#define ID_UDP    (35) /**< \brief USB DEVICE (UDP) */
+#define ID_PWM    (36) /**< \brief PWM (PWM) */
+#define ID_CAN0   (37) /**< \brief CAN0 (CAN0) */
+#define ID_CAN1   (38) /**< \brief CAN1 (CAN1) */
+#define ID_AES    (39) /**< \brief AES (AES) */
+#define ID_GMAC   (44) /**< \brief EMAC (GMAC) */
+#define ID_UART1  (45) /**< \brief UART (UART1) */
+
+#define ID_PERIPH_COUNT (46) /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define PWM        (0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    (0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        (0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       (0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       (0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       (0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      (0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define UART1      (0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  (0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      (0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  (0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        (0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        (0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    (0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        (0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    (0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        (0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    (0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        (0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     (0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 (0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     (0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 (0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       (0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   (0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       (0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   (0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      (0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  (0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      (0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  (0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       (0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   (0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        (0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       (0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       (0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     (0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        (0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      (0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  (0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     (0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        (0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       (0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   (0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       (0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       (0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       (0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       (0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       (0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       (0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        (0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        (0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        (0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       (0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#else
+#define PWM        ((Pwm    *)0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    ((Pdc    *)0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        ((Aes    *)0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       ((Can    *)0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       ((Can    *)0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       ((Gmac   *)0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      ((Crccu  *)0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define UART1      ((Uart   *)0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  ((Pdc    *)0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      ((Hsmci  *)0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  ((Pdc    *)0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        ((Udp    *)0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        ((Spi    *)0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    ((Pdc    *)0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        ((Tc     *)0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    ((Pdc    *)0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        ((Tc     *)0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    ((Pdc    *)0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        ((Tc     *)0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     ((Usart  *)0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 ((Pdc    *)0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     ((Usart  *)0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 ((Pdc    *)0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       ((Twi    *)0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   ((Pdc    *)0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       ((Twi    *)0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   ((Pdc    *)0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      ((Afec   *)0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  ((Pdc    *)0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      ((Afec   *)0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  ((Pdc    *)0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       ((Dacc   *)0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   ((Pdc    *)0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        ((Acc    *)0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       ((Dmac   *)0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       ((Cmcc   *)0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     ((Matrix *)0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        ((Pmc    *)0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      ((Uart   *)0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  ((Pdc    *)0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     ((Chipid *)0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        ((Efc    *)0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       ((Pio    *)0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   ((Pdc    *)0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       ((Pio    *)0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       ((Pio    *)0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       ((Pio    *)0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       ((Pio    *)0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       ((Rstc   *)0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       ((Supc   *)0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        ((Rtt    *)0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        ((Wdt    *)0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        ((Rtc    *)0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       ((Gpbr   *)0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16C_pio Peripheral Pio Definitions */
+/*@{*/
+
+#include "pio/sam4e16c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+
+#define IFLASH_SIZE             (0x100000u)
+#define IFLASH_PAGE_SIZE        (512u)
+#define IFLASH_LOCK_REGION_SIZE (8192u)
+#define IFLASH_NB_OF_PAGES      (2048u)
+#define IFLASH_NB_OF_LOCK_BITS  (128u)
+#define IRAM_SIZE               (0x20000u)
+
+#define IFLASH_ADDR  (0x00400000u) /**< Internal Flash base address */
+#define IROM_ADDR    (0x00800000u) /**< Internal ROM base address */
+#define IRAM_ADDR    (0x20000000u) /**< Internal RAM base address */
+#define EBI_CS0_ADDR (0x60000000u) /**< EBI Chip Select 0 base address */
+#define EBI_CS1_ADDR (0x61000000u) /**< EBI Chip Select 1 base address */
+#define EBI_CS2_ADDR (0x62000000u) /**< EBI Chip Select 2 base address */
+#define EBI_CS3_ADDR (0x63000000u) /**< EBI Chip Select 3 base address */
+
+/* ************************************************************************** */
+/*   MISCELLANEOUS DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+
+#define CHIP_JTAGID (0x05B3703FUL)
+#define CHIP_CIDR (0xA3CC0CE0UL)
+#define CHIP_EXID (0x00110201UL)
+
+/* ************************************************************************** */
+/*   ELECTRICAL DEFINITIONS FOR SAM4E16C */
+/* ************************************************************************** */
+
+/* Device characteristics */
+#define CHIP_FREQ_SLCK_RC_MIN           (20000UL)
+#define CHIP_FREQ_SLCK_RC               (32000UL)
+#define CHIP_FREQ_SLCK_RC_MAX           (44000UL)
+#define CHIP_FREQ_MAINCK_RC_4MHZ        (4000000UL)
+#define CHIP_FREQ_MAINCK_RC_8MHZ        (8000000UL)
+#define CHIP_FREQ_MAINCK_RC_12MHZ       (12000000UL)
+#define CHIP_FREQ_CPU_MAX               (120000000UL)
+#define CHIP_FREQ_XTAL_32K              (32768UL)
+#define CHIP_FREQ_XTAL_12M              (12000000UL)
+
+/* Embedded Flash Write Wait State */
+#define CHIP_FLASH_WRITE_WAIT_STATE     (6U)
+
+/* Embedded Flash Read Wait State (VDDCORE set at 1.20V) */
+#define CHIP_FREQ_FWS_0                 (20000000UL)  /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1                 (40000000UL)  /**< \brief Maximum operating frequency when FWS is 1 */
+#define CHIP_FREQ_FWS_2                 (60000000UL)  /**< \brief Maximum operating frequency when FWS is 2 */
+#define CHIP_FREQ_FWS_3                 (80000000UL)  /**< \brief Maximum operating frequency when FWS is 3 */
+#define CHIP_FREQ_FWS_4                 (100000000UL) /**< \brief Maximum operating frequency when FWS is 4 */
+#define CHIP_FREQ_FWS_5                 (123000000UL) /**< \brief Maximum operating frequency when FWS is 5 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* _SAM4E16C_ */

--- a/asf/sam/include/sam4e/sam4e16e.h
+++ b/asf/sam/include/sam4e/sam4e16e.h
@@ -1,0 +1,596 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E16E_
+#define _SAM4E16E_
+
+/** \addtogroup SAM4E16E_definitions SAM4E16E definitions
+  This file defines all structures and symbols for SAM4E16E:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg; /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg; /**< Read-Write 32-bit register (volatile unsigned int) */
+#endif
+
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_cmsis CMSIS Definitions */
+/*@{*/
+
+/**< Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,  /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,  /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
+/******  SAM4E16E specific Interrupt Numbers *********************************/
+  
+  SUPC_IRQn            =  0, /**<  0 SAM4E16E Supply Controller (SUPC) */
+  RSTC_IRQn            =  1, /**<  1 SAM4E16E Reset Controller (RSTC) */
+  RTC_IRQn             =  2, /**<  2 SAM4E16E Real Time Clock (RTC) */
+  RTT_IRQn             =  3, /**<  3 SAM4E16E Real Time Timer (RTT) */
+  WDT_IRQn             =  4, /**<  4 SAM4E16E Watchdog/Dual Watchdog Timer (WDT) */
+  PMC_IRQn             =  5, /**<  5 SAM4E16E Power Management Controller (PMC) */
+  EFC_IRQn             =  6, /**<  6 SAM4E16E Enhanced Embedded Flash Controller (EFC) */
+  UART0_IRQn           =  7, /**<  7 SAM4E16E UART 0 (UART0) */
+  PIOA_IRQn            =  9, /**<  9 SAM4E16E Parallel I/O Controller A (PIOA) */
+  PIOB_IRQn            = 10, /**< 10 SAM4E16E Parallel I/O Controller B (PIOB) */
+  PIOC_IRQn            = 11, /**< 11 SAM4E16E Parallel I/O Controller C (PIOC) */
+  PIOD_IRQn            = 12, /**< 12 SAM4E16E Parallel I/O Controller D (PIOD) */
+  PIOE_IRQn            = 13, /**< 13 SAM4E16E Parallel I/O Controller E (PIOE) */
+  USART0_IRQn          = 14, /**< 14 SAM4E16E USART 0 (USART0) */
+  USART1_IRQn          = 15, /**< 15 SAM4E16E USART 1 (USART1) */
+  HSMCI_IRQn           = 16, /**< 16 SAM4E16E Multimedia Card Interface (HSMCI) */
+  TWI0_IRQn            = 17, /**< 17 SAM4E16E Two Wire Interface 0 (TWI0) */
+  TWI1_IRQn            = 18, /**< 18 SAM4E16E Two Wire Interface 1 (TWI1) */
+  SPI_IRQn             = 19, /**< 19 SAM4E16E Serial Peripheral Interface (SPI) */
+  DMAC_IRQn            = 20, /**< 20 SAM4E16E DMAC (DMAC) */
+  TC0_IRQn             = 21, /**< 21 SAM4E16E Timer/Counter 0 (TC0) */
+  TC1_IRQn             = 22, /**< 22 SAM4E16E Timer/Counter 1 (TC1) */
+  TC2_IRQn             = 23, /**< 23 SAM4E16E Timer/Counter 2 (TC2) */
+  TC3_IRQn             = 24, /**< 24 SAM4E16E Timer/Counter 3 (TC3) */
+  TC4_IRQn             = 25, /**< 25 SAM4E16E Timer/Counter 4 (TC4) */
+  TC5_IRQn             = 26, /**< 26 SAM4E16E Timer/Counter 5 (TC5) */
+  TC6_IRQn             = 27, /**< 27 SAM4E16E Timer/Counter 6 (TC6) */
+  TC7_IRQn             = 28, /**< 28 SAM4E16E Timer/Counter 7 (TC7) */
+  TC8_IRQn             = 29, /**< 29 SAM4E16E Timer/Counter 8 (TC8) */
+  AFEC0_IRQn           = 30, /**< 30 SAM4E16E Analog Front End 0 (AFEC0) */
+  AFEC1_IRQn           = 31, /**< 31 SAM4E16E Analog Front End 1 (AFEC1) */
+  DACC_IRQn            = 32, /**< 32 SAM4E16E Digital To Analog Converter (DACC) */
+  ACC_IRQn             = 33, /**< 33 SAM4E16E Analog Comparator (ACC) */
+  ARM_IRQn             = 34, /**< 34 SAM4E16E FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+  UDP_IRQn             = 35, /**< 35 SAM4E16E USB DEVICE (UDP) */
+  PWM_IRQn             = 36, /**< 36 SAM4E16E PWM (PWM) */
+  CAN0_IRQn            = 37, /**< 37 SAM4E16E CAN0 (CAN0) */
+  CAN1_IRQn            = 38, /**< 38 SAM4E16E CAN1 (CAN1) */
+  AES_IRQn             = 39, /**< 39 SAM4E16E AES (AES) */
+  GMAC_IRQn            = 44, /**< 44 SAM4E16E EMAC (GMAC) */
+  UART1_IRQn           = 45, /**< 45 SAM4E16E UART (UART1) */
+
+  PERIPH_COUNT_IRQn    = 46  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pfnReserved1_Handler;
+  void* pfnReserved2_Handler;
+  void* pfnReserved3_Handler;
+  void* pfnReserved4_Handler;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pfnReserved5_Handler;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;   /*  0 Supply Controller */
+  void* pfnRSTC_Handler;   /*  1 Reset Controller */
+  void* pfnRTC_Handler;    /*  2 Real Time Clock */
+  void* pfnRTT_Handler;    /*  3 Real Time Timer */
+  void* pfnWDT_Handler;    /*  4 Watchdog/Dual Watchdog Timer */
+  void* pfnPMC_Handler;    /*  5 Power Management Controller */
+  void* pfnEFC_Handler;    /*  6 Enhanced Embedded Flash Controller */
+  void* pfnUART0_Handler;  /*  7 UART 0 */
+  void* pvReserved8;
+  void* pfnPIOA_Handler;   /*  9 Parallel I/O Controller A */
+  void* pfnPIOB_Handler;   /* 10 Parallel I/O Controller B */
+  void* pfnPIOC_Handler;   /* 11 Parallel I/O Controller C */
+  void* pfnPIOD_Handler;   /* 12 Parallel I/O Controller D */
+  void* pfnPIOE_Handler;   /* 13 Parallel I/O Controller E */
+  void* pfnUSART0_Handler; /* 14 USART 0 */
+  void* pfnUSART1_Handler; /* 15 USART 1 */
+  void* pfnHSMCI_Handler;  /* 16 Multimedia Card Interface */
+  void* pfnTWI0_Handler;   /* 17 Two Wire Interface 0 */
+  void* pfnTWI1_Handler;   /* 18 Two Wire Interface 1 */
+  void* pfnSPI_Handler;    /* 19 Serial Peripheral Interface */
+  void* pfnDMAC_Handler;   /* 20 DMAC */
+  void* pfnTC0_Handler;    /* 21 Timer/Counter 0 */
+  void* pfnTC1_Handler;    /* 22 Timer/Counter 1 */
+  void* pfnTC2_Handler;    /* 23 Timer/Counter 2 */
+  void* pfnTC3_Handler;    /* 24 Timer/Counter 3 */
+  void* pfnTC4_Handler;    /* 25 Timer/Counter 4 */
+  void* pfnTC5_Handler;    /* 26 Timer/Counter 5 */
+  void* pfnTC6_Handler;    /* 27 Timer/Counter 6 */
+  void* pfnTC7_Handler;    /* 28 Timer/Counter 7 */
+  void* pfnTC8_Handler;    /* 29 Timer/Counter 8 */
+  void* pfnAFEC0_Handler;  /* 30 Analog Front End 0 */
+  void* pfnAFEC1_Handler;  /* 31 Analog Front End 1 */
+  void* pfnDACC_Handler;   /* 32 Digital To Analog Converter */
+  void* pfnACC_Handler;    /* 33 Analog Comparator */
+  void* pfnARM_Handler;    /* 34 FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC */
+  void* pfnUDP_Handler;    /* 35 USB DEVICE */
+  void* pfnPWM_Handler;    /* 36 PWM */
+  void* pfnCAN0_Handler;   /* 37 CAN0 */
+  void* pfnCAN1_Handler;   /* 38 CAN1 */
+  void* pfnAES_Handler;    /* 39 AES */
+  void* pvReserved40;
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pvReserved43;
+  void* pfnGMAC_Handler;   /* 44 EMAC */
+  void* pfnUART1_Handler;  /* 45 UART */
+} DeviceVectors;
+
+/* Cortex-M4 core handlers */
+void Reset_Handler      ( void );
+void NMI_Handler        ( void );
+void HardFault_Handler  ( void );
+void MemManage_Handler  ( void );
+void BusFault_Handler   ( void );
+void UsageFault_Handler ( void );
+void SVC_Handler        ( void );
+void DebugMon_Handler   ( void );
+void PendSV_Handler     ( void );
+void SysTick_Handler    ( void );
+
+/* Peripherals handlers */
+void ACC_Handler        ( void );
+void AES_Handler        ( void );
+void AFEC0_Handler      ( void );
+void AFEC1_Handler      ( void );
+void ARM_Handler        ( void );
+void CAN0_Handler       ( void );
+void CAN1_Handler       ( void );
+void DACC_Handler       ( void );
+void DMAC_Handler       ( void );
+void EFC_Handler        ( void );
+void GMAC_Handler       ( void );
+void HSMCI_Handler      ( void );
+void PIOA_Handler       ( void );
+void PIOB_Handler       ( void );
+void PIOC_Handler       ( void );
+void PIOD_Handler       ( void );
+void PIOE_Handler       ( void );
+void PMC_Handler        ( void );
+void PWM_Handler        ( void );
+void RSTC_Handler       ( void );
+void RTC_Handler        ( void );
+void RTT_Handler        ( void );
+void SPI_Handler        ( void );
+void SUPC_Handler       ( void );
+void TC0_Handler        ( void );
+void TC1_Handler        ( void );
+void TC2_Handler        ( void );
+void TC3_Handler        ( void );
+void TC4_Handler        ( void );
+void TC5_Handler        ( void );
+void TC6_Handler        ( void );
+void TC7_Handler        ( void );
+void TC8_Handler        ( void );
+void TWI0_Handler       ( void );
+void TWI1_Handler       ( void );
+void UART0_Handler      ( void );
+void UART1_Handler      ( void );
+void UDP_Handler        ( void );
+void USART0_Handler     ( void );
+void USART1_Handler     ( void );
+void WDT_Handler        ( void );
+
+/**
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ */
+
+#define __CM4_REV              0x0000 /**< SAM4E16E core revision number ([15:8] revision number, [7:0] patch number) */
+#define __MPU_PRESENT          0      /**< SAM4E16E does not provide a MPU */
+#define __FPU_PRESENT          1      /**< SAM4E16E does provide a FPU */
+#define __NVIC_PRIO_BITS       4      /**< SAM4E16E uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */
+
+/*
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4e.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_api Peripheral Software API */
+/*@{*/
+
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/can.h"
+#include "component/chipid.h"
+#include "component/cmcc.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/dmac.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/matrix.h"
+#include "component/pdc.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/twi.h"
+#include "component/uart.h"
+#include "component/udp.h"
+#include "component/usart.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/pwm.h"
+#include "instance/aes.h"
+#include "instance/can0.h"
+#include "instance/can1.h"
+#include "instance/gmac.h"
+#include "instance/crccu.h"
+#include "instance/smc.h"
+#include "instance/uart1.h"
+#include "instance/hsmci.h"
+#include "instance/udp.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/twi0.h"
+#include "instance/twi1.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/dacc.h"
+#include "instance/acc.h"
+#include "instance/dmac.h"
+#include "instance/cmcc.h"
+#include "instance/matrix.h"
+#include "instance/pmc.h"
+#include "instance/uart0.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/rstc.h"
+#include "instance/supc.h"
+#include "instance/rtt.h"
+#include "instance/wdt.h"
+#include "instance/rtc.h"
+#include "instance/gpbr.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   PERIPHERAL ID DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_id Peripheral Ids Definitions */
+/*@{*/
+
+#define ID_SUPC   ( 0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC   ( 1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC    ( 2) /**< \brief Real Time Clock (RTC) */
+#define ID_RTT    ( 3) /**< \brief Real Time Timer (RTT) */
+#define ID_WDT    ( 4) /**< \brief Watchdog/Dual Watchdog Timer (WDT) */
+#define ID_PMC    ( 5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC    ( 6) /**< \brief Enhanced Embedded Flash Controller (EFC) */
+#define ID_UART0  ( 7) /**< \brief UART 0 (UART0) */
+#define ID_SMC    ( 8) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA   ( 9) /**< \brief Parallel I/O Controller A (PIOA) */
+#define ID_PIOB   (10) /**< \brief Parallel I/O Controller B (PIOB) */
+#define ID_PIOC   (11) /**< \brief Parallel I/O Controller C (PIOC) */
+#define ID_PIOD   (12) /**< \brief Parallel I/O Controller D (PIOD) */
+#define ID_PIOE   (13) /**< \brief Parallel I/O Controller E (PIOE) */
+#define ID_USART0 (14) /**< \brief USART 0 (USART0) */
+#define ID_USART1 (15) /**< \brief USART 1 (USART1) */
+#define ID_HSMCI  (16) /**< \brief Multimedia Card Interface (HSMCI) */
+#define ID_TWI0   (17) /**< \brief Two Wire Interface 0 (TWI0) */
+#define ID_TWI1   (18) /**< \brief Two Wire Interface 1 (TWI1) */
+#define ID_SPI    (19) /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_DMAC   (20) /**< \brief DMAC (DMAC) */
+#define ID_TC0    (21) /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1    (22) /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TC2    (23) /**< \brief Timer/Counter 2 (TC2) */
+#define ID_TC3    (24) /**< \brief Timer/Counter 3 (TC3) */
+#define ID_TC4    (25) /**< \brief Timer/Counter 4 (TC4) */
+#define ID_TC5    (26) /**< \brief Timer/Counter 5 (TC5) */
+#define ID_TC6    (27) /**< \brief Timer/Counter 6 (TC6) */
+#define ID_TC7    (28) /**< \brief Timer/Counter 7 (TC7) */
+#define ID_TC8    (29) /**< \brief Timer/Counter 8 (TC8) */
+#define ID_AFEC0  (30) /**< \brief Analog Front End 0 (AFEC0) */
+#define ID_AFEC1  (31) /**< \brief Analog Front End 1 (AFEC1) */
+#define ID_DACC   (32) /**< \brief Digital To Analog Converter (DACC) */
+#define ID_ACC    (33) /**< \brief Analog Comparator (ACC) */
+#define ID_ARM    (34) /**< \brief FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+#define ID_UDP    (35) /**< \brief USB DEVICE (UDP) */
+#define ID_PWM    (36) /**< \brief PWM (PWM) */
+#define ID_CAN0   (37) /**< \brief CAN0 (CAN0) */
+#define ID_CAN1   (38) /**< \brief CAN1 (CAN1) */
+#define ID_AES    (39) /**< \brief AES (AES) */
+#define ID_GMAC   (44) /**< \brief EMAC (GMAC) */
+#define ID_UART1  (45) /**< \brief UART (UART1) */
+
+#define ID_PERIPH_COUNT (46) /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define PWM        (0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    (0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        (0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       (0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       (0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       (0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      (0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define SMC        (0x40060000U) /**< \brief (SMC       ) Base Address */
+#define UART1      (0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  (0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      (0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  (0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        (0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        (0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    (0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        (0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    (0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        (0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    (0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        (0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     (0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 (0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     (0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 (0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       (0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   (0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       (0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   (0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      (0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  (0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      (0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  (0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       (0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   (0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        (0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       (0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       (0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     (0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        (0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      (0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  (0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     (0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        (0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       (0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   (0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       (0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       (0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       (0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       (0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       (0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       (0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        (0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        (0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        (0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       (0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#else
+#define PWM        ((Pwm    *)0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    ((Pdc    *)0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        ((Aes    *)0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       ((Can    *)0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       ((Can    *)0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       ((Gmac   *)0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      ((Crccu  *)0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define SMC        ((Smc    *)0x40060000U) /**< \brief (SMC       ) Base Address */
+#define UART1      ((Uart   *)0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  ((Pdc    *)0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      ((Hsmci  *)0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  ((Pdc    *)0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        ((Udp    *)0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        ((Spi    *)0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    ((Pdc    *)0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        ((Tc     *)0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    ((Pdc    *)0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        ((Tc     *)0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    ((Pdc    *)0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        ((Tc     *)0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     ((Usart  *)0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 ((Pdc    *)0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     ((Usart  *)0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 ((Pdc    *)0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       ((Twi    *)0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   ((Pdc    *)0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       ((Twi    *)0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   ((Pdc    *)0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      ((Afec   *)0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  ((Pdc    *)0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      ((Afec   *)0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  ((Pdc    *)0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       ((Dacc   *)0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   ((Pdc    *)0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        ((Acc    *)0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       ((Dmac   *)0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       ((Cmcc   *)0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     ((Matrix *)0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        ((Pmc    *)0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      ((Uart   *)0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  ((Pdc    *)0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     ((Chipid *)0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        ((Efc    *)0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       ((Pio    *)0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   ((Pdc    *)0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       ((Pio    *)0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       ((Pio    *)0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       ((Pio    *)0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       ((Pio    *)0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       ((Rstc   *)0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       ((Supc   *)0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        ((Rtt    *)0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        ((Wdt    *)0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        ((Rtc    *)0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       ((Gpbr   *)0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E16E_pio Peripheral Pio Definitions */
+/*@{*/
+
+#include "pio/sam4e16e.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+
+#define IFLASH_SIZE             (0x100000u)
+#define IFLASH_PAGE_SIZE        (512u)
+#define IFLASH_LOCK_REGION_SIZE (8192u)
+#define IFLASH_NB_OF_PAGES      (2048u)
+#define IFLASH_NB_OF_LOCK_BITS  (128u)
+#define IRAM_SIZE               (0x20000u)
+
+#define IFLASH_ADDR  (0x00400000u) /**< Internal Flash base address */
+#define IROM_ADDR    (0x00800000u) /**< Internal ROM base address */
+#define IRAM_ADDR    (0x20000000u) /**< Internal RAM base address */
+#define EBI_CS0_ADDR (0x60000000u) /**< EBI Chip Select 0 base address */
+#define EBI_CS1_ADDR (0x61000000u) /**< EBI Chip Select 1 base address */
+#define EBI_CS2_ADDR (0x62000000u) /**< EBI Chip Select 2 base address */
+#define EBI_CS3_ADDR (0x63000000u) /**< EBI Chip Select 3 base address */
+
+/* ************************************************************************** */
+/*   MISCELLANEOUS DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+
+#define CHIP_JTAGID (0x05B3703FUL)
+#define CHIP_CIDR (0xA3CC0CE0UL)
+#define CHIP_EXID (0x00120200UL)
+
+/* ************************************************************************** */
+/*   ELECTRICAL DEFINITIONS FOR SAM4E16E */
+/* ************************************************************************** */
+
+/* Device characteristics */
+#define CHIP_FREQ_SLCK_RC_MIN           (20000UL)
+#define CHIP_FREQ_SLCK_RC               (32000UL)
+#define CHIP_FREQ_SLCK_RC_MAX           (44000UL)
+#define CHIP_FREQ_MAINCK_RC_4MHZ        (4000000UL)
+#define CHIP_FREQ_MAINCK_RC_8MHZ        (8000000UL)
+#define CHIP_FREQ_MAINCK_RC_12MHZ       (12000000UL)
+#define CHIP_FREQ_CPU_MAX               (120000000UL)
+#define CHIP_FREQ_XTAL_32K              (32768UL)
+#define CHIP_FREQ_XTAL_12M              (12000000UL)
+
+/* Embedded Flash Write Wait State */
+#define CHIP_FLASH_WRITE_WAIT_STATE     (6U)
+
+/* Embedded Flash Read Wait State (VDDCORE set at 1.20V) */
+#define CHIP_FREQ_FWS_0                 (20000000UL)  /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1                 (40000000UL)  /**< \brief Maximum operating frequency when FWS is 1 */
+#define CHIP_FREQ_FWS_2                 (60000000UL)  /**< \brief Maximum operating frequency when FWS is 2 */
+#define CHIP_FREQ_FWS_3                 (80000000UL)  /**< \brief Maximum operating frequency when FWS is 3 */
+#define CHIP_FREQ_FWS_4                 (100000000UL) /**< \brief Maximum operating frequency when FWS is 4 */
+#define CHIP_FREQ_FWS_5                 (123000000UL) /**< \brief Maximum operating frequency when FWS is 5 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* _SAM4E16E_ */

--- a/asf/sam/include/sam4e/sam4e8c.h
+++ b/asf/sam/include/sam4e/sam4e8c.h
@@ -1,0 +1,591 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E8C_
+#define _SAM4E8C_
+
+/** \addtogroup SAM4E8C_definitions SAM4E8C definitions
+  This file defines all structures and symbols for SAM4E8C:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg; /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg; /**< Read-Write 32-bit register (volatile unsigned int) */
+#endif
+
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_cmsis CMSIS Definitions */
+/*@{*/
+
+/**< Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,  /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,  /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
+/******  SAM4E8C specific Interrupt Numbers *********************************/
+  
+  SUPC_IRQn            =  0, /**<  0 SAM4E8C Supply Controller (SUPC) */
+  RSTC_IRQn            =  1, /**<  1 SAM4E8C Reset Controller (RSTC) */
+  RTC_IRQn             =  2, /**<  2 SAM4E8C Real Time Clock (RTC) */
+  RTT_IRQn             =  3, /**<  3 SAM4E8C Real Time Timer (RTT) */
+  WDT_IRQn             =  4, /**<  4 SAM4E8C Watchdog/Dual Watchdog Timer (WDT) */
+  PMC_IRQn             =  5, /**<  5 SAM4E8C Power Management Controller (PMC) */
+  EFC_IRQn             =  6, /**<  6 SAM4E8C Enhanced Embedded Flash Controller (EFC) */
+  UART0_IRQn           =  7, /**<  7 SAM4E8C UART 0 (UART0) */
+  PIOA_IRQn            =  9, /**<  9 SAM4E8C Parallel I/O Controller A (PIOA) */
+  PIOB_IRQn            = 10, /**< 10 SAM4E8C Parallel I/O Controller B (PIOB) */
+  PIOC_IRQn            = 11, /**< 11 SAM4E8C Parallel I/O Controller C (PIOC) */
+  PIOD_IRQn            = 12, /**< 12 SAM4E8C Parallel I/O Controller D (PIOD) */
+  PIOE_IRQn            = 13, /**< 13 SAM4E8C Parallel I/O Controller E (PIOE) */
+  USART0_IRQn          = 14, /**< 14 SAM4E8C USART 0 (USART0) */
+  USART1_IRQn          = 15, /**< 15 SAM4E8C USART 1 (USART1) */
+  HSMCI_IRQn           = 16, /**< 16 SAM4E8C Multimedia Card Interface (HSMCI) */
+  TWI0_IRQn            = 17, /**< 17 SAM4E8C Two Wire Interface 0 (TWI0) */
+  TWI1_IRQn            = 18, /**< 18 SAM4E8C Two Wire Interface 1 (TWI1) */
+  SPI_IRQn             = 19, /**< 19 SAM4E8C Serial Peripheral Interface (SPI) */
+  DMAC_IRQn            = 20, /**< 20 SAM4E8C DMAC (DMAC) */
+  TC0_IRQn             = 21, /**< 21 SAM4E8C Timer/Counter 0 (TC0) */
+  TC1_IRQn             = 22, /**< 22 SAM4E8C Timer/Counter 1 (TC1) */
+  TC2_IRQn             = 23, /**< 23 SAM4E8C Timer/Counter 2 (TC2) */
+  TC3_IRQn             = 24, /**< 24 SAM4E8C Timer/Counter 3 (TC3) */
+  TC4_IRQn             = 25, /**< 25 SAM4E8C Timer/Counter 4 (TC4) */
+  TC5_IRQn             = 26, /**< 26 SAM4E8C Timer/Counter 5 (TC5) */
+  TC6_IRQn             = 27, /**< 27 SAM4E8C Timer/Counter 6 (TC6) */
+  TC7_IRQn             = 28, /**< 28 SAM4E8C Timer/Counter 7 (TC7) */
+  TC8_IRQn             = 29, /**< 29 SAM4E8C Timer/Counter 8 (TC8) */
+  AFEC0_IRQn           = 30, /**< 30 SAM4E8C Analog Front End 0 (AFEC0) */
+  AFEC1_IRQn           = 31, /**< 31 SAM4E8C Analog Front End 1 (AFEC1) */
+  DACC_IRQn            = 32, /**< 32 SAM4E8C Digital To Analog Converter (DACC) */
+  ACC_IRQn             = 33, /**< 33 SAM4E8C Analog Comparator (ACC) */
+  ARM_IRQn             = 34, /**< 34 SAM4E8C FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+  UDP_IRQn             = 35, /**< 35 SAM4E8C USB DEVICE (UDP) */
+  PWM_IRQn             = 36, /**< 36 SAM4E8C PWM (PWM) */
+  CAN0_IRQn            = 37, /**< 37 SAM4E8C CAN0 (CAN0) */
+  CAN1_IRQn            = 38, /**< 38 SAM4E8C CAN1 (CAN1) */
+  AES_IRQn             = 39, /**< 39 SAM4E8C AES (AES) */
+  GMAC_IRQn            = 44, /**< 44 SAM4E8C EMAC (GMAC) */
+  UART1_IRQn           = 45, /**< 45 SAM4E8C UART (UART1) */
+
+  PERIPH_COUNT_IRQn    = 46  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pfnReserved1_Handler;
+  void* pfnReserved2_Handler;
+  void* pfnReserved3_Handler;
+  void* pfnReserved4_Handler;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pfnReserved5_Handler;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;   /*  0 Supply Controller */
+  void* pfnRSTC_Handler;   /*  1 Reset Controller */
+  void* pfnRTC_Handler;    /*  2 Real Time Clock */
+  void* pfnRTT_Handler;    /*  3 Real Time Timer */
+  void* pfnWDT_Handler;    /*  4 Watchdog/Dual Watchdog Timer */
+  void* pfnPMC_Handler;    /*  5 Power Management Controller */
+  void* pfnEFC_Handler;    /*  6 Enhanced Embedded Flash Controller */
+  void* pfnUART0_Handler;  /*  7 UART 0 */
+  void* pvReserved8;
+  void* pfnPIOA_Handler;   /*  9 Parallel I/O Controller A */
+  void* pfnPIOB_Handler;   /* 10 Parallel I/O Controller B */
+  void* pfnPIOC_Handler;   /* 11 Parallel I/O Controller C */
+  void* pfnPIOD_Handler;   /* 12 Parallel I/O Controller D */
+  void* pfnPIOE_Handler;   /* 13 Parallel I/O Controller E */
+  void* pfnUSART0_Handler; /* 14 USART 0 */
+  void* pfnUSART1_Handler; /* 15 USART 1 */
+  void* pfnHSMCI_Handler;  /* 16 Multimedia Card Interface */
+  void* pfnTWI0_Handler;   /* 17 Two Wire Interface 0 */
+  void* pfnTWI1_Handler;   /* 18 Two Wire Interface 1 */
+  void* pfnSPI_Handler;    /* 19 Serial Peripheral Interface */
+  void* pfnDMAC_Handler;   /* 20 DMAC */
+  void* pfnTC0_Handler;    /* 21 Timer/Counter 0 */
+  void* pfnTC1_Handler;    /* 22 Timer/Counter 1 */
+  void* pfnTC2_Handler;    /* 23 Timer/Counter 2 */
+  void* pfnTC3_Handler;    /* 24 Timer/Counter 3 */
+  void* pfnTC4_Handler;    /* 25 Timer/Counter 4 */
+  void* pfnTC5_Handler;    /* 26 Timer/Counter 5 */
+  void* pfnTC6_Handler;    /* 27 Timer/Counter 6 */
+  void* pfnTC7_Handler;    /* 28 Timer/Counter 7 */
+  void* pfnTC8_Handler;    /* 29 Timer/Counter 8 */
+  void* pfnAFEC0_Handler;  /* 30 Analog Front End 0 */
+  void* pfnAFEC1_Handler;  /* 31 Analog Front End 1 */
+  void* pfnDACC_Handler;   /* 32 Digital To Analog Converter */
+  void* pfnACC_Handler;    /* 33 Analog Comparator */
+  void* pfnARM_Handler;    /* 34 FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC */
+  void* pfnUDP_Handler;    /* 35 USB DEVICE */
+  void* pfnPWM_Handler;    /* 36 PWM */
+  void* pfnCAN0_Handler;   /* 37 CAN0 */
+  void* pfnCAN1_Handler;   /* 38 CAN1 */
+  void* pfnAES_Handler;    /* 39 AES */
+  void* pvReserved40;
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pvReserved43;
+  void* pfnGMAC_Handler;   /* 44 EMAC */
+  void* pfnUART1_Handler;  /* 45 UART */
+} DeviceVectors;
+
+/* Cortex-M4 core handlers */
+void Reset_Handler      ( void );
+void NMI_Handler        ( void );
+void HardFault_Handler  ( void );
+void MemManage_Handler  ( void );
+void BusFault_Handler   ( void );
+void UsageFault_Handler ( void );
+void SVC_Handler        ( void );
+void DebugMon_Handler   ( void );
+void PendSV_Handler     ( void );
+void SysTick_Handler    ( void );
+
+/* Peripherals handlers */
+void ACC_Handler        ( void );
+void AES_Handler        ( void );
+void AFEC0_Handler      ( void );
+void AFEC1_Handler      ( void );
+void ARM_Handler        ( void );
+void CAN0_Handler       ( void );
+void CAN1_Handler       ( void );
+void DACC_Handler       ( void );
+void DMAC_Handler       ( void );
+void EFC_Handler        ( void );
+void GMAC_Handler       ( void );
+void HSMCI_Handler      ( void );
+void PIOA_Handler       ( void );
+void PIOB_Handler       ( void );
+void PIOC_Handler       ( void );
+void PIOD_Handler       ( void );
+void PIOE_Handler       ( void );
+void PMC_Handler        ( void );
+void PWM_Handler        ( void );
+void RSTC_Handler       ( void );
+void RTC_Handler        ( void );
+void RTT_Handler        ( void );
+void SPI_Handler        ( void );
+void SUPC_Handler       ( void );
+void TC0_Handler        ( void );
+void TC1_Handler        ( void );
+void TC2_Handler        ( void );
+void TC3_Handler        ( void );
+void TC4_Handler        ( void );
+void TC5_Handler        ( void );
+void TC6_Handler        ( void );
+void TC7_Handler        ( void );
+void TC8_Handler        ( void );
+void TWI0_Handler       ( void );
+void TWI1_Handler       ( void );
+void UART0_Handler      ( void );
+void UART1_Handler      ( void );
+void UDP_Handler        ( void );
+void USART0_Handler     ( void );
+void USART1_Handler     ( void );
+void WDT_Handler        ( void );
+
+/**
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ */
+
+#define __CM4_REV              0x0000 /**< SAM4E8C core revision number ([15:8] revision number, [7:0] patch number) */
+#define __MPU_PRESENT          0      /**< SAM4E8C does not provide a MPU */
+#define __FPU_PRESENT          1      /**< SAM4E8C does provide a FPU */
+#define __NVIC_PRIO_BITS       4      /**< SAM4E8C uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */
+
+/*
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4e.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_api Peripheral Software API */
+/*@{*/
+
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/can.h"
+#include "component/chipid.h"
+#include "component/cmcc.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/dmac.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/matrix.h"
+#include "component/pdc.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/spi.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/twi.h"
+#include "component/uart.h"
+#include "component/udp.h"
+#include "component/usart.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/pwm.h"
+#include "instance/aes.h"
+#include "instance/can0.h"
+#include "instance/can1.h"
+#include "instance/gmac.h"
+#include "instance/crccu.h"
+#include "instance/uart1.h"
+#include "instance/hsmci.h"
+#include "instance/udp.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/twi0.h"
+#include "instance/twi1.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/dacc.h"
+#include "instance/acc.h"
+#include "instance/dmac.h"
+#include "instance/cmcc.h"
+#include "instance/matrix.h"
+#include "instance/pmc.h"
+#include "instance/uart0.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/rstc.h"
+#include "instance/supc.h"
+#include "instance/rtt.h"
+#include "instance/wdt.h"
+#include "instance/rtc.h"
+#include "instance/gpbr.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   PERIPHERAL ID DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_id Peripheral Ids Definitions */
+/*@{*/
+
+#define ID_SUPC   ( 0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC   ( 1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC    ( 2) /**< \brief Real Time Clock (RTC) */
+#define ID_RTT    ( 3) /**< \brief Real Time Timer (RTT) */
+#define ID_WDT    ( 4) /**< \brief Watchdog/Dual Watchdog Timer (WDT) */
+#define ID_PMC    ( 5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC    ( 6) /**< \brief Enhanced Embedded Flash Controller (EFC) */
+#define ID_UART0  ( 7) /**< \brief UART 0 (UART0) */
+#define ID_PIOA   ( 9) /**< \brief Parallel I/O Controller A (PIOA) */
+#define ID_PIOB   (10) /**< \brief Parallel I/O Controller B (PIOB) */
+#define ID_PIOC   (11) /**< \brief Parallel I/O Controller C (PIOC) */
+#define ID_PIOD   (12) /**< \brief Parallel I/O Controller D (PIOD) */
+#define ID_PIOE   (13) /**< \brief Parallel I/O Controller E (PIOE) */
+#define ID_USART0 (14) /**< \brief USART 0 (USART0) */
+#define ID_USART1 (15) /**< \brief USART 1 (USART1) */
+#define ID_HSMCI  (16) /**< \brief Multimedia Card Interface (HSMCI) */
+#define ID_TWI0   (17) /**< \brief Two Wire Interface 0 (TWI0) */
+#define ID_TWI1   (18) /**< \brief Two Wire Interface 1 (TWI1) */
+#define ID_SPI    (19) /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_DMAC   (20) /**< \brief DMAC (DMAC) */
+#define ID_TC0    (21) /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1    (22) /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TC2    (23) /**< \brief Timer/Counter 2 (TC2) */
+#define ID_TC3    (24) /**< \brief Timer/Counter 3 (TC3) */
+#define ID_TC4    (25) /**< \brief Timer/Counter 4 (TC4) */
+#define ID_TC5    (26) /**< \brief Timer/Counter 5 (TC5) */
+#define ID_TC6    (27) /**< \brief Timer/Counter 6 (TC6) */
+#define ID_TC7    (28) /**< \brief Timer/Counter 7 (TC7) */
+#define ID_TC8    (29) /**< \brief Timer/Counter 8 (TC8) */
+#define ID_AFEC0  (30) /**< \brief Analog Front End 0 (AFEC0) */
+#define ID_AFEC1  (31) /**< \brief Analog Front End 1 (AFEC1) */
+#define ID_DACC   (32) /**< \brief Digital To Analog Converter (DACC) */
+#define ID_ACC    (33) /**< \brief Analog Comparator (ACC) */
+#define ID_ARM    (34) /**< \brief FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+#define ID_UDP    (35) /**< \brief USB DEVICE (UDP) */
+#define ID_PWM    (36) /**< \brief PWM (PWM) */
+#define ID_CAN0   (37) /**< \brief CAN0 (CAN0) */
+#define ID_CAN1   (38) /**< \brief CAN1 (CAN1) */
+#define ID_AES    (39) /**< \brief AES (AES) */
+#define ID_GMAC   (44) /**< \brief EMAC (GMAC) */
+#define ID_UART1  (45) /**< \brief UART (UART1) */
+
+#define ID_PERIPH_COUNT (46) /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define PWM        (0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    (0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        (0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       (0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       (0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       (0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      (0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define UART1      (0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  (0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      (0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  (0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        (0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        (0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    (0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        (0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    (0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        (0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    (0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        (0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     (0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 (0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     (0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 (0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       (0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   (0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       (0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   (0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      (0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  (0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      (0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  (0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       (0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   (0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        (0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       (0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       (0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     (0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        (0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      (0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  (0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     (0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        (0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       (0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   (0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       (0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       (0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       (0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       (0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       (0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       (0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        (0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        (0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        (0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       (0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#else
+#define PWM        ((Pwm    *)0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    ((Pdc    *)0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        ((Aes    *)0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       ((Can    *)0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       ((Can    *)0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       ((Gmac   *)0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      ((Crccu  *)0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define UART1      ((Uart   *)0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  ((Pdc    *)0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      ((Hsmci  *)0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  ((Pdc    *)0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        ((Udp    *)0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        ((Spi    *)0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    ((Pdc    *)0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        ((Tc     *)0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    ((Pdc    *)0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        ((Tc     *)0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    ((Pdc    *)0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        ((Tc     *)0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     ((Usart  *)0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 ((Pdc    *)0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     ((Usart  *)0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 ((Pdc    *)0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       ((Twi    *)0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   ((Pdc    *)0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       ((Twi    *)0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   ((Pdc    *)0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      ((Afec   *)0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  ((Pdc    *)0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      ((Afec   *)0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  ((Pdc    *)0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       ((Dacc   *)0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   ((Pdc    *)0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        ((Acc    *)0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       ((Dmac   *)0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       ((Cmcc   *)0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     ((Matrix *)0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        ((Pmc    *)0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      ((Uart   *)0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  ((Pdc    *)0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     ((Chipid *)0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        ((Efc    *)0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       ((Pio    *)0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   ((Pdc    *)0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       ((Pio    *)0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       ((Pio    *)0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       ((Pio    *)0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       ((Pio    *)0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       ((Rstc   *)0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       ((Supc   *)0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        ((Rtt    *)0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        ((Wdt    *)0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        ((Rtc    *)0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       ((Gpbr   *)0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8C_pio Peripheral Pio Definitions */
+/*@{*/
+
+#include "pio/sam4e8c.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+
+#define IFLASH_SIZE             (0x80000u)
+#define IFLASH_PAGE_SIZE        (512u)
+#define IFLASH_LOCK_REGION_SIZE (8192u)
+#define IFLASH_NB_OF_PAGES      (1024u)
+#define IFLASH_NB_OF_LOCK_BITS  (128u)
+#define IRAM_SIZE               (0x20000u)
+
+#define IFLASH_ADDR  (0x00400000u) /**< Internal Flash base address */
+#define IROM_ADDR    (0x00800000u) /**< Internal ROM base address */
+#define IRAM_ADDR    (0x20000000u) /**< Internal RAM base address */
+#define EBI_CS0_ADDR (0x60000000u) /**< EBI Chip Select 0 base address */
+#define EBI_CS1_ADDR (0x61000000u) /**< EBI Chip Select 1 base address */
+#define EBI_CS2_ADDR (0x62000000u) /**< EBI Chip Select 2 base address */
+#define EBI_CS3_ADDR (0x63000000u) /**< EBI Chip Select 3 base address */
+
+/* ************************************************************************** */
+/*   MISCELLANEOUS DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+
+#define CHIP_JTAGID (0x05B3703FUL)
+#define CHIP_CIDR (0xA3CC0CE0UL)
+#define CHIP_EXID (0x00110209UL)
+
+/* ************************************************************************** */
+/*   ELECTRICAL DEFINITIONS FOR SAM4E8C */
+/* ************************************************************************** */
+
+/* Device characteristics */
+#define CHIP_FREQ_SLCK_RC_MIN           (20000UL)
+#define CHIP_FREQ_SLCK_RC               (32000UL)
+#define CHIP_FREQ_SLCK_RC_MAX           (44000UL)
+#define CHIP_FREQ_MAINCK_RC_4MHZ        (4000000UL)
+#define CHIP_FREQ_MAINCK_RC_8MHZ        (8000000UL)
+#define CHIP_FREQ_MAINCK_RC_12MHZ       (12000000UL)
+#define CHIP_FREQ_CPU_MAX               (120000000UL)
+#define CHIP_FREQ_XTAL_32K              (32768UL)
+#define CHIP_FREQ_XTAL_12M              (12000000UL)
+
+/* Embedded Flash Write Wait State */
+#define CHIP_FLASH_WRITE_WAIT_STATE     (6U)
+
+/* Embedded Flash Read Wait State (VDDCORE set at 1.20V) */
+#define CHIP_FREQ_FWS_0                 (20000000UL)  /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1                 (40000000UL)  /**< \brief Maximum operating frequency when FWS is 1 */
+#define CHIP_FREQ_FWS_2                 (60000000UL)  /**< \brief Maximum operating frequency when FWS is 2 */
+#define CHIP_FREQ_FWS_3                 (80000000UL)  /**< \brief Maximum operating frequency when FWS is 3 */
+#define CHIP_FREQ_FWS_4                 (100000000UL) /**< \brief Maximum operating frequency when FWS is 4 */
+#define CHIP_FREQ_FWS_5                 (123000000UL) /**< \brief Maximum operating frequency when FWS is 5 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* _SAM4E8C_ */

--- a/asf/sam/include/sam4e/sam4e8e.h
+++ b/asf/sam/include/sam4e/sam4e8e.h
@@ -1,0 +1,596 @@
+/* ---------------------------------------------------------------------------- */
+/*                  Atmel Microcontroller Software Support                      */
+/*                       SAM Software Package License                           */
+/* ---------------------------------------------------------------------------- */
+/* Copyright (c) %copyright_year%, Atmel Corporation                                        */
+/*                                                                              */
+/* All rights reserved.                                                         */
+/*                                                                              */
+/* Redistribution and use in source and binary forms, with or without           */
+/* modification, are permitted provided that the following condition is met:    */
+/*                                                                              */
+/* - Redistributions of source code must retain the above copyright notice,     */
+/* this list of conditions and the disclaimer below.                            */
+/*                                                                              */
+/* Atmel's name may not be used to endorse or promote products derived from     */
+/* this software without specific prior written permission.                     */
+/*                                                                              */
+/* DISCLAIMER:  THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR   */
+/* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE   */
+/* DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR ANY DIRECT, INDIRECT,      */
+/* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT */
+/* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,  */
+/* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF    */
+/* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING         */
+/* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, */
+/* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/* ---------------------------------------------------------------------------- */
+
+#ifndef _SAM4E8E_
+#define _SAM4E8E_
+
+/** \addtogroup SAM4E8E_definitions SAM4E8E definitions
+  This file defines all structures and symbols for SAM4E8E:
+    - registers and bitfields
+    - peripheral base address
+    - peripheral ID
+    - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg; /**< Read only 32-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg; /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg; /**< Read-Write 32-bit register (volatile unsigned int) */
+#endif
+
+/* ************************************************************************** */
+/*   CMSIS DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_cmsis CMSIS Definitions */
+/*@{*/
+
+/**< Interrupt Number Definition */
+typedef enum IRQn
+{
+/******  Cortex-M4 Processor Exceptions Numbers ******************************/
+  NonMaskableInt_IRQn   = -14, /**<  2 Non Maskable Interrupt                */
+  MemoryManagement_IRQn = -12, /**<  4 Cortex-M4 Memory Management Interrupt */
+  BusFault_IRQn         = -11, /**<  5 Cortex-M4 Bus Fault Interrupt         */
+  UsageFault_IRQn       = -10, /**<  6 Cortex-M4 Usage Fault Interrupt       */
+  SVCall_IRQn           = -5,  /**< 11 Cortex-M4 SV Call Interrupt           */
+  DebugMonitor_IRQn     = -4,  /**< 12 Cortex-M4 Debug Monitor Interrupt     */
+  PendSV_IRQn           = -2,  /**< 14 Cortex-M4 Pend SV Interrupt           */
+  SysTick_IRQn          = -1,  /**< 15 Cortex-M4 System Tick Interrupt       */
+/******  SAM4E8E specific Interrupt Numbers *********************************/
+  
+  SUPC_IRQn            =  0, /**<  0 SAM4E8E Supply Controller (SUPC) */
+  RSTC_IRQn            =  1, /**<  1 SAM4E8E Reset Controller (RSTC) */
+  RTC_IRQn             =  2, /**<  2 SAM4E8E Real Time Clock (RTC) */
+  RTT_IRQn             =  3, /**<  3 SAM4E8E Real Time Timer (RTT) */
+  WDT_IRQn             =  4, /**<  4 SAM4E8E Watchdog/Dual Watchdog Timer (WDT) */
+  PMC_IRQn             =  5, /**<  5 SAM4E8E Power Management Controller (PMC) */
+  EFC_IRQn             =  6, /**<  6 SAM4E8E Enhanced Embedded Flash Controller (EFC) */
+  UART0_IRQn           =  7, /**<  7 SAM4E8E UART 0 (UART0) */
+  PIOA_IRQn            =  9, /**<  9 SAM4E8E Parallel I/O Controller A (PIOA) */
+  PIOB_IRQn            = 10, /**< 10 SAM4E8E Parallel I/O Controller B (PIOB) */
+  PIOC_IRQn            = 11, /**< 11 SAM4E8E Parallel I/O Controller C (PIOC) */
+  PIOD_IRQn            = 12, /**< 12 SAM4E8E Parallel I/O Controller D (PIOD) */
+  PIOE_IRQn            = 13, /**< 13 SAM4E8E Parallel I/O Controller E (PIOE) */
+  USART0_IRQn          = 14, /**< 14 SAM4E8E USART 0 (USART0) */
+  USART1_IRQn          = 15, /**< 15 SAM4E8E USART 1 (USART1) */
+  HSMCI_IRQn           = 16, /**< 16 SAM4E8E Multimedia Card Interface (HSMCI) */
+  TWI0_IRQn            = 17, /**< 17 SAM4E8E Two Wire Interface 0 (TWI0) */
+  TWI1_IRQn            = 18, /**< 18 SAM4E8E Two Wire Interface 1 (TWI1) */
+  SPI_IRQn             = 19, /**< 19 SAM4E8E Serial Peripheral Interface (SPI) */
+  DMAC_IRQn            = 20, /**< 20 SAM4E8E DMAC (DMAC) */
+  TC0_IRQn             = 21, /**< 21 SAM4E8E Timer/Counter 0 (TC0) */
+  TC1_IRQn             = 22, /**< 22 SAM4E8E Timer/Counter 1 (TC1) */
+  TC2_IRQn             = 23, /**< 23 SAM4E8E Timer/Counter 2 (TC2) */
+  TC3_IRQn             = 24, /**< 24 SAM4E8E Timer/Counter 3 (TC3) */
+  TC4_IRQn             = 25, /**< 25 SAM4E8E Timer/Counter 4 (TC4) */
+  TC5_IRQn             = 26, /**< 26 SAM4E8E Timer/Counter 5 (TC5) */
+  TC6_IRQn             = 27, /**< 27 SAM4E8E Timer/Counter 6 (TC6) */
+  TC7_IRQn             = 28, /**< 28 SAM4E8E Timer/Counter 7 (TC7) */
+  TC8_IRQn             = 29, /**< 29 SAM4E8E Timer/Counter 8 (TC8) */
+  AFEC0_IRQn           = 30, /**< 30 SAM4E8E Analog Front End 0 (AFEC0) */
+  AFEC1_IRQn           = 31, /**< 31 SAM4E8E Analog Front End 1 (AFEC1) */
+  DACC_IRQn            = 32, /**< 32 SAM4E8E Digital To Analog Converter (DACC) */
+  ACC_IRQn             = 33, /**< 33 SAM4E8E Analog Comparator (ACC) */
+  ARM_IRQn             = 34, /**< 34 SAM4E8E FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+  UDP_IRQn             = 35, /**< 35 SAM4E8E USB DEVICE (UDP) */
+  PWM_IRQn             = 36, /**< 36 SAM4E8E PWM (PWM) */
+  CAN0_IRQn            = 37, /**< 37 SAM4E8E CAN0 (CAN0) */
+  CAN1_IRQn            = 38, /**< 38 SAM4E8E CAN1 (CAN1) */
+  AES_IRQn             = 39, /**< 39 SAM4E8E AES (AES) */
+  GMAC_IRQn            = 44, /**< 44 SAM4E8E EMAC (GMAC) */
+  UART1_IRQn           = 45, /**< 45 SAM4E8E UART (UART1) */
+
+  PERIPH_COUNT_IRQn    = 46  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+  
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNMI_Handler;
+  void* pfnHardFault_Handler;
+  void* pfnMemManage_Handler;
+  void* pfnBusFault_Handler;
+  void* pfnUsageFault_Handler;
+  void* pfnReserved1_Handler;
+  void* pfnReserved2_Handler;
+  void* pfnReserved3_Handler;
+  void* pfnReserved4_Handler;
+  void* pfnSVC_Handler;
+  void* pfnDebugMon_Handler;
+  void* pfnReserved5_Handler;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnSUPC_Handler;   /*  0 Supply Controller */
+  void* pfnRSTC_Handler;   /*  1 Reset Controller */
+  void* pfnRTC_Handler;    /*  2 Real Time Clock */
+  void* pfnRTT_Handler;    /*  3 Real Time Timer */
+  void* pfnWDT_Handler;    /*  4 Watchdog/Dual Watchdog Timer */
+  void* pfnPMC_Handler;    /*  5 Power Management Controller */
+  void* pfnEFC_Handler;    /*  6 Enhanced Embedded Flash Controller */
+  void* pfnUART0_Handler;  /*  7 UART 0 */
+  void* pvReserved8;
+  void* pfnPIOA_Handler;   /*  9 Parallel I/O Controller A */
+  void* pfnPIOB_Handler;   /* 10 Parallel I/O Controller B */
+  void* pfnPIOC_Handler;   /* 11 Parallel I/O Controller C */
+  void* pfnPIOD_Handler;   /* 12 Parallel I/O Controller D */
+  void* pfnPIOE_Handler;   /* 13 Parallel I/O Controller E */
+  void* pfnUSART0_Handler; /* 14 USART 0 */
+  void* pfnUSART1_Handler; /* 15 USART 1 */
+  void* pfnHSMCI_Handler;  /* 16 Multimedia Card Interface */
+  void* pfnTWI0_Handler;   /* 17 Two Wire Interface 0 */
+  void* pfnTWI1_Handler;   /* 18 Two Wire Interface 1 */
+  void* pfnSPI_Handler;    /* 19 Serial Peripheral Interface */
+  void* pfnDMAC_Handler;   /* 20 DMAC */
+  void* pfnTC0_Handler;    /* 21 Timer/Counter 0 */
+  void* pfnTC1_Handler;    /* 22 Timer/Counter 1 */
+  void* pfnTC2_Handler;    /* 23 Timer/Counter 2 */
+  void* pfnTC3_Handler;    /* 24 Timer/Counter 3 */
+  void* pfnTC4_Handler;    /* 25 Timer/Counter 4 */
+  void* pfnTC5_Handler;    /* 26 Timer/Counter 5 */
+  void* pfnTC6_Handler;    /* 27 Timer/Counter 6 */
+  void* pfnTC7_Handler;    /* 28 Timer/Counter 7 */
+  void* pfnTC8_Handler;    /* 29 Timer/Counter 8 */
+  void* pfnAFEC0_Handler;  /* 30 Analog Front End 0 */
+  void* pfnAFEC1_Handler;  /* 31 Analog Front End 1 */
+  void* pfnDACC_Handler;   /* 32 Digital To Analog Converter */
+  void* pfnACC_Handler;    /* 33 Analog Comparator */
+  void* pfnARM_Handler;    /* 34 FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC */
+  void* pfnUDP_Handler;    /* 35 USB DEVICE */
+  void* pfnPWM_Handler;    /* 36 PWM */
+  void* pfnCAN0_Handler;   /* 37 CAN0 */
+  void* pfnCAN1_Handler;   /* 38 CAN1 */
+  void* pfnAES_Handler;    /* 39 AES */
+  void* pvReserved40;
+  void* pvReserved41;
+  void* pvReserved42;
+  void* pvReserved43;
+  void* pfnGMAC_Handler;   /* 44 EMAC */
+  void* pfnUART1_Handler;  /* 45 UART */
+} DeviceVectors;
+
+/* Cortex-M4 core handlers */
+void Reset_Handler      ( void );
+void NMI_Handler        ( void );
+void HardFault_Handler  ( void );
+void MemManage_Handler  ( void );
+void BusFault_Handler   ( void );
+void UsageFault_Handler ( void );
+void SVC_Handler        ( void );
+void DebugMon_Handler   ( void );
+void PendSV_Handler     ( void );
+void SysTick_Handler    ( void );
+
+/* Peripherals handlers */
+void ACC_Handler        ( void );
+void AES_Handler        ( void );
+void AFEC0_Handler      ( void );
+void AFEC1_Handler      ( void );
+void ARM_Handler        ( void );
+void CAN0_Handler       ( void );
+void CAN1_Handler       ( void );
+void DACC_Handler       ( void );
+void DMAC_Handler       ( void );
+void EFC_Handler        ( void );
+void GMAC_Handler       ( void );
+void HSMCI_Handler      ( void );
+void PIOA_Handler       ( void );
+void PIOB_Handler       ( void );
+void PIOC_Handler       ( void );
+void PIOD_Handler       ( void );
+void PIOE_Handler       ( void );
+void PMC_Handler        ( void );
+void PWM_Handler        ( void );
+void RSTC_Handler       ( void );
+void RTC_Handler        ( void );
+void RTT_Handler        ( void );
+void SPI_Handler        ( void );
+void SUPC_Handler       ( void );
+void TC0_Handler        ( void );
+void TC1_Handler        ( void );
+void TC2_Handler        ( void );
+void TC3_Handler        ( void );
+void TC4_Handler        ( void );
+void TC5_Handler        ( void );
+void TC6_Handler        ( void );
+void TC7_Handler        ( void );
+void TC8_Handler        ( void );
+void TWI0_Handler       ( void );
+void TWI1_Handler       ( void );
+void UART0_Handler      ( void );
+void UART1_Handler      ( void );
+void UDP_Handler        ( void );
+void USART0_Handler     ( void );
+void USART1_Handler     ( void );
+void WDT_Handler        ( void );
+
+/**
+ * \brief Configuration of the Cortex-M4 Processor and Core Peripherals 
+ */
+
+#define __CM4_REV              0x0000 /**< SAM4E8E core revision number ([15:8] revision number, [7:0] patch number) */
+#define __MPU_PRESENT          0      /**< SAM4E8E does not provide a MPU */
+#define __FPU_PRESENT          1      /**< SAM4E8E does provide a FPU */
+#define __NVIC_PRIO_BITS       4      /**< SAM4E8E uses 4 Bits for the Priority Levels */
+#define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */
+
+/*
+ * \brief CMSIS includes
+ */
+
+#include <core_cm4.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_sam4e.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_api Peripheral Software API */
+/*@{*/
+
+#include "component/acc.h"
+#include "component/aes.h"
+#include "component/afec.h"
+#include "component/can.h"
+#include "component/chipid.h"
+#include "component/cmcc.h"
+#include "component/crccu.h"
+#include "component/dacc.h"
+#include "component/dmac.h"
+#include "component/efc.h"
+#include "component/gmac.h"
+#include "component/gpbr.h"
+#include "component/hsmci.h"
+#include "component/matrix.h"
+#include "component/pdc.h"
+#include "component/pio.h"
+#include "component/pmc.h"
+#include "component/pwm.h"
+#include "component/rstc.h"
+#include "component/rtc.h"
+#include "component/rtt.h"
+#include "component/smc.h"
+#include "component/spi.h"
+#include "component/supc.h"
+#include "component/tc.h"
+#include "component/twi.h"
+#include "component/uart.h"
+#include "component/udp.h"
+#include "component/usart.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   REGISTER ACCESS DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/pwm.h"
+#include "instance/aes.h"
+#include "instance/can0.h"
+#include "instance/can1.h"
+#include "instance/gmac.h"
+#include "instance/crccu.h"
+#include "instance/smc.h"
+#include "instance/uart1.h"
+#include "instance/hsmci.h"
+#include "instance/udp.h"
+#include "instance/spi.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/usart0.h"
+#include "instance/usart1.h"
+#include "instance/twi0.h"
+#include "instance/twi1.h"
+#include "instance/afec0.h"
+#include "instance/afec1.h"
+#include "instance/dacc.h"
+#include "instance/acc.h"
+#include "instance/dmac.h"
+#include "instance/cmcc.h"
+#include "instance/matrix.h"
+#include "instance/pmc.h"
+#include "instance/uart0.h"
+#include "instance/chipid.h"
+#include "instance/efc.h"
+#include "instance/pioa.h"
+#include "instance/piob.h"
+#include "instance/pioc.h"
+#include "instance/piod.h"
+#include "instance/pioe.h"
+#include "instance/rstc.h"
+#include "instance/supc.h"
+#include "instance/rtt.h"
+#include "instance/wdt.h"
+#include "instance/rtc.h"
+#include "instance/gpbr.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   PERIPHERAL ID DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_id Peripheral Ids Definitions */
+/*@{*/
+
+#define ID_SUPC   ( 0) /**< \brief Supply Controller (SUPC) */
+#define ID_RSTC   ( 1) /**< \brief Reset Controller (RSTC) */
+#define ID_RTC    ( 2) /**< \brief Real Time Clock (RTC) */
+#define ID_RTT    ( 3) /**< \brief Real Time Timer (RTT) */
+#define ID_WDT    ( 4) /**< \brief Watchdog/Dual Watchdog Timer (WDT) */
+#define ID_PMC    ( 5) /**< \brief Power Management Controller (PMC) */
+#define ID_EFC    ( 6) /**< \brief Enhanced Embedded Flash Controller (EFC) */
+#define ID_UART0  ( 7) /**< \brief UART 0 (UART0) */
+#define ID_SMC    ( 8) /**< \brief Static Memory Controller (SMC) */
+#define ID_PIOA   ( 9) /**< \brief Parallel I/O Controller A (PIOA) */
+#define ID_PIOB   (10) /**< \brief Parallel I/O Controller B (PIOB) */
+#define ID_PIOC   (11) /**< \brief Parallel I/O Controller C (PIOC) */
+#define ID_PIOD   (12) /**< \brief Parallel I/O Controller D (PIOD) */
+#define ID_PIOE   (13) /**< \brief Parallel I/O Controller E (PIOE) */
+#define ID_USART0 (14) /**< \brief USART 0 (USART0) */
+#define ID_USART1 (15) /**< \brief USART 1 (USART1) */
+#define ID_HSMCI  (16) /**< \brief Multimedia Card Interface (HSMCI) */
+#define ID_TWI0   (17) /**< \brief Two Wire Interface 0 (TWI0) */
+#define ID_TWI1   (18) /**< \brief Two Wire Interface 1 (TWI1) */
+#define ID_SPI    (19) /**< \brief Serial Peripheral Interface (SPI) */
+#define ID_DMAC   (20) /**< \brief DMAC (DMAC) */
+#define ID_TC0    (21) /**< \brief Timer/Counter 0 (TC0) */
+#define ID_TC1    (22) /**< \brief Timer/Counter 1 (TC1) */
+#define ID_TC2    (23) /**< \brief Timer/Counter 2 (TC2) */
+#define ID_TC3    (24) /**< \brief Timer/Counter 3 (TC3) */
+#define ID_TC4    (25) /**< \brief Timer/Counter 4 (TC4) */
+#define ID_TC5    (26) /**< \brief Timer/Counter 5 (TC5) */
+#define ID_TC6    (27) /**< \brief Timer/Counter 6 (TC6) */
+#define ID_TC7    (28) /**< \brief Timer/Counter 7 (TC7) */
+#define ID_TC8    (29) /**< \brief Timer/Counter 8 (TC8) */
+#define ID_AFEC0  (30) /**< \brief Analog Front End 0 (AFEC0) */
+#define ID_AFEC1  (31) /**< \brief Analog Front End 1 (AFEC1) */
+#define ID_DACC   (32) /**< \brief Digital To Analog Converter (DACC) */
+#define ID_ACC    (33) /**< \brief Analog Comparator (ACC) */
+#define ID_ARM    (34) /**< \brief FPU signals : FPIXC, FPOFC, FPUFC, FPIOC, FPDZC, FPIDC, FPIXC (ARM) */
+#define ID_UDP    (35) /**< \brief USB DEVICE (UDP) */
+#define ID_PWM    (36) /**< \brief PWM (PWM) */
+#define ID_CAN0   (37) /**< \brief CAN0 (CAN0) */
+#define ID_CAN1   (38) /**< \brief CAN1 (CAN1) */
+#define ID_AES    (39) /**< \brief AES (AES) */
+#define ID_GMAC   (44) /**< \brief EMAC (GMAC) */
+#define ID_UART1  (45) /**< \brief UART (UART1) */
+
+#define ID_PERIPH_COUNT (46) /**< \brief Number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/*   BASE ADDRESS DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define PWM        (0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    (0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        (0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       (0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       (0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       (0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      (0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define SMC        (0x40060000U) /**< \brief (SMC       ) Base Address */
+#define UART1      (0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  (0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      (0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  (0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        (0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        (0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    (0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        (0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    (0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        (0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    (0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        (0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     (0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 (0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     (0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 (0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       (0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   (0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       (0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   (0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      (0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  (0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      (0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  (0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       (0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   (0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        (0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       (0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       (0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     (0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        (0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      (0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  (0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     (0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        (0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       (0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   (0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       (0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       (0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       (0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       (0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       (0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       (0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        (0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        (0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        (0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       (0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#else
+#define PWM        ((Pwm    *)0x40000000U) /**< \brief (PWM       ) Base Address */
+#define PDC_PWM    ((Pdc    *)0x40000100U) /**< \brief (PDC_PWM   ) Base Address */
+#define AES        ((Aes    *)0x40004000U) /**< \brief (AES       ) Base Address */
+#define CAN0       ((Can    *)0x40010000U) /**< \brief (CAN0      ) Base Address */
+#define CAN1       ((Can    *)0x40014000U) /**< \brief (CAN1      ) Base Address */
+#define GMAC       ((Gmac   *)0x40034000U) /**< \brief (GMAC      ) Base Address */
+#define CRCCU      ((Crccu  *)0x40044000U) /**< \brief (CRCCU     ) Base Address */
+#define SMC        ((Smc    *)0x40060000U) /**< \brief (SMC       ) Base Address */
+#define UART1      ((Uart   *)0x40060600U) /**< \brief (UART1     ) Base Address */
+#define PDC_UART1  ((Pdc    *)0x40060700U) /**< \brief (PDC_UART1 ) Base Address */
+#define HSMCI      ((Hsmci  *)0x40080000U) /**< \brief (HSMCI     ) Base Address */
+#define PDC_HSMCI  ((Pdc    *)0x40080100U) /**< \brief (PDC_HSMCI ) Base Address */
+#define UDP        ((Udp    *)0x40084000U) /**< \brief (UDP       ) Base Address */
+#define SPI        ((Spi    *)0x40088000U) /**< \brief (SPI       ) Base Address */
+#define PDC_SPI    ((Pdc    *)0x40088100U) /**< \brief (PDC_SPI   ) Base Address */
+#define TC0        ((Tc     *)0x40090000U) /**< \brief (TC0       ) Base Address */
+#define PDC_TC0    ((Pdc    *)0x40090100U) /**< \brief (PDC_TC0   ) Base Address */
+#define TC1        ((Tc     *)0x40094000U) /**< \brief (TC1       ) Base Address */
+#define PDC_TC1    ((Pdc    *)0x40094100U) /**< \brief (PDC_TC1   ) Base Address */
+#define TC2        ((Tc     *)0x40098000U) /**< \brief (TC2       ) Base Address */
+#define USART0     ((Usart  *)0x400A0000U) /**< \brief (USART0    ) Base Address */
+#define PDC_USART0 ((Pdc    *)0x400A0100U) /**< \brief (PDC_USART0) Base Address */
+#define USART1     ((Usart  *)0x400A4000U) /**< \brief (USART1    ) Base Address */
+#define PDC_USART1 ((Pdc    *)0x400A4100U) /**< \brief (PDC_USART1) Base Address */
+#define TWI0       ((Twi    *)0x400A8000U) /**< \brief (TWI0      ) Base Address */
+#define PDC_TWI0   ((Pdc    *)0x400A8100U) /**< \brief (PDC_TWI0  ) Base Address */
+#define TWI1       ((Twi    *)0x400AC000U) /**< \brief (TWI1      ) Base Address */
+#define PDC_TWI1   ((Pdc    *)0x400AC100U) /**< \brief (PDC_TWI1  ) Base Address */
+#define AFEC0      ((Afec   *)0x400B0000U) /**< \brief (AFEC0     ) Base Address */
+#define PDC_AFEC0  ((Pdc    *)0x400B0100U) /**< \brief (PDC_AFEC0 ) Base Address */
+#define AFEC1      ((Afec   *)0x400B4000U) /**< \brief (AFEC1     ) Base Address */
+#define PDC_AFEC1  ((Pdc    *)0x400B4100U) /**< \brief (PDC_AFEC1 ) Base Address */
+#define DACC       ((Dacc   *)0x400B8000U) /**< \brief (DACC      ) Base Address */
+#define PDC_DACC   ((Pdc    *)0x400B8100U) /**< \brief (PDC_DACC  ) Base Address */
+#define ACC        ((Acc    *)0x400BC000U) /**< \brief (ACC       ) Base Address */
+#define DMAC       ((Dmac   *)0x400C0000U) /**< \brief (DMAC      ) Base Address */
+#define CMCC       ((Cmcc   *)0x400C4000U) /**< \brief (CMCC      ) Base Address */
+#define MATRIX     ((Matrix *)0x400E0200U) /**< \brief (MATRIX    ) Base Address */
+#define PMC        ((Pmc    *)0x400E0400U) /**< \brief (PMC       ) Base Address */
+#define UART0      ((Uart   *)0x400E0600U) /**< \brief (UART0     ) Base Address */
+#define PDC_UART0  ((Pdc    *)0x400E0700U) /**< \brief (PDC_UART0 ) Base Address */
+#define CHIPID     ((Chipid *)0x400E0740U) /**< \brief (CHIPID    ) Base Address */
+#define EFC        ((Efc    *)0x400E0A00U) /**< \brief (EFC       ) Base Address */
+#define PIOA       ((Pio    *)0x400E0E00U) /**< \brief (PIOA      ) Base Address */
+#define PDC_PIOA   ((Pdc    *)0x400E0F68U) /**< \brief (PDC_PIOA  ) Base Address */
+#define PIOB       ((Pio    *)0x400E1000U) /**< \brief (PIOB      ) Base Address */
+#define PIOC       ((Pio    *)0x400E1200U) /**< \brief (PIOC      ) Base Address */
+#define PIOD       ((Pio    *)0x400E1400U) /**< \brief (PIOD      ) Base Address */
+#define PIOE       ((Pio    *)0x400E1600U) /**< \brief (PIOE      ) Base Address */
+#define RSTC       ((Rstc   *)0x400E1800U) /**< \brief (RSTC      ) Base Address */
+#define SUPC       ((Supc   *)0x400E1810U) /**< \brief (SUPC      ) Base Address */
+#define RTT        ((Rtt    *)0x400E1830U) /**< \brief (RTT       ) Base Address */
+#define WDT        ((Wdt    *)0x400E1850U) /**< \brief (WDT       ) Base Address */
+#define RTC        ((Rtc    *)0x400E1860U) /**< \brief (RTC       ) Base Address */
+#define GPBR       ((Gpbr   *)0x400E1890U) /**< \brief (GPBR      ) Base Address */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/*   PIO DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+/** \addtogroup SAM4E8E_pio Peripheral Pio Definitions */
+/*@{*/
+
+#include "pio/sam4e8e.h"
+/*@}*/
+
+/* ************************************************************************** */
+/*   MEMORY MAPPING DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+
+#define IFLASH_SIZE             (0x80000u)
+#define IFLASH_PAGE_SIZE        (512u)
+#define IFLASH_LOCK_REGION_SIZE (8192u)
+#define IFLASH_NB_OF_PAGES      (1024u)
+#define IFLASH_NB_OF_LOCK_BITS  (128u)
+#define IRAM_SIZE               (0x20000u)
+
+#define IFLASH_ADDR  (0x00400000u) /**< Internal Flash base address */
+#define IROM_ADDR    (0x00800000u) /**< Internal ROM base address */
+#define IRAM_ADDR    (0x20000000u) /**< Internal RAM base address */
+#define EBI_CS0_ADDR (0x60000000u) /**< EBI Chip Select 0 base address */
+#define EBI_CS1_ADDR (0x61000000u) /**< EBI Chip Select 1 base address */
+#define EBI_CS2_ADDR (0x62000000u) /**< EBI Chip Select 2 base address */
+#define EBI_CS3_ADDR (0x63000000u) /**< EBI Chip Select 3 base address */
+
+/* ************************************************************************** */
+/*   MISCELLANEOUS DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+
+#define CHIP_JTAGID (0x05B3703FUL)
+#define CHIP_CIDR (0xA3CC0CE0UL)
+#define CHIP_EXID (0x00120208UL)
+
+/* ************************************************************************** */
+/*   ELECTRICAL DEFINITIONS FOR SAM4E8E */
+/* ************************************************************************** */
+
+/* Device characteristics */
+#define CHIP_FREQ_SLCK_RC_MIN           (20000UL)
+#define CHIP_FREQ_SLCK_RC               (32000UL)
+#define CHIP_FREQ_SLCK_RC_MAX           (44000UL)
+#define CHIP_FREQ_MAINCK_RC_4MHZ        (4000000UL)
+#define CHIP_FREQ_MAINCK_RC_8MHZ        (8000000UL)
+#define CHIP_FREQ_MAINCK_RC_12MHZ       (12000000UL)
+#define CHIP_FREQ_CPU_MAX               (120000000UL)
+#define CHIP_FREQ_XTAL_32K              (32768UL)
+#define CHIP_FREQ_XTAL_12M              (12000000UL)
+
+/* Embedded Flash Write Wait State */
+#define CHIP_FLASH_WRITE_WAIT_STATE     (6U)
+
+/* Embedded Flash Read Wait State (VDDCORE set at 1.20V) */
+#define CHIP_FREQ_FWS_0                 (20000000UL)  /**< \brief Maximum operating frequency when FWS is 0 */
+#define CHIP_FREQ_FWS_1                 (40000000UL)  /**< \brief Maximum operating frequency when FWS is 1 */
+#define CHIP_FREQ_FWS_2                 (60000000UL)  /**< \brief Maximum operating frequency when FWS is 2 */
+#define CHIP_FREQ_FWS_3                 (80000000UL)  /**< \brief Maximum operating frequency when FWS is 3 */
+#define CHIP_FREQ_FWS_4                 (100000000UL) /**< \brief Maximum operating frequency when FWS is 4 */
+#define CHIP_FREQ_FWS_5                 (123000000UL) /**< \brief Maximum operating frequency when FWS is 5 */
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* _SAM4E8E_ */


### PR DESCRIPTION
Origin: Atmel SAM4E Series Device Support (1.1.57)
License: SAM Software Package License
URL: http://packs.download.atmel.com/Atmel.SAM4E_DFP.1.1.57.atpack
Purpose: Introduction of ASF for the SAM4E series.
Maintained-by: External
depends on: https://github.com/zephyrproject-rtos/zephyr/pull/20551

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>