### PR TITLE
changed Reserved17 field size in Gmac struct (from 0x90 to 0x8c) for SAME70B

### DIFF
--- a/asf/sam/include/same70b/component/gmac.h
+++ b/asf/sam/include/same70b/component/gmac.h
@@ -4648,7 +4648,7 @@ typedef struct {
   __O  uint32_t GMAC_IDRPQ[5];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (index = 1) 0 */
   RoReg8  Reserved16[0xC];
   __IO uint32_t GMAC_IMRPQ[5];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved17[0x90];
+  RoReg8  Reserved17[0x8C];
   __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register (index = 0) 0 */
   RoReg8  Reserved18[0x10];
   __IO uint32_t GMAC_ST2CW00;   /**< (GMAC Offset: 0x700) Screening Type 2 Compare Word 0 Register (index = 0) */


### PR DESCRIPTION
this makes the offset to the following registers (GMAC_ST2ER, etc)
correct (was off by 4 bytes).  This has been fixed in more recent header
files available from Atmel.  The most recent header file (extracted from
Atmel.SAME70_DFP.2.4.166.atpack) has the following comment near the top:

/* file generated from device description version 2019-01-18T21:19:59Z */

The corresponding gmac.h header file currently in the hal_atmel repository is an older version:

/* file generated from device description version 2017-09-13T14:00:00Z */

Perhaps it would be worth importing the latest version of the header files?