### PR TITLE
Import SAME70 DFP version 2.4.166

### DIFF
--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -44,3 +44,4 @@ Patch List:
    * Fix USBHS_HSTDMA register name.
    * Fix MATRIX_PR register name.
    * Fix PWM_CMP register name.
+   * Fix PWM_CH_NUM register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -34,3 +34,6 @@ License:
 
 License Link:
    https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix the GMAC priority queue registers to match the datasheet.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -45,3 +45,4 @@ Patch List:
    * Fix MATRIX_PR register name.
    * Fix PWM_CMP register name.
    * Fix PWM_CH_NUM register name.
+   * Fix SMC_CS_NUMBER register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -40,3 +40,4 @@ Patch List:
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.
    * Fix TC_CHANNEL register name.
+   * Fix USBHS_DEVDMA register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -39,3 +39,4 @@ Patch List:
    * Fix the GMAC priority queue registers to match the datasheet.
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.
+   * Fix TC_CHANNEL register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -42,3 +42,4 @@ Patch List:
    * Fix TC_CHANNEL register name.
    * Fix USBHS_DEVDMA register name.
    * Fix USBHS_HSTDMA register name.
+   * Fix MATRIX_PR register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -38,3 +38,4 @@ License Link:
 Patch List:
    * Fix the GMAC priority queue registers to match the datasheet.
    * Fix GMAC_SA register name.
+   * Fix XDMAC_CHID register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -43,3 +43,4 @@ Patch List:
    * Fix USBHS_DEVDMA register name.
    * Fix USBHS_HSTDMA register name.
    * Fix MATRIX_PR register name.
+   * Fix PWM_CMP register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -41,3 +41,4 @@ Patch List:
    * Fix XDMAC_CHID register name.
    * Fix TC_CHANNEL register name.
    * Fix USBHS_DEVDMA register name.
+   * Fix USBHS_HSTDMA register name.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -5,11 +5,11 @@ Origin:
    Microchip Packs Repository
    http://packs.download.atmel.com/
 
-   Atmel SAME70 Series Device Support (2.3.98)
-   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.3.98.atpack
+   Atmel SAME70 Series Device Support (2.4.166)
+   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.4.166.atpack
 
 Status:
-   version 2.3.98
+   version 2.4.166
 
 Purpose:
    Official package for SAM E70.
@@ -21,7 +21,7 @@ Description:
 
 URL:
    http://packs.download.atmel.com/
-   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.3.98.atpack
+   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.4.166.atpack
 
 commit:
   n/a
@@ -34,11 +34,3 @@ License:
 
 License Link:
    https://www.apache.org/licenses/LICENSE-2.0
-
-Patch Lst:
-   * Add missing header files symbols for Atmel SAM E70
-      Several missing symbols for same70q21 SoC are added:
-      - TC Channel Mode Register: Waveform Mode definitions
-      - Legacy peripheral IDs definitions
-   * Fix the GMAC priority queues related register to match the
-     datasheet.

--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix the GMAC priority queue registers to match the datasheet.
+   * Fix GMAC_SA register name.

--- a/asf/sam/include/same70/component-version.h
+++ b/asf/sam/include/same70/component-version.h
@@ -3,7 +3,7 @@
  *
  * \brief Component version header file
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \license_start
  *
@@ -29,7 +29,7 @@
 #define _COMPONENT_VERSION_H_INCLUDED
 
 #define COMPONENT_VERSION_MAJOR 2
-#define COMPONENT_VERSION_MINOR 3
+#define COMPONENT_VERSION_MINOR 4
 
 //
 // The COMPONENT_VERSION define is composed of the major and the minor version number.
@@ -37,18 +37,18 @@
 // The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
 // The rest of the COMPONENT_VERSION is the major version.
 //
-#define COMPONENT_VERSION 20003
+#define COMPONENT_VERSION 20004
 
 //
 // The build number does not refer to the component, but to the build number
 // of the device pack that provides the component.
 //
-#define BUILD_NUMBER 98
+#define BUILD_NUMBER 166
 
 //
 // The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
 //
-#define COMPONENT_VERSION_STRING "2.3"
+#define COMPONENT_VERSION_STRING "2.4"
 
 //
 // The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
@@ -58,7 +58,7 @@
 //     "%Y-%m-%d %H:%M:%S"
 //
 //
-#define COMPONENT_DATE_STRING "2018-01-30 13:59:10"
+#define COMPONENT_DATE_STRING "2019-02-18 11:43:31"
 
 #endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
 

--- a/asf/sam/include/same70/component/acc.h
+++ b/asf/sam/include/same70/component/acc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- ACC_CR : (ACC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_CR_OFFSET                       (0x00)                                        /**<  (ACC_CR) Control Register  Offset */
@@ -65,6 +69,7 @@ typedef union {
 
 /* -------- ACC_MR : (ACC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SELMINUS:3;                /**< bit:   0..2  Selection for Minus Comparator Input     */
@@ -81,6 +86,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_MR_OFFSET                       (0x04)                                        /**<  (ACC_MR) Mode Register  Offset */
@@ -166,6 +172,7 @@ typedef union {
 
 /* -------- ACC_IER : (ACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -173,6 +180,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IER_OFFSET                      (0x24)                                        /**<  (ACC_IER) Interrupt Enable Register  Offset */
@@ -186,6 +194,7 @@ typedef union {
 
 /* -------- ACC_IDR : (ACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -193,6 +202,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IDR_OFFSET                      (0x28)                                        /**<  (ACC_IDR) Interrupt Disable Register  Offset */
@@ -206,6 +216,7 @@ typedef union {
 
 /* -------- ACC_IMR : (ACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -213,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IMR_OFFSET                      (0x2C)                                        /**<  (ACC_IMR) Interrupt Mask Register  Offset */
@@ -226,6 +238,7 @@ typedef union {
 
 /* -------- ACC_ISR : (ACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge (cleared on read)        */
@@ -235,6 +248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_ISR_OFFSET                      (0x30)                                        /**<  (ACC_ISR) Interrupt Status Register  Offset */
@@ -253,6 +267,7 @@ typedef union {
 
 /* -------- ACC_ACR : (ACC Offset: 0x94) (R/W 32) Analog Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ISEL:1;                    /**< bit:      0  Current Selection                        */
@@ -261,6 +276,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_ACR_OFFSET                      (0x94)                                        /**<  (ACC_ACR) Analog Control Register  Offset */
@@ -281,6 +297,7 @@ typedef union {
 
 /* -------- ACC_WPMR : (ACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -289,6 +306,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_WPMR_OFFSET                     (0xE4)                                        /**<  (ACC_WPMR) Write Protection Mode Register  Offset */
@@ -307,6 +325,7 @@ typedef union {
 
 /* -------- ACC_WPSR : (ACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -314,6 +333,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_WPSR_OFFSET                     (0xE8)                                        /**<  (ACC_WPSR) Write Protection Status Register  Offset */
@@ -331,14 +351,14 @@ typedef union {
 typedef struct {  
   __O  uint32_t ACC_CR;         /**< (ACC Offset: 0x00) Control Register */
   __IO uint32_t ACC_MR;         /**< (ACC Offset: 0x04) Mode Register */
-  RoReg8  Reserved1[0x1C];
+  __I  uint8_t                        Reserved1[28];
   __O  uint32_t ACC_IER;        /**< (ACC Offset: 0x24) Interrupt Enable Register */
   __O  uint32_t ACC_IDR;        /**< (ACC Offset: 0x28) Interrupt Disable Register */
   __I  uint32_t ACC_IMR;        /**< (ACC Offset: 0x2C) Interrupt Mask Register */
   __I  uint32_t ACC_ISR;        /**< (ACC Offset: 0x30) Interrupt Status Register */
-  RoReg8  Reserved2[0x60];
+  __I  uint8_t                        Reserved2[96];
   __IO uint32_t ACC_ACR;        /**< (ACC Offset: 0x94) Analog Control Register */
-  RoReg8  Reserved3[0x4C];
+  __I  uint8_t                        Reserved3[76];
   __IO uint32_t ACC_WPMR;       /**< (ACC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t ACC_WPSR;       /**< (ACC Offset: 0xE8) Write Protection Status Register */
 } Acc;
@@ -348,14 +368,14 @@ typedef struct {
 typedef struct {  
   __O  ACC_CR_Type                    ACC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO ACC_MR_Type                    ACC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
-  __I  uint32_t                       Reserved1[7];
+  __I  uint8_t                        Reserved1[28];
   __O  ACC_IER_Type                   ACC_IER;        /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
   __O  ACC_IDR_Type                   ACC_IDR;        /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
   __I  ACC_IMR_Type                   ACC_IMR;        /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
   __I  ACC_ISR_Type                   ACC_ISR;        /**< Offset: 0x30 (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[24];
+  __I  uint8_t                        Reserved2[96];
   __IO ACC_ACR_Type                   ACC_ACR;        /**< Offset: 0x94 (R/W  32) Analog Control Register */
-  __I  uint32_t                       Reserved3[19];
+  __I  uint8_t                        Reserved3[76];
   __IO ACC_WPMR_Type                  ACC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  ACC_WPSR_Type                  ACC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Acc;

--- a/asf/sam/include/same70/component/aes.h
+++ b/asf/sam/include/same70/component/aes.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for AES
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- AES_CR : (AES Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t START:1;                   /**< bit:      0  Start Processing                         */
@@ -54,6 +57,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CR_OFFSET                       (0x00)                                        /**<  (AES_CR) Control Register  Offset */
@@ -70,6 +74,7 @@ typedef union {
 
 /* -------- AES_MR : (AES Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CIPHER:1;                  /**< bit:      0  Processing Mode                          */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_MR_OFFSET                       (0x04)                                        /**<  (AES_MR) Mode Register  Offset */
@@ -168,6 +174,7 @@ typedef union {
 
 /* -------- AES_IER : (AES Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
@@ -179,6 +186,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IER_OFFSET                      (0x10)                                        /**<  (AES_IER) Interrupt Enable Register  Offset */
@@ -198,6 +206,7 @@ typedef union {
 
 /* -------- AES_IDR : (AES Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
@@ -209,6 +218,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IDR_OFFSET                      (0x14)                                        /**<  (AES_IDR) Interrupt Disable Register  Offset */
@@ -228,6 +238,7 @@ typedef union {
 
 /* -------- AES_IMR : (AES Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
@@ -239,6 +250,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IMR_OFFSET                      (0x18)                                        /**<  (AES_IMR) Interrupt Mask Register  Offset */
@@ -258,6 +270,7 @@ typedef union {
 
 /* -------- AES_ISR : (AES Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) */
@@ -270,6 +283,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_ISR_OFFSET                      (0x1C)                                        /**<  (AES_ISR) Interrupt Status Register  Offset */
@@ -304,12 +318,14 @@ typedef union {
 
 /* -------- AES_KEYWR : (AES Offset: 0x20) (/W 32) Key Word Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEYW:32;                   /**< bit:  0..31  Key Word                                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_KEYWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_KEYWR_OFFSET                    (0x20)                                        /**<  (AES_KEYWR) Key Word Register 0  Offset */
@@ -323,12 +339,14 @@ typedef union {
 
 /* -------- AES_IDATAR : (AES Offset: 0x40) (/W 32) Input Data Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDATA:32;                  /**< bit:  0..31  Input Data Word                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IDATAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IDATAR_OFFSET                   (0x40)                                        /**<  (AES_IDATAR) Input Data Register 0  Offset */
@@ -342,12 +360,14 @@ typedef union {
 
 /* -------- AES_ODATAR : (AES Offset: 0x50) (R/ 32) Output Data Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_ODATAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_ODATAR_OFFSET                   (0x50)                                        /**<  (AES_ODATAR) Output Data Register 0  Offset */
@@ -361,12 +381,14 @@ typedef union {
 
 /* -------- AES_IVR : (AES Offset: 0x60) (/W 32) Initialization Vector Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IV:32;                     /**< bit:  0..31  Initialization Vector                    */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IVR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IVR_OFFSET                      (0x60)                                        /**<  (AES_IVR) Initialization Vector Register 0  Offset */
@@ -380,12 +402,14 @@ typedef union {
 
 /* -------- AES_AADLENR : (AES Offset: 0x70) (R/W 32) Additional Authenticated Data Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AADLEN:32;                 /**< bit:  0..31  Additional Authenticated Data Length     */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_AADLENR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_AADLENR_OFFSET                  (0x70)                                        /**<  (AES_AADLENR) Additional Authenticated Data Length Register  Offset */
@@ -399,12 +423,14 @@ typedef union {
 
 /* -------- AES_CLENR : (AES Offset: 0x74) (R/W 32) Plaintext/Ciphertext Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLEN:32;                   /**< bit:  0..31  Plaintext/Ciphertext Length              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CLENR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CLENR_OFFSET                    (0x74)                                        /**<  (AES_CLENR) Plaintext/Ciphertext Length Register  Offset */
@@ -418,12 +444,14 @@ typedef union {
 
 /* -------- AES_GHASHR : (AES Offset: 0x78) (R/W 32) GCM Intermediate Hash Word Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GHASH:32;                  /**< bit:  0..31  Intermediate GCM Hash Word x             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_GHASHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_GHASHR_OFFSET                   (0x78)                                        /**<  (AES_GHASHR) GCM Intermediate Hash Word Register 0  Offset */
@@ -437,12 +465,14 @@ typedef union {
 
 /* -------- AES_TAGR : (AES Offset: 0x88) (R/ 32) GCM Authentication Tag Word Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TAG:32;                    /**< bit:  0..31  GCM Authentication Tag x                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_TAGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_TAGR_OFFSET                     (0x88)                                        /**<  (AES_TAGR) GCM Authentication Tag Word Register 0  Offset */
@@ -456,12 +486,14 @@ typedef union {
 
 /* -------- AES_CTRR : (AES Offset: 0x98) (R/ 32) GCM Encryption Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CTR:32;                    /**< bit:  0..31  GCM Encryption Counter                   */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CTRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CTRR_OFFSET                     (0x98)                                        /**<  (AES_CTRR) GCM Encryption Counter Value Register  Offset */
@@ -475,12 +507,14 @@ typedef union {
 
 /* -------- AES_GCMHR : (AES Offset: 0x9c) (R/W 32) GCM H Word Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t H:32;                      /**< bit:  0..31  GCM H Word x                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_GCMHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_GCMHR_OFFSET                    (0x9C)                                        /**<  (AES_GCMHR) GCM H Word Register 0  Offset */
@@ -498,7 +532,7 @@ typedef union {
 typedef struct {  
   __O  uint32_t AES_CR;         /**< (AES Offset: 0x00) Control Register */
   __IO uint32_t AES_MR;         /**< (AES Offset: 0x04) Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __O  uint32_t AES_IER;        /**< (AES Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t AES_IDR;        /**< (AES Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t AES_IMR;        /**< (AES Offset: 0x18) Interrupt Mask Register */
@@ -520,7 +554,7 @@ typedef struct {
 typedef struct {  
   __O  AES_CR_Type                    AES_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO AES_MR_Type                    AES_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __O  AES_IER_Type                   AES_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  AES_IDR_Type                   AES_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  AES_IMR_Type                   AES_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */

--- a/asf/sam/include/same70/component/afec.h
+++ b/asf/sam/include/same70/component/afec.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for AFEC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- AFEC_CR : (AFEC Offset: 0x00) (/W 32) AFEC Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CR_OFFSET                      (0x00)                                        /**<  (AFEC_CR) AFEC Control Register  Offset */
@@ -69,6 +73,7 @@ typedef union {
 
 /* -------- AFEC_MR : (AFEC Offset: 0x04) (R/W 32) AFEC Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRGEN:1;                   /**< bit:      0  Trigger Enable                           */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_MR_OFFSET                      (0x04)                                        /**<  (AFEC_MR) AFEC Mode Register  Offset */
@@ -197,6 +203,7 @@ typedef union {
 
 /* -------- AFEC_EMR : (AFEC Offset: 0x08) (R/W 32) AFEC Extended Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMPMODE:2;                 /**< bit:   0..1  Comparison Mode                          */
@@ -217,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_EMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_EMR_OFFSET                     (0x08)                                        /**<  (AFEC_EMR) AFEC Extended Mode Register  Offset */
@@ -277,6 +285,7 @@ typedef union {
 
 /* -------- AFEC_SEQ1R : (AFEC Offset: 0x0c) (R/W 32) AFEC Channel Sequence 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USCH0:4;                   /**< bit:   0..3  User Sequence Number 0                   */
@@ -290,6 +299,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SEQ1R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SEQ1R_OFFSET                   (0x0C)                                        /**<  (AFEC_SEQ1R) AFEC Channel Sequence 1 Register  Offset */
@@ -324,6 +334,7 @@ typedef union {
 
 /* -------- AFEC_SEQ2R : (AFEC Offset: 0x10) (R/W 32) AFEC Channel Sequence 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USCH8:4;                   /**< bit:   0..3  User Sequence Number 8                   */
@@ -334,6 +345,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SEQ2R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SEQ2R_OFFSET                   (0x10)                                        /**<  (AFEC_SEQ2R) AFEC Channel Sequence 2 Register  Offset */
@@ -356,6 +368,7 @@ typedef union {
 
 /* -------- AFEC_CHER : (AFEC Offset: 0x14) (/W 32) AFEC Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
@@ -378,6 +391,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHER_OFFSET                    (0x14)                                        /**<  (AFEC_CHER) AFEC Channel Enable Register  Offset */
@@ -427,6 +441,7 @@ typedef union {
 
 /* -------- AFEC_CHDR : (AFEC Offset: 0x18) (/W 32) AFEC Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
@@ -449,6 +464,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHDR_OFFSET                    (0x18)                                        /**<  (AFEC_CHDR) AFEC Channel Disable Register  Offset */
@@ -498,6 +514,7 @@ typedef union {
 
 /* -------- AFEC_CHSR : (AFEC Offset: 0x1c) (R/ 32) AFEC Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
@@ -520,6 +537,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHSR_OFFSET                    (0x1C)                                        /**<  (AFEC_CHSR) AFEC Channel Status Register  Offset */
@@ -569,6 +587,7 @@ typedef union {
 
 /* -------- AFEC_LCDR : (AFEC Offset: 0x20) (R/ 32) AFEC Last Converted Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LDATA:16;                  /**< bit:  0..15  Last Data Converted                      */
@@ -578,6 +597,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_LCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_LCDR_OFFSET                    (0x20)                                        /**<  (AFEC_LCDR) AFEC Last Converted Data Register  Offset */
@@ -594,6 +614,7 @@ typedef union {
 
 /* -------- AFEC_IER : (AFEC Offset: 0x24) (/W 32) AFEC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Enable 0     */
@@ -622,6 +643,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IER_OFFSET                     (0x24)                                        /**<  (AFEC_IER) AFEC Interrupt Enable Register  Offset */
@@ -683,6 +705,7 @@ typedef union {
 
 /* -------- AFEC_IDR : (AFEC Offset: 0x28) (/W 32) AFEC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Disable 0    */
@@ -711,6 +734,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IDR_OFFSET                     (0x28)                                        /**<  (AFEC_IDR) AFEC Interrupt Disable Register  Offset */
@@ -772,6 +796,7 @@ typedef union {
 
 /* -------- AFEC_IMR : (AFEC Offset: 0x2c) (R/ 32) AFEC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Mask 0       */
@@ -800,6 +825,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IMR_OFFSET                     (0x2C)                                        /**<  (AFEC_IMR) AFEC Interrupt Mask Register  Offset */
@@ -861,6 +887,7 @@ typedef union {
 
 /* -------- AFEC_ISR : (AFEC Offset: 0x30) (R/ 32) AFEC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion 0 (cleared by reading AFEC_CDRx) */
@@ -889,6 +916,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_ISR_OFFSET                     (0x30)                                        /**<  (AFEC_ISR) AFEC Interrupt Status Register  Offset */
@@ -950,6 +978,7 @@ typedef union {
 
 /* -------- AFEC_OVER : (AFEC Offset: 0x4c) (R/ 32) AFEC Overrun Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OVRE0:1;                   /**< bit:      0  Overrun Error 0                          */
@@ -972,6 +1001,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_OVER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_OVER_OFFSET                    (0x4C)                                        /**<  (AFEC_OVER) AFEC Overrun Status Register  Offset */
@@ -1021,6 +1051,7 @@ typedef union {
 
 /* -------- AFEC_CWR : (AFEC Offset: 0x50) (R/W 32) AFEC Compare Window Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LOWTHRES:16;               /**< bit:  0..15  Low Threshold                            */
@@ -1028,6 +1059,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CWR_OFFSET                     (0x50)                                        /**<  (AFEC_CWR) AFEC Compare Window Register  Offset */
@@ -1044,6 +1076,7 @@ typedef union {
 
 /* -------- AFEC_CGR : (AFEC Offset: 0x54) (R/W 32) AFEC Channel Gain Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GAIN0:2;                   /**< bit:   0..1  Gain for Channel 0                       */
@@ -1062,6 +1095,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CGR_OFFSET                     (0x54)                                        /**<  (AFEC_CGR) AFEC Channel Gain Register  Offset */
@@ -1108,6 +1142,7 @@ typedef union {
 
 /* -------- AFEC_DIFFR : (AFEC Offset: 0x60) (R/W 32) AFEC Channel Differential Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIFF0:1;                   /**< bit:      0  Differential inputs for channel 0        */
@@ -1130,6 +1165,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_DIFFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_DIFFR_OFFSET                   (0x60)                                        /**<  (AFEC_DIFFR) AFEC Channel Differential Register  Offset */
@@ -1179,6 +1215,7 @@ typedef union {
 
 /* -------- AFEC_CSELR : (AFEC Offset: 0x64) (R/W 32) AFEC Channel Selection Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL:4;                    /**< bit:   0..3  Channel Selection                        */
@@ -1186,6 +1223,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CSELR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CSELR_OFFSET                   (0x64)                                        /**<  (AFEC_CSELR) AFEC Channel Selection Register  Offset */
@@ -1199,6 +1237,7 @@ typedef union {
 
 /* -------- AFEC_CDR : (AFEC Offset: 0x68) (R/ 32) AFEC Channel Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:16;                   /**< bit:  0..15  Converted Data                           */
@@ -1206,6 +1245,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CDR_OFFSET                     (0x68)                                        /**<  (AFEC_CDR) AFEC Channel Data Register  Offset */
@@ -1219,6 +1259,7 @@ typedef union {
 
 /* -------- AFEC_COCR : (AFEC Offset: 0x6c) (R/W 32) AFEC Channel Offset Compensation Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AOFF:10;                   /**< bit:   0..9  Analog Offset                            */
@@ -1226,6 +1267,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_COCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_COCR_OFFSET                    (0x6C)                                        /**<  (AFEC_COCR) AFEC Channel Offset Compensation Register  Offset */
@@ -1239,6 +1281,7 @@ typedef union {
 
 /* -------- AFEC_TEMPMR : (AFEC Offset: 0x70) (R/W 32) AFEC Temperature Sensor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RTCT:1;                    /**< bit:      0  Temperature Sensor RTC Trigger Mode      */
@@ -1248,6 +1291,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_TEMPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_TEMPMR_OFFSET                  (0x70)                                        /**<  (AFEC_TEMPMR) AFEC Temperature Sensor Mode Register  Offset */
@@ -1272,6 +1316,7 @@ typedef union {
 
 /* -------- AFEC_TEMPCWR : (AFEC Offset: 0x74) (R/W 32) AFEC Temperature Compare Window Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TLOWTHRES:16;              /**< bit:  0..15  Temperature Low Threshold                */
@@ -1279,6 +1324,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_TEMPCWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_TEMPCWR_OFFSET                 (0x74)                                        /**<  (AFEC_TEMPCWR) AFEC Temperature Compare Window Register  Offset */
@@ -1295,6 +1341,7 @@ typedef union {
 
 /* -------- AFEC_ACR : (AFEC Offset: 0x94) (R/W 32) AFEC Analog Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1306,6 +1353,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_ACR_OFFSET                     (0x94)                                        /**<  (AFEC_ACR) AFEC Analog Control Register  Offset */
@@ -1325,6 +1373,7 @@ typedef union {
 
 /* -------- AFEC_SHMR : (AFEC Offset: 0xa0) (R/W 32) AFEC Sample & Hold Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DUAL0:1;                   /**< bit:      0  Dual Sample & Hold for channel 0         */
@@ -1347,6 +1396,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SHMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SHMR_OFFSET                    (0xA0)                                        /**<  (AFEC_SHMR) AFEC Sample & Hold Mode Register  Offset */
@@ -1396,6 +1446,7 @@ typedef union {
 
 /* -------- AFEC_COSR : (AFEC Offset: 0xd0) (R/W 32) AFEC Correction Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL:1;                    /**< bit:      0  Sample & Hold unit Correction Select     */
@@ -1403,6 +1454,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_COSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_COSR_OFFSET                    (0xD0)                                        /**<  (AFEC_COSR) AFEC Correction Select Register  Offset */
@@ -1416,6 +1468,7 @@ typedef union {
 
 /* -------- AFEC_CVR : (AFEC Offset: 0xd4) (R/W 32) AFEC Correction Values Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSETCORR:16;             /**< bit:  0..15  Offset Correction                        */
@@ -1423,6 +1476,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CVR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CVR_OFFSET                     (0xD4)                                        /**<  (AFEC_CVR) AFEC Correction Values Register  Offset */
@@ -1439,6 +1493,7 @@ typedef union {
 
 /* -------- AFEC_CECR : (AFEC Offset: 0xd8) (R/W 32) AFEC Channel Error Correction Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ECORR0:1;                  /**< bit:      0  Error Correction Enable for channel 0    */
@@ -1461,6 +1516,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CECR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CECR_OFFSET                    (0xD8)                                        /**<  (AFEC_CECR) AFEC Channel Error Correction Register  Offset */
@@ -1510,6 +1566,7 @@ typedef union {
 
 /* -------- AFEC_WPMR : (AFEC Offset: 0xe4) (R/W 32) AFEC Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1518,6 +1575,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_WPMR_OFFSET                    (0xE4)                                        /**<  (AFEC_WPMR) AFEC Write Protection Mode Register  Offset */
@@ -1536,6 +1594,7 @@ typedef union {
 
 /* -------- AFEC_WPSR : (AFEC Offset: 0xe8) (R/ 32) AFEC Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protect Violation Status           */
@@ -1545,6 +1604,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_WPSR_OFFSET                    (0xE8)                                        /**<  (AFEC_WPSR) AFEC Write Protection Status Register  Offset */
@@ -1576,26 +1636,26 @@ typedef struct {
   __O  uint32_t AFEC_IDR;       /**< (AFEC Offset: 0x28) AFEC Interrupt Disable Register */
   __I  uint32_t AFEC_IMR;       /**< (AFEC Offset: 0x2C) AFEC Interrupt Mask Register */
   __I  uint32_t AFEC_ISR;       /**< (AFEC Offset: 0x30) AFEC Interrupt Status Register */
-  RoReg8  Reserved1[0x18];
+  __I  uint8_t                        Reserved1[24];
   __I  uint32_t AFEC_OVER;      /**< (AFEC Offset: 0x4C) AFEC Overrun Status Register */
   __IO uint32_t AFEC_CWR;       /**< (AFEC Offset: 0x50) AFEC Compare Window Register */
   __IO uint32_t AFEC_CGR;       /**< (AFEC Offset: 0x54) AFEC Channel Gain Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __IO uint32_t AFEC_DIFFR;     /**< (AFEC Offset: 0x60) AFEC Channel Differential Register */
   __IO uint32_t AFEC_CSELR;     /**< (AFEC Offset: 0x64) AFEC Channel Selection Register */
   __I  uint32_t AFEC_CDR;       /**< (AFEC Offset: 0x68) AFEC Channel Data Register */
   __IO uint32_t AFEC_COCR;      /**< (AFEC Offset: 0x6C) AFEC Channel Offset Compensation Register */
   __IO uint32_t AFEC_TEMPMR;    /**< (AFEC Offset: 0x70) AFEC Temperature Sensor Mode Register */
   __IO uint32_t AFEC_TEMPCWR;   /**< (AFEC Offset: 0x74) AFEC Temperature Compare Window Register */
-  RoReg8  Reserved3[0x1C];
+  __I  uint8_t                        Reserved3[28];
   __IO uint32_t AFEC_ACR;       /**< (AFEC Offset: 0x94) AFEC Analog Control Register */
-  RoReg8  Reserved4[0x8];
+  __I  uint8_t                        Reserved4[8];
   __IO uint32_t AFEC_SHMR;      /**< (AFEC Offset: 0xA0) AFEC Sample & Hold Mode Register */
-  RoReg8  Reserved5[0x2C];
+  __I  uint8_t                        Reserved5[44];
   __IO uint32_t AFEC_COSR;      /**< (AFEC Offset: 0xD0) AFEC Correction Select Register */
   __IO uint32_t AFEC_CVR;       /**< (AFEC Offset: 0xD4) AFEC Correction Values Register */
   __IO uint32_t AFEC_CECR;      /**< (AFEC Offset: 0xD8) AFEC Channel Error Correction Register */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __IO uint32_t AFEC_WPMR;      /**< (AFEC Offset: 0xE4) AFEC Write Protection Mode Register */
   __I  uint32_t AFEC_WPSR;      /**< (AFEC Offset: 0xE8) AFEC Write Protection Status Register */
 } Afec;
@@ -1616,26 +1676,26 @@ typedef struct {
   __O  AFEC_IDR_Type                  AFEC_IDR;       /**< Offset: 0x28 ( /W  32) AFEC Interrupt Disable Register */
   __I  AFEC_IMR_Type                  AFEC_IMR;       /**< Offset: 0x2C (R/   32) AFEC Interrupt Mask Register */
   __I  AFEC_ISR_Type                  AFEC_ISR;       /**< Offset: 0x30 (R/   32) AFEC Interrupt Status Register */
-  __I  uint32_t                       Reserved1[6];
+  __I  uint8_t                        Reserved1[24];
   __I  AFEC_OVER_Type                 AFEC_OVER;      /**< Offset: 0x4C (R/   32) AFEC Overrun Status Register */
   __IO AFEC_CWR_Type                  AFEC_CWR;       /**< Offset: 0x50 (R/W  32) AFEC Compare Window Register */
   __IO AFEC_CGR_Type                  AFEC_CGR;       /**< Offset: 0x54 (R/W  32) AFEC Channel Gain Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __IO AFEC_DIFFR_Type                AFEC_DIFFR;     /**< Offset: 0x60 (R/W  32) AFEC Channel Differential Register */
   __IO AFEC_CSELR_Type                AFEC_CSELR;     /**< Offset: 0x64 (R/W  32) AFEC Channel Selection Register */
   __I  AFEC_CDR_Type                  AFEC_CDR;       /**< Offset: 0x68 (R/   32) AFEC Channel Data Register */
   __IO AFEC_COCR_Type                 AFEC_COCR;      /**< Offset: 0x6C (R/W  32) AFEC Channel Offset Compensation Register */
   __IO AFEC_TEMPMR_Type               AFEC_TEMPMR;    /**< Offset: 0x70 (R/W  32) AFEC Temperature Sensor Mode Register */
   __IO AFEC_TEMPCWR_Type              AFEC_TEMPCWR;   /**< Offset: 0x74 (R/W  32) AFEC Temperature Compare Window Register */
-  __I  uint32_t                       Reserved3[7];
+  __I  uint8_t                        Reserved3[28];
   __IO AFEC_ACR_Type                  AFEC_ACR;       /**< Offset: 0x94 (R/W  32) AFEC Analog Control Register */
-  __I  uint32_t                       Reserved4[2];
+  __I  uint8_t                        Reserved4[8];
   __IO AFEC_SHMR_Type                 AFEC_SHMR;      /**< Offset: 0xA0 (R/W  32) AFEC Sample & Hold Mode Register */
-  __I  uint32_t                       Reserved5[11];
+  __I  uint8_t                        Reserved5[44];
   __IO AFEC_COSR_Type                 AFEC_COSR;      /**< Offset: 0xD0 (R/W  32) AFEC Correction Select Register */
   __IO AFEC_CVR_Type                  AFEC_CVR;       /**< Offset: 0xD4 (R/W  32) AFEC Correction Values Register */
   __IO AFEC_CECR_Type                 AFEC_CECR;      /**< Offset: 0xD8 (R/W  32) AFEC Channel Error Correction Register */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __IO AFEC_WPMR_Type                 AFEC_WPMR;      /**< Offset: 0xE4 (R/W  32) AFEC Write Protection Mode Register */
   __I  AFEC_WPSR_Type                 AFEC_WPSR;      /**< Offset: 0xE8 (R/   32) AFEC Write Protection Status Register */
 } Afec;

--- a/asf/sam/include/same70/component/chipid.h
+++ b/asf/sam/include/same70/component/chipid.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for CHIPID
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- CHIPID_CIDR : (CHIPID Offset: 0x00) (R/ 32) Chip ID Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VERSION:5;                 /**< bit:   0..4  Version of the Device                    */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CHIPID_CIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_CIDR_OFFSET                  (0x00)                                        /**<  (CHIPID_CIDR) Chip ID Register  Offset */
@@ -200,12 +204,14 @@ typedef union {
 
 /* -------- CHIPID_EXID : (CHIPID Offset: 0x04) (R/ 32) Chip ID Extension Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EXID:32;                   /**< bit:  0..31  Chip ID Extension                        */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CHIPID_EXID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_EXID_OFFSET                  (0x04)                                        /**<  (CHIPID_EXID) Chip ID Extension Register  Offset */

--- a/asf/sam/include/same70/component/dacc.h
+++ b/asf/sam/include/same70/component/dacc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for DACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- DACC_CR : (DACC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CR_OFFSET                      (0x00)                                        /**<  (DACC_CR) Control Register  Offset */
@@ -65,6 +69,7 @@ typedef union {
 
 /* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXS0:1;                   /**< bit:      0  Max Speed Mode for Channel 0             */
@@ -83,6 +88,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_MR_OFFSET                      (0x04)                                        /**<  (DACC_MR) Mode Register  Offset */
@@ -130,6 +136,7 @@ typedef union {
 
 /* -------- DACC_TRIGR : (DACC Offset: 0x08) (R/W 32) Trigger Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRGEN0:1;                  /**< bit:      0  Trigger Enable of Channel 0              */
@@ -150,6 +157,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_TRIGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_TRIGR_OFFSET                   (0x08)                                        /**<  (DACC_TRIGR) Trigger Register  Offset */
@@ -245,6 +253,7 @@ typedef union {
 
 /* -------- DACC_CHER : (DACC Offset: 0x10) (/W 32) Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
@@ -257,6 +266,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHER_OFFSET                    (0x10)                                        /**<  (DACC_CHER) Channel Enable Register  Offset */
@@ -276,6 +286,7 @@ typedef union {
 
 /* -------- DACC_CHDR : (DACC Offset: 0x14) (/W 32) Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
@@ -288,6 +299,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHDR_OFFSET                    (0x14)                                        /**<  (DACC_CHDR) Channel Disable Register  Offset */
@@ -307,6 +319,7 @@ typedef union {
 
 /* -------- DACC_CHSR : (DACC Offset: 0x18) (R/ 32) Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
@@ -324,6 +337,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHSR_OFFSET                    (0x18)                                        /**<  (DACC_CHSR) Channel Status Register  Offset */
@@ -352,6 +366,7 @@ typedef union {
 
 /* -------- DACC_CDR : (DACC Offset: 0x1c) (/W 32) Conversion Data Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA0:16;                  /**< bit:  0..15  Data to Convert for channel 0            */
@@ -359,6 +374,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CDR_OFFSET                     (0x1C)                                        /**<  (DACC_CDR) Conversion Data Register 0  Offset */
@@ -375,6 +391,7 @@ typedef union {
 
 /* -------- DACC_IER : (DACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Enable of channel 0 */
@@ -392,6 +409,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IER_OFFSET                     (0x24)                                        /**<  (DACC_IER) Interrupt Enable Register  Offset */
@@ -420,6 +438,7 @@ typedef union {
 
 /* -------- DACC_IDR : (DACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Disable of channel 0 */
@@ -437,6 +456,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IDR_OFFSET                     (0x28)                                        /**<  (DACC_IDR) Interrupt Disable Register  Offset */
@@ -465,6 +485,7 @@ typedef union {
 
 /* -------- DACC_IMR : (DACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Mask of channel 0 */
@@ -482,6 +503,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IMR_OFFSET                     (0x2C)                                        /**<  (DACC_IMR) Interrupt Mask Register  Offset */
@@ -510,6 +532,7 @@ typedef union {
 
 /* -------- DACC_ISR : (DACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Flag of channel 0 */
@@ -527,6 +550,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_ISR_OFFSET                     (0x30)                                        /**<  (DACC_ISR) Interrupt Status Register  Offset */
@@ -555,6 +579,7 @@ typedef union {
 
 /* -------- DACC_ACR : (DACC Offset: 0x94) (R/W 32) Analog Current Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IBCTLCH0:2;                /**< bit:   0..1  Analog Output Current Control            */
@@ -563,6 +588,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_ACR_OFFSET                     (0x94)                                        /**<  (DACC_ACR) Analog Current Register  Offset */
@@ -579,6 +605,7 @@ typedef union {
 
 /* -------- DACC_WPMR : (DACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -587,6 +614,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPMR_OFFSET                    (0xE4)                                        /**<  (DACC_WPMR) Write Protection Mode Register  Offset */
@@ -605,6 +633,7 @@ typedef union {
 
 /* -------- DACC_WPSR : (DACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -614,6 +643,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPSR_OFFSET                    (0xE8)                                        /**<  (DACC_WPSR) Write Protection Status Register  Offset */
@@ -635,7 +665,7 @@ typedef struct {
   __O  uint32_t DACC_CR;        /**< (DACC Offset: 0x00) Control Register */
   __IO uint32_t DACC_MR;        /**< (DACC Offset: 0x04) Mode Register */
   __IO uint32_t DACC_TRIGR;     /**< (DACC Offset: 0x08) Trigger Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t DACC_CHER;      /**< (DACC Offset: 0x10) Channel Enable Register */
   __O  uint32_t DACC_CHDR;      /**< (DACC Offset: 0x14) Channel Disable Register */
   __I  uint32_t DACC_CHSR;      /**< (DACC Offset: 0x18) Channel Status Register */
@@ -644,9 +674,9 @@ typedef struct {
   __O  uint32_t DACC_IDR;       /**< (DACC Offset: 0x28) Interrupt Disable Register */
   __I  uint32_t DACC_IMR;       /**< (DACC Offset: 0x2C) Interrupt Mask Register */
   __I  uint32_t DACC_ISR;       /**< (DACC Offset: 0x30) Interrupt Status Register */
-  RoReg8  Reserved2[0x60];
+  __I  uint8_t                        Reserved2[96];
   __IO uint32_t DACC_ACR;       /**< (DACC Offset: 0x94) Analog Current Register */
-  RoReg8  Reserved3[0x4C];
+  __I  uint8_t                        Reserved3[76];
   __IO uint32_t DACC_WPMR;      /**< (DACC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t DACC_WPSR;      /**< (DACC Offset: 0xE8) Write Protection Status Register */
 } Dacc;
@@ -657,7 +687,7 @@ typedef struct {
   __O  DACC_CR_Type                   DACC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
   __IO DACC_MR_Type                   DACC_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
   __IO DACC_TRIGR_Type                DACC_TRIGR;     /**< Offset: 0x08 (R/W  32) Trigger Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  DACC_CHER_Type                 DACC_CHER;      /**< Offset: 0x10 ( /W  32) Channel Enable Register */
   __O  DACC_CHDR_Type                 DACC_CHDR;      /**< Offset: 0x14 ( /W  32) Channel Disable Register */
   __I  DACC_CHSR_Type                 DACC_CHSR;      /**< Offset: 0x18 (R/   32) Channel Status Register */
@@ -666,9 +696,9 @@ typedef struct {
   __O  DACC_IDR_Type                  DACC_IDR;       /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
   __I  DACC_IMR_Type                  DACC_IMR;       /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
   __I  DACC_ISR_Type                  DACC_ISR;       /**< Offset: 0x30 (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[24];
+  __I  uint8_t                        Reserved2[96];
   __IO DACC_ACR_Type                  DACC_ACR;       /**< Offset: 0x94 (R/W  32) Analog Current Register */
-  __I  uint32_t                       Reserved3[19];
+  __I  uint8_t                        Reserved3[76];
   __IO DACC_WPMR_Type                 DACC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  DACC_WPSR_Type                 DACC_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Dacc;

--- a/asf/sam/include/same70/component/efc.h
+++ b/asf/sam/include/same70/component/efc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for EFC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- EEFC_FMR : (EFC Offset: 0x00) (R/W 32) EEFC Flash Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Interrupt Enable             */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FMR_OFFSET                     (0x00)                                        /**<  (EEFC_FMR) EEFC Flash Mode Register  Offset */
@@ -80,6 +84,7 @@ typedef union {
 
 /* -------- EEFC_FCR : (EFC Offset: 0x04) (/W 32) EEFC Flash Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCMD:8;                    /**< bit:   0..7  Flash Command                            */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FCR_OFFSET                     (0x04)                                        /**<  (EEFC_FCR) EEFC Flash Command Register  Offset */
@@ -151,6 +157,7 @@ typedef union {
 
 /* -------- EEFC_FSR : (EFC Offset: 0x08) (R/ 32) EEFC Flash Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Status (cleared when Flash is busy) */
@@ -166,6 +173,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FSR_OFFSET                     (0x08)                                        /**<  (EEFC_FSR) EEFC Flash Status Register  Offset */
@@ -200,12 +208,14 @@ typedef union {
 
 /* -------- EEFC_FRR : (EFC Offset: 0x0c) (R/ 32) EEFC Flash Result Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FVALUE:32;                 /**< bit:  0..31  Flash Result Value                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FRR_OFFSET                     (0x0C)                                        /**<  (EEFC_FRR) EEFC Flash Result Register  Offset */
@@ -219,6 +229,7 @@ typedef union {
 
 /* -------- EEFC_WPMR : (EFC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -227,6 +238,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_WPMR_OFFSET                    (0xE4)                                        /**<  (EEFC_WPMR) Write Protection Mode Register  Offset */
@@ -251,7 +263,7 @@ typedef struct {
   __O  uint32_t EEFC_FCR;       /**< (EFC Offset: 0x04) EEFC Flash Command Register */
   __I  uint32_t EEFC_FSR;       /**< (EFC Offset: 0x08) EEFC Flash Status Register */
   __I  uint32_t EEFC_FRR;       /**< (EFC Offset: 0x0C) EEFC Flash Result Register */
-  RoReg8  Reserved1[0xD4];
+  __I  uint8_t                        Reserved1[212];
   __IO uint32_t EEFC_WPMR;      /**< (EFC Offset: 0xE4) Write Protection Mode Register */
 } Efc;
 
@@ -262,7 +274,7 @@ typedef struct {
   __O  EEFC_FCR_Type                  EEFC_FCR;       /**< Offset: 0x04 ( /W  32) EEFC Flash Command Register */
   __I  EEFC_FSR_Type                  EEFC_FSR;       /**< Offset: 0x08 (R/   32) EEFC Flash Status Register */
   __I  EEFC_FRR_Type                  EEFC_FRR;       /**< Offset: 0x0C (R/   32) EEFC Flash Result Register */
-  __I  uint32_t                       Reserved1[53];
+  __I  uint8_t                        Reserved1[212];
   __IO EEFC_WPMR_Type                 EEFC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Efc;
 

--- a/asf/sam/include/same70/component/gmac.h
+++ b/asf/sam/include/same70/component/gmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for GMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +47,14 @@
 
 /* -------- GMAC_SAB : (GMAC Offset: 0x00) (R/W 32) Specific Address 1 Bottom Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAB_OFFSET                     (0x00)                                        /**<  (GMAC_SAB) Specific Address 1 Bottom Register  Offset */
@@ -64,6 +68,7 @@ typedef union {
 
 /* -------- GMAC_SAT : (GMAC Offset: 0x04) (R/W 32) Specific Address 1 Top Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1                       */
@@ -71,6 +76,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAT_OFFSET                     (0x04)                                        /**<  (GMAC_SAT) Specific Address 1 Top Register  Offset */
@@ -84,6 +90,7 @@ typedef union {
 
 /* -------- GMAC_NCR : (GMAC Offset: 0x00) (R/W 32) Network Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -108,6 +115,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NCR_OFFSET                     (0x00)                                        /**<  (GMAC_NCR) Network Control Register  Offset */
@@ -166,6 +174,7 @@ typedef union {
 
 /* -------- GMAC_NCFGR : (GMAC Offset: 0x04) (R/W 32) Network Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPD:1;                     /**< bit:      0  Speed                                    */
@@ -197,6 +206,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NCFGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NCFGR_OFFSET                   (0x04)                                        /**<  (GMAC_NCFGR) Network Configuration Register  Offset */
@@ -288,6 +298,7 @@ typedef union {
 
 /* -------- GMAC_NSR : (GMAC Offset: 0x08) (R/ 32) Network Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -297,6 +308,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NSR_OFFSET                     (0x08)                                        /**<  (GMAC_NSR) Network Status Register  Offset */
@@ -313,6 +325,7 @@ typedef union {
 
 /* -------- GMAC_UR : (GMAC Offset: 0x0c) (R/W 32) User Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RMII:1;                    /**< bit:      0  Reduced MII Mode                         */
@@ -320,6 +333,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UR_OFFSET                      (0x0C)                                        /**<  (GMAC_UR) User Register  Offset */
@@ -333,6 +347,7 @@ typedef union {
 
 /* -------- GMAC_DCFGR : (GMAC Offset: 0x10) (R/W 32) DMA Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FBLDO:5;                   /**< bit:   0..4  Fixed Burst Length for DMA Data Operations: */
@@ -349,6 +364,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_DCFGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_DCFGR_OFFSET                   (0x10)                                        /**<  (GMAC_DCFGR) DMA Configuration Register  Offset */
@@ -399,6 +415,7 @@ typedef union {
 
 /* -------- GMAC_TSR : (GMAC Offset: 0x14) (R/W 32) Transmit Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UBR:1;                     /**< bit:      0  Used Bit Read                            */
@@ -413,6 +430,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSR_OFFSET                     (0x14)                                        /**<  (GMAC_TSR) Transmit Status Register  Offset */
@@ -444,6 +462,7 @@ typedef union {
 
 /* -------- GMAC_RBQB : (GMAC Offset: 0x18) (R/W 32) Receive Buffer Queue Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -451,6 +470,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RBQB_OFFSET                    (0x18)                                        /**<  (GMAC_RBQB) Receive Buffer Queue Base Address Register  Offset */
@@ -464,6 +484,7 @@ typedef union {
 
 /* -------- GMAC_TBQB : (GMAC Offset: 0x1c) (R/W 32) Transmit Buffer Queue Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -471,6 +492,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBQB_OFFSET                    (0x1C)                                        /**<  (GMAC_TBQB) Transmit Buffer Queue Base Address Register  Offset */
@@ -484,6 +506,7 @@ typedef union {
 
 /* -------- GMAC_RSR : (GMAC Offset: 0x20) (R/W 32) Receive Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BNA:1;                     /**< bit:      0  Buffer Not Available                     */
@@ -494,6 +517,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RSR_OFFSET                     (0x20)                                        /**<  (GMAC_RSR) Receive Status Register  Offset */
@@ -516,6 +540,7 @@ typedef union {
 
 /* -------- GMAC_ISR : (GMAC Offset: 0x24) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -548,6 +573,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ISR_OFFSET                     (0x24)                                        /**<  (GMAC_ISR) Interrupt Status Register  Offset */
@@ -627,6 +653,7 @@ typedef union {
 
 /* -------- GMAC_IER : (GMAC Offset: 0x28) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -660,6 +687,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IER_OFFSET                     (0x28)                                        /**<  (GMAC_IER) Interrupt Enable Register  Offset */
@@ -742,6 +770,7 @@ typedef union {
 
 /* -------- GMAC_IDR : (GMAC Offset: 0x2c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -775,6 +804,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IDR_OFFSET                     (0x2C)                                        /**<  (GMAC_IDR) Interrupt Disable Register  Offset */
@@ -857,6 +887,7 @@ typedef union {
 
 /* -------- GMAC_IMR : (GMAC Offset: 0x30) (R/W 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -890,6 +921,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IMR_OFFSET                     (0x30)                                        /**<  (GMAC_IMR) Interrupt Mask Register  Offset */
@@ -972,6 +1004,7 @@ typedef union {
 
 /* -------- GMAC_MAN : (GMAC Offset: 0x34) (R/W 32) PHY Maintenance Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:16;                   /**< bit:  0..15  PHY Data                                 */
@@ -984,6 +1017,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MAN_OFFSET                     (0x34)                                        /**<  (GMAC_MAN) PHY Maintenance Register  Offset */
@@ -1015,6 +1049,7 @@ typedef union {
 
 /* -------- GMAC_RPQ : (GMAC Offset: 0x38) (R/ 32) Received Pause Quantum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RPQ:16;                    /**< bit:  0..15  Received Pause Quantum                   */
@@ -1022,6 +1057,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RPQ_OFFSET                     (0x38)                                        /**<  (GMAC_RPQ) Received Pause Quantum Register  Offset */
@@ -1035,6 +1071,7 @@ typedef union {
 
 /* -------- GMAC_TPQ : (GMAC Offset: 0x3c) (R/W 32) Transmit Pause Quantum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TPQ:16;                    /**< bit:  0..15  Transmit Pause Quantum                   */
@@ -1042,6 +1079,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPQ_OFFSET                     (0x3C)                                        /**<  (GMAC_TPQ) Transmit Pause Quantum Register  Offset */
@@ -1055,6 +1093,7 @@ typedef union {
 
 /* -------- GMAC_TPSF : (GMAC Offset: 0x40) (R/W 32) TX Partial Store and Forward Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TPB1ADR:12;                /**< bit:  0..11  Transmit Partial Store and Forward Address */
@@ -1063,6 +1102,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPSF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPSF_OFFSET                    (0x40)                                        /**<  (GMAC_TPSF) TX Partial Store and Forward Register  Offset */
@@ -1079,6 +1119,7 @@ typedef union {
 
 /* -------- GMAC_RPSF : (GMAC Offset: 0x44) (R/W 32) RX Partial Store and Forward Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RPB1ADR:12;                /**< bit:  0..11  Receive Partial Store and Forward Address */
@@ -1087,6 +1128,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RPSF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RPSF_OFFSET                    (0x44)                                        /**<  (GMAC_RPSF) RX Partial Store and Forward Register  Offset */
@@ -1103,6 +1145,7 @@ typedef union {
 
 /* -------- GMAC_RJFML : (GMAC Offset: 0x48) (R/W 32) RX Jumbo Frame Max Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FML:14;                    /**< bit:  0..13  Frame Max Length                         */
@@ -1110,6 +1153,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RJFML_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RJFML_OFFSET                   (0x48)                                        /**<  (GMAC_RJFML) RX Jumbo Frame Max Length Register  Offset */
@@ -1123,12 +1167,14 @@ typedef union {
 
 /* -------- GMAC_HRB : (GMAC Offset: 0x80) (R/W 32) Hash Register Bottom -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_HRB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_HRB_OFFSET                     (0x80)                                        /**<  (GMAC_HRB) Hash Register Bottom  Offset */
@@ -1142,12 +1188,14 @@ typedef union {
 
 /* -------- GMAC_HRT : (GMAC Offset: 0x84) (R/W 32) Hash Register Top -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_HRT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_HRT_OFFSET                     (0x84)                                        /**<  (GMAC_HRT) Hash Register Top  Offset */
@@ -1161,14 +1209,20 @@ typedef union {
 
 /* -------- GMAC_TIDM1 : (GMAC Offset: 0xa8) (R/W 32) Type ID Match 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 1                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID1:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM1_OFFSET                   (0xA8)                                        /**<  (GMAC_TIDM1) Type ID Match 1 Register  Offset */
@@ -1182,17 +1236,26 @@ typedef union {
 #define GMAC_TIDM1_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM1) Register MASK  (Use GMAC_TIDM1_Msk instead)  */
 #define GMAC_TIDM1_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM1) Register Mask  */
 
+#define GMAC_TIDM1_ENID_Pos                 31                                             /**< (GMAC_TIDM1 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM1_ENID_Msk                 (_U_(0x1) << GMAC_TIDM1_ENID_Pos)              /**< (GMAC_TIDM1 Mask) ENID */
+#define GMAC_TIDM1_ENID(value)              (GMAC_TIDM1_ENID_Msk & ((value) << GMAC_TIDM1_ENID_Pos))  
 
 /* -------- GMAC_TIDM2 : (GMAC Offset: 0xac) (R/W 32) Type ID Match 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 2                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID2:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM2_OFFSET                   (0xAC)                                        /**<  (GMAC_TIDM2) Type ID Match 2 Register  Offset */
@@ -1206,17 +1269,26 @@ typedef union {
 #define GMAC_TIDM2_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM2) Register MASK  (Use GMAC_TIDM2_Msk instead)  */
 #define GMAC_TIDM2_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM2) Register Mask  */
 
+#define GMAC_TIDM2_ENID_Pos                 31                                             /**< (GMAC_TIDM2 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM2_ENID_Msk                 (_U_(0x1) << GMAC_TIDM2_ENID_Pos)              /**< (GMAC_TIDM2 Mask) ENID */
+#define GMAC_TIDM2_ENID(value)              (GMAC_TIDM2_ENID_Msk & ((value) << GMAC_TIDM2_ENID_Pos))  
 
 /* -------- GMAC_TIDM3 : (GMAC Offset: 0xb0) (R/W 32) Type ID Match 3 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 3                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID3:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM3_OFFSET                   (0xB0)                                        /**<  (GMAC_TIDM3) Type ID Match 3 Register  Offset */
@@ -1230,17 +1302,26 @@ typedef union {
 #define GMAC_TIDM3_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM3) Register MASK  (Use GMAC_TIDM3_Msk instead)  */
 #define GMAC_TIDM3_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM3) Register Mask  */
 
+#define GMAC_TIDM3_ENID_Pos                 31                                             /**< (GMAC_TIDM3 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM3_ENID_Msk                 (_U_(0x1) << GMAC_TIDM3_ENID_Pos)              /**< (GMAC_TIDM3 Mask) ENID */
+#define GMAC_TIDM3_ENID(value)              (GMAC_TIDM3_ENID_Msk & ((value) << GMAC_TIDM3_ENID_Pos))  
 
 /* -------- GMAC_TIDM4 : (GMAC Offset: 0xb4) (R/W 32) Type ID Match 4 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 4                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID4:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM4_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM4_OFFSET                   (0xB4)                                        /**<  (GMAC_TIDM4) Type ID Match 4 Register  Offset */
@@ -1254,9 +1335,13 @@ typedef union {
 #define GMAC_TIDM4_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM4) Register MASK  (Use GMAC_TIDM4_Msk instead)  */
 #define GMAC_TIDM4_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM4) Register Mask  */
 
+#define GMAC_TIDM4_ENID_Pos                 31                                             /**< (GMAC_TIDM4 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM4_ENID_Msk                 (_U_(0x1) << GMAC_TIDM4_ENID_Pos)              /**< (GMAC_TIDM4 Mask) ENID */
+#define GMAC_TIDM4_ENID(value)              (GMAC_TIDM4_ENID_Msk & ((value) << GMAC_TIDM4_ENID_Pos))  
 
 /* -------- GMAC_WOL : (GMAC Offset: 0xb8) (R/W 32) Wake on LAN Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IP:16;                     /**< bit:  0..15  ARP Request IP Address                   */
@@ -1266,8 +1351,14 @@ typedef union {
     uint32_t MTI:1;                     /**< bit:     19  Multicast Hash Event Enable              */
     uint32_t :12;                       /**< bit: 20..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t SA:1;                      /**< bit:     18  Specific Address Register x Event Enable */
+    uint32_t :13;                       /**< bit: 19..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_WOL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_WOL_OFFSET                     (0xB8)                                        /**<  (GMAC_WOL) Wake on LAN Register  Offset */
@@ -1290,9 +1381,13 @@ typedef union {
 #define GMAC_WOL_MASK                       _U_(0xFFFFF)                                   /**< \deprecated (GMAC_WOL) Register MASK  (Use GMAC_WOL_Msk instead)  */
 #define GMAC_WOL_Msk                        _U_(0xFFFFF)                                   /**< (GMAC_WOL) Register Mask  */
 
+#define GMAC_WOL_SA_Pos                     18                                             /**< (GMAC_WOL Position) Specific Address Register x Event Enable */
+#define GMAC_WOL_SA_Msk                     (_U_(0x1) << GMAC_WOL_SA_Pos)                  /**< (GMAC_WOL Mask) SA */
+#define GMAC_WOL_SA(value)                  (GMAC_WOL_SA_Msk & ((value) << GMAC_WOL_SA_Pos))  
 
 /* -------- GMAC_IPGS : (GMAC Offset: 0xbc) (R/W 32) IPG Stretch Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FL:16;                     /**< bit:  0..15  Frame Length                             */
@@ -1300,6 +1395,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IPGS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IPGS_OFFSET                    (0xBC)                                        /**<  (GMAC_IPGS) IPG Stretch Register  Offset */
@@ -1313,6 +1409,7 @@ typedef union {
 
 /* -------- GMAC_SVLAN : (GMAC Offset: 0xc0) (R/W 32) Stacked VLAN Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VLAN_TYPE:16;              /**< bit:  0..15  User Defined VLAN_TYPE Field             */
@@ -1321,6 +1418,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SVLAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SVLAN_OFFSET                   (0xC0)                                        /**<  (GMAC_SVLAN) Stacked VLAN Register  Offset */
@@ -1337,6 +1435,7 @@ typedef union {
 
 /* -------- GMAC_TPFCP : (GMAC Offset: 0xc4) (R/W 32) Transmit PFC Pause Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PEV:8;                     /**< bit:   0..7  Priority Enable Vector                   */
@@ -1345,6 +1444,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPFCP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPFCP_OFFSET                   (0xC4)                                        /**<  (GMAC_TPFCP) Transmit PFC Pause Register  Offset */
@@ -1361,12 +1461,14 @@ typedef union {
 
 /* -------- GMAC_SAMB1 : (GMAC Offset: 0xc8) (R/W 32) Specific Address 1 Mask Bottom Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1 Mask                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAMB1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAMB1_OFFSET                   (0xC8)                                        /**<  (GMAC_SAMB1) Specific Address 1 Mask Bottom Register  Offset */
@@ -1380,6 +1482,7 @@ typedef union {
 
 /* -------- GMAC_SAMT1 : (GMAC Offset: 0xcc) (R/W 32) Specific Address 1 Mask Top Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1 Mask                  */
@@ -1387,6 +1490,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAMT1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAMT1_OFFSET                   (0xCC)                                        /**<  (GMAC_SAMT1) Specific Address 1 Mask Top Register  Offset */
@@ -1400,6 +1504,7 @@ typedef union {
 
 /* -------- GMAC_NSC : (GMAC Offset: 0xdc) (R/W 32) 1588 Timer Nanosecond Comparison Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NANOSEC:22;                /**< bit:  0..21  1588 Timer Nanosecond Comparison Value   */
@@ -1407,6 +1512,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NSC_OFFSET                     (0xDC)                                        /**<  (GMAC_NSC) 1588 Timer Nanosecond Comparison Register  Offset */
@@ -1420,12 +1526,14 @@ typedef union {
 
 /* -------- GMAC_SCL : (GMAC Offset: 0xe0) (R/W 32) 1588 Timer Second Comparison Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:32;                    /**< bit:  0..31  1588 Timer Second Comparison Value       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCL_OFFSET                     (0xE0)                                        /**<  (GMAC_SCL) 1588 Timer Second Comparison Low Register  Offset */
@@ -1439,6 +1547,7 @@ typedef union {
 
 /* -------- GMAC_SCH : (GMAC Offset: 0xe4) (R/W 32) 1588 Timer Second Comparison High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:16;                    /**< bit:  0..15  1588 Timer Second Comparison Value       */
@@ -1446,6 +1555,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCH_OFFSET                     (0xE4)                                        /**<  (GMAC_SCH) 1588 Timer Second Comparison High Register  Offset */
@@ -1459,6 +1569,7 @@ typedef union {
 
 /* -------- GMAC_EFTSH : (GMAC Offset: 0xe8) (R/ 32) PTP Event Frame Transmitted Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1466,6 +1577,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTSH_OFFSET                   (0xE8)                                        /**<  (GMAC_EFTSH) PTP Event Frame Transmitted Seconds High Register  Offset */
@@ -1479,6 +1591,7 @@ typedef union {
 
 /* -------- GMAC_EFRSH : (GMAC Offset: 0xec) (R/ 32) PTP Event Frame Received Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1486,6 +1599,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRSH_OFFSET                   (0xEC)                                        /**<  (GMAC_EFRSH) PTP Event Frame Received Seconds High Register  Offset */
@@ -1499,6 +1613,7 @@ typedef union {
 
 /* -------- GMAC_PEFTSH : (GMAC Offset: 0xf0) (R/ 32) PTP Peer Event Frame Transmitted Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1506,6 +1621,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTSH_OFFSET                  (0xF0)                                        /**<  (GMAC_PEFTSH) PTP Peer Event Frame Transmitted Seconds High Register  Offset */
@@ -1519,6 +1635,7 @@ typedef union {
 
 /* -------- GMAC_PEFRSH : (GMAC Offset: 0xf4) (R/ 32) PTP Peer Event Frame Received Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1526,6 +1643,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRSH_OFFSET                  (0xF4)                                        /**<  (GMAC_PEFRSH) PTP Peer Event Frame Received Seconds High Register  Offset */
@@ -1539,12 +1657,14 @@ typedef union {
 
 /* -------- GMAC_OTLO : (GMAC Offset: 0x100) (R/ 32) Octets Transmitted Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXO:32;                    /**< bit:  0..31  Transmitted Octets                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OTLO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OTLO_OFFSET                    (0x100)                                       /**<  (GMAC_OTLO) Octets Transmitted Low Register  Offset */
@@ -1558,6 +1678,7 @@ typedef union {
 
 /* -------- GMAC_OTHI : (GMAC Offset: 0x104) (R/ 32) Octets Transmitted High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXO:16;                    /**< bit:  0..15  Transmitted Octets                       */
@@ -1565,6 +1686,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OTHI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OTHI_OFFSET                    (0x104)                                       /**<  (GMAC_OTHI) Octets Transmitted High Register  Offset */
@@ -1578,12 +1700,14 @@ typedef union {
 
 /* -------- GMAC_FT : (GMAC Offset: 0x108) (R/ 32) Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FTX:32;                    /**< bit:  0..31  Frames Transmitted without Error         */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FT_OFFSET                      (0x108)                                       /**<  (GMAC_FT) Frames Transmitted Register  Offset */
@@ -1597,12 +1721,14 @@ typedef union {
 
 /* -------- GMAC_BCFT : (GMAC Offset: 0x10c) (R/ 32) Broadcast Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BFTX:32;                   /**< bit:  0..31  Broadcast Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BCFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BCFT_OFFSET                    (0x10C)                                       /**<  (GMAC_BCFT) Broadcast Frames Transmitted Register  Offset */
@@ -1616,12 +1742,14 @@ typedef union {
 
 /* -------- GMAC_MFT : (GMAC Offset: 0x110) (R/ 32) Multicast Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFTX:32;                   /**< bit:  0..31  Multicast Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MFT_OFFSET                     (0x110)                                       /**<  (GMAC_MFT) Multicast Frames Transmitted Register  Offset */
@@ -1635,6 +1763,7 @@ typedef union {
 
 /* -------- GMAC_PFT : (GMAC Offset: 0x114) (R/ 32) Pause Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PFTX:16;                   /**< bit:  0..15  Pause Frames Transmitted Register        */
@@ -1642,6 +1771,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PFT_OFFSET                     (0x114)                                       /**<  (GMAC_PFT) Pause Frames Transmitted Register  Offset */
@@ -1655,12 +1785,14 @@ typedef union {
 
 /* -------- GMAC_BFT64 : (GMAC Offset: 0x118) (R/ 32) 64 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  64 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BFT64_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BFT64_OFFSET                   (0x118)                                       /**<  (GMAC_BFT64) 64 Byte Frames Transmitted Register  Offset */
@@ -1674,12 +1806,14 @@ typedef union {
 
 /* -------- GMAC_TBFT127 : (GMAC Offset: 0x11c) (R/ 32) 65 to 127 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT127_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT127_OFFSET                 (0x11C)                                       /**<  (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted Register  Offset */
@@ -1693,12 +1827,14 @@ typedef union {
 
 /* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) (R/ 32) 128 to 255 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT255_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT255_OFFSET                 (0x120)                                       /**<  (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted Register  Offset */
@@ -1712,12 +1848,14 @@ typedef union {
 
 /* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) (R/ 32) 256 to 511 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT511_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT511_OFFSET                 (0x124)                                       /**<  (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted Register  Offset */
@@ -1731,12 +1869,14 @@ typedef union {
 
 /* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) (R/ 32) 512 to 1023 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT1023_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT1023_OFFSET                (0x128)                                       /**<  (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted Register  Offset */
@@ -1750,12 +1890,14 @@ typedef union {
 
 /* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12c) (R/ 32) 1024 to 1518 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT1518_OFFSET                (0x12C)                                       /**<  (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted Register  Offset */
@@ -1769,12 +1911,14 @@ typedef union {
 
 /* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) (R/ 32) Greater Than 1518 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  Greater than 1518 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_GTBFT1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_GTBFT1518_OFFSET               (0x130)                                       /**<  (GMAC_GTBFT1518) Greater Than 1518 Byte Frames Transmitted Register  Offset */
@@ -1788,6 +1932,7 @@ typedef union {
 
 /* -------- GMAC_TUR : (GMAC Offset: 0x134) (R/ 32) Transmit Underruns Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXUNR:10;                  /**< bit:   0..9  Transmit Underruns                       */
@@ -1795,6 +1940,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TUR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TUR_OFFSET                     (0x134)                                       /**<  (GMAC_TUR) Transmit Underruns Register  Offset */
@@ -1808,6 +1954,7 @@ typedef union {
 
 /* -------- GMAC_SCF : (GMAC Offset: 0x138) (R/ 32) Single Collision Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCOL:18;                   /**< bit:  0..17  Single Collision                         */
@@ -1815,6 +1962,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCF_OFFSET                     (0x138)                                       /**<  (GMAC_SCF) Single Collision Frames Register  Offset */
@@ -1828,6 +1976,7 @@ typedef union {
 
 /* -------- GMAC_MCF : (GMAC Offset: 0x13c) (R/ 32) Multiple Collision Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MCOL:18;                   /**< bit:  0..17  Multiple Collision                       */
@@ -1835,6 +1984,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MCF_OFFSET                     (0x13C)                                       /**<  (GMAC_MCF) Multiple Collision Frames Register  Offset */
@@ -1848,6 +1998,7 @@ typedef union {
 
 /* -------- GMAC_EC : (GMAC Offset: 0x140) (R/ 32) Excessive Collisions Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t XCOL:10;                   /**< bit:   0..9  Excessive Collisions                     */
@@ -1855,6 +2006,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EC_OFFSET                      (0x140)                                       /**<  (GMAC_EC) Excessive Collisions Register  Offset */
@@ -1868,6 +2020,7 @@ typedef union {
 
 /* -------- GMAC_LC : (GMAC Offset: 0x144) (R/ 32) Late Collisions Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LCOL:10;                   /**< bit:   0..9  Late Collisions                          */
@@ -1875,6 +2028,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_LC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_LC_OFFSET                      (0x144)                                       /**<  (GMAC_LC) Late Collisions Register  Offset */
@@ -1888,6 +2042,7 @@ typedef union {
 
 /* -------- GMAC_DTF : (GMAC Offset: 0x148) (R/ 32) Deferred Transmission Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DEFT:18;                   /**< bit:  0..17  Deferred Transmission                    */
@@ -1895,6 +2050,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_DTF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_DTF_OFFSET                     (0x148)                                       /**<  (GMAC_DTF) Deferred Transmission Frames Register  Offset */
@@ -1908,6 +2064,7 @@ typedef union {
 
 /* -------- GMAC_CSE : (GMAC Offset: 0x14c) (R/ 32) Carrier Sense Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSR:10;                    /**< bit:   0..9  Carrier Sense Error                      */
@@ -1915,6 +2072,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CSE_OFFSET                     (0x14C)                                       /**<  (GMAC_CSE) Carrier Sense Errors Register  Offset */
@@ -1928,12 +2086,14 @@ typedef union {
 
 /* -------- GMAC_ORLO : (GMAC Offset: 0x150) (R/ 32) Octets Received Low Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXO:32;                    /**< bit:  0..31  Received Octets                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ORLO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ORLO_OFFSET                    (0x150)                                       /**<  (GMAC_ORLO) Octets Received Low Received Register  Offset */
@@ -1947,6 +2107,7 @@ typedef union {
 
 /* -------- GMAC_ORHI : (GMAC Offset: 0x154) (R/ 32) Octets Received High Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXO:16;                    /**< bit:  0..15  Received Octets                          */
@@ -1954,6 +2115,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ORHI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ORHI_OFFSET                    (0x154)                                       /**<  (GMAC_ORHI) Octets Received High Received Register  Offset */
@@ -1967,12 +2129,14 @@ typedef union {
 
 /* -------- GMAC_FR : (GMAC Offset: 0x158) (R/ 32) Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRX:32;                    /**< bit:  0..31  Frames Received without Error            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FR_OFFSET                      (0x158)                                       /**<  (GMAC_FR) Frames Received Register  Offset */
@@ -1986,12 +2150,14 @@ typedef union {
 
 /* -------- GMAC_BCFR : (GMAC Offset: 0x15c) (R/ 32) Broadcast Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BFRX:32;                   /**< bit:  0..31  Broadcast Frames Received without Error  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BCFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BCFR_OFFSET                    (0x15C)                                       /**<  (GMAC_BCFR) Broadcast Frames Received Register  Offset */
@@ -2005,12 +2171,14 @@ typedef union {
 
 /* -------- GMAC_MFR : (GMAC Offset: 0x160) (R/ 32) Multicast Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFRX:32;                   /**< bit:  0..31  Multicast Frames Received without Error  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MFR_OFFSET                     (0x160)                                       /**<  (GMAC_MFR) Multicast Frames Received Register  Offset */
@@ -2024,6 +2192,7 @@ typedef union {
 
 /* -------- GMAC_PFR : (GMAC Offset: 0x164) (R/ 32) Pause Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PFRX:16;                   /**< bit:  0..15  Pause Frames Received Register           */
@@ -2031,6 +2200,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PFR_OFFSET                     (0x164)                                       /**<  (GMAC_PFR) Pause Frames Received Register  Offset */
@@ -2044,12 +2214,14 @@ typedef union {
 
 /* -------- GMAC_BFR64 : (GMAC Offset: 0x168) (R/ 32) 64 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  64 Byte Frames Received without Error    */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BFR64_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BFR64_OFFSET                   (0x168)                                       /**<  (GMAC_BFR64) 64 Byte Frames Received Register  Offset */
@@ -2063,12 +2235,14 @@ typedef union {
 
 /* -------- GMAC_TBFR127 : (GMAC Offset: 0x16c) (R/ 32) 65 to 127 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR127_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR127_OFFSET                 (0x16C)                                       /**<  (GMAC_TBFR127) 65 to 127 Byte Frames Received Register  Offset */
@@ -2082,12 +2256,14 @@ typedef union {
 
 /* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) (R/ 32) 128 to 255 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR255_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR255_OFFSET                 (0x170)                                       /**<  (GMAC_TBFR255) 128 to 255 Byte Frames Received Register  Offset */
@@ -2101,12 +2277,14 @@ typedef union {
 
 /* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) (R/ 32) 256 to 511 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR511_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR511_OFFSET                 (0x174)                                       /**<  (GMAC_TBFR511) 256 to 511 Byte Frames Received Register  Offset */
@@ -2120,12 +2298,14 @@ typedef union {
 
 /* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) (R/ 32) 512 to 1023 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR1023_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR1023_OFFSET                (0x178)                                       /**<  (GMAC_TBFR1023) 512 to 1023 Byte Frames Received Register  Offset */
@@ -2139,12 +2319,14 @@ typedef union {
 
 /* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17c) (R/ 32) 1024 to 1518 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR1518_OFFSET                (0x17C)                                       /**<  (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received Register  Offset */
@@ -2158,12 +2340,14 @@ typedef union {
 
 /* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) (R/ 32) 1519 to Maximum Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  1519 to Maximum Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TMXBFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TMXBFR_OFFSET                  (0x180)                                       /**<  (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received Register  Offset */
@@ -2177,6 +2361,7 @@ typedef union {
 
 /* -------- GMAC_UFR : (GMAC Offset: 0x184) (R/ 32) Undersize Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UFRX:10;                   /**< bit:   0..9  Undersize Frames Received                */
@@ -2184,6 +2369,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UFR_OFFSET                     (0x184)                                       /**<  (GMAC_UFR) Undersize Frames Received Register  Offset */
@@ -2197,6 +2383,7 @@ typedef union {
 
 /* -------- GMAC_OFR : (GMAC Offset: 0x188) (R/ 32) Oversize Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFRX:10;                   /**< bit:   0..9  Oversized Frames Received                */
@@ -2204,6 +2391,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OFR_OFFSET                     (0x188)                                       /**<  (GMAC_OFR) Oversize Frames Received Register  Offset */
@@ -2217,6 +2405,7 @@ typedef union {
 
 /* -------- GMAC_JR : (GMAC Offset: 0x18c) (R/ 32) Jabbers Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t JRX:10;                    /**< bit:   0..9  Jabbers Received                         */
@@ -2224,6 +2413,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_JR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_JR_OFFSET                      (0x18C)                                       /**<  (GMAC_JR) Jabbers Received Register  Offset */
@@ -2237,6 +2427,7 @@ typedef union {
 
 /* -------- GMAC_FCSE : (GMAC Offset: 0x190) (R/ 32) Frame Check Sequence Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCKR:10;                   /**< bit:   0..9  Frame Check Sequence Errors              */
@@ -2244,6 +2435,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FCSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FCSE_OFFSET                    (0x190)                                       /**<  (GMAC_FCSE) Frame Check Sequence Errors Register  Offset */
@@ -2257,6 +2449,7 @@ typedef union {
 
 /* -------- GMAC_LFFE : (GMAC Offset: 0x194) (R/ 32) Length Field Frame Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LFER:10;                   /**< bit:   0..9  Length Field Frame Errors                */
@@ -2264,6 +2457,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_LFFE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_LFFE_OFFSET                    (0x194)                                       /**<  (GMAC_LFFE) Length Field Frame Errors Register  Offset */
@@ -2277,6 +2471,7 @@ typedef union {
 
 /* -------- GMAC_RSE : (GMAC Offset: 0x198) (R/ 32) Receive Symbol Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXSE:10;                   /**< bit:   0..9  Receive Symbol Errors                    */
@@ -2284,6 +2479,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RSE_OFFSET                     (0x198)                                       /**<  (GMAC_RSE) Receive Symbol Errors Register  Offset */
@@ -2297,6 +2493,7 @@ typedef union {
 
 /* -------- GMAC_AE : (GMAC Offset: 0x19c) (R/ 32) Alignment Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AER:10;                    /**< bit:   0..9  Alignment Errors                         */
@@ -2304,6 +2501,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_AE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_AE_OFFSET                      (0x19C)                                       /**<  (GMAC_AE) Alignment Errors Register  Offset */
@@ -2317,6 +2515,7 @@ typedef union {
 
 /* -------- GMAC_RRE : (GMAC Offset: 0x1a0) (R/ 32) Receive Resource Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRER:18;                  /**< bit:  0..17  Receive Resource Errors                  */
@@ -2324,6 +2523,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RRE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RRE_OFFSET                     (0x1A0)                                       /**<  (GMAC_RRE) Receive Resource Errors Register  Offset */
@@ -2337,6 +2537,7 @@ typedef union {
 
 /* -------- GMAC_ROE : (GMAC Offset: 0x1a4) (R/ 32) Receive Overrun Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXOVR:10;                  /**< bit:   0..9  Receive Overruns                         */
@@ -2344,6 +2545,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ROE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ROE_OFFSET                     (0x1A4)                                       /**<  (GMAC_ROE) Receive Overrun Register  Offset */
@@ -2357,6 +2559,7 @@ typedef union {
 
 /* -------- GMAC_IHCE : (GMAC Offset: 0x1a8) (R/ 32) IP Header Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HCKER:8;                   /**< bit:   0..7  IP Header Checksum Errors                */
@@ -2364,6 +2567,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IHCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IHCE_OFFSET                    (0x1A8)                                       /**<  (GMAC_IHCE) IP Header Checksum Errors Register  Offset */
@@ -2377,6 +2581,7 @@ typedef union {
 
 /* -------- GMAC_TCE : (GMAC Offset: 0x1ac) (R/ 32) TCP Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCKER:8;                   /**< bit:   0..7  TCP Checksum Errors                      */
@@ -2384,6 +2589,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TCE_OFFSET                     (0x1AC)                                       /**<  (GMAC_TCE) TCP Checksum Errors Register  Offset */
@@ -2397,6 +2603,7 @@ typedef union {
 
 /* -------- GMAC_UCE : (GMAC Offset: 0x1b0) (R/ 32) UDP Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UCKER:8;                   /**< bit:   0..7  UDP Checksum Errors                      */
@@ -2404,6 +2611,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UCE_OFFSET                     (0x1B0)                                       /**<  (GMAC_UCE) UDP Checksum Errors Register  Offset */
@@ -2417,6 +2625,7 @@ typedef union {
 
 /* -------- GMAC_TISUBN : (GMAC Offset: 0x1bc) (R/W 32) 1588 Timer Increment Sub-nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LSBTIR:16;                 /**< bit:  0..15  Lower Significant Bits of Timer Increment Register */
@@ -2424,6 +2633,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TISUBN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TISUBN_OFFSET                  (0x1BC)                                       /**<  (GMAC_TISUBN) 1588 Timer Increment Sub-nanoseconds Register  Offset */
@@ -2437,6 +2647,7 @@ typedef union {
 
 /* -------- GMAC_TSH : (GMAC Offset: 0x1c0) (R/W 32) 1588 Timer Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCS:16;                    /**< bit:  0..15  Timer Count in Seconds                   */
@@ -2444,6 +2655,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSH_OFFSET                     (0x1C0)                                       /**<  (GMAC_TSH) 1588 Timer Seconds High Register  Offset */
@@ -2457,12 +2669,14 @@ typedef union {
 
 /* -------- GMAC_TSL : (GMAC Offset: 0x1d0) (R/W 32) 1588 Timer Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCS:32;                    /**< bit:  0..31  Timer Count in Seconds                   */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSL_OFFSET                     (0x1D0)                                       /**<  (GMAC_TSL) 1588 Timer Seconds Low Register  Offset */
@@ -2476,6 +2690,7 @@ typedef union {
 
 /* -------- GMAC_TN : (GMAC Offset: 0x1d4) (R/W 32) 1588 Timer Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TNS:30;                    /**< bit:  0..29  Timer Count in Nanoseconds               */
@@ -2483,6 +2698,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TN_OFFSET                      (0x1D4)                                       /**<  (GMAC_TN) 1588 Timer Nanoseconds Register  Offset */
@@ -2496,6 +2712,7 @@ typedef union {
 
 /* -------- GMAC_TA : (GMAC Offset: 0x1d8) (/W 32) 1588 Timer Adjust Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ITDT:30;                   /**< bit:  0..29  Increment/Decrement                      */
@@ -2504,6 +2721,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TA_OFFSET                      (0x1D8)                                       /**<  (GMAC_TA) 1588 Timer Adjust Register  Offset */
@@ -2520,6 +2738,7 @@ typedef union {
 
 /* -------- GMAC_TI : (GMAC Offset: 0x1dc) (R/W 32) 1588 Timer Increment Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CNS:8;                     /**< bit:   0..7  Count Nanoseconds                        */
@@ -2529,6 +2748,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TI_OFFSET                      (0x1DC)                                       /**<  (GMAC_TI) 1588 Timer Increment Register  Offset */
@@ -2548,12 +2768,14 @@ typedef union {
 
 /* -------- GMAC_EFTSL : (GMAC Offset: 0x1e0) (R/ 32) PTP Event Frame Transmitted Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTSL_OFFSET                   (0x1E0)                                       /**<  (GMAC_EFTSL) PTP Event Frame Transmitted Seconds Low Register  Offset */
@@ -2567,6 +2789,7 @@ typedef union {
 
 /* -------- GMAC_EFTN : (GMAC Offset: 0x1e4) (R/ 32) PTP Event Frame Transmitted Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2574,6 +2797,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTN_OFFSET                    (0x1E4)                                       /**<  (GMAC_EFTN) PTP Event Frame Transmitted Nanoseconds Register  Offset */
@@ -2587,12 +2811,14 @@ typedef union {
 
 /* -------- GMAC_EFRSL : (GMAC Offset: 0x1e8) (R/ 32) PTP Event Frame Received Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRSL_OFFSET                   (0x1E8)                                       /**<  (GMAC_EFRSL) PTP Event Frame Received Seconds Low Register  Offset */
@@ -2606,6 +2832,7 @@ typedef union {
 
 /* -------- GMAC_EFRN : (GMAC Offset: 0x1ec) (R/ 32) PTP Event Frame Received Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2613,6 +2840,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRN_OFFSET                    (0x1EC)                                       /**<  (GMAC_EFRN) PTP Event Frame Received Nanoseconds Register  Offset */
@@ -2626,12 +2854,14 @@ typedef union {
 
 /* -------- GMAC_PEFTSL : (GMAC Offset: 0x1f0) (R/ 32) PTP Peer Event Frame Transmitted Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTSL_OFFSET                  (0x1F0)                                       /**<  (GMAC_PEFTSL) PTP Peer Event Frame Transmitted Seconds Low Register  Offset */
@@ -2645,6 +2875,7 @@ typedef union {
 
 /* -------- GMAC_PEFTN : (GMAC Offset: 0x1f4) (R/ 32) PTP Peer Event Frame Transmitted Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2652,6 +2883,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTN_OFFSET                   (0x1F4)                                       /**<  (GMAC_PEFTN) PTP Peer Event Frame Transmitted Nanoseconds Register  Offset */
@@ -2665,12 +2897,14 @@ typedef union {
 
 /* -------- GMAC_PEFRSL : (GMAC Offset: 0x1f8) (R/ 32) PTP Peer Event Frame Received Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRSL_OFFSET                  (0x1F8)                                       /**<  (GMAC_PEFRSL) PTP Peer Event Frame Received Seconds Low Register  Offset */
@@ -2684,6 +2918,7 @@ typedef union {
 
 /* -------- GMAC_PEFRN : (GMAC Offset: 0x1fc) (R/ 32) PTP Peer Event Frame Received Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2691,6 +2926,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRN_OFFSET                   (0x1FC)                                       /**<  (GMAC_PEFRN) PTP Peer Event Frame Received Nanoseconds Register  Offset */
@@ -2702,8 +2938,9 @@ typedef union {
 #define GMAC_PEFRN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFRN) Register Mask  */
 
 
-/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x3fc) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -2720,9 +2957,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ISRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_ISRPQ_OFFSET                   (0x3FC)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
 #define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
@@ -2749,8 +2987,9 @@ typedef union {
 #define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
 
 
-/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x43c) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2758,9 +2997,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBQBAPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_TBQBAPQ_OFFSET                 (0x43C)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
 #define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
@@ -2769,8 +3009,9 @@ typedef union {
 #define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x47c) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2778,9 +3019,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBQBAPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBQBAPQ_OFFSET                 (0x47C)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
 #define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
@@ -2789,8 +3031,9 @@ typedef union {
 #define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x49c) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RBS:16;                    /**< bit:  0..15  Receive Buffer Size                      */
@@ -2798,9 +3041,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBSRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBSRPQ_OFFSET                  (0x49C)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
 #define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
@@ -2811,6 +3055,7 @@ typedef union {
 
 /* -------- GMAC_CBSCR : (GMAC Offset: 0x4bc) (R/W 32) Credit-Based Shaping Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QBE:1;                     /**< bit:      0  Queue B CBS Enable                       */
@@ -2819,6 +3064,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSCR_OFFSET                   (0x4BC)                                       /**<  (GMAC_CBSCR) Credit-Based Shaping Control Register  Offset */
@@ -2835,12 +3081,14 @@ typedef union {
 
 /* -------- GMAC_CBSISQA : (GMAC Offset: 0x4c0) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue A -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSISQA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSISQA_OFFSET                 (0x4C0)                                       /**<  (GMAC_CBSISQA) Credit-Based Shaping IdleSlope Register for Queue A  Offset */
@@ -2854,12 +3102,14 @@ typedef union {
 
 /* -------- GMAC_CBSISQB : (GMAC Offset: 0x4c4) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue B -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSISQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSISQB_OFFSET                 (0x4C4)                                       /**<  (GMAC_CBSISQB) Credit-Based Shaping IdleSlope Register for Queue B  Offset */
@@ -2873,6 +3123,7 @@ typedef union {
 
 /* -------- GMAC_ST1RPQ : (GMAC Offset: 0x500) (R/W 32) Screening Type 1 Register Priority Queue (index = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
@@ -2885,6 +3136,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST1RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST1RPQ_OFFSET                  (0x500)                                       /**<  (GMAC_ST1RPQ) Screening Type 1 Register Priority Queue (index = 0) 0  Offset */
@@ -2910,6 +3162,7 @@ typedef union {
 
 /* -------- GMAC_ST2RPQ : (GMAC Offset: 0x540) (R/W 32) Screening Type 2 Register Priority Queue (index = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
@@ -2929,6 +3182,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2RPQ_OFFSET                  (0x540)                                       /**<  (GMAC_ST2RPQ) Screening Type 2 Register Priority Queue (index = 0) 0  Offset */
@@ -2970,8 +3224,9 @@ typedef union {
 #define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
 
 
-/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x5fc) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -2988,9 +3243,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IERPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IERPQ_OFFSET                   (0x5FC)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
 #define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
@@ -3017,8 +3273,9 @@ typedef union {
 #define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
 
 
-/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x61c) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -3035,9 +3292,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IDRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IDRPQ_OFFSET                   (0x61C)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
 #define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
@@ -3064,8 +3322,9 @@ typedef union {
 #define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
 
 
-/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x63c) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -3082,9 +3341,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IMRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IMRPQ_OFFSET                   (0x63C)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
 #define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */
@@ -3113,6 +3373,7 @@ typedef union {
 
 /* -------- GMAC_ST2ER : (GMAC Offset: 0x6e0) (R/W 32) Screening Type 2 Ethertype Register (index = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COMPVAL:16;                /**< bit:  0..15  Ethertype Compare Value                  */
@@ -3120,6 +3381,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2ER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2ER_OFFSET                   (0x6E0)                                       /**<  (GMAC_ST2ER) Screening Type 2 Ethertype Register (index = 0) 0  Offset */
@@ -3133,6 +3395,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW00 : (GMAC Offset: 0x700) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3140,6 +3403,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW00_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW00_OFFSET                 (0x700)                                       /**<  (GMAC_ST2CW00) Screening Type 2 Compare Word 0 Register (index = 0)  Offset */
@@ -3155,6 +3419,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW10 : (GMAC Offset: 0x704) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3163,6 +3428,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW10_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW10_OFFSET                 (0x704)                                       /**<  (GMAC_ST2CW10) Screening Type 2 Compare Word 1 Register (index = 0)  Offset */
@@ -3187,6 +3453,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW01 : (GMAC Offset: 0x708) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3194,6 +3461,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW01_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW01_OFFSET                 (0x708)                                       /**<  (GMAC_ST2CW01) Screening Type 2 Compare Word 0 Register (index = 1)  Offset */
@@ -3209,6 +3477,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW11 : (GMAC Offset: 0x70c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3217,6 +3486,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW11_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW11_OFFSET                 (0x70C)                                       /**<  (GMAC_ST2CW11) Screening Type 2 Compare Word 1 Register (index = 1)  Offset */
@@ -3241,6 +3511,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW02 : (GMAC Offset: 0x710) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3248,6 +3519,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW02_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW02_OFFSET                 (0x710)                                       /**<  (GMAC_ST2CW02) Screening Type 2 Compare Word 0 Register (index = 2)  Offset */
@@ -3263,6 +3535,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW12 : (GMAC Offset: 0x714) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3271,6 +3544,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW12_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW12_OFFSET                 (0x714)                                       /**<  (GMAC_ST2CW12) Screening Type 2 Compare Word 1 Register (index = 2)  Offset */
@@ -3295,6 +3569,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW03 : (GMAC Offset: 0x718) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 3) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3302,6 +3577,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW03_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW03_OFFSET                 (0x718)                                       /**<  (GMAC_ST2CW03) Screening Type 2 Compare Word 0 Register (index = 3)  Offset */
@@ -3317,6 +3593,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW13 : (GMAC Offset: 0x71c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 3) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3325,6 +3602,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW13_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW13_OFFSET                 (0x71C)                                       /**<  (GMAC_ST2CW13) Screening Type 2 Compare Word 1 Register (index = 3)  Offset */
@@ -3349,6 +3627,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW04 : (GMAC Offset: 0x720) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 4) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3356,6 +3635,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW04_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW04_OFFSET                 (0x720)                                       /**<  (GMAC_ST2CW04) Screening Type 2 Compare Word 0 Register (index = 4)  Offset */
@@ -3371,6 +3651,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW14 : (GMAC Offset: 0x724) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 4) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3379,6 +3660,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW14_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW14_OFFSET                 (0x724)                                       /**<  (GMAC_ST2CW14) Screening Type 2 Compare Word 1 Register (index = 4)  Offset */
@@ -3403,6 +3685,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW05 : (GMAC Offset: 0x728) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3410,6 +3693,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW05_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW05_OFFSET                 (0x728)                                       /**<  (GMAC_ST2CW05) Screening Type 2 Compare Word 0 Register (index = 5)  Offset */
@@ -3425,6 +3709,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW15 : (GMAC Offset: 0x72c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3433,6 +3718,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW15_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW15_OFFSET                 (0x72C)                                       /**<  (GMAC_ST2CW15) Screening Type 2 Compare Word 1 Register (index = 5)  Offset */
@@ -3457,6 +3743,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW06 : (GMAC Offset: 0x730) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 6) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3464,6 +3751,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW06_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW06_OFFSET                 (0x730)                                       /**<  (GMAC_ST2CW06) Screening Type 2 Compare Word 0 Register (index = 6)  Offset */
@@ -3479,6 +3767,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW16 : (GMAC Offset: 0x734) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 6) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3487,6 +3776,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW16_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW16_OFFSET                 (0x734)                                       /**<  (GMAC_ST2CW16) Screening Type 2 Compare Word 1 Register (index = 6)  Offset */
@@ -3511,6 +3801,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW07 : (GMAC Offset: 0x738) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 7) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3518,6 +3809,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW07_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW07_OFFSET                 (0x738)                                       /**<  (GMAC_ST2CW07) Screening Type 2 Compare Word 0 Register (index = 7)  Offset */
@@ -3533,6 +3825,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW17 : (GMAC Offset: 0x73c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 7) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3541,6 +3834,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW17_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW17_OFFSET                 (0x73C)                                       /**<  (GMAC_ST2CW17) Screening Type 2 Compare Word 1 Register (index = 7)  Offset */
@@ -3565,6 +3859,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW08 : (GMAC Offset: 0x740) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 8) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3572,6 +3867,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW08_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW08_OFFSET                 (0x740)                                       /**<  (GMAC_ST2CW08) Screening Type 2 Compare Word 0 Register (index = 8)  Offset */
@@ -3587,6 +3883,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW18 : (GMAC Offset: 0x744) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 8) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3595,6 +3892,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW18_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW18_OFFSET                 (0x744)                                       /**<  (GMAC_ST2CW18) Screening Type 2 Compare Word 1 Register (index = 8)  Offset */
@@ -3619,6 +3917,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW09 : (GMAC Offset: 0x748) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 9) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3626,6 +3925,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW09_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW09_OFFSET                 (0x748)                                       /**<  (GMAC_ST2CW09) Screening Type 2 Compare Word 0 Register (index = 9)  Offset */
@@ -3641,6 +3941,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW19 : (GMAC Offset: 0x74c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 9) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3649,6 +3950,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW19_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW19_OFFSET                 (0x74C)                                       /**<  (GMAC_ST2CW19) Screening Type 2 Compare Word 1 Register (index = 9)  Offset */
@@ -3673,6 +3975,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW010 : (GMAC Offset: 0x750) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 10) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3680,6 +3983,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW010_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW010_OFFSET                (0x750)                                       /**<  (GMAC_ST2CW010) Screening Type 2 Compare Word 0 Register (index = 10)  Offset */
@@ -3695,6 +3999,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW110 : (GMAC Offset: 0x754) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 10) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3703,6 +4008,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW110_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW110_OFFSET                (0x754)                                       /**<  (GMAC_ST2CW110) Screening Type 2 Compare Word 1 Register (index = 10)  Offset */
@@ -3727,6 +4033,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW011 : (GMAC Offset: 0x758) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 11) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3734,6 +4041,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW011_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW011_OFFSET                (0x758)                                       /**<  (GMAC_ST2CW011) Screening Type 2 Compare Word 0 Register (index = 11)  Offset */
@@ -3749,6 +4057,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW111 : (GMAC Offset: 0x75c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 11) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3757,6 +4066,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW111_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW111_OFFSET                (0x75C)                                       /**<  (GMAC_ST2CW111) Screening Type 2 Compare Word 1 Register (index = 11)  Offset */
@@ -3781,6 +4091,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW012 : (GMAC Offset: 0x760) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 12) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3788,6 +4099,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW012_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW012_OFFSET                (0x760)                                       /**<  (GMAC_ST2CW012) Screening Type 2 Compare Word 0 Register (index = 12)  Offset */
@@ -3803,6 +4115,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW112 : (GMAC Offset: 0x764) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 12) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3811,6 +4124,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW112_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW112_OFFSET                (0x764)                                       /**<  (GMAC_ST2CW112) Screening Type 2 Compare Word 1 Register (index = 12)  Offset */
@@ -3835,6 +4149,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW013 : (GMAC Offset: 0x768) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 13) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3842,6 +4157,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW013_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW013_OFFSET                (0x768)                                       /**<  (GMAC_ST2CW013) Screening Type 2 Compare Word 0 Register (index = 13)  Offset */
@@ -3857,6 +4173,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW113 : (GMAC Offset: 0x76c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 13) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3865,6 +4182,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW113_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW113_OFFSET                (0x76C)                                       /**<  (GMAC_ST2CW113) Screening Type 2 Compare Word 1 Register (index = 13)  Offset */
@@ -3889,6 +4207,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW014 : (GMAC Offset: 0x770) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 14) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3896,6 +4215,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW014_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW014_OFFSET                (0x770)                                       /**<  (GMAC_ST2CW014) Screening Type 2 Compare Word 0 Register (index = 14)  Offset */
@@ -3911,6 +4231,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW114 : (GMAC Offset: 0x774) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 14) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3919,6 +4240,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW114_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW114_OFFSET                (0x774)                                       /**<  (GMAC_ST2CW114) Screening Type 2 Compare Word 1 Register (index = 14)  Offset */
@@ -3943,6 +4265,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW015 : (GMAC Offset: 0x778) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 15) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -3950,6 +4273,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW015_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW015_OFFSET                (0x778)                                       /**<  (GMAC_ST2CW015) Screening Type 2 Compare Word 0 Register (index = 15)  Offset */
@@ -3965,6 +4289,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW115 : (GMAC Offset: 0x77c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 15) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -3973,6 +4298,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW115_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW115_OFFSET                (0x77C)                                       /**<  (GMAC_ST2CW115) Screening Type 2 Compare Word 1 Register (index = 15)  Offset */
@@ -3997,6 +4323,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW016 : (GMAC Offset: 0x780) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 16) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4004,6 +4331,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW016_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW016_OFFSET                (0x780)                                       /**<  (GMAC_ST2CW016) Screening Type 2 Compare Word 0 Register (index = 16)  Offset */
@@ -4019,6 +4347,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW116 : (GMAC Offset: 0x784) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 16) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4027,6 +4356,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW116_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW116_OFFSET                (0x784)                                       /**<  (GMAC_ST2CW116) Screening Type 2 Compare Word 1 Register (index = 16)  Offset */
@@ -4051,6 +4381,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW017 : (GMAC Offset: 0x788) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 17) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4058,6 +4389,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW017_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW017_OFFSET                (0x788)                                       /**<  (GMAC_ST2CW017) Screening Type 2 Compare Word 0 Register (index = 17)  Offset */
@@ -4073,6 +4405,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW117 : (GMAC Offset: 0x78c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 17) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4081,6 +4414,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW117_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW117_OFFSET                (0x78C)                                       /**<  (GMAC_ST2CW117) Screening Type 2 Compare Word 1 Register (index = 17)  Offset */
@@ -4105,6 +4439,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW018 : (GMAC Offset: 0x790) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 18) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4112,6 +4447,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW018_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW018_OFFSET                (0x790)                                       /**<  (GMAC_ST2CW018) Screening Type 2 Compare Word 0 Register (index = 18)  Offset */
@@ -4127,6 +4463,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW118 : (GMAC Offset: 0x794) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 18) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4135,6 +4472,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW118_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW118_OFFSET                (0x794)                                       /**<  (GMAC_ST2CW118) Screening Type 2 Compare Word 1 Register (index = 18)  Offset */
@@ -4159,6 +4497,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW019 : (GMAC Offset: 0x798) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 19) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4166,6 +4505,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW019_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW019_OFFSET                (0x798)                                       /**<  (GMAC_ST2CW019) Screening Type 2 Compare Word 0 Register (index = 19)  Offset */
@@ -4181,6 +4521,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW119 : (GMAC Offset: 0x79c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 19) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4189,6 +4530,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW119_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW119_OFFSET                (0x79C)                                       /**<  (GMAC_ST2CW119) Screening Type 2 Compare Word 1 Register (index = 19)  Offset */
@@ -4213,6 +4555,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW020 : (GMAC Offset: 0x7a0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 20) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4220,6 +4563,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW020_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW020_OFFSET                (0x7A0)                                       /**<  (GMAC_ST2CW020) Screening Type 2 Compare Word 0 Register (index = 20)  Offset */
@@ -4235,6 +4579,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW120 : (GMAC Offset: 0x7a4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 20) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4243,6 +4588,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW120_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW120_OFFSET                (0x7A4)                                       /**<  (GMAC_ST2CW120) Screening Type 2 Compare Word 1 Register (index = 20)  Offset */
@@ -4267,6 +4613,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW021 : (GMAC Offset: 0x7a8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 21) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4274,6 +4621,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW021_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW021_OFFSET                (0x7A8)                                       /**<  (GMAC_ST2CW021) Screening Type 2 Compare Word 0 Register (index = 21)  Offset */
@@ -4289,6 +4637,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW121 : (GMAC Offset: 0x7ac) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 21) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4297,6 +4646,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW121_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW121_OFFSET                (0x7AC)                                       /**<  (GMAC_ST2CW121) Screening Type 2 Compare Word 1 Register (index = 21)  Offset */
@@ -4321,6 +4671,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW022 : (GMAC Offset: 0x7b0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 22) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4328,6 +4679,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW022_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW022_OFFSET                (0x7B0)                                       /**<  (GMAC_ST2CW022) Screening Type 2 Compare Word 0 Register (index = 22)  Offset */
@@ -4343,6 +4695,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW122 : (GMAC Offset: 0x7b4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 22) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4351,6 +4704,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW122_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW122_OFFSET                (0x7B4)                                       /**<  (GMAC_ST2CW122) Screening Type 2 Compare Word 1 Register (index = 22)  Offset */
@@ -4375,6 +4729,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW023 : (GMAC Offset: 0x7b8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 23) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
@@ -4382,6 +4737,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW023_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW023_OFFSET                (0x7B8)                                       /**<  (GMAC_ST2CW023) Screening Type 2 Compare Word 0 Register (index = 23)  Offset */
@@ -4397,6 +4753,7 @@ typedef union {
 
 /* -------- GMAC_ST2CW123 : (GMAC Offset: 0x7bc) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 23) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
@@ -4405,6 +4762,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2CW123_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ST2CW123_OFFSET                (0x7BC)                                       /**<  (GMAC_ST2CW123) Screening Type 2 Compare Word 1 Register (index = 23)  Offset */
@@ -4457,10 +4815,10 @@ typedef struct {
   __IO uint32_t GMAC_TPSF;      /**< (GMAC Offset: 0x40) TX Partial Store and Forward Register */
   __IO uint32_t GMAC_RPSF;      /**< (GMAC Offset: 0x44) RX Partial Store and Forward Register */
   __IO uint32_t GMAC_RJFML;     /**< (GMAC Offset: 0x48) RX Jumbo Frame Max Length Register */
-  RoReg8  Reserved1[0x34];
+  __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -4471,7 +4829,7 @@ typedef struct {
   __IO uint32_t GMAC_TPFCP;     /**< (GMAC Offset: 0xC4) Transmit PFC Pause Register */
   __IO uint32_t GMAC_SAMB1;     /**< (GMAC Offset: 0xC8) Specific Address 1 Mask Bottom Register */
   __IO uint32_t GMAC_SAMT1;     /**< (GMAC Offset: 0xCC) Specific Address 1 Mask Top Register */
-  RoReg8  Reserved2[0xC];
+  __I  uint8_t                        Reserved2[12];
   __IO uint32_t GMAC_NSC;       /**< (GMAC Offset: 0xDC) 1588 Timer Nanosecond Comparison Register */
   __IO uint32_t GMAC_SCL;       /**< (GMAC Offset: 0xE0) 1588 Timer Second Comparison Low Register */
   __IO uint32_t GMAC_SCH;       /**< (GMAC Offset: 0xE4) 1588 Timer Second Comparison High Register */
@@ -4479,7 +4837,7 @@ typedef struct {
   __I  uint32_t GMAC_EFRSH;     /**< (GMAC Offset: 0xEC) PTP Event Frame Received Seconds High Register */
   __I  uint32_t GMAC_PEFTSH;    /**< (GMAC Offset: 0xF0) PTP Peer Event Frame Transmitted Seconds High Register */
   __I  uint32_t GMAC_PEFRSH;    /**< (GMAC Offset: 0xF4) PTP Peer Event Frame Received Seconds High Register */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __I  uint32_t GMAC_OTLO;      /**< (GMAC Offset: 0x100) Octets Transmitted Low Register */
   __I  uint32_t GMAC_OTHI;      /**< (GMAC Offset: 0x104) Octets Transmitted High Register */
   __I  uint32_t GMAC_FT;        /**< (GMAC Offset: 0x108) Frames Transmitted Register */
@@ -4525,10 +4883,10 @@ typedef struct {
   __I  uint32_t GMAC_IHCE;      /**< (GMAC Offset: 0x1A8) IP Header Checksum Errors Register */
   __I  uint32_t GMAC_TCE;       /**< (GMAC Offset: 0x1AC) TCP Checksum Errors Register */
   __I  uint32_t GMAC_UCE;       /**< (GMAC Offset: 0x1B0) UDP Checksum Errors Register */
-  RoReg8  Reserved4[0x8];
+  __I  uint8_t                        Reserved4[8];
   __IO uint32_t GMAC_TISUBN;    /**< (GMAC Offset: 0x1BC) 1588 Timer Increment Sub-nanoseconds Register */
   __IO uint32_t GMAC_TSH;       /**< (GMAC Offset: 0x1C0) 1588 Timer Seconds High Register */
-  RoReg8  Reserved5[0xC];
+  __I  uint8_t                        Reserved5[12];
   __IO uint32_t GMAC_TSL;       /**< (GMAC Offset: 0x1D0) 1588 Timer Seconds Low Register */
   __IO uint32_t GMAC_TN;        /**< (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register */
   __O  uint32_t GMAC_TA;        /**< (GMAC Offset: 0x1D8) 1588 Timer Adjust Register */
@@ -4541,31 +4899,31 @@ typedef struct {
   __I  uint32_t GMAC_PEFTN;     /**< (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  uint32_t GMAC_PEFRSL;    /**< (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds Low Register */
   __I  uint32_t GMAC_PEFRN;     /**< (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds Register */
-  RoReg8  Reserved6[0x200];
-  __I  uint32_t GMAC_ISRPQ[2];  /**< (GMAC Offset: 0x400) Interrupt Status Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved7[0x38];
-  __IO uint32_t GMAC_TBQBAPQ[2]; /**< (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved8[0x38];
-  __IO uint32_t GMAC_RBQBAPQ[2]; /**< (GMAC Offset: 0x480) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved9[0x18];
-  __IO uint32_t GMAC_RBSRPQ[2]; /**< (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved10[0x14];
+  __I  uint8_t                        Reserved6[508];
+  __I  uint32_t GMAC_ISRPQ[2];  /**< (GMAC Offset: 0x3FC) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved7[56];
+  __IO uint32_t GMAC_TBQBAPQ[2]; /**< (GMAC Offset: 0x43C) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved8[56];
+  __IO uint32_t GMAC_RBQBAPQ[2]; /**< (GMAC Offset: 0x47C) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved9[24];
+  __IO uint32_t GMAC_RBSRPQ[2]; /**< (GMAC Offset: 0x49C) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[24];
   __IO uint32_t GMAC_CBSCR;     /**< (GMAC Offset: 0x4BC) Credit-Based Shaping Control Register */
   __IO uint32_t GMAC_CBSISQA;   /**< (GMAC Offset: 0x4C0) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO uint32_t GMAC_CBSISQB;   /**< (GMAC Offset: 0x4C4) Credit-Based Shaping IdleSlope Register for Queue B */
-  RoReg8  Reserved11[0x38];
+  __I  uint8_t                        Reserved11[56];
   __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue (index = 0) 0 */
-  RoReg8  Reserved12[0x30];
+  __I  uint8_t                        Reserved12[48];
   __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  RoReg8  Reserved13[0xA0];
-  __O  uint32_t GMAC_IERPQ[2];  /**< (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved14[0x18];
-  __O  uint32_t GMAC_IDRPQ[2];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved15[0x18];
-  __IO uint32_t GMAC_IMRPQ[2];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved16[0x98];
+  __I  uint8_t                        Reserved13[156];
+  __O  uint32_t GMAC_IERPQ[2];  /**< (GMAC Offset: 0x5FC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved14[24];
+  __O  uint32_t GMAC_IDRPQ[2];  /**< (GMAC Offset: 0x61C) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved15[24];
+  __IO uint32_t GMAC_IMRPQ[2];  /**< (GMAC Offset: 0x63C) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[156];
   __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register (index = 0) 0 */
-  RoReg8  Reserved17[0x10];
+  __I  uint8_t                        Reserved17[16];
   __IO uint32_t GMAC_ST2CW00;   /**< (GMAC Offset: 0x700) Screening Type 2 Compare Word 0 Register (index = 0) */
   __IO uint32_t GMAC_ST2CW10;   /**< (GMAC Offset: 0x704) Screening Type 2 Compare Word 1 Register (index = 0) */
   __IO uint32_t GMAC_ST2CW01;   /**< (GMAC Offset: 0x708) Screening Type 2 Compare Word 0 Register (index = 1) */
@@ -4644,10 +5002,10 @@ typedef struct {
   __IO GMAC_TPSF_Type                 GMAC_TPSF;      /**< Offset: 0x40 (R/W  32) TX Partial Store and Forward Register */
   __IO GMAC_RPSF_Type                 GMAC_RPSF;      /**< Offset: 0x44 (R/W  32) RX Partial Store and Forward Register */
   __IO GMAC_RJFML_Type                GMAC_RJFML;     /**< Offset: 0x48 (R/W  32) RX Jumbo Frame Max Length Register */
-  __I  uint32_t                       Reserved1[13];
+  __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GMAC_SA[4];     /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */
@@ -4658,7 +5016,7 @@ typedef struct {
   __IO GMAC_TPFCP_Type                GMAC_TPFCP;     /**< Offset: 0xC4 (R/W  32) Transmit PFC Pause Register */
   __IO GMAC_SAMB1_Type                GMAC_SAMB1;     /**< Offset: 0xC8 (R/W  32) Specific Address 1 Mask Bottom Register */
   __IO GMAC_SAMT1_Type                GMAC_SAMT1;     /**< Offset: 0xCC (R/W  32) Specific Address 1 Mask Top Register */
-  __I  uint32_t                       Reserved2[3];
+  __I  uint8_t                        Reserved2[12];
   __IO GMAC_NSC_Type                  GMAC_NSC;       /**< Offset: 0xDC (R/W  32) 1588 Timer Nanosecond Comparison Register */
   __IO GMAC_SCL_Type                  GMAC_SCL;       /**< Offset: 0xE0 (R/W  32) 1588 Timer Second Comparison Low Register */
   __IO GMAC_SCH_Type                  GMAC_SCH;       /**< Offset: 0xE4 (R/W  32) 1588 Timer Second Comparison High Register */
@@ -4666,7 +5024,7 @@ typedef struct {
   __I  GMAC_EFRSH_Type                GMAC_EFRSH;     /**< Offset: 0xEC (R/   32) PTP Event Frame Received Seconds High Register */
   __I  GMAC_PEFTSH_Type               GMAC_PEFTSH;    /**< Offset: 0xF0 (R/   32) PTP Peer Event Frame Transmitted Seconds High Register */
   __I  GMAC_PEFRSH_Type               GMAC_PEFRSH;    /**< Offset: 0xF4 (R/   32) PTP Peer Event Frame Received Seconds High Register */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __I  GMAC_OTLO_Type                 GMAC_OTLO;      /**< Offset: 0x100 (R/   32) Octets Transmitted Low Register */
   __I  GMAC_OTHI_Type                 GMAC_OTHI;      /**< Offset: 0x104 (R/   32) Octets Transmitted High Register */
   __I  GMAC_FT_Type                   GMAC_FT;        /**< Offset: 0x108 (R/   32) Frames Transmitted Register */
@@ -4712,10 +5070,10 @@ typedef struct {
   __I  GMAC_IHCE_Type                 GMAC_IHCE;      /**< Offset: 0x1A8 (R/   32) IP Header Checksum Errors Register */
   __I  GMAC_TCE_Type                  GMAC_TCE;       /**< Offset: 0x1AC (R/   32) TCP Checksum Errors Register */
   __I  GMAC_UCE_Type                  GMAC_UCE;       /**< Offset: 0x1B0 (R/   32) UDP Checksum Errors Register */
-  __I  uint32_t                       Reserved4[2];
+  __I  uint8_t                        Reserved4[8];
   __IO GMAC_TISUBN_Type               GMAC_TISUBN;    /**< Offset: 0x1BC (R/W  32) 1588 Timer Increment Sub-nanoseconds Register */
   __IO GMAC_TSH_Type                  GMAC_TSH;       /**< Offset: 0x1C0 (R/W  32) 1588 Timer Seconds High Register */
-  __I  uint32_t                       Reserved5[3];
+  __I  uint8_t                        Reserved5[12];
   __IO GMAC_TSL_Type                  GMAC_TSL;       /**< Offset: 0x1D0 (R/W  32) 1588 Timer Seconds Low Register */
   __IO GMAC_TN_Type                   GMAC_TN;        /**< Offset: 0x1D4 (R/W  32) 1588 Timer Nanoseconds Register */
   __O  GMAC_TA_Type                   GMAC_TA;        /**< Offset: 0x1D8 ( /W  32) 1588 Timer Adjust Register */
@@ -4728,31 +5086,31 @@ typedef struct {
   __I  GMAC_PEFTN_Type                GMAC_PEFTN;     /**< Offset: 0x1F4 (R/   32) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  GMAC_PEFRSL_Type               GMAC_PEFRSL;    /**< Offset: 0x1F8 (R/   32) PTP Peer Event Frame Received Seconds Low Register */
   __I  GMAC_PEFRN_Type                GMAC_PEFRN;     /**< Offset: 0x1FC (R/   32) PTP Peer Event Frame Received Nanoseconds Register */
-  __I  uint32_t                       Reserved6[128];
-  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[2];  /**< Offset: 0x400 (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved7[14];
-  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[2]; /**< Offset: 0x440 (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved8[14];
-  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[2]; /**< Offset: 0x480 (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved9[6];
-  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[2]; /**< Offset: 0x4A0 (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved10[5];
+  __I  uint8_t                        Reserved6[508];
+  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[2];  /**< Offset: 0x3FC (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved7[56];
+  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[2]; /**< Offset: 0x43C (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved8[56];
+  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[2]; /**< Offset: 0x47C (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved9[24];
+  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[2]; /**< Offset: 0x49C (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[24];
   __IO GMAC_CBSCR_Type                GMAC_CBSCR;     /**< Offset: 0x4BC (R/W  32) Credit-Based Shaping Control Register */
   __IO GMAC_CBSISQA_Type              GMAC_CBSISQA;   /**< Offset: 0x4C0 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO GMAC_CBSISQB_Type              GMAC_CBSISQB;   /**< Offset: 0x4C4 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue B */
-  __I  uint32_t                       Reserved11[14];
+  __I  uint8_t                        Reserved11[56];
   __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue (index = 0) 0 */
-  __I  uint32_t                       Reserved12[12];
+  __I  uint8_t                        Reserved12[48];
   __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  __I  uint32_t                       Reserved13[40];
-  __O  GMAC_IERPQ_Type                GMAC_IERPQ[2];  /**< Offset: 0x600 ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved14[6];
-  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[2];  /**< Offset: 0x620 ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved15[6];
-  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[2];  /**< Offset: 0x640 (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved16[38];
+  __I  uint8_t                        Reserved13[156];
+  __O  GMAC_IERPQ_Type                GMAC_IERPQ[2];  /**< Offset: 0x5FC ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved14[24];
+  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[2];  /**< Offset: 0x61C ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved15[24];
+  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[2];  /**< Offset: 0x63C (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[156];
   __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register (index = 0) 0 */
-  __I  uint32_t                       Reserved17[4];
+  __I  uint8_t                        Reserved17[16];
   __IO GMAC_ST2CW00_Type              GMAC_ST2CW00;   /**< Offset: 0x700 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 0) */
   __IO GMAC_ST2CW10_Type              GMAC_ST2CW10;   /**< Offset: 0x704 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 0) */
   __IO GMAC_ST2CW01_Type              GMAC_ST2CW01;   /**< Offset: 0x708 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 1) */

--- a/asf/sam/include/same70/component/gmac.h
+++ b/asf/sam/include/same70/component/gmac.h
@@ -4818,7 +4818,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -5005,7 +5005,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GMAC_SA[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */

--- a/asf/sam/include/same70/component/gmac.h
+++ b/asf/sam/include/same70/component/gmac.h
@@ -2938,7 +2938,7 @@ typedef union {
 #define GMAC_PEFRN_Msk                      _U_(0x3FFFFFFF)                                /**< (GMAC_PEFRN) Register Mask  */
 
 
-/* -------- GMAC_ISRPQ : (GMAC Offset: 0x3fc) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -2960,7 +2960,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ISRPQ_OFFSET                   (0x3FC)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
 #define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
@@ -2987,7 +2987,7 @@ typedef union {
 #define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
 
 
-/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x43c) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3000,7 +3000,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_TBQBAPQ_OFFSET                 (0x43C)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
 #define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
@@ -3009,7 +3009,7 @@ typedef union {
 #define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x47c) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3022,7 +3022,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBQBAPQ_OFFSET                 (0x47C)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
 #define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
@@ -3031,7 +3031,7 @@ typedef union {
 #define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x49c) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3044,7 +3044,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBSRPQ_OFFSET                  (0x49C)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
 #define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
@@ -3224,7 +3224,7 @@ typedef union {
 #define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
 
 
-/* -------- GMAC_IERPQ : (GMAC Offset: 0x5fc) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3246,7 +3246,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IERPQ_OFFSET                   (0x5FC)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
 #define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
@@ -3273,7 +3273,7 @@ typedef union {
 #define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
 
 
-/* -------- GMAC_IDRPQ : (GMAC Offset: 0x61c) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3295,7 +3295,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IDRPQ_OFFSET                   (0x61C)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
 #define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
@@ -3322,7 +3322,7 @@ typedef union {
 #define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
 
 
-/* -------- GMAC_IMRPQ : (GMAC Offset: 0x63c) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
@@ -3344,7 +3344,7 @@ typedef union {
 #endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IMRPQ_OFFSET                   (0x63C)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
 
 #define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
 #define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */
@@ -4899,15 +4899,15 @@ typedef struct {
   __I  uint32_t GMAC_PEFTN;     /**< (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  uint32_t GMAC_PEFRSL;    /**< (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds Low Register */
   __I  uint32_t GMAC_PEFRN;     /**< (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds Register */
-  __I  uint8_t                        Reserved6[508];
-  __I  uint32_t GMAC_ISRPQ[2];  /**< (GMAC Offset: 0x3FC) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved6[512];
+  __I  uint32_t GMAC_ISRPQ[2];  /**< (GMAC Offset: 0x400) Interrupt Status Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved7[56];
-  __IO uint32_t GMAC_TBQBAPQ[2]; /**< (GMAC Offset: 0x43C) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __IO uint32_t GMAC_TBQBAPQ[2]; /**< (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved8[56];
-  __IO uint32_t GMAC_RBQBAPQ[2]; /**< (GMAC Offset: 0x47C) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __IO uint32_t GMAC_RBQBAPQ[2]; /**< (GMAC Offset: 0x480) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved9[24];
-  __IO uint32_t GMAC_RBSRPQ[2]; /**< (GMAC Offset: 0x49C) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  __I  uint8_t                        Reserved10[24];
+  __IO uint32_t GMAC_RBSRPQ[2]; /**< (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[20];
   __IO uint32_t GMAC_CBSCR;     /**< (GMAC Offset: 0x4BC) Credit-Based Shaping Control Register */
   __IO uint32_t GMAC_CBSISQA;   /**< (GMAC Offset: 0x4C0) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO uint32_t GMAC_CBSISQB;   /**< (GMAC Offset: 0x4C4) Credit-Based Shaping IdleSlope Register for Queue B */
@@ -4915,13 +4915,13 @@ typedef struct {
   __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue (index = 0) 0 */
   __I  uint8_t                        Reserved12[48];
   __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  __I  uint8_t                        Reserved13[156];
-  __O  uint32_t GMAC_IERPQ[2];  /**< (GMAC Offset: 0x5FC) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved13[160];
+  __O  uint32_t GMAC_IERPQ[2];  /**< (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved14[24];
-  __O  uint32_t GMAC_IDRPQ[2];  /**< (GMAC Offset: 0x61C) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __O  uint32_t GMAC_IDRPQ[2];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved15[24];
-  __IO uint32_t GMAC_IMRPQ[2];  /**< (GMAC Offset: 0x63C) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  __I  uint8_t                        Reserved16[156];
+  __IO uint32_t GMAC_IMRPQ[2];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[152];
   __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register (index = 0) 0 */
   __I  uint8_t                        Reserved17[16];
   __IO uint32_t GMAC_ST2CW00;   /**< (GMAC Offset: 0x700) Screening Type 2 Compare Word 0 Register (index = 0) */
@@ -5086,15 +5086,15 @@ typedef struct {
   __I  GMAC_PEFTN_Type                GMAC_PEFTN;     /**< Offset: 0x1F4 (R/   32) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  GMAC_PEFRSL_Type               GMAC_PEFRSL;    /**< Offset: 0x1F8 (R/   32) PTP Peer Event Frame Received Seconds Low Register */
   __I  GMAC_PEFRN_Type                GMAC_PEFRN;     /**< Offset: 0x1FC (R/   32) PTP Peer Event Frame Received Nanoseconds Register */
-  __I  uint8_t                        Reserved6[508];
-  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[2];  /**< Offset: 0x3FC (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved6[512];
+  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[2];  /**< Offset: 0x400 (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved7[56];
-  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[2]; /**< Offset: 0x43C (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[2]; /**< Offset: 0x440 (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved8[56];
-  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[2]; /**< Offset: 0x47C (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
+  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[2]; /**< Offset: 0x480 (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved9[24];
-  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[2]; /**< Offset: 0x49C (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  __I  uint8_t                        Reserved10[24];
+  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[2]; /**< Offset: 0x4A0 (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved10[20];
   __IO GMAC_CBSCR_Type                GMAC_CBSCR;     /**< Offset: 0x4BC (R/W  32) Credit-Based Shaping Control Register */
   __IO GMAC_CBSISQA_Type              GMAC_CBSISQA;   /**< Offset: 0x4C0 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO GMAC_CBSISQB_Type              GMAC_CBSISQB;   /**< Offset: 0x4C4 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue B */
@@ -5102,13 +5102,13 @@ typedef struct {
   __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue (index = 0) 0 */
   __I  uint8_t                        Reserved12[48];
   __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  __I  uint8_t                        Reserved13[156];
-  __O  GMAC_IERPQ_Type                GMAC_IERPQ[2];  /**< Offset: 0x5FC ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved13[160];
+  __O  GMAC_IERPQ_Type                GMAC_IERPQ[2];  /**< Offset: 0x600 ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved14[24];
-  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[2];  /**< Offset: 0x61C ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
+  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[2];  /**< Offset: 0x620 ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
   __I  uint8_t                        Reserved15[24];
-  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[2];  /**< Offset: 0x63C (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  __I  uint8_t                        Reserved16[156];
+  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[2];  /**< Offset: 0x640 (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
+  __I  uint8_t                        Reserved16[152];
   __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register (index = 0) 0 */
   __I  uint8_t                        Reserved17[16];
   __IO GMAC_ST2CW00_Type              GMAC_ST2CW00;   /**< Offset: 0x700 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 0) */

--- a/asf/sam/include/same70/component/gpbr.h
+++ b/asf/sam/include/same70/component/gpbr.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for GPBR
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +47,14 @@
 
 /* -------- GPBR_SYS_GPBR : (GPBR Offset: 0x00) (R/W 32) General Purpose Backup Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GPBR_VALUE:32;             /**< bit:  0..31  Value of GPBR x                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GPBR_SYS_GPBR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GPBR_SYS_GPBR_OFFSET                (0x00)                                        /**<  (GPBR_SYS_GPBR) General Purpose Backup Register 0  Offset */

--- a/asf/sam/include/same70/component/hsmci.h
+++ b/asf/sam/include/same70/component/hsmci.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for HSMCI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- HSMCI_CR : (HSMCI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MCIEN:1;                   /**< bit:      0  Multi-Media Interface Enable             */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CR_OFFSET                     (0x00)                                        /**<  (HSMCI_CR) Control Register  Offset */
@@ -82,6 +86,7 @@ typedef union {
 
 /* -------- HSMCI_MR : (HSMCI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLKDIV:8;                  /**< bit:   0..7  Clock Divider                            */
@@ -96,6 +101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_MR_OFFSET                     (0x04)                                        /**<  (HSMCI_MR) Mode Register  Offset */
@@ -127,6 +133,7 @@ typedef union {
 
 /* -------- HSMCI_DTOR : (HSMCI Offset: 0x08) (R/W 32) Data Timeout Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTOCYC:4;                  /**< bit:   0..3  Data Timeout Cycle Number                */
@@ -135,6 +142,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_DTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_DTOR_OFFSET                   (0x08)                                        /**<  (HSMCI_DTOR) Data Timeout Register  Offset */
@@ -167,6 +175,7 @@ typedef union {
 
 /* -------- HSMCI_SDCR : (HSMCI Offset: 0x0c) (R/W 32) SD/SDIO Card Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDCSEL:2;                  /**< bit:   0..1  SDCard/SDIO Slot                         */
@@ -176,6 +185,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_SDCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_SDCR_OFFSET                   (0x0C)                                        /**<  (HSMCI_SDCR) SD/SDIO Card Register  Offset */
@@ -200,12 +210,14 @@ typedef union {
 
 /* -------- HSMCI_ARGR : (HSMCI Offset: 0x10) (R/W 32) Argument Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ARG:32;                    /**< bit:  0..31  Command Argument                         */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_ARGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_ARGR_OFFSET                   (0x10)                                        /**<  (HSMCI_ARGR) Argument Register  Offset */
@@ -219,6 +231,7 @@ typedef union {
 
 /* -------- HSMCI_CMDR : (HSMCI Offset: 0x14) (/W 32) Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDNB:6;                   /**< bit:   0..5  Command Number                           */
@@ -238,6 +251,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CMDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CMDR_OFFSET                   (0x14)                                        /**<  (HSMCI_CMDR) Command Register  Offset */
@@ -343,6 +357,7 @@ typedef union {
 
 /* -------- HSMCI_BLKR : (HSMCI Offset: 0x18) (R/W 32) Block Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BCNT:16;                   /**< bit:  0..15  MMC/SDIO Block Count - SDIO Byte Count   */
@@ -350,6 +365,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_BLKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_BLKR_OFFSET                   (0x18)                                        /**<  (HSMCI_BLKR) Block Register  Offset */
@@ -366,6 +382,7 @@ typedef union {
 
 /* -------- HSMCI_CSTOR : (HSMCI Offset: 0x1c) (R/W 32) Completion Signal Timeout Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSTOCYC:4;                 /**< bit:   0..3  Completion Signal Timeout Cycle Number   */
@@ -374,6 +391,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CSTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CSTOR_OFFSET                  (0x1C)                                        /**<  (HSMCI_CSTOR) Completion Signal Timeout Register  Offset */
@@ -406,12 +424,14 @@ typedef union {
 
 /* -------- HSMCI_RSPR : (HSMCI Offset: 0x20) (R/ 32) Response Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RSP:32;                    /**< bit:  0..31  Response                                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_RSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_RSPR_OFFSET                   (0x20)                                        /**<  (HSMCI_RSPR) Response Register 0  Offset */
@@ -425,12 +445,14 @@ typedef union {
 
 /* -------- HSMCI_RDR : (HSMCI Offset: 0x30) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Read                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_RDR_OFFSET                    (0x30)                                        /**<  (HSMCI_RDR) Receive Data Register  Offset */
@@ -444,12 +466,14 @@ typedef union {
 
 /* -------- HSMCI_TDR : (HSMCI Offset: 0x34) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Write                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_TDR_OFFSET                    (0x34)                                        /**<  (HSMCI_TDR) Transmit Data Register  Offset */
@@ -463,6 +487,7 @@ typedef union {
 
 /* -------- HSMCI_SR : (HSMCI Offset: 0x40) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready (cleared by writing in HSMCI_CMDR) */
@@ -496,6 +521,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_SR_OFFSET                     (0x40)                                        /**<  (HSMCI_SR) Status Register  Offset */
@@ -578,6 +604,7 @@ typedef union {
 
 /* -------- HSMCI_IER : (HSMCI Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Enable           */
@@ -611,6 +638,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IER_OFFSET                    (0x44)                                        /**<  (HSMCI_IER) Interrupt Enable Register  Offset */
@@ -693,6 +721,7 @@ typedef union {
 
 /* -------- HSMCI_IDR : (HSMCI Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Disable          */
@@ -726,6 +755,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IDR_OFFSET                    (0x48)                                        /**<  (HSMCI_IDR) Interrupt Disable Register  Offset */
@@ -808,6 +838,7 @@ typedef union {
 
 /* -------- HSMCI_IMR : (HSMCI Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Mask             */
@@ -841,6 +872,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IMR_OFFSET                    (0x4C)                                        /**<  (HSMCI_IMR) Interrupt Mask Register  Offset */
@@ -923,6 +955,7 @@ typedef union {
 
 /* -------- HSMCI_DMA : (HSMCI Offset: 0x50) (R/W 32) DMA Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -933,6 +966,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_DMA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_DMA_OFFSET                    (0x50)                                        /**<  (HSMCI_DMA) DMA Configuration Register  Offset */
@@ -959,6 +993,7 @@ typedef union {
 
 /* -------- HSMCI_CFG : (HSMCI Offset: 0x54) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FIFOMODE:1;                /**< bit:      0  HSMCI Internal FIFO control mode         */
@@ -972,6 +1007,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CFG_OFFSET                    (0x54)                                        /**<  (HSMCI_CFG) Configuration Register  Offset */
@@ -994,6 +1030,7 @@ typedef union {
 
 /* -------- HSMCI_WPMR : (HSMCI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
@@ -1002,6 +1039,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_WPMR_OFFSET                   (0xE4)                                        /**<  (HSMCI_WPMR) Write Protection Mode Register  Offset */
@@ -1020,6 +1058,7 @@ typedef union {
 
 /* -------- HSMCI_WPSR : (HSMCI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1029,6 +1068,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_WPSR_OFFSET                   (0xE8)                                        /**<  (HSMCI_WPSR) Write Protection Status Register  Offset */
@@ -1045,12 +1085,14 @@ typedef union {
 
 /* -------- HSMCI_FIFO : (HSMCI Offset: 0x200) (R/W 32) FIFO Memory Aperture0 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Read or Data to Write            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_FIFO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_FIFO_OFFSET                   (0x200)                                       /**<  (HSMCI_FIFO) FIFO Memory Aperture0 0  Offset */
@@ -1077,17 +1119,17 @@ typedef struct {
   __I  uint32_t HSMCI_RSPR[4];  /**< (HSMCI Offset: 0x20) Response Register 0 */
   __I  uint32_t HSMCI_RDR;      /**< (HSMCI Offset: 0x30) Receive Data Register */
   __O  uint32_t HSMCI_TDR;      /**< (HSMCI Offset: 0x34) Transmit Data Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __I  uint32_t HSMCI_SR;       /**< (HSMCI Offset: 0x40) Status Register */
   __O  uint32_t HSMCI_IER;      /**< (HSMCI Offset: 0x44) Interrupt Enable Register */
   __O  uint32_t HSMCI_IDR;      /**< (HSMCI Offset: 0x48) Interrupt Disable Register */
   __I  uint32_t HSMCI_IMR;      /**< (HSMCI Offset: 0x4C) Interrupt Mask Register */
   __IO uint32_t HSMCI_DMA;      /**< (HSMCI Offset: 0x50) DMA Configuration Register */
   __IO uint32_t HSMCI_CFG;      /**< (HSMCI Offset: 0x54) Configuration Register */
-  RoReg8  Reserved2[0x8C];
+  __I  uint8_t                        Reserved2[140];
   __IO uint32_t HSMCI_WPMR;     /**< (HSMCI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t HSMCI_WPSR;     /**< (HSMCI Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved3[0x114];
+  __I  uint8_t                        Reserved3[276];
   __IO uint32_t HSMCI_FIFO[256]; /**< (HSMCI Offset: 0x200) FIFO Memory Aperture0 0 */
 } Hsmci;
 
@@ -1105,17 +1147,17 @@ typedef struct {
   __I  HSMCI_RSPR_Type                HSMCI_RSPR[4];  /**< Offset: 0x20 (R/   32) Response Register 0 */
   __I  HSMCI_RDR_Type                 HSMCI_RDR;      /**< Offset: 0x30 (R/   32) Receive Data Register */
   __O  HSMCI_TDR_Type                 HSMCI_TDR;      /**< Offset: 0x34 ( /W  32) Transmit Data Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __I  HSMCI_SR_Type                  HSMCI_SR;       /**< Offset: 0x40 (R/   32) Status Register */
   __O  HSMCI_IER_Type                 HSMCI_IER;      /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
   __O  HSMCI_IDR_Type                 HSMCI_IDR;      /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
   __I  HSMCI_IMR_Type                 HSMCI_IMR;      /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
   __IO HSMCI_DMA_Type                 HSMCI_DMA;      /**< Offset: 0x50 (R/W  32) DMA Configuration Register */
   __IO HSMCI_CFG_Type                 HSMCI_CFG;      /**< Offset: 0x54 (R/W  32) Configuration Register */
-  __I  uint32_t                       Reserved2[35];
+  __I  uint8_t                        Reserved2[140];
   __IO HSMCI_WPMR_Type                HSMCI_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  HSMCI_WPSR_Type                HSMCI_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved3[69];
+  __I  uint8_t                        Reserved3[276];
   __IO HSMCI_FIFO_Type                HSMCI_FIFO[256]; /**< Offset: 0x200 (R/W  32) FIFO Memory Aperture0 0 */
 } Hsmci;
 

--- a/asf/sam/include/same70/component/icm.h
+++ b/asf/sam/include/same70/component/icm.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ICM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- ICM_CFG : (ICM Offset: 0x00) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WBDIS:1;                   /**< bit:      0  Write Back Disable                       */
@@ -61,6 +64,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_CFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_CFG_OFFSET                      (0x00)                                        /**<  (ICM_CFG) Configuration Register  Offset */
@@ -101,6 +105,7 @@ typedef union {
 
 /* -------- ICM_CTRL : (ICM Offset: 0x04) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  ICM Enable                               */
@@ -114,6 +119,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_CTRL_OFFSET                     (0x04)                                        /**<  (ICM_CTRL) Control Register  Offset */
@@ -142,6 +148,7 @@ typedef union {
 
 /* -------- ICM_SR : (ICM Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  ICM Controller Enable Register           */
@@ -152,6 +159,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_SR_OFFSET                       (0x08)                                        /**<  (ICM_SR) Status Register  Offset */
@@ -171,6 +179,7 @@ typedef union {
 
 /* -------- ICM_IER : (ICM Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Enable   */
@@ -184,6 +193,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IER_OFFSET                      (0x10)                                        /**<  (ICM_IER) Interrupt Enable Register  Offset */
@@ -215,6 +225,7 @@ typedef union {
 
 /* -------- ICM_IDR : (ICM Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Disable  */
@@ -228,6 +239,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IDR_OFFSET                      (0x14)                                        /**<  (ICM_IDR) Interrupt Disable Register  Offset */
@@ -259,6 +271,7 @@ typedef union {
 
 /* -------- ICM_IMR : (ICM Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Mask     */
@@ -272,6 +285,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IMR_OFFSET                      (0x18)                                        /**<  (ICM_IMR) Interrupt Mask Register  Offset */
@@ -303,6 +317,7 @@ typedef union {
 
 /* -------- ICM_ISR : (ICM Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed                    */
@@ -316,6 +331,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_ISR_OFFSET                      (0x1C)                                        /**<  (ICM_ISR) Interrupt Status Register  Offset */
@@ -347,6 +363,7 @@ typedef union {
 
 /* -------- ICM_UASR : (ICM Offset: 0x20) (R/ 32) Undefined Access Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URAT:3;                    /**< bit:   0..2  Undefined Register Access Trace          */
@@ -354,6 +371,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_UASR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_UASR_OFFSET                     (0x20)                                        /**<  (ICM_UASR) Undefined Access Status Register  Offset */
@@ -377,6 +395,7 @@ typedef union {
 
 /* -------- ICM_DSCR : (ICM Offset: 0x30) (R/W 32) Region Descriptor Area Start Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :6;                        /**< bit:   0..5  Reserved */
@@ -384,6 +403,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_DSCR_OFFSET                     (0x30)                                        /**<  (ICM_DSCR) Region Descriptor Area Start Address Register  Offset */
@@ -397,6 +417,7 @@ typedef union {
 
 /* -------- ICM_HASH : (ICM Offset: 0x34) (R/W 32) Region Hash Area Start Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -404,6 +425,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_HASH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_HASH_OFFSET                     (0x34)                                        /**<  (ICM_HASH) Region Hash Area Start Address Register  Offset */
@@ -417,12 +439,14 @@ typedef union {
 
 /* -------- ICM_UIHVAL : (ICM Offset: 0x38) (/W 32) User Initial Hash Value 0 Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VAL:32;                    /**< bit:  0..31  Initial Hash Value                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_UIHVAL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_UIHVAL_OFFSET                   (0x38)                                        /**<  (ICM_UIHVAL) User Initial Hash Value 0 Register 0  Offset */
@@ -441,13 +465,13 @@ typedef struct {
   __IO uint32_t ICM_CFG;        /**< (ICM Offset: 0x00) Configuration Register */
   __O  uint32_t ICM_CTRL;       /**< (ICM Offset: 0x04) Control Register */
   __I  uint32_t ICM_SR;         /**< (ICM Offset: 0x08) Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t ICM_IER;        /**< (ICM Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t ICM_IDR;        /**< (ICM Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t ICM_IMR;        /**< (ICM Offset: 0x18) Interrupt Mask Register */
   __I  uint32_t ICM_ISR;        /**< (ICM Offset: 0x1C) Interrupt Status Register */
   __I  uint32_t ICM_UASR;       /**< (ICM Offset: 0x20) Undefined Access Status Register */
-  RoReg8  Reserved2[0xC];
+  __I  uint8_t                        Reserved2[12];
   __IO uint32_t ICM_DSCR;       /**< (ICM Offset: 0x30) Region Descriptor Area Start Address Register */
   __IO uint32_t ICM_HASH;       /**< (ICM Offset: 0x34) Region Hash Area Start Address Register */
   __O  uint32_t ICM_UIHVAL[8];  /**< (ICM Offset: 0x38) User Initial Hash Value 0 Register 0 */
@@ -459,13 +483,13 @@ typedef struct {
   __IO ICM_CFG_Type                   ICM_CFG;        /**< Offset: 0x00 (R/W  32) Configuration Register */
   __O  ICM_CTRL_Type                  ICM_CTRL;       /**< Offset: 0x04 ( /W  32) Control Register */
   __I  ICM_SR_Type                    ICM_SR;         /**< Offset: 0x08 (R/   32) Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  ICM_IER_Type                   ICM_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  ICM_IDR_Type                   ICM_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  ICM_IMR_Type                   ICM_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
   __I  ICM_ISR_Type                   ICM_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
   __I  ICM_UASR_Type                  ICM_UASR;       /**< Offset: 0x20 (R/   32) Undefined Access Status Register */
-  __I  uint32_t                       Reserved2[3];
+  __I  uint8_t                        Reserved2[12];
   __IO ICM_DSCR_Type                  ICM_DSCR;       /**< Offset: 0x30 (R/W  32) Region Descriptor Area Start Address Register */
   __IO ICM_HASH_Type                  ICM_HASH;       /**< Offset: 0x34 (R/W  32) Region Hash Area Start Address Register */
   __O  ICM_UIHVAL_Type                ICM_UIHVAL[8];  /**< Offset: 0x38 ( /W  32) User Initial Hash Value 0 Register 0 */

--- a/asf/sam/include/same70/component/isi.h
+++ b/asf/sam/include/same70/component/isi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ISI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- ISI_CFG1 : (ISI Offset: 0x00) (R/W 32) ISI Configuration 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CFG1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CFG1_OFFSET                     (0x00)                                        /**<  (ISI_CFG1) ISI Configuration 1 Register  Offset */
@@ -115,6 +119,7 @@ typedef union {
 
 /* -------- ISI_CFG2 : (ISI Offset: 0x04) (R/W 32) ISI Configuration 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IM_VSIZE:11;               /**< bit:  0..10  Vertical Size of the Image Sensor [0..2047] */
@@ -130,6 +135,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CFG2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CFG2_OFFSET                     (0x04)                                        /**<  (ISI_CFG2) ISI Configuration 2 Register  Offset */
@@ -183,6 +189,7 @@ typedef union {
 
 /* -------- ISI_PSIZE : (ISI Offset: 0x08) (R/W 32) ISI Preview Size Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PREV_VSIZE:10;             /**< bit:   0..9  Vertical Size for the Preview Path       */
@@ -192,6 +199,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_PSIZE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_PSIZE_OFFSET                    (0x08)                                        /**<  (ISI_PSIZE) ISI Preview Size Register  Offset */
@@ -208,6 +216,7 @@ typedef union {
 
 /* -------- ISI_PDECF : (ISI Offset: 0x0c) (R/W 32) ISI Preview Decimation Factor Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DEC_FACTOR:8;              /**< bit:   0..7  Decimation Factor                        */
@@ -215,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_PDECF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_PDECF_OFFSET                    (0x0C)                                        /**<  (ISI_PDECF) ISI Preview Decimation Factor Register  Offset */
@@ -228,6 +238,7 @@ typedef union {
 
 /* -------- ISI_Y2R_SET0 : (ISI Offset: 0x10) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C0:8;                      /**< bit:   0..7  Color Space Conversion Matrix Coefficient C0 */
@@ -237,6 +248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_Y2R_SET0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_Y2R_SET0_OFFSET                 (0x10)                                        /**<  (ISI_Y2R_SET0) ISI Color Space Conversion YCrCb To RGB Set 0 Register  Offset */
@@ -259,6 +271,7 @@ typedef union {
 
 /* -------- ISI_Y2R_SET1 : (ISI Offset: 0x14) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C4:9;                      /**< bit:   0..8  Color Space Conversion Matrix Coefficient C4 */
@@ -270,6 +283,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_Y2R_SET1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_Y2R_SET1_OFFSET                 (0x14)                                        /**<  (ISI_Y2R_SET1) ISI Color Space Conversion YCrCb To RGB Set 1 Register  Offset */
@@ -292,6 +306,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET0 : (ISI Offset: 0x18) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C0:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C0 */
@@ -305,6 +320,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET0_OFFSET                 (0x18)                                        /**<  (ISI_R2Y_SET0) ISI Color Space Conversion RGB To YCrCb Set 0 Register  Offset */
@@ -327,6 +343,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET1 : (ISI Offset: 0x1c) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C3:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C3 */
@@ -340,6 +357,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET1_OFFSET                 (0x1C)                                        /**<  (ISI_R2Y_SET1) ISI Color Space Conversion RGB To YCrCb Set 1 Register  Offset */
@@ -362,6 +380,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET2 : (ISI Offset: 0x20) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C6:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C6 */
@@ -375,6 +394,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET2_OFFSET                 (0x20)                                        /**<  (ISI_R2Y_SET2) ISI Color Space Conversion RGB To YCrCb Set 2 Register  Offset */
@@ -397,6 +417,7 @@ typedef union {
 
 /* -------- ISI_CR : (ISI Offset: 0x24) (/W 32) ISI Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ISI_EN:1;                  /**< bit:      0  ISI Module Enable Request                */
@@ -408,6 +429,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CR_OFFSET                       (0x24)                                        /**<  (ISI_CR) ISI Control Register  Offset */
@@ -430,6 +452,7 @@ typedef union {
 
 /* -------- ISI_SR : (ISI Offset: 0x28) (R/ 32) ISI Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  Module Enable                            */
@@ -453,6 +476,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_SR_OFFSET                       (0x28)                                        /**<  (ISI_SR) ISI Status Register  Offset */
@@ -499,6 +523,7 @@ typedef union {
 
 /* -------- ISI_IER : (ISI Offset: 0x2c) (/W 32) ISI Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -518,6 +543,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IER_OFFSET                      (0x2C)                                        /**<  (ISI_IER) ISI Interrupt Enable Register  Offset */
@@ -555,6 +581,7 @@ typedef union {
 
 /* -------- ISI_IDR : (ISI Offset: 0x30) (/W 32) ISI Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -574,6 +601,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IDR_OFFSET                      (0x30)                                        /**<  (ISI_IDR) ISI Interrupt Disable Register  Offset */
@@ -611,6 +639,7 @@ typedef union {
 
 /* -------- ISI_IMR : (ISI Offset: 0x34) (R/ 32) ISI Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -630,6 +659,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IMR_OFFSET                      (0x34)                                        /**<  (ISI_IMR) ISI Interrupt Mask Register  Offset */
@@ -667,6 +697,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHER : (ISI Offset: 0x38) (/W 32) DMA Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_EN:1;                 /**< bit:      0  Preview Channel Enable                   */
@@ -675,6 +706,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHER_OFFSET                 (0x38)                                        /**<  (ISI_DMA_CHER) DMA Channel Enable Register  Offset */
@@ -691,6 +723,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHDR : (ISI Offset: 0x3c) (/W 32) DMA Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_DIS:1;                /**< bit:      0  Preview Channel Disable Request          */
@@ -699,6 +732,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHDR_OFFSET                 (0x3C)                                        /**<  (ISI_DMA_CHDR) DMA Channel Disable Register  Offset */
@@ -715,6 +749,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHSR : (ISI Offset: 0x40) (R/ 32) DMA Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_S:1;                  /**< bit:      0  Preview DMA Channel Status               */
@@ -723,6 +758,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHSR_OFFSET                 (0x40)                                        /**<  (ISI_DMA_CHSR) DMA Channel Status Register  Offset */
@@ -739,6 +775,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_ADDR : (ISI Offset: 0x44) (R/W 32) DMA Preview Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -746,6 +783,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_ADDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_ADDR_OFFSET               (0x44)                                        /**<  (ISI_DMA_P_ADDR) DMA Preview Base Address Register  Offset */
@@ -759,6 +797,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_CTRL : (ISI Offset: 0x48) (R/W 32) DMA Preview Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
@@ -769,6 +808,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_CTRL_OFFSET               (0x48)                                        /**<  (ISI_DMA_P_CTRL) DMA Preview Control Register  Offset */
@@ -791,6 +831,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_DSCR : (ISI Offset: 0x4c) (R/W 32) DMA Preview Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -798,6 +839,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_DSCR_OFFSET               (0x4C)                                        /**<  (ISI_DMA_P_DSCR) DMA Preview Descriptor Address Register  Offset */
@@ -811,6 +853,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_ADDR : (ISI Offset: 0x50) (R/W 32) DMA Codec Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -818,6 +861,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_ADDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_ADDR_OFFSET               (0x50)                                        /**<  (ISI_DMA_C_ADDR) DMA Codec Base Address Register  Offset */
@@ -831,6 +875,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_CTRL : (ISI Offset: 0x54) (R/W 32) DMA Codec Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
@@ -841,6 +886,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_CTRL_OFFSET               (0x54)                                        /**<  (ISI_DMA_C_CTRL) DMA Codec Control Register  Offset */
@@ -863,6 +909,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_DSCR : (ISI Offset: 0x58) (R/W 32) DMA Codec Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -870,6 +917,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_DSCR_OFFSET               (0x58)                                        /**<  (ISI_DMA_C_DSCR) DMA Codec Descriptor Address Register  Offset */
@@ -883,6 +931,7 @@ typedef union {
 
 /* -------- ISI_WPMR : (ISI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -891,6 +940,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_WPMR_OFFSET                     (0xE4)                                        /**<  (ISI_WPMR) Write Protection Mode Register  Offset */
@@ -909,6 +959,7 @@ typedef union {
 
 /* -------- ISI_WPSR : (ISI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -918,6 +969,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_WPSR_OFFSET                     (0xE8)                                        /**<  (ISI_WPSR) Write Protection Status Register  Offset */
@@ -959,7 +1011,7 @@ typedef struct {
   __IO uint32_t ISI_DMA_C_ADDR; /**< (ISI Offset: 0x50) DMA Codec Base Address Register */
   __IO uint32_t ISI_DMA_C_CTRL; /**< (ISI Offset: 0x54) DMA Codec Control Register */
   __IO uint32_t ISI_DMA_C_DSCR; /**< (ISI Offset: 0x58) DMA Codec Descriptor Address Register */
-  RoReg8  Reserved1[0x88];
+  __I  uint8_t                        Reserved1[136];
   __IO uint32_t ISI_WPMR;       /**< (ISI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t ISI_WPSR;       /**< (ISI Offset: 0xE8) Write Protection Status Register */
 } Isi;
@@ -990,7 +1042,7 @@ typedef struct {
   __IO ISI_DMA_C_ADDR_Type            ISI_DMA_C_ADDR; /**< Offset: 0x50 (R/W  32) DMA Codec Base Address Register */
   __IO ISI_DMA_C_CTRL_Type            ISI_DMA_C_CTRL; /**< Offset: 0x54 (R/W  32) DMA Codec Control Register */
   __IO ISI_DMA_C_DSCR_Type            ISI_DMA_C_DSCR; /**< Offset: 0x58 (R/W  32) DMA Codec Descriptor Address Register */
-  __I  uint32_t                       Reserved1[34];
+  __I  uint8_t                        Reserved1[136];
   __IO ISI_WPMR_Type                  ISI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  ISI_WPSR_Type                  ISI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Isi;

--- a/asf/sam/include/same70/component/matrix.h
+++ b/asf/sam/include/same70/component/matrix.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for MATRIX
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- MATRIX_PRAS : (MATRIX Offset: 0x00) (R/W 32) Priority Register A for Slave 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t M0PR:2;                    /**< bit:   0..1  Master 0 Priority                        */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_PRAS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_PRAS_OFFSET                  (0x00)                                        /**<  (MATRIX_PRAS) Priority Register A for Slave 0  Offset */
@@ -95,6 +99,7 @@ typedef union {
 
 /* -------- MATRIX_PRBS : (MATRIX Offset: 0x04) (R/W 32) Priority Register B for Slave 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t M8PR:2;                    /**< bit:   0..1  Master 8 Priority                        */
@@ -108,6 +113,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_PRBS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_PRBS_OFFSET                  (0x04)                                        /**<  (MATRIX_PRBS) Priority Register B for Slave 0  Offset */
@@ -130,6 +136,7 @@ typedef union {
 
 /* -------- MATRIX_MCFG : (MATRIX Offset: 0x00) (R/W 32) Master Configuration Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ULBT:3;                    /**< bit:   0..2  Undefined Length Burst Type              */
@@ -137,6 +144,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_MCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_MCFG_OFFSET                  (0x00)                                        /**<  (MATRIX_MCFG) Master Configuration Register 0  Offset */
@@ -166,6 +174,7 @@ typedef union {
 
 /* -------- MATRIX_SCFG : (MATRIX Offset: 0x40) (R/W 32) Slave Configuration Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SLOT_CYCLE:9;              /**< bit:   0..8  Maximum Bus Grant Duration for Masters   */
@@ -176,6 +185,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_SCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_SCFG_OFFSET                  (0x40)                                        /**<  (MATRIX_SCFG) Slave Configuration Register 0  Offset */
@@ -201,6 +211,7 @@ typedef union {
 
 /* -------- MATRIX_MRCR : (MATRIX Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RCB0:1;                    /**< bit:      0  Remap Command Bit for Master 0           */
@@ -223,6 +234,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_MRCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_MRCR_OFFSET                  (0x100)                                       /**<  (MATRIX_MRCR) Master Remap Control Register  Offset */
@@ -269,6 +281,7 @@ typedef union {
 
 /* -------- CCFG_CAN0 : (MATRIX Offset: 0x110) (R/W 32) CAN0 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -276,6 +289,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_CAN0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_CAN0_OFFSET                    (0x110)                                       /**<  (CCFG_CAN0) CAN0 Configuration Register  Offset */
@@ -289,6 +303,7 @@ typedef union {
 
 /* -------- CCFG_SYSIO : (MATRIX Offset: 0x114) (R/W 32) System I/O and CAN1 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -308,6 +323,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_SYSIO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_SYSIO_OFFSET                   (0x114)                                       /**<  (CCFG_SYSIO) System I/O and CAN1 Configuration Register  Offset */
@@ -339,6 +355,7 @@ typedef union {
 
 /* -------- CCFG_SMCNFCS : (MATRIX Offset: 0x124) (R/W 32) SMC NAND Flash Chip Select Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMC_NFCS0:1;               /**< bit:      0  SMC NAND Flash Chip Select 0 Assignment  */
@@ -354,6 +371,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_SMCNFCS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_SMCNFCS_OFFSET                 (0x124)                                       /**<  (CCFG_SMCNFCS) SMC NAND Flash Chip Select Configuration Register  Offset */
@@ -382,6 +400,7 @@ typedef union {
 
 /* -------- MATRIX_WPMR : (MATRIX Offset: 0x1e4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -390,6 +409,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_WPMR_OFFSET                  (0x1E4)                                       /**<  (MATRIX_WPMR) Write Protection Mode Register  Offset */
@@ -408,6 +428,7 @@ typedef union {
 
 /* -------- MATRIX_WPSR : (MATRIX Offset: 0x1e8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -417,6 +438,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_WPSR_OFFSET                  (0x1E8)                                       /**<  (MATRIX_WPSR) Write Protection Status Register  Offset */
@@ -443,18 +465,18 @@ typedef struct {
 /** \brief MATRIX hardware registers */
 typedef struct {  
   __IO uint32_t MATRIX_MCFG[12]; /**< (MATRIX Offset: 0x00) Master Configuration Register 0 */
-  RoReg8  Reserved1[0x10];
+  __I  uint8_t                        Reserved1[16];
   __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
-  RoReg8  Reserved2[0x1C];
-       MatrixPr MATRIX_PR[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
-  RoReg8  Reserved3[0x38];
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
   __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
-  RoReg8  Reserved4[0xC];
+  __I  uint8_t                        Reserved4[12];
   __IO uint32_t CCFG_CAN0;      /**< (MATRIX Offset: 0x110) CAN0 Configuration Register */
   __IO uint32_t CCFG_SYSIO;     /**< (MATRIX Offset: 0x114) System I/O and CAN1 Configuration Register */
-  RoReg8  Reserved5[0xC];
+  __I  uint8_t                        Reserved5[12];
   __IO uint32_t CCFG_SMCNFCS;   /**< (MATRIX Offset: 0x124) SMC NAND Flash Chip Select Configuration Register */
-  RoReg8  Reserved6[0xBC];
+  __I  uint8_t                        Reserved6[188];
   __IO uint32_t MATRIX_WPMR;    /**< (MATRIX Offset: 0x1E4) Write Protection Mode Register */
   __I  uint32_t MATRIX_WPSR;    /**< (MATRIX Offset: 0x1E8) Write Protection Status Register */
 } Matrix;
@@ -469,18 +491,18 @@ typedef struct {
 /** \brief MATRIX hardware registers */
 typedef struct {  
   __IO MATRIX_MCFG_Type               MATRIX_MCFG[12]; /**< Offset: 0x00 (R/W  32) Master Configuration Register 0 */
-  __I  uint32_t                       Reserved1[4];
+  __I  uint8_t                        Reserved1[16];
   __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
-  __I  uint32_t                       Reserved2[7];
-       MatrixPr                       MATRIX_PR[9];   /**< Offset: 0x80 Priority Register A for Slave 0 */
-  __I  uint32_t                       Reserved3[14];
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
   __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
-  __I  uint32_t                       Reserved4[3];
+  __I  uint8_t                        Reserved4[12];
   __IO CCFG_CAN0_Type                 CCFG_CAN0;      /**< Offset: 0x110 (R/W  32) CAN0 Configuration Register */
   __IO CCFG_SYSIO_Type                CCFG_SYSIO;     /**< Offset: 0x114 (R/W  32) System I/O and CAN1 Configuration Register */
-  __I  uint32_t                       Reserved5[3];
+  __I  uint8_t                        Reserved5[12];
   __IO CCFG_SMCNFCS_Type              CCFG_SMCNFCS;   /**< Offset: 0x124 (R/W  32) SMC NAND Flash Chip Select Configuration Register */
-  __I  uint32_t                       Reserved6[47];
+  __I  uint8_t                        Reserved6[188];
   __IO MATRIX_WPMR_Type               MATRIX_WPMR;    /**< Offset: 0x1E4 (R/W  32) Write Protection Mode Register */
   __I  MATRIX_WPSR_Type               MATRIX_WPSR;    /**< Offset: 0x1E8 (R/   32) Write Protection Status Register */
 } Matrix;

--- a/asf/sam/include/same70/component/matrix.h
+++ b/asf/sam/include/same70/component/matrix.h
@@ -468,7 +468,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[16];
   __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
   __I  uint8_t                        Reserved2[28];
-       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+       MatrixPr MATRIX_PR[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
   __I  uint8_t                        Reserved3[56];
   __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
   __I  uint8_t                        Reserved4[12];
@@ -494,7 +494,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[16];
   __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
   __I  uint8_t                        Reserved2[28];
-       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+       MatrixPr                       MATRIX_PR[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
   __I  uint8_t                        Reserved3[56];
   __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
   __I  uint8_t                        Reserved4[12];

--- a/asf/sam/include/same70/component/mcan.h
+++ b/asf/sam/include/same70/component/mcan.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for MCAN
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +47,14 @@
 
 /* -------- MCAN_CUST : (MCAN Offset: 0x08) (R/W 32) Customer Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSV:32;                    /**< bit:  0..31  Customer-specific Value                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_CUST_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_CUST_OFFSET                    (0x08)                                        /**<  (MCAN_CUST) Customer Register  Offset */
@@ -64,6 +68,7 @@ typedef union {
 
 /* -------- MCAN_FBTP : (MCAN Offset: 0x0c) (R/W 32) Fast Bit Timing and Prescaler Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FSJW:2;                    /**< bit:   0..1  Fast (Re) Synchronization Jump Width     */
@@ -80,6 +85,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_FBTP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_FBTP_OFFSET                    (0x0C)                                        /**<  (MCAN_FBTP) Fast Bit Timing and Prescaler Register  Offset */
@@ -112,6 +118,7 @@ typedef union {
 
 /* -------- MCAN_TEST : (MCAN Offset: 0x10) (R/W 32) Test Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -123,6 +130,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TEST_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TEST_OFFSET                    (0x10)                                        /**<  (MCAN_TEST) Test Register  Offset */
@@ -157,6 +165,7 @@ typedef union {
 
 /* -------- MCAN_RWD : (MCAN Offset: 0x14) (R/W 32) RAM Watchdog Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDC:8;                     /**< bit:   0..7  Watchdog Configuration (read/write)      */
@@ -165,6 +174,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RWD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RWD_OFFSET                     (0x14)                                        /**<  (MCAN_RWD) RAM Watchdog Register  Offset */
@@ -181,6 +191,7 @@ typedef union {
 
 /* -------- MCAN_CCCR : (MCAN Offset: 0x18) (R/W 32) CC Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INIT:1;                    /**< bit:      0  Initialization (read/write)              */
@@ -200,6 +211,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_CCCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_CCCR_OFFSET                    (0x18)                                        /**<  (MCAN_CCCR) CC Control Register  Offset */
@@ -289,6 +301,7 @@ typedef union {
 
 /* -------- MCAN_BTP : (MCAN Offset: 0x1c) (R/W 32) Bit Timing and Prescaler Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SJW:4;                     /**< bit:   0..3  (Re) Synchronization Jump Width          */
@@ -300,6 +313,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_BTP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_BTP_OFFSET                     (0x1C)                                        /**<  (MCAN_BTP) Bit Timing and Prescaler Register  Offset */
@@ -322,6 +336,7 @@ typedef union {
 
 /* -------- MCAN_TSCC : (MCAN Offset: 0x20) (R/W 32) Timestamp Counter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSS:2;                     /**< bit:   0..1  Timestamp Select                         */
@@ -331,6 +346,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TSCC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TSCC_OFFSET                    (0x20)                                        /**<  (MCAN_TSCC) Timestamp Counter Configuration Register  Offset */
@@ -353,6 +369,7 @@ typedef union {
 
 /* -------- MCAN_TSCV : (MCAN Offset: 0x24) (R/W 32) Timestamp Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSC:16;                    /**< bit:  0..15  Timestamp Counter (cleared on write)     */
@@ -360,6 +377,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TSCV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TSCV_OFFSET                    (0x24)                                        /**<  (MCAN_TSCV) Timestamp Counter Value Register  Offset */
@@ -373,6 +391,7 @@ typedef union {
 
 /* -------- MCAN_TOCC : (MCAN Offset: 0x28) (R/W 32) Timeout Counter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ETOC:1;                    /**< bit:      0  Enable Timeout Counter                   */
@@ -382,6 +401,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TOCC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TOCC_OFFSET                    (0x28)                                        /**<  (MCAN_TOCC) Timeout Counter Configuration Register  Offset */
@@ -413,6 +433,7 @@ typedef union {
 
 /* -------- MCAN_TOCV : (MCAN Offset: 0x2c) (R/W 32) Timeout Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TOC:16;                    /**< bit:  0..15  Timeout Counter (cleared on write)       */
@@ -420,6 +441,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TOCV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TOCV_OFFSET                    (0x2C)                                        /**<  (MCAN_TOCV) Timeout Counter Value Register  Offset */
@@ -433,6 +455,7 @@ typedef union {
 
 /* -------- MCAN_ECR : (MCAN Offset: 0x40) (R/ 32) Error Counter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TEC:8;                     /**< bit:   0..7  Transmit Error Counter                   */
@@ -443,6 +466,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ECR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ECR_OFFSET                     (0x40)                                        /**<  (MCAN_ECR) Error Counter Register  Offset */
@@ -465,6 +489,7 @@ typedef union {
 
 /* -------- MCAN_PSR : (MCAN Offset: 0x44) (R/ 32) Protocol Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEC:3;                     /**< bit:   0..2  Last Error Code (set to 111 on read)     */
@@ -480,6 +505,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_PSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_PSR_OFFSET                     (0x44)                                        /**<  (MCAN_PSR) Protocol Status Register  Offset */
@@ -541,6 +567,7 @@ typedef union {
 
 /* -------- MCAN_IR : (MCAN Offset: 0x50) (R/W 32) Interrupt Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0N:1;                    /**< bit:      0  Receive FIFO 0 New Message               */
@@ -577,6 +604,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_IR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_IR_OFFSET                      (0x50)                                        /**<  (MCAN_IR) Interrupt Register  Offset */
@@ -677,6 +705,7 @@ typedef union {
 
 /* -------- MCAN_IE : (MCAN Offset: 0x54) (R/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0NE:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Enable */
@@ -713,6 +742,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_IE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_IE_OFFSET                      (0x54)                                        /**<  (MCAN_IE) Interrupt Enable Register  Offset */
@@ -813,6 +843,7 @@ typedef union {
 
 /* -------- MCAN_ILS : (MCAN Offset: 0x58) (R/W 32) Interrupt Line Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0NL:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Line */
@@ -849,6 +880,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ILS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ILS_OFFSET                     (0x58)                                        /**<  (MCAN_ILS) Interrupt Line Select Register  Offset */
@@ -949,6 +981,7 @@ typedef union {
 
 /* -------- MCAN_ILE : (MCAN Offset: 0x5c) (R/W 32) Interrupt Line Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EINT0:1;                   /**< bit:      0  Enable Interrupt Line 0                  */
@@ -961,6 +994,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ILE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ILE_OFFSET                     (0x5C)                                        /**<  (MCAN_ILE) Interrupt Line Enable Register  Offset */
@@ -980,6 +1014,7 @@ typedef union {
 
 /* -------- MCAN_GFC : (MCAN Offset: 0x80) (R/W 32) Global Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RRFE:1;                    /**< bit:      0  Reject Remote Frames Extended            */
@@ -990,6 +1025,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_GFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_GFC_OFFSET                     (0x80)                                        /**<  (MCAN_GFC) Global Filter Configuration Register  Offset */
@@ -1028,6 +1064,7 @@ typedef union {
 
 /* -------- MCAN_SIDFC : (MCAN Offset: 0x84) (R/W 32) Standard ID Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1037,6 +1074,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_SIDFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_SIDFC_OFFSET                   (0x84)                                        /**<  (MCAN_SIDFC) Standard ID Filter Configuration Register  Offset */
@@ -1053,6 +1091,7 @@ typedef union {
 
 /* -------- MCAN_XIDFC : (MCAN Offset: 0x88) (R/W 32) Extended ID Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1062,6 +1101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_XIDFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_XIDFC_OFFSET                   (0x88)                                        /**<  (MCAN_XIDFC) Extended ID Filter Configuration Register  Offset */
@@ -1078,6 +1118,7 @@ typedef union {
 
 /* -------- MCAN_XIDAM : (MCAN Offset: 0x90) (R/W 32) Extended ID AND Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EIDM:29;                   /**< bit:  0..28  Extended ID Mask                         */
@@ -1085,6 +1126,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_XIDAM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_XIDAM_OFFSET                   (0x90)                                        /**<  (MCAN_XIDAM) Extended ID AND Mask Register  Offset */
@@ -1098,6 +1140,7 @@ typedef union {
 
 /* -------- MCAN_HPMS : (MCAN Offset: 0x94) (R/ 32) High Priority Message Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIDX:6;                    /**< bit:   0..5  Buffer Index                             */
@@ -1108,6 +1151,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_HPMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_HPMS_OFFSET                    (0x94)                                        /**<  (MCAN_HPMS) High Priority Message Status Register  Offset */
@@ -1138,6 +1182,7 @@ typedef union {
 
 /* -------- MCAN_NDAT1 : (MCAN Offset: 0x98) (R/W 32) New Data 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ND0:1;                     /**< bit:      0  New Data                                 */
@@ -1178,6 +1223,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_NDAT1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_NDAT1_OFFSET                   (0x98)                                        /**<  (MCAN_NDAT1) New Data 1 Register  Offset */
@@ -1287,6 +1333,7 @@ typedef union {
 
 /* -------- MCAN_NDAT2 : (MCAN Offset: 0x9c) (R/W 32) New Data 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ND32:1;                    /**< bit:      0  New Data                                 */
@@ -1327,6 +1374,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_NDAT2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_NDAT2_OFFSET                   (0x9C)                                        /**<  (MCAN_NDAT2) New Data 2 Register  Offset */
@@ -1436,6 +1484,7 @@ typedef union {
 
 /* -------- MCAN_RXF0C : (MCAN Offset: 0xa0) (R/W 32) Receive FIFO 0 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1447,6 +1496,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0C_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0C_OFFSET                   (0xA0)                                        /**<  (MCAN_RXF0C) Receive FIFO 0 Configuration Register  Offset */
@@ -1469,6 +1519,7 @@ typedef union {
 
 /* -------- MCAN_RXF0S : (MCAN Offset: 0xa4) (R/ 32) Receive FIFO 0 Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0FL:7;                    /**< bit:   0..6  Receive FIFO 0 Fill Level                */
@@ -1483,6 +1534,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0S_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0S_OFFSET                   (0xA4)                                        /**<  (MCAN_RXF0S) Receive FIFO 0 Status Register  Offset */
@@ -1508,6 +1560,7 @@ typedef union {
 
 /* -------- MCAN_RXF0A : (MCAN Offset: 0xa8) (R/W 32) Receive FIFO 0 Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0AI:6;                    /**< bit:   0..5  Receive FIFO 0 Acknowledge Index         */
@@ -1515,6 +1568,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0A_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0A_OFFSET                   (0xA8)                                        /**<  (MCAN_RXF0A) Receive FIFO 0 Acknowledge Register  Offset */
@@ -1528,6 +1582,7 @@ typedef union {
 
 /* -------- MCAN_RXBC : (MCAN Offset: 0xac) (R/W 32) Receive Rx Buffer Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1536,6 +1591,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXBC_OFFSET                    (0xAC)                                        /**<  (MCAN_RXBC) Receive Rx Buffer Configuration Register  Offset */
@@ -1549,6 +1605,7 @@ typedef union {
 
 /* -------- MCAN_RXF1C : (MCAN Offset: 0xb0) (R/W 32) Receive FIFO 1 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1560,6 +1617,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1C_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1C_OFFSET                   (0xB0)                                        /**<  (MCAN_RXF1C) Receive FIFO 1 Configuration Register  Offset */
@@ -1582,6 +1640,7 @@ typedef union {
 
 /* -------- MCAN_RXF1S : (MCAN Offset: 0xb4) (R/ 32) Receive FIFO 1 Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F1FL:7;                    /**< bit:   0..6  Receive FIFO 1 Fill Level                */
@@ -1597,6 +1656,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1S_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1S_OFFSET                   (0xB4)                                        /**<  (MCAN_RXF1S) Receive FIFO 1 Status Register  Offset */
@@ -1633,6 +1693,7 @@ typedef union {
 
 /* -------- MCAN_RXF1A : (MCAN Offset: 0xb8) (R/W 32) Receive FIFO 1 Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F1AI:6;                    /**< bit:   0..5  Receive FIFO 1 Acknowledge Index         */
@@ -1640,6 +1701,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1A_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1A_OFFSET                   (0xB8)                                        /**<  (MCAN_RXF1A) Receive FIFO 1 Acknowledge Register  Offset */
@@ -1653,6 +1715,7 @@ typedef union {
 
 /* -------- MCAN_RXESC : (MCAN Offset: 0xbc) (R/W 32) Receive Buffer / FIFO Element Size Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0DS:3;                    /**< bit:   0..2  Receive FIFO 0 Data Field Size           */
@@ -1664,6 +1727,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXESC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXESC_OFFSET                   (0xBC)                                        /**<  (MCAN_RXESC) Receive Buffer / FIFO Element Size Configuration Register  Offset */
@@ -1731,6 +1795,7 @@ typedef union {
 
 /* -------- MCAN_TXBC : (MCAN Offset: 0xc0) (R/W 32) Transmit Buffer Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1743,6 +1808,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBC_OFFSET                    (0xC0)                                        /**<  (MCAN_TXBC) Transmit Buffer Configuration Register  Offset */
@@ -1765,6 +1831,7 @@ typedef union {
 
 /* -------- MCAN_TXFQS : (MCAN Offset: 0xc4) (R/ 32) Transmit FIFO/Queue Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TFFL:6;                    /**< bit:   0..5  Tx FIFO Free Level                       */
@@ -1777,6 +1844,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXFQS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXFQS_OFFSET                   (0xC4)                                        /**<  (MCAN_TXFQS) Transmit FIFO/Queue Status Register  Offset */
@@ -1799,6 +1867,7 @@ typedef union {
 
 /* -------- MCAN_TXESC : (MCAN Offset: 0xc8) (R/W 32) Transmit Buffer Element Size Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TBDS:3;                    /**< bit:   0..2  Tx Buffer Data Field Size                */
@@ -1806,6 +1875,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXESC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXESC_OFFSET                   (0xC8)                                        /**<  (MCAN_TXESC) Transmit Buffer Element Size Configuration Register  Offset */
@@ -1835,6 +1905,7 @@ typedef union {
 
 /* -------- MCAN_TXBRP : (MCAN Offset: 0xcc) (R/ 32) Transmit Buffer Request Pending Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRP0:1;                    /**< bit:      0  Transmission Request Pending for Buffer 0 */
@@ -1875,6 +1946,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBRP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBRP_OFFSET                   (0xCC)                                        /**<  (MCAN_TXBRP) Transmit Buffer Request Pending Register  Offset */
@@ -1984,6 +2056,7 @@ typedef union {
 
 /* -------- MCAN_TXBAR : (MCAN Offset: 0xd0) (R/W 32) Transmit Buffer Add Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AR0:1;                     /**< bit:      0  Add Request for Transmit Buffer 0        */
@@ -2024,6 +2097,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBAR_OFFSET                   (0xD0)                                        /**<  (MCAN_TXBAR) Transmit Buffer Add Request Register  Offset */
@@ -2133,6 +2207,7 @@ typedef union {
 
 /* -------- MCAN_TXBCR : (MCAN Offset: 0xd4) (R/W 32) Transmit Buffer Cancellation Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CR0:1;                     /**< bit:      0  Cancellation Request for Transmit Buffer 0 */
@@ -2173,6 +2248,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCR_OFFSET                   (0xD4)                                        /**<  (MCAN_TXBCR) Transmit Buffer Cancellation Request Register  Offset */
@@ -2282,6 +2358,7 @@ typedef union {
 
 /* -------- MCAN_TXBTO : (MCAN Offset: 0xd8) (R/ 32) Transmit Buffer Transmission Occurred Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TO0:1;                     /**< bit:      0  Transmission Occurred for Buffer 0       */
@@ -2322,6 +2399,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBTO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBTO_OFFSET                   (0xD8)                                        /**<  (MCAN_TXBTO) Transmit Buffer Transmission Occurred Register  Offset */
@@ -2431,6 +2509,7 @@ typedef union {
 
 /* -------- MCAN_TXBCF : (MCAN Offset: 0xdc) (R/ 32) Transmit Buffer Cancellation Finished Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CF0:1;                     /**< bit:      0  Cancellation Finished for Transmit Buffer 0 */
@@ -2471,6 +2550,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCF_OFFSET                   (0xDC)                                        /**<  (MCAN_TXBCF) Transmit Buffer Cancellation Finished Register  Offset */
@@ -2580,6 +2660,7 @@ typedef union {
 
 /* -------- MCAN_TXBTIE : (MCAN Offset: 0xe0) (R/W 32) Transmit Buffer Transmission Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TIE0:1;                    /**< bit:      0  Transmission Interrupt Enable for Buffer 0 */
@@ -2620,6 +2701,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBTIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBTIE_OFFSET                  (0xE0)                                        /**<  (MCAN_TXBTIE) Transmit Buffer Transmission Interrupt Enable Register  Offset */
@@ -2729,6 +2811,7 @@ typedef union {
 
 /* -------- MCAN_TXBCIE : (MCAN Offset: 0xe4) (R/W 32) Transmit Buffer Cancellation Finished Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CFIE0:1;                   /**< bit:      0  Cancellation Finished Interrupt Enable for Transmit Buffer 0 */
@@ -2769,6 +2852,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCIE_OFFSET                  (0xE4)                                        /**<  (MCAN_TXBCIE) Transmit Buffer Cancellation Finished Interrupt Enable Register  Offset */
@@ -2878,6 +2962,7 @@ typedef union {
 
 /* -------- MCAN_TXEFC : (MCAN Offset: 0xf0) (R/W 32) Transmit Event FIFO Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2889,6 +2974,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFC_OFFSET                   (0xF0)                                        /**<  (MCAN_TXEFC) Transmit Event FIFO Configuration Register  Offset */
@@ -2908,6 +2994,7 @@ typedef union {
 
 /* -------- MCAN_TXEFS : (MCAN Offset: 0xf4) (R/ 32) Transmit Event FIFO Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EFFL:6;                    /**< bit:   0..5  Event FIFO Fill Level                    */
@@ -2922,6 +3009,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFS_OFFSET                   (0xF4)                                        /**<  (MCAN_TXEFS) Transmit Event FIFO Status Register  Offset */
@@ -2947,6 +3035,7 @@ typedef union {
 
 /* -------- MCAN_TXEFA : (MCAN Offset: 0xf8) (R/W 32) Transmit Event FIFO Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EFAI:5;                    /**< bit:   0..4  Event FIFO Acknowledge Index             */
@@ -2954,6 +3043,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFA_OFFSET                   (0xF8)                                        /**<  (MCAN_TXEFA) Transmit Event FIFO Acknowledge Register  Offset */
@@ -2969,7 +3059,7 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief MCAN hardware registers */
 typedef struct {  
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __IO uint32_t MCAN_CUST;      /**< (MCAN Offset: 0x08) Customer Register */
   __IO uint32_t MCAN_FBTP;      /**< (MCAN Offset: 0x0C) Fast Bit Timing and Prescaler Register */
   __IO uint32_t MCAN_TEST;      /**< (MCAN Offset: 0x10) Test Register */
@@ -2980,19 +3070,19 @@ typedef struct {
   __IO uint32_t MCAN_TSCV;      /**< (MCAN Offset: 0x24) Timestamp Counter Value Register */
   __IO uint32_t MCAN_TOCC;      /**< (MCAN Offset: 0x28) Timeout Counter Configuration Register */
   __IO uint32_t MCAN_TOCV;      /**< (MCAN Offset: 0x2C) Timeout Counter Value Register */
-  RoReg8  Reserved2[0x10];
+  __I  uint8_t                        Reserved2[16];
   __I  uint32_t MCAN_ECR;       /**< (MCAN Offset: 0x40) Error Counter Register */
   __I  uint32_t MCAN_PSR;       /**< (MCAN Offset: 0x44) Protocol Status Register */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __IO uint32_t MCAN_IR;        /**< (MCAN Offset: 0x50) Interrupt Register */
   __IO uint32_t MCAN_IE;        /**< (MCAN Offset: 0x54) Interrupt Enable Register */
   __IO uint32_t MCAN_ILS;       /**< (MCAN Offset: 0x58) Interrupt Line Select Register */
   __IO uint32_t MCAN_ILE;       /**< (MCAN Offset: 0x5C) Interrupt Line Enable Register */
-  RoReg8  Reserved4[0x20];
+  __I  uint8_t                        Reserved4[32];
   __IO uint32_t MCAN_GFC;       /**< (MCAN Offset: 0x80) Global Filter Configuration Register */
   __IO uint32_t MCAN_SIDFC;     /**< (MCAN Offset: 0x84) Standard ID Filter Configuration Register */
   __IO uint32_t MCAN_XIDFC;     /**< (MCAN Offset: 0x88) Extended ID Filter Configuration Register */
-  RoReg8  Reserved5[0x4];
+  __I  uint8_t                        Reserved5[4];
   __IO uint32_t MCAN_XIDAM;     /**< (MCAN Offset: 0x90) Extended ID AND Mask Register */
   __I  uint32_t MCAN_HPMS;      /**< (MCAN Offset: 0x94) High Priority Message Status Register */
   __IO uint32_t MCAN_NDAT1;     /**< (MCAN Offset: 0x98) New Data 1 Register */
@@ -3015,7 +3105,7 @@ typedef struct {
   __I  uint32_t MCAN_TXBCF;     /**< (MCAN Offset: 0xDC) Transmit Buffer Cancellation Finished Register */
   __IO uint32_t MCAN_TXBTIE;    /**< (MCAN Offset: 0xE0) Transmit Buffer Transmission Interrupt Enable Register */
   __IO uint32_t MCAN_TXBCIE;    /**< (MCAN Offset: 0xE4) Transmit Buffer Cancellation Finished Interrupt Enable Register */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __IO uint32_t MCAN_TXEFC;     /**< (MCAN Offset: 0xF0) Transmit Event FIFO Configuration Register */
   __I  uint32_t MCAN_TXEFS;     /**< (MCAN Offset: 0xF4) Transmit Event FIFO Status Register */
   __IO uint32_t MCAN_TXEFA;     /**< (MCAN Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
@@ -3024,7 +3114,7 @@ typedef struct {
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief MCAN hardware registers */
 typedef struct {  
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __IO MCAN_CUST_Type                 MCAN_CUST;      /**< Offset: 0x08 (R/W  32) Customer Register */
   __IO MCAN_FBTP_Type                 MCAN_FBTP;      /**< Offset: 0x0C (R/W  32) Fast Bit Timing and Prescaler Register */
   __IO MCAN_TEST_Type                 MCAN_TEST;      /**< Offset: 0x10 (R/W  32) Test Register */
@@ -3035,19 +3125,19 @@ typedef struct {
   __IO MCAN_TSCV_Type                 MCAN_TSCV;      /**< Offset: 0x24 (R/W  32) Timestamp Counter Value Register */
   __IO MCAN_TOCC_Type                 MCAN_TOCC;      /**< Offset: 0x28 (R/W  32) Timeout Counter Configuration Register */
   __IO MCAN_TOCV_Type                 MCAN_TOCV;      /**< Offset: 0x2C (R/W  32) Timeout Counter Value Register */
-  __I  uint32_t                       Reserved2[4];
+  __I  uint8_t                        Reserved2[16];
   __I  MCAN_ECR_Type                  MCAN_ECR;       /**< Offset: 0x40 (R/   32) Error Counter Register */
   __I  MCAN_PSR_Type                  MCAN_PSR;       /**< Offset: 0x44 (R/   32) Protocol Status Register */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __IO MCAN_IR_Type                   MCAN_IR;        /**< Offset: 0x50 (R/W  32) Interrupt Register */
   __IO MCAN_IE_Type                   MCAN_IE;        /**< Offset: 0x54 (R/W  32) Interrupt Enable Register */
   __IO MCAN_ILS_Type                  MCAN_ILS;       /**< Offset: 0x58 (R/W  32) Interrupt Line Select Register */
   __IO MCAN_ILE_Type                  MCAN_ILE;       /**< Offset: 0x5C (R/W  32) Interrupt Line Enable Register */
-  __I  uint32_t                       Reserved4[8];
+  __I  uint8_t                        Reserved4[32];
   __IO MCAN_GFC_Type                  MCAN_GFC;       /**< Offset: 0x80 (R/W  32) Global Filter Configuration Register */
   __IO MCAN_SIDFC_Type                MCAN_SIDFC;     /**< Offset: 0x84 (R/W  32) Standard ID Filter Configuration Register */
   __IO MCAN_XIDFC_Type                MCAN_XIDFC;     /**< Offset: 0x88 (R/W  32) Extended ID Filter Configuration Register */
-  __I  uint32_t                       Reserved5[1];
+  __I  uint8_t                        Reserved5[4];
   __IO MCAN_XIDAM_Type                MCAN_XIDAM;     /**< Offset: 0x90 (R/W  32) Extended ID AND Mask Register */
   __I  MCAN_HPMS_Type                 MCAN_HPMS;      /**< Offset: 0x94 (R/   32) High Priority Message Status Register */
   __IO MCAN_NDAT1_Type                MCAN_NDAT1;     /**< Offset: 0x98 (R/W  32) New Data 1 Register */
@@ -3070,7 +3160,7 @@ typedef struct {
   __I  MCAN_TXBCF_Type                MCAN_TXBCF;     /**< Offset: 0xDC (R/   32) Transmit Buffer Cancellation Finished Register */
   __IO MCAN_TXBTIE_Type               MCAN_TXBTIE;    /**< Offset: 0xE0 (R/W  32) Transmit Buffer Transmission Interrupt Enable Register */
   __IO MCAN_TXBCIE_Type               MCAN_TXBCIE;    /**< Offset: 0xE4 (R/W  32) Transmit Buffer Cancellation Finished Interrupt Enable Register */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __IO MCAN_TXEFC_Type                MCAN_TXEFC;     /**< Offset: 0xF0 (R/W  32) Transmit Event FIFO Configuration Register */
   __I  MCAN_TXEFS_Type                MCAN_TXEFS;     /**< Offset: 0xF4 (R/   32) Transmit Event FIFO Status Register */
   __IO MCAN_TXEFA_Type                MCAN_TXEFA;     /**< Offset: 0xF8 (R/W  32) Transmit Event FIFO Acknowledge Register */

--- a/asf/sam/include/same70/component/pio.h
+++ b/asf/sam/include/same70/component/pio.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PIO
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- PIO_PER : (PIO Offset: 0x00) (/W 32) PIO Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Enable                               */
@@ -85,6 +88,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PER_OFFSET                      (0x00)                                        /**<  (PIO_PER) PIO Enable Register  Offset */
@@ -194,6 +198,7 @@ typedef union {
 
 /* -------- PIO_PDR : (PIO Offset: 0x04) (/W 32) PIO Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Disable                              */
@@ -234,6 +239,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PDR_OFFSET                      (0x04)                                        /**<  (PIO_PDR) PIO Disable Register  Offset */
@@ -343,6 +349,7 @@ typedef union {
 
 /* -------- PIO_PSR : (PIO Offset: 0x08) (R/ 32) PIO Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Status                               */
@@ -383,6 +390,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PSR_OFFSET                      (0x08)                                        /**<  (PIO_PSR) PIO Status Register  Offset */
@@ -492,6 +500,7 @@ typedef union {
 
 /* -------- PIO_OER : (PIO Offset: 0x10) (/W 32) Output Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Enable                            */
@@ -532,6 +541,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OER_OFFSET                      (0x10)                                        /**<  (PIO_OER) Output Enable Register  Offset */
@@ -641,6 +651,7 @@ typedef union {
 
 /* -------- PIO_ODR : (PIO Offset: 0x14) (/W 32) Output Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Disable                           */
@@ -681,6 +692,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ODR_OFFSET                      (0x14)                                        /**<  (PIO_ODR) Output Disable Register  Offset */
@@ -790,6 +802,7 @@ typedef union {
 
 /* -------- PIO_OSR : (PIO Offset: 0x18) (R/ 32) Output Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Status                            */
@@ -830,6 +843,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OSR_OFFSET                      (0x18)                                        /**<  (PIO_OSR) Output Status Register  Offset */
@@ -939,6 +953,7 @@ typedef union {
 
 /* -------- PIO_IFER : (PIO Offset: 0x20) (/W 32) Glitch Input Filter Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Enable                      */
@@ -979,6 +994,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFER_OFFSET                     (0x20)                                        /**<  (PIO_IFER) Glitch Input Filter Enable Register  Offset */
@@ -1088,6 +1104,7 @@ typedef union {
 
 /* -------- PIO_IFDR : (PIO Offset: 0x24) (/W 32) Glitch Input Filter Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Disable                     */
@@ -1128,6 +1145,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFDR_OFFSET                     (0x24)                                        /**<  (PIO_IFDR) Glitch Input Filter Disable Register  Offset */
@@ -1237,6 +1255,7 @@ typedef union {
 
 /* -------- PIO_IFSR : (PIO Offset: 0x28) (R/ 32) Glitch Input Filter Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Status                      */
@@ -1277,6 +1296,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSR_OFFSET                     (0x28)                                        /**<  (PIO_IFSR) Glitch Input Filter Status Register  Offset */
@@ -1386,6 +1406,7 @@ typedef union {
 
 /* -------- PIO_SODR : (PIO Offset: 0x30) (/W 32) Set Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Set Output Data                          */
@@ -1426,6 +1447,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SODR_OFFSET                     (0x30)                                        /**<  (PIO_SODR) Set Output Data Register  Offset */
@@ -1535,6 +1557,7 @@ typedef union {
 
 /* -------- PIO_CODR : (PIO Offset: 0x34) (/W 32) Clear Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Clear Output Data                        */
@@ -1575,6 +1598,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_CODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_CODR_OFFSET                     (0x34)                                        /**<  (PIO_CODR) Clear Output Data Register  Offset */
@@ -1684,6 +1708,7 @@ typedef union {
 
 /* -------- PIO_ODSR : (PIO Offset: 0x38) (R/W 32) Output Data Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
@@ -1724,6 +1749,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ODSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ODSR_OFFSET                     (0x38)                                        /**<  (PIO_ODSR) Output Data Status Register  Offset */
@@ -1833,6 +1859,7 @@ typedef union {
 
 /* -------- PIO_PDSR : (PIO Offset: 0x3c) (R/ 32) Pin Data Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
@@ -1873,6 +1900,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PDSR_OFFSET                     (0x3C)                                        /**<  (PIO_PDSR) Pin Data Status Register  Offset */
@@ -1982,6 +2010,7 @@ typedef union {
 
 /* -------- PIO_IER : (PIO Offset: 0x40) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Enable            */
@@ -2022,6 +2051,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IER_OFFSET                      (0x40)                                        /**<  (PIO_IER) Interrupt Enable Register  Offset */
@@ -2131,6 +2161,7 @@ typedef union {
 
 /* -------- PIO_IDR : (PIO Offset: 0x44) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Disable           */
@@ -2171,6 +2202,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IDR_OFFSET                      (0x44)                                        /**<  (PIO_IDR) Interrupt Disable Register  Offset */
@@ -2280,6 +2312,7 @@ typedef union {
 
 /* -------- PIO_IMR : (PIO Offset: 0x48) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Mask              */
@@ -2320,6 +2353,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IMR_OFFSET                      (0x48)                                        /**<  (PIO_IMR) Interrupt Mask Register  Offset */
@@ -2429,6 +2463,7 @@ typedef union {
 
 /* -------- PIO_ISR : (PIO Offset: 0x4c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Status            */
@@ -2469,6 +2504,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ISR_OFFSET                      (0x4C)                                        /**<  (PIO_ISR) Interrupt Status Register  Offset */
@@ -2578,6 +2614,7 @@ typedef union {
 
 /* -------- PIO_MDER : (PIO Offset: 0x50) (/W 32) Multi-driver Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Enable                       */
@@ -2618,6 +2655,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDER_OFFSET                     (0x50)                                        /**<  (PIO_MDER) Multi-driver Enable Register  Offset */
@@ -2727,6 +2765,7 @@ typedef union {
 
 /* -------- PIO_MDDR : (PIO Offset: 0x54) (/W 32) Multi-driver Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Disable                      */
@@ -2767,6 +2806,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDDR_OFFSET                     (0x54)                                        /**<  (PIO_MDDR) Multi-driver Disable Register  Offset */
@@ -2876,6 +2916,7 @@ typedef union {
 
 /* -------- PIO_MDSR : (PIO Offset: 0x58) (R/ 32) Multi-driver Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Status                       */
@@ -2916,6 +2957,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDSR_OFFSET                     (0x58)                                        /**<  (PIO_MDSR) Multi-driver Status Register  Offset */
@@ -3025,6 +3067,7 @@ typedef union {
 
 /* -------- PIO_PUDR : (PIO Offset: 0x60) (/W 32) Pull-up Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Disable                          */
@@ -3065,6 +3108,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUDR_OFFSET                     (0x60)                                        /**<  (PIO_PUDR) Pull-up Disable Register  Offset */
@@ -3174,6 +3218,7 @@ typedef union {
 
 /* -------- PIO_PUER : (PIO Offset: 0x64) (/W 32) Pull-up Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Enable                           */
@@ -3214,6 +3259,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUER_OFFSET                     (0x64)                                        /**<  (PIO_PUER) Pull-up Enable Register  Offset */
@@ -3323,6 +3369,7 @@ typedef union {
 
 /* -------- PIO_PUSR : (PIO Offset: 0x68) (R/ 32) Pad Pull-up Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Status                           */
@@ -3363,6 +3410,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUSR_OFFSET                     (0x68)                                        /**<  (PIO_PUSR) Pad Pull-up Status Register  Offset */
@@ -3472,6 +3520,7 @@ typedef union {
 
 /* -------- PIO_ABCDSR : (PIO Offset: 0x70) (R/W 32) Peripheral ABCD Select Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Peripheral Select                        */
@@ -3512,6 +3561,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ABCDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ABCDSR_OFFSET                   (0x70)                                        /**<  (PIO_ABCDSR) Peripheral ABCD Select Register 0  Offset */
@@ -3621,6 +3671,7 @@ typedef union {
 
 /* -------- PIO_IFSCDR : (PIO Offset: 0x80) (/W 32) Input Filter Slow Clock Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Peripheral Clock Glitch Filtering Select */
@@ -3661,6 +3712,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCDR_OFFSET                   (0x80)                                        /**<  (PIO_IFSCDR) Input Filter Slow Clock Disable Register  Offset */
@@ -3770,6 +3822,7 @@ typedef union {
 
 /* -------- PIO_IFSCER : (PIO Offset: 0x84) (/W 32) Input Filter Slow Clock Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Slow Clock Debouncing Filtering Select   */
@@ -3810,6 +3863,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCER_OFFSET                   (0x84)                                        /**<  (PIO_IFSCER) Input Filter Slow Clock Enable Register  Offset */
@@ -3919,6 +3973,7 @@ typedef union {
 
 /* -------- PIO_IFSCSR : (PIO Offset: 0x88) (R/ 32) Input Filter Slow Clock Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Glitch or Debouncing Filter Selection Status */
@@ -3959,6 +4014,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCSR_OFFSET                   (0x88)                                        /**<  (PIO_IFSCSR) Input Filter Slow Clock Status Register  Offset */
@@ -4068,6 +4124,7 @@ typedef union {
 
 /* -------- PIO_SCDR : (PIO Offset: 0x8c) (R/W 32) Slow Clock Divider Debouncing Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIV:14;                    /**< bit:  0..13  Slow Clock Divider Selection for Debouncing */
@@ -4075,6 +4132,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SCDR_OFFSET                     (0x8C)                                        /**<  (PIO_SCDR) Slow Clock Divider Debouncing Register  Offset */
@@ -4088,6 +4146,7 @@ typedef union {
 
 /* -------- PIO_PPDDR : (PIO Offset: 0x90) (/W 32) Pad Pull-down Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Disable                        */
@@ -4128,6 +4187,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDDR_OFFSET                    (0x90)                                        /**<  (PIO_PPDDR) Pad Pull-down Disable Register  Offset */
@@ -4237,6 +4297,7 @@ typedef union {
 
 /* -------- PIO_PPDER : (PIO Offset: 0x94) (/W 32) Pad Pull-down Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Enable                         */
@@ -4277,6 +4338,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDER_OFFSET                    (0x94)                                        /**<  (PIO_PPDER) Pad Pull-down Enable Register  Offset */
@@ -4386,6 +4448,7 @@ typedef union {
 
 /* -------- PIO_PPDSR : (PIO Offset: 0x98) (R/ 32) Pad Pull-down Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Status                         */
@@ -4426,6 +4489,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDSR_OFFSET                    (0x98)                                        /**<  (PIO_PPDSR) Pad Pull-down Status Register  Offset */
@@ -4535,6 +4599,7 @@ typedef union {
 
 /* -------- PIO_OWER : (PIO Offset: 0xa0) (/W 32) Output Write Enable -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Enable                      */
@@ -4575,6 +4640,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWER_OFFSET                     (0xA0)                                        /**<  (PIO_OWER) Output Write Enable  Offset */
@@ -4684,6 +4750,7 @@ typedef union {
 
 /* -------- PIO_OWDR : (PIO Offset: 0xa4) (/W 32) Output Write Disable -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Disable                     */
@@ -4724,6 +4791,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWDR_OFFSET                     (0xA4)                                        /**<  (PIO_OWDR) Output Write Disable  Offset */
@@ -4833,6 +4901,7 @@ typedef union {
 
 /* -------- PIO_OWSR : (PIO Offset: 0xa8) (R/ 32) Output Write Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Status                      */
@@ -4873,6 +4942,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWSR_OFFSET                     (0xA8)                                        /**<  (PIO_OWSR) Output Write Status Register  Offset */
@@ -4982,6 +5052,7 @@ typedef union {
 
 /* -------- PIO_AIMER : (PIO Offset: 0xb0) (/W 32) Additional Interrupt Modes Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Enable        */
@@ -5022,6 +5093,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMER_OFFSET                    (0xB0)                                        /**<  (PIO_AIMER) Additional Interrupt Modes Enable Register  Offset */
@@ -5131,6 +5203,7 @@ typedef union {
 
 /* -------- PIO_AIMDR : (PIO Offset: 0xb4) (/W 32) Additional Interrupt Modes Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Disable       */
@@ -5171,6 +5244,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMDR_OFFSET                    (0xB4)                                        /**<  (PIO_AIMDR) Additional Interrupt Modes Disable Register  Offset */
@@ -5280,6 +5354,7 @@ typedef union {
 
 /* -------- PIO_AIMMR : (PIO Offset: 0xb8) (R/ 32) Additional Interrupt Modes Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  IO Line Index                            */
@@ -5320,6 +5395,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMMR_OFFSET                    (0xB8)                                        /**<  (PIO_AIMMR) Additional Interrupt Modes Mask Register  Offset */
@@ -5429,6 +5505,7 @@ typedef union {
 
 /* -------- PIO_ESR : (PIO Offset: 0xc0) (/W 32) Edge Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge Interrupt Selection                 */
@@ -5469,6 +5546,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ESR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ESR_OFFSET                      (0xC0)                                        /**<  (PIO_ESR) Edge Select Register  Offset */
@@ -5578,6 +5656,7 @@ typedef union {
 
 /* -------- PIO_LSR : (PIO Offset: 0xc4) (/W 32) Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Level Interrupt Selection                */
@@ -5618,6 +5697,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_LSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_LSR_OFFSET                      (0xC4)                                        /**<  (PIO_LSR) Level Select Register  Offset */
@@ -5727,6 +5807,7 @@ typedef union {
 
 /* -------- PIO_ELSR : (PIO Offset: 0xc8) (R/ 32) Edge/Level Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
@@ -5767,6 +5848,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ELSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ELSR_OFFSET                     (0xC8)                                        /**<  (PIO_ELSR) Edge/Level Status Register  Offset */
@@ -5876,6 +5958,7 @@ typedef union {
 
 /* -------- PIO_FELLSR : (PIO Offset: 0xd0) (/W 32) Falling Edge/Low-Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Falling Edge/Low-Level Interrupt Selection */
@@ -5916,6 +5999,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_FELLSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_FELLSR_OFFSET                   (0xD0)                                        /**<  (PIO_FELLSR) Falling Edge/Low-Level Select Register  Offset */
@@ -6025,6 +6109,7 @@ typedef union {
 
 /* -------- PIO_REHLSR : (PIO Offset: 0xd4) (/W 32) Rising Edge/High-Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Rising Edge/High-Level Interrupt Selection */
@@ -6065,6 +6150,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_REHLSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_REHLSR_OFFSET                   (0xD4)                                        /**<  (PIO_REHLSR) Rising Edge/High-Level Select Register  Offset */
@@ -6174,6 +6260,7 @@ typedef union {
 
 /* -------- PIO_FRLHSR : (PIO Offset: 0xd8) (R/ 32) Fall/Rise - Low/High Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
@@ -6214,6 +6301,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_FRLHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_FRLHSR_OFFSET                   (0xD8)                                        /**<  (PIO_FRLHSR) Fall/Rise - Low/High Status Register  Offset */
@@ -6323,6 +6411,7 @@ typedef union {
 
 /* -------- PIO_LOCKSR : (PIO Offset: 0xe0) (R/ 32) Lock Status -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Lock Status                              */
@@ -6363,6 +6452,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_LOCKSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_LOCKSR_OFFSET                   (0xE0)                                        /**<  (PIO_LOCKSR) Lock Status  Offset */
@@ -6472,6 +6562,7 @@ typedef union {
 
 /* -------- PIO_WPMR : (PIO Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -6480,6 +6571,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_WPMR_OFFSET                     (0xE4)                                        /**<  (PIO_WPMR) Write Protection Mode Register  Offset */
@@ -6498,6 +6590,7 @@ typedef union {
 
 /* -------- PIO_WPSR : (PIO Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -6507,6 +6600,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_WPSR_OFFSET                     (0xE8)                                        /**<  (PIO_WPSR) Write Protection Status Register  Offset */
@@ -6523,6 +6617,7 @@ typedef union {
 
 /* -------- PIO_SCHMITT : (PIO Offset: 0x100) (R/W 32) Schmitt Trigger Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCHMITT0:1;                /**< bit:      0  Schmitt Trigger Control                  */
@@ -6563,6 +6658,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SCHMITT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SCHMITT_OFFSET                  (0x100)                                       /**<  (PIO_SCHMITT) Schmitt Trigger Register  Offset */
@@ -6672,6 +6768,7 @@ typedef union {
 
 /* -------- PIO_DRIVER : (PIO Offset: 0x118) (R/W 32) I/O Drive Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LINE0:1;                   /**< bit:      0  Drive of PIO Line 0                      */
@@ -6712,6 +6809,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_DRIVER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_DRIVER_OFFSET                   (0x118)                                       /**<  (PIO_DRIVER) I/O Drive Register  Offset */
@@ -6949,6 +7047,7 @@ typedef union {
 
 /* -------- PIO_PCMR : (PIO Offset: 0x150) (R/W 32) Parallel Capture Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PCEN:1;                    /**< bit:      0  Parallel Capture Mode Enable             */
@@ -6962,6 +7061,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCMR_OFFSET                     (0x150)                                       /**<  (PIO_PCMR) Parallel Capture Mode Register  Offset */
@@ -6993,6 +7093,7 @@ typedef union {
 
 /* -------- PIO_PCIER : (PIO Offset: 0x154) (/W 32) Parallel Capture Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Enable */
@@ -7003,6 +7104,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIER_OFFSET                    (0x154)                                       /**<  (PIO_PCIER) Parallel Capture Interrupt Enable Register  Offset */
@@ -7025,6 +7127,7 @@ typedef union {
 
 /* -------- PIO_PCIDR : (PIO Offset: 0x158) (/W 32) Parallel Capture Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Disable */
@@ -7035,6 +7138,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIDR_OFFSET                    (0x158)                                       /**<  (PIO_PCIDR) Parallel Capture Interrupt Disable Register  Offset */
@@ -7057,6 +7161,7 @@ typedef union {
 
 /* -------- PIO_PCIMR : (PIO Offset: 0x15c) (R/ 32) Parallel Capture Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Mask */
@@ -7067,6 +7172,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIMR_OFFSET                    (0x15C)                                       /**<  (PIO_PCIMR) Parallel Capture Interrupt Mask Register  Offset */
@@ -7089,6 +7195,7 @@ typedef union {
 
 /* -------- PIO_PCISR : (PIO Offset: 0x160) (R/ 32) Parallel Capture Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready         */
@@ -7097,6 +7204,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCISR_OFFSET                    (0x160)                                       /**<  (PIO_PCISR) Parallel Capture Interrupt Status Register  Offset */
@@ -7113,12 +7221,14 @@ typedef union {
 
 /* -------- PIO_PCRHR : (PIO Offset: 0x164) (R/ 32) Parallel Capture Reception Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDATA:32;                  /**< bit:  0..31  Parallel Capture Mode Reception Data     */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCRHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCRHR_OFFSET                    (0x164)                                       /**<  (PIO_PCRHR) Parallel Capture Reception Holding Register  Offset */
@@ -7137,15 +7247,15 @@ typedef struct {
   __O  uint32_t PIO_PER;        /**< (PIO Offset: 0x00) PIO Enable Register */
   __O  uint32_t PIO_PDR;        /**< (PIO Offset: 0x04) PIO Disable Register */
   __I  uint32_t PIO_PSR;        /**< (PIO Offset: 0x08) PIO Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t PIO_OER;        /**< (PIO Offset: 0x10) Output Enable Register */
   __O  uint32_t PIO_ODR;        /**< (PIO Offset: 0x14) Output Disable Register */
   __I  uint32_t PIO_OSR;        /**< (PIO Offset: 0x18) Output Status Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __O  uint32_t PIO_IFER;       /**< (PIO Offset: 0x20) Glitch Input Filter Enable Register */
   __O  uint32_t PIO_IFDR;       /**< (PIO Offset: 0x24) Glitch Input Filter Disable Register */
   __I  uint32_t PIO_IFSR;       /**< (PIO Offset: 0x28) Glitch Input Filter Status Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __O  uint32_t PIO_SODR;       /**< (PIO Offset: 0x30) Set Output Data Register */
   __O  uint32_t PIO_CODR;       /**< (PIO Offset: 0x34) Clear Output Data Register */
   __IO uint32_t PIO_ODSR;       /**< (PIO Offset: 0x38) Output Data Status Register */
@@ -7157,13 +7267,13 @@ typedef struct {
   __O  uint32_t PIO_MDER;       /**< (PIO Offset: 0x50) Multi-driver Enable Register */
   __O  uint32_t PIO_MDDR;       /**< (PIO Offset: 0x54) Multi-driver Disable Register */
   __I  uint32_t PIO_MDSR;       /**< (PIO Offset: 0x58) Multi-driver Status Register */
-  RoReg8  Reserved4[0x4];
+  __I  uint8_t                        Reserved4[4];
   __O  uint32_t PIO_PUDR;       /**< (PIO Offset: 0x60) Pull-up Disable Register */
   __O  uint32_t PIO_PUER;       /**< (PIO Offset: 0x64) Pull-up Enable Register */
   __I  uint32_t PIO_PUSR;       /**< (PIO Offset: 0x68) Pad Pull-up Status Register */
-  RoReg8  Reserved5[0x4];
+  __I  uint8_t                        Reserved5[4];
   __IO uint32_t PIO_ABCDSR[2];  /**< (PIO Offset: 0x70) Peripheral ABCD Select Register 0 */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __O  uint32_t PIO_IFSCDR;     /**< (PIO Offset: 0x80) Input Filter Slow Clock Disable Register */
   __O  uint32_t PIO_IFSCER;     /**< (PIO Offset: 0x84) Input Filter Slow Clock Enable Register */
   __I  uint32_t PIO_IFSCSR;     /**< (PIO Offset: 0x88) Input Filter Slow Clock Status Register */
@@ -7171,31 +7281,31 @@ typedef struct {
   __O  uint32_t PIO_PPDDR;      /**< (PIO Offset: 0x90) Pad Pull-down Disable Register */
   __O  uint32_t PIO_PPDER;      /**< (PIO Offset: 0x94) Pad Pull-down Enable Register */
   __I  uint32_t PIO_PPDSR;      /**< (PIO Offset: 0x98) Pad Pull-down Status Register */
-  RoReg8  Reserved7[0x4];
+  __I  uint8_t                        Reserved7[4];
   __O  uint32_t PIO_OWER;       /**< (PIO Offset: 0xA0) Output Write Enable */
   __O  uint32_t PIO_OWDR;       /**< (PIO Offset: 0xA4) Output Write Disable */
   __I  uint32_t PIO_OWSR;       /**< (PIO Offset: 0xA8) Output Write Status Register */
-  RoReg8  Reserved8[0x4];
+  __I  uint8_t                        Reserved8[4];
   __O  uint32_t PIO_AIMER;      /**< (PIO Offset: 0xB0) Additional Interrupt Modes Enable Register */
   __O  uint32_t PIO_AIMDR;      /**< (PIO Offset: 0xB4) Additional Interrupt Modes Disable Register */
   __I  uint32_t PIO_AIMMR;      /**< (PIO Offset: 0xB8) Additional Interrupt Modes Mask Register */
-  RoReg8  Reserved9[0x4];
+  __I  uint8_t                        Reserved9[4];
   __O  uint32_t PIO_ESR;        /**< (PIO Offset: 0xC0) Edge Select Register */
   __O  uint32_t PIO_LSR;        /**< (PIO Offset: 0xC4) Level Select Register */
   __I  uint32_t PIO_ELSR;       /**< (PIO Offset: 0xC8) Edge/Level Status Register */
-  RoReg8  Reserved10[0x4];
+  __I  uint8_t                        Reserved10[4];
   __O  uint32_t PIO_FELLSR;     /**< (PIO Offset: 0xD0) Falling Edge/Low-Level Select Register */
   __O  uint32_t PIO_REHLSR;     /**< (PIO Offset: 0xD4) Rising Edge/High-Level Select Register */
   __I  uint32_t PIO_FRLHSR;     /**< (PIO Offset: 0xD8) Fall/Rise - Low/High Status Register */
-  RoReg8  Reserved11[0x4];
+  __I  uint8_t                        Reserved11[4];
   __I  uint32_t PIO_LOCKSR;     /**< (PIO Offset: 0xE0) Lock Status */
   __IO uint32_t PIO_WPMR;       /**< (PIO Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t PIO_WPSR;       /**< (PIO Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved12[0x14];
+  __I  uint8_t                        Reserved12[20];
   __IO uint32_t PIO_SCHMITT;    /**< (PIO Offset: 0x100) Schmitt Trigger Register */
-  RoReg8  Reserved13[0x14];
+  __I  uint8_t                        Reserved13[20];
   __IO uint32_t PIO_DRIVER;     /**< (PIO Offset: 0x118) I/O Drive Register */
-  RoReg8  Reserved14[0x34];
+  __I  uint8_t                        Reserved14[52];
   __IO uint32_t PIO_PCMR;       /**< (PIO Offset: 0x150) Parallel Capture Mode Register */
   __O  uint32_t PIO_PCIER;      /**< (PIO Offset: 0x154) Parallel Capture Interrupt Enable Register */
   __O  uint32_t PIO_PCIDR;      /**< (PIO Offset: 0x158) Parallel Capture Interrupt Disable Register */
@@ -7210,15 +7320,15 @@ typedef struct {
   __O  PIO_PER_Type                   PIO_PER;        /**< Offset: 0x00 ( /W  32) PIO Enable Register */
   __O  PIO_PDR_Type                   PIO_PDR;        /**< Offset: 0x04 ( /W  32) PIO Disable Register */
   __I  PIO_PSR_Type                   PIO_PSR;        /**< Offset: 0x08 (R/   32) PIO Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  PIO_OER_Type                   PIO_OER;        /**< Offset: 0x10 ( /W  32) Output Enable Register */
   __O  PIO_ODR_Type                   PIO_ODR;        /**< Offset: 0x14 ( /W  32) Output Disable Register */
   __I  PIO_OSR_Type                   PIO_OSR;        /**< Offset: 0x18 (R/   32) Output Status Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __O  PIO_IFER_Type                  PIO_IFER;       /**< Offset: 0x20 ( /W  32) Glitch Input Filter Enable Register */
   __O  PIO_IFDR_Type                  PIO_IFDR;       /**< Offset: 0x24 ( /W  32) Glitch Input Filter Disable Register */
   __I  PIO_IFSR_Type                  PIO_IFSR;       /**< Offset: 0x28 (R/   32) Glitch Input Filter Status Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __O  PIO_SODR_Type                  PIO_SODR;       /**< Offset: 0x30 ( /W  32) Set Output Data Register */
   __O  PIO_CODR_Type                  PIO_CODR;       /**< Offset: 0x34 ( /W  32) Clear Output Data Register */
   __IO PIO_ODSR_Type                  PIO_ODSR;       /**< Offset: 0x38 (R/W  32) Output Data Status Register */
@@ -7230,13 +7340,13 @@ typedef struct {
   __O  PIO_MDER_Type                  PIO_MDER;       /**< Offset: 0x50 ( /W  32) Multi-driver Enable Register */
   __O  PIO_MDDR_Type                  PIO_MDDR;       /**< Offset: 0x54 ( /W  32) Multi-driver Disable Register */
   __I  PIO_MDSR_Type                  PIO_MDSR;       /**< Offset: 0x58 (R/   32) Multi-driver Status Register */
-  __I  uint32_t                       Reserved4[1];
+  __I  uint8_t                        Reserved4[4];
   __O  PIO_PUDR_Type                  PIO_PUDR;       /**< Offset: 0x60 ( /W  32) Pull-up Disable Register */
   __O  PIO_PUER_Type                  PIO_PUER;       /**< Offset: 0x64 ( /W  32) Pull-up Enable Register */
   __I  PIO_PUSR_Type                  PIO_PUSR;       /**< Offset: 0x68 (R/   32) Pad Pull-up Status Register */
-  __I  uint32_t                       Reserved5[1];
+  __I  uint8_t                        Reserved5[4];
   __IO PIO_ABCDSR_Type                PIO_ABCDSR[2];  /**< Offset: 0x70 (R/W  32) Peripheral ABCD Select Register 0 */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __O  PIO_IFSCDR_Type                PIO_IFSCDR;     /**< Offset: 0x80 ( /W  32) Input Filter Slow Clock Disable Register */
   __O  PIO_IFSCER_Type                PIO_IFSCER;     /**< Offset: 0x84 ( /W  32) Input Filter Slow Clock Enable Register */
   __I  PIO_IFSCSR_Type                PIO_IFSCSR;     /**< Offset: 0x88 (R/   32) Input Filter Slow Clock Status Register */
@@ -7244,31 +7354,31 @@ typedef struct {
   __O  PIO_PPDDR_Type                 PIO_PPDDR;      /**< Offset: 0x90 ( /W  32) Pad Pull-down Disable Register */
   __O  PIO_PPDER_Type                 PIO_PPDER;      /**< Offset: 0x94 ( /W  32) Pad Pull-down Enable Register */
   __I  PIO_PPDSR_Type                 PIO_PPDSR;      /**< Offset: 0x98 (R/   32) Pad Pull-down Status Register */
-  __I  uint32_t                       Reserved7[1];
+  __I  uint8_t                        Reserved7[4];
   __O  PIO_OWER_Type                  PIO_OWER;       /**< Offset: 0xA0 ( /W  32) Output Write Enable */
   __O  PIO_OWDR_Type                  PIO_OWDR;       /**< Offset: 0xA4 ( /W  32) Output Write Disable */
   __I  PIO_OWSR_Type                  PIO_OWSR;       /**< Offset: 0xA8 (R/   32) Output Write Status Register */
-  __I  uint32_t                       Reserved8[1];
+  __I  uint8_t                        Reserved8[4];
   __O  PIO_AIMER_Type                 PIO_AIMER;      /**< Offset: 0xB0 ( /W  32) Additional Interrupt Modes Enable Register */
   __O  PIO_AIMDR_Type                 PIO_AIMDR;      /**< Offset: 0xB4 ( /W  32) Additional Interrupt Modes Disable Register */
   __I  PIO_AIMMR_Type                 PIO_AIMMR;      /**< Offset: 0xB8 (R/   32) Additional Interrupt Modes Mask Register */
-  __I  uint32_t                       Reserved9[1];
+  __I  uint8_t                        Reserved9[4];
   __O  PIO_ESR_Type                   PIO_ESR;        /**< Offset: 0xC0 ( /W  32) Edge Select Register */
   __O  PIO_LSR_Type                   PIO_LSR;        /**< Offset: 0xC4 ( /W  32) Level Select Register */
   __I  PIO_ELSR_Type                  PIO_ELSR;       /**< Offset: 0xC8 (R/   32) Edge/Level Status Register */
-  __I  uint32_t                       Reserved10[1];
+  __I  uint8_t                        Reserved10[4];
   __O  PIO_FELLSR_Type                PIO_FELLSR;     /**< Offset: 0xD0 ( /W  32) Falling Edge/Low-Level Select Register */
   __O  PIO_REHLSR_Type                PIO_REHLSR;     /**< Offset: 0xD4 ( /W  32) Rising Edge/High-Level Select Register */
   __I  PIO_FRLHSR_Type                PIO_FRLHSR;     /**< Offset: 0xD8 (R/   32) Fall/Rise - Low/High Status Register */
-  __I  uint32_t                       Reserved11[1];
+  __I  uint8_t                        Reserved11[4];
   __I  PIO_LOCKSR_Type                PIO_LOCKSR;     /**< Offset: 0xE0 (R/   32) Lock Status */
   __IO PIO_WPMR_Type                  PIO_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  PIO_WPSR_Type                  PIO_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved12[5];
+  __I  uint8_t                        Reserved12[20];
   __IO PIO_SCHMITT_Type               PIO_SCHMITT;    /**< Offset: 0x100 (R/W  32) Schmitt Trigger Register */
-  __I  uint32_t                       Reserved13[5];
+  __I  uint8_t                        Reserved13[20];
   __IO PIO_DRIVER_Type                PIO_DRIVER;     /**< Offset: 0x118 (R/W  32) I/O Drive Register */
-  __I  uint32_t                       Reserved14[13];
+  __I  uint8_t                        Reserved14[52];
   __IO PIO_PCMR_Type                  PIO_PCMR;       /**< Offset: 0x150 (R/W  32) Parallel Capture Mode Register */
   __O  PIO_PCIER_Type                 PIO_PCIER;      /**< Offset: 0x154 ( /W  32) Parallel Capture Interrupt Enable Register */
   __O  PIO_PCIDR_Type                 PIO_PCIDR;      /**< Offset: 0x158 ( /W  32) Parallel Capture Interrupt Disable Register */

--- a/asf/sam/include/same70/component/pmc.h
+++ b/asf/sam/include/same70/component/pmc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- PMC_SCER : (PMC Offset: 0x00) (/W 32) System Clock Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :5;                        /**< bit:   0..4  Reserved */
@@ -66,6 +69,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCER_OFFSET                     (0x00)                                        /**<  (PMC_SCER) System Clock Enable Register  Offset */
@@ -103,6 +107,7 @@ typedef union {
 
 /* -------- PMC_SCDR : (PMC Offset: 0x04) (/W 32) System Clock Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :5;                        /**< bit:   0..4  Reserved */
@@ -124,6 +129,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCDR_OFFSET                     (0x04)                                        /**<  (PMC_SCDR) System Clock Disable Register  Offset */
@@ -161,6 +167,7 @@ typedef union {
 
 /* -------- PMC_SCSR : (PMC Offset: 0x08) (R/ 32) System Clock Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HCLKS:1;                   /**< bit:      0  HCLK Status                              */
@@ -183,6 +190,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCSR_OFFSET                     (0x08)                                        /**<  (PMC_SCSR) System Clock Status Register  Offset */
@@ -223,12 +231,19 @@ typedef union {
 
 /* -------- PMC_PCER0 : (PMC Offset: 0x10) (/W 32) Peripheral Clock Enable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Enable                */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Enable                */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Enable                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Enable               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Enable               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Enable               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Enable               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Enable               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Enable               */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Enable               */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Enable               */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Enable               */
@@ -248,11 +263,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Enable               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Enable               */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCER0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCER0_OFFSET                    (0x10)                                        /**<  (PMC_PCER0) Peripheral Clock Enable Register 0  Offset */
@@ -263,6 +278,27 @@ typedef union {
 #define PMC_PCER0_PID8_Pos                  8                                              /**< (PMC_PCER0) Peripheral Clock 8 Enable Position */
 #define PMC_PCER0_PID8_Msk                  (_U_(0x1) << PMC_PCER0_PID8_Pos)               /**< (PMC_PCER0) Peripheral Clock 8 Enable Mask */
 #define PMC_PCER0_PID8                      PMC_PCER0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID8_Msk instead */
+#define PMC_PCER0_PID9_Pos                  9                                              /**< (PMC_PCER0) Peripheral Clock 9 Enable Position */
+#define PMC_PCER0_PID9_Msk                  (_U_(0x1) << PMC_PCER0_PID9_Pos)               /**< (PMC_PCER0) Peripheral Clock 9 Enable Mask */
+#define PMC_PCER0_PID9                      PMC_PCER0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID9_Msk instead */
+#define PMC_PCER0_PID10_Pos                 10                                             /**< (PMC_PCER0) Peripheral Clock 10 Enable Position */
+#define PMC_PCER0_PID10_Msk                 (_U_(0x1) << PMC_PCER0_PID10_Pos)              /**< (PMC_PCER0) Peripheral Clock 10 Enable Mask */
+#define PMC_PCER0_PID10                     PMC_PCER0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID10_Msk instead */
+#define PMC_PCER0_PID11_Pos                 11                                             /**< (PMC_PCER0) Peripheral Clock 11 Enable Position */
+#define PMC_PCER0_PID11_Msk                 (_U_(0x1) << PMC_PCER0_PID11_Pos)              /**< (PMC_PCER0) Peripheral Clock 11 Enable Mask */
+#define PMC_PCER0_PID11                     PMC_PCER0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID11_Msk instead */
+#define PMC_PCER0_PID12_Pos                 12                                             /**< (PMC_PCER0) Peripheral Clock 12 Enable Position */
+#define PMC_PCER0_PID12_Msk                 (_U_(0x1) << PMC_PCER0_PID12_Pos)              /**< (PMC_PCER0) Peripheral Clock 12 Enable Mask */
+#define PMC_PCER0_PID12                     PMC_PCER0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID12_Msk instead */
+#define PMC_PCER0_PID13_Pos                 13                                             /**< (PMC_PCER0) Peripheral Clock 13 Enable Position */
+#define PMC_PCER0_PID13_Msk                 (_U_(0x1) << PMC_PCER0_PID13_Pos)              /**< (PMC_PCER0) Peripheral Clock 13 Enable Mask */
+#define PMC_PCER0_PID13                     PMC_PCER0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID13_Msk instead */
+#define PMC_PCER0_PID14_Pos                 14                                             /**< (PMC_PCER0) Peripheral Clock 14 Enable Position */
+#define PMC_PCER0_PID14_Msk                 (_U_(0x1) << PMC_PCER0_PID14_Pos)              /**< (PMC_PCER0) Peripheral Clock 14 Enable Mask */
+#define PMC_PCER0_PID14                     PMC_PCER0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID14_Msk instead */
+#define PMC_PCER0_PID15_Pos                 15                                             /**< (PMC_PCER0) Peripheral Clock 15 Enable Position */
+#define PMC_PCER0_PID15_Msk                 (_U_(0x1) << PMC_PCER0_PID15_Pos)              /**< (PMC_PCER0) Peripheral Clock 15 Enable Mask */
+#define PMC_PCER0_PID15                     PMC_PCER0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID15_Msk instead */
 #define PMC_PCER0_PID16_Pos                 16                                             /**< (PMC_PCER0) Peripheral Clock 16 Enable Position */
 #define PMC_PCER0_PID16_Msk                 (_U_(0x1) << PMC_PCER0_PID16_Pos)              /**< (PMC_PCER0) Peripheral Clock 16 Enable Mask */
 #define PMC_PCER0_PID16                     PMC_PCER0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID16_Msk instead */
@@ -311,21 +347,28 @@ typedef union {
 #define PMC_PCER0_PID31_Pos                 31                                             /**< (PMC_PCER0) Peripheral Clock 31 Enable Position */
 #define PMC_PCER0_PID31_Msk                 (_U_(0x1) << PMC_PCER0_PID31_Pos)              /**< (PMC_PCER0) Peripheral Clock 31 Enable Mask */
 #define PMC_PCER0_PID31                     PMC_PCER0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID31_Msk instead */
-#define PMC_PCER0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
-#define PMC_PCER0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCER0) Register Mask  */
+#define PMC_PCER0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
+#define PMC_PCER0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCER0) Register Mask  */
 
 #define PMC_PCER0_PID_Pos                   7                                              /**< (PMC_PCER0 Position) Peripheral Clock 3x Enable */
-#define PMC_PCER0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCER0_PID_Pos)            /**< (PMC_PCER0 Mask) PID */
+#define PMC_PCER0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER0_PID_Pos)          /**< (PMC_PCER0 Mask) PID */
 #define PMC_PCER0_PID(value)                (PMC_PCER0_PID_Msk & ((value) << PMC_PCER0_PID_Pos))  
 
 /* -------- PMC_PCDR0 : (PMC Offset: 0x14) (/W 32) Peripheral Clock Disable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Disable               */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Disable               */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Disable               */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Disable              */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Disable              */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Disable              */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Disable              */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Disable              */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Disable              */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Disable              */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Disable              */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Disable              */
@@ -345,11 +388,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Disable              */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Disable              */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCDR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCDR0_OFFSET                    (0x14)                                        /**<  (PMC_PCDR0) Peripheral Clock Disable Register 0  Offset */
@@ -360,6 +403,27 @@ typedef union {
 #define PMC_PCDR0_PID8_Pos                  8                                              /**< (PMC_PCDR0) Peripheral Clock 8 Disable Position */
 #define PMC_PCDR0_PID8_Msk                  (_U_(0x1) << PMC_PCDR0_PID8_Pos)               /**< (PMC_PCDR0) Peripheral Clock 8 Disable Mask */
 #define PMC_PCDR0_PID8                      PMC_PCDR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID8_Msk instead */
+#define PMC_PCDR0_PID9_Pos                  9                                              /**< (PMC_PCDR0) Peripheral Clock 9 Disable Position */
+#define PMC_PCDR0_PID9_Msk                  (_U_(0x1) << PMC_PCDR0_PID9_Pos)               /**< (PMC_PCDR0) Peripheral Clock 9 Disable Mask */
+#define PMC_PCDR0_PID9                      PMC_PCDR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID9_Msk instead */
+#define PMC_PCDR0_PID10_Pos                 10                                             /**< (PMC_PCDR0) Peripheral Clock 10 Disable Position */
+#define PMC_PCDR0_PID10_Msk                 (_U_(0x1) << PMC_PCDR0_PID10_Pos)              /**< (PMC_PCDR0) Peripheral Clock 10 Disable Mask */
+#define PMC_PCDR0_PID10                     PMC_PCDR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID10_Msk instead */
+#define PMC_PCDR0_PID11_Pos                 11                                             /**< (PMC_PCDR0) Peripheral Clock 11 Disable Position */
+#define PMC_PCDR0_PID11_Msk                 (_U_(0x1) << PMC_PCDR0_PID11_Pos)              /**< (PMC_PCDR0) Peripheral Clock 11 Disable Mask */
+#define PMC_PCDR0_PID11                     PMC_PCDR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID11_Msk instead */
+#define PMC_PCDR0_PID12_Pos                 12                                             /**< (PMC_PCDR0) Peripheral Clock 12 Disable Position */
+#define PMC_PCDR0_PID12_Msk                 (_U_(0x1) << PMC_PCDR0_PID12_Pos)              /**< (PMC_PCDR0) Peripheral Clock 12 Disable Mask */
+#define PMC_PCDR0_PID12                     PMC_PCDR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID12_Msk instead */
+#define PMC_PCDR0_PID13_Pos                 13                                             /**< (PMC_PCDR0) Peripheral Clock 13 Disable Position */
+#define PMC_PCDR0_PID13_Msk                 (_U_(0x1) << PMC_PCDR0_PID13_Pos)              /**< (PMC_PCDR0) Peripheral Clock 13 Disable Mask */
+#define PMC_PCDR0_PID13                     PMC_PCDR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID13_Msk instead */
+#define PMC_PCDR0_PID14_Pos                 14                                             /**< (PMC_PCDR0) Peripheral Clock 14 Disable Position */
+#define PMC_PCDR0_PID14_Msk                 (_U_(0x1) << PMC_PCDR0_PID14_Pos)              /**< (PMC_PCDR0) Peripheral Clock 14 Disable Mask */
+#define PMC_PCDR0_PID14                     PMC_PCDR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID14_Msk instead */
+#define PMC_PCDR0_PID15_Pos                 15                                             /**< (PMC_PCDR0) Peripheral Clock 15 Disable Position */
+#define PMC_PCDR0_PID15_Msk                 (_U_(0x1) << PMC_PCDR0_PID15_Pos)              /**< (PMC_PCDR0) Peripheral Clock 15 Disable Mask */
+#define PMC_PCDR0_PID15                     PMC_PCDR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID15_Msk instead */
 #define PMC_PCDR0_PID16_Pos                 16                                             /**< (PMC_PCDR0) Peripheral Clock 16 Disable Position */
 #define PMC_PCDR0_PID16_Msk                 (_U_(0x1) << PMC_PCDR0_PID16_Pos)              /**< (PMC_PCDR0) Peripheral Clock 16 Disable Mask */
 #define PMC_PCDR0_PID16                     PMC_PCDR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID16_Msk instead */
@@ -408,21 +472,28 @@ typedef union {
 #define PMC_PCDR0_PID31_Pos                 31                                             /**< (PMC_PCDR0) Peripheral Clock 31 Disable Position */
 #define PMC_PCDR0_PID31_Msk                 (_U_(0x1) << PMC_PCDR0_PID31_Pos)              /**< (PMC_PCDR0) Peripheral Clock 31 Disable Mask */
 #define PMC_PCDR0_PID31                     PMC_PCDR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID31_Msk instead */
-#define PMC_PCDR0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
-#define PMC_PCDR0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCDR0) Register Mask  */
+#define PMC_PCDR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
+#define PMC_PCDR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCDR0) Register Mask  */
 
 #define PMC_PCDR0_PID_Pos                   7                                              /**< (PMC_PCDR0 Position) Peripheral Clock 3x Disable */
-#define PMC_PCDR0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCDR0_PID_Pos)            /**< (PMC_PCDR0 Mask) PID */
+#define PMC_PCDR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR0_PID_Pos)          /**< (PMC_PCDR0 Mask) PID */
 #define PMC_PCDR0_PID(value)                (PMC_PCDR0_PID_Msk & ((value) << PMC_PCDR0_PID_Pos))  
 
 /* -------- PMC_PCSR0 : (PMC Offset: 0x18) (R/ 32) Peripheral Clock Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Status                */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Status                */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Status                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Status               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Status               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Status               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Status               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Status               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Status               */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Status               */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Status               */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Status               */
@@ -442,11 +513,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Status               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Status               */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCSR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCSR0_OFFSET                    (0x18)                                        /**<  (PMC_PCSR0) Peripheral Clock Status Register 0  Offset */
@@ -457,6 +528,27 @@ typedef union {
 #define PMC_PCSR0_PID8_Pos                  8                                              /**< (PMC_PCSR0) Peripheral Clock 8 Status Position */
 #define PMC_PCSR0_PID8_Msk                  (_U_(0x1) << PMC_PCSR0_PID8_Pos)               /**< (PMC_PCSR0) Peripheral Clock 8 Status Mask */
 #define PMC_PCSR0_PID8                      PMC_PCSR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID8_Msk instead */
+#define PMC_PCSR0_PID9_Pos                  9                                              /**< (PMC_PCSR0) Peripheral Clock 9 Status Position */
+#define PMC_PCSR0_PID9_Msk                  (_U_(0x1) << PMC_PCSR0_PID9_Pos)               /**< (PMC_PCSR0) Peripheral Clock 9 Status Mask */
+#define PMC_PCSR0_PID9                      PMC_PCSR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID9_Msk instead */
+#define PMC_PCSR0_PID10_Pos                 10                                             /**< (PMC_PCSR0) Peripheral Clock 10 Status Position */
+#define PMC_PCSR0_PID10_Msk                 (_U_(0x1) << PMC_PCSR0_PID10_Pos)              /**< (PMC_PCSR0) Peripheral Clock 10 Status Mask */
+#define PMC_PCSR0_PID10                     PMC_PCSR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID10_Msk instead */
+#define PMC_PCSR0_PID11_Pos                 11                                             /**< (PMC_PCSR0) Peripheral Clock 11 Status Position */
+#define PMC_PCSR0_PID11_Msk                 (_U_(0x1) << PMC_PCSR0_PID11_Pos)              /**< (PMC_PCSR0) Peripheral Clock 11 Status Mask */
+#define PMC_PCSR0_PID11                     PMC_PCSR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID11_Msk instead */
+#define PMC_PCSR0_PID12_Pos                 12                                             /**< (PMC_PCSR0) Peripheral Clock 12 Status Position */
+#define PMC_PCSR0_PID12_Msk                 (_U_(0x1) << PMC_PCSR0_PID12_Pos)              /**< (PMC_PCSR0) Peripheral Clock 12 Status Mask */
+#define PMC_PCSR0_PID12                     PMC_PCSR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID12_Msk instead */
+#define PMC_PCSR0_PID13_Pos                 13                                             /**< (PMC_PCSR0) Peripheral Clock 13 Status Position */
+#define PMC_PCSR0_PID13_Msk                 (_U_(0x1) << PMC_PCSR0_PID13_Pos)              /**< (PMC_PCSR0) Peripheral Clock 13 Status Mask */
+#define PMC_PCSR0_PID13                     PMC_PCSR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID13_Msk instead */
+#define PMC_PCSR0_PID14_Pos                 14                                             /**< (PMC_PCSR0) Peripheral Clock 14 Status Position */
+#define PMC_PCSR0_PID14_Msk                 (_U_(0x1) << PMC_PCSR0_PID14_Pos)              /**< (PMC_PCSR0) Peripheral Clock 14 Status Mask */
+#define PMC_PCSR0_PID14                     PMC_PCSR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID14_Msk instead */
+#define PMC_PCSR0_PID15_Pos                 15                                             /**< (PMC_PCSR0) Peripheral Clock 15 Status Position */
+#define PMC_PCSR0_PID15_Msk                 (_U_(0x1) << PMC_PCSR0_PID15_Pos)              /**< (PMC_PCSR0) Peripheral Clock 15 Status Mask */
+#define PMC_PCSR0_PID15                     PMC_PCSR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID15_Msk instead */
 #define PMC_PCSR0_PID16_Pos                 16                                             /**< (PMC_PCSR0) Peripheral Clock 16 Status Position */
 #define PMC_PCSR0_PID16_Msk                 (_U_(0x1) << PMC_PCSR0_PID16_Pos)              /**< (PMC_PCSR0) Peripheral Clock 16 Status Mask */
 #define PMC_PCSR0_PID16                     PMC_PCSR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID16_Msk instead */
@@ -505,15 +597,16 @@ typedef union {
 #define PMC_PCSR0_PID31_Pos                 31                                             /**< (PMC_PCSR0) Peripheral Clock 31 Status Position */
 #define PMC_PCSR0_PID31_Msk                 (_U_(0x1) << PMC_PCSR0_PID31_Pos)              /**< (PMC_PCSR0) Peripheral Clock 31 Status Mask */
 #define PMC_PCSR0_PID31                     PMC_PCSR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID31_Msk instead */
-#define PMC_PCSR0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
-#define PMC_PCSR0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCSR0) Register Mask  */
+#define PMC_PCSR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
+#define PMC_PCSR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCSR0) Register Mask  */
 
 #define PMC_PCSR0_PID_Pos                   7                                              /**< (PMC_PCSR0 Position) Peripheral Clock 3x Status */
-#define PMC_PCSR0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCSR0_PID_Pos)            /**< (PMC_PCSR0 Mask) PID */
+#define PMC_PCSR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR0_PID_Pos)          /**< (PMC_PCSR0 Mask) PID */
 #define PMC_PCSR0_PID(value)                (PMC_PCSR0_PID_Msk & ((value) << PMC_PCSR0_PID_Pos))  
 
 /* -------- CKGR_UCKR : (PMC Offset: 0x1c) (R/W 32) UTMI Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -524,6 +617,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_UCKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_UCKR_OFFSET                    (0x1C)                                        /**<  (CKGR_UCKR) UTMI Clock Register  Offset */
@@ -540,6 +634,7 @@ typedef union {
 
 /* -------- CKGR_MOR : (PMC Offset: 0x20) (R/W 32) Main Oscillator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTEN:1;                /**< bit:      0  Main Crystal Oscillator Enable           */
@@ -557,6 +652,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_MOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_MOR_OFFSET                     (0x20)                                        /**<  (CKGR_MOR) Main Oscillator Register  Offset */
@@ -605,6 +701,7 @@ typedef union {
 
 /* -------- CKGR_MCFR : (PMC Offset: 0x24) (R/W 32) Main Clock Frequency Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAINF:16;                  /**< bit:  0..15  Main Clock Frequency                     */
@@ -617,6 +714,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_MCFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_MCFR_OFFSET                    (0x24)                                        /**<  (CKGR_MCFR) Main Clock Frequency Register  Offset */
@@ -639,6 +737,7 @@ typedef union {
 
 /* -------- CKGR_PLLAR : (PMC Offset: 0x28) (R/W 32) PLLA Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIVA:8;                    /**< bit:   0..7  PLLA Front End Divider                   */
@@ -651,6 +750,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_PLLAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_PLLAR_OFFSET                   (0x28)                                        /**<  (CKGR_PLLAR) PLLA Register  Offset */
@@ -677,6 +777,7 @@ typedef union {
 
 /* -------- PMC_MCKR : (PMC Offset: 0x30) (R/W 32) Master Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSS:2;                     /**< bit:   0..1  Master Clock Source Selection            */
@@ -688,8 +789,14 @@ typedef union {
     uint32_t UPLLDIV2:1;                /**< bit:     13  UPLL Divider by 2                        */
     uint32_t :18;                       /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t UPLLDIV:1;                 /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_MCKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_MCKR_OFFSET                     (0x30)                                        /**<  (PMC_MCKR) Master Clock Register  Offset */
@@ -741,9 +848,13 @@ typedef union {
 #define PMC_MCKR_MASK                       _U_(0x2373)                                    /**< \deprecated (PMC_MCKR) Register MASK  (Use PMC_MCKR_Msk instead)  */
 #define PMC_MCKR_Msk                        _U_(0x2373)                                    /**< (PMC_MCKR) Register Mask  */
 
+#define PMC_MCKR_UPLLDIV_Pos                13                                             /**< (PMC_MCKR Position) UPLL Divider by 2 */
+#define PMC_MCKR_UPLLDIV_Msk                (_U_(0x1) << PMC_MCKR_UPLLDIV_Pos)             /**< (PMC_MCKR Mask) UPLLDIV */
+#define PMC_MCKR_UPLLDIV(value)             (PMC_MCKR_UPLLDIV_Msk & ((value) << PMC_MCKR_UPLLDIV_Pos))  
 
 /* -------- PMC_USB : (PMC Offset: 0x38) (R/W 32) USB Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USBS:1;                    /**< bit:      0  USB Input Clock Selection                */
@@ -753,6 +864,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_USB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_USB_OFFSET                      (0x38)                                        /**<  (PMC_USB) USB Clock Register  Offset */
@@ -769,6 +881,7 @@ typedef union {
 
 /* -------- PMC_PCK : (PMC Offset: 0x40) (R/W 32) Programmable Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSS:3;                     /**< bit:   0..2  Programmable Clock Source Selection      */
@@ -778,6 +891,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCK_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCK_OFFSET                      (0x40)                                        /**<  (PMC_PCK) Programmable Clock Register  Offset */
@@ -804,6 +918,7 @@ typedef union {
 
 /* -------- PMC_IER : (PMC Offset: 0x60) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Enable */
@@ -835,6 +950,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IER_OFFSET                      (0x60)                                        /**<  (PMC_IER) Interrupt Enable Register  Offset */
@@ -893,6 +1009,7 @@ typedef union {
 
 /* -------- PMC_IDR : (PMC Offset: 0x64) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Disable */
@@ -924,6 +1041,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IDR_OFFSET                      (0x64)                                        /**<  (PMC_IDR) Interrupt Disable Register  Offset */
@@ -982,6 +1100,7 @@ typedef union {
 
 /* -------- PMC_SR : (PMC Offset: 0x68) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status           */
@@ -1014,6 +1133,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SR_OFFSET                       (0x68)                                        /**<  (PMC_SR) Status Register  Offset */
@@ -1081,6 +1201,7 @@ typedef union {
 
 /* -------- PMC_IMR : (PMC Offset: 0x6c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Mask */
@@ -1112,6 +1233,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IMR_OFFSET                      (0x6C)                                        /**<  (PMC_IMR) Interrupt Mask Register  Offset */
@@ -1170,6 +1292,7 @@ typedef union {
 
 /* -------- PMC_FSMR : (PMC Offset: 0x70) (R/W 32) Fast Startup Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FSTT0:1;                   /**< bit:      0  Fast Startup Input Enable 0              */
@@ -1203,6 +1326,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FSMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FSMR_OFFSET                     (0x70)                                        /**<  (PMC_FSMR) Fast Startup Mode Register  Offset */
@@ -1288,6 +1412,7 @@ typedef union {
 
 /* -------- PMC_FSPR : (PMC Offset: 0x74) (R/W 32) Fast Startup Polarity Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FSTP0:1;                   /**< bit:      0  Fast Startup Input Polarity 0            */
@@ -1314,6 +1439,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FSPR_OFFSET                     (0x74)                                        /**<  (PMC_FSPR) Fast Startup Polarity Register  Offset */
@@ -1375,6 +1501,7 @@ typedef union {
 
 /* -------- PMC_FOCR : (PMC Offset: 0x78) (/W 32) Fault Output Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FOCLR:1;                   /**< bit:      0  Fault Output Clear                       */
@@ -1382,6 +1509,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FOCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FOCR_OFFSET                     (0x78)                                        /**<  (PMC_FOCR) Fault Output Clear Register  Offset */
@@ -1395,6 +1523,7 @@ typedef union {
 
 /* -------- PMC_WPMR : (PMC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1403,6 +1532,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_WPMR_OFFSET                     (0xE4)                                        /**<  (PMC_WPMR) Write Protection Mode Register  Offset */
@@ -1421,6 +1551,7 @@ typedef union {
 
 /* -------- PMC_WPSR : (PMC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1430,6 +1561,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_WPSR_OFFSET                     (0xE8)                                        /**<  (PMC_WPSR) Write Protection Status Register  Offset */
@@ -1446,6 +1578,7 @@ typedef union {
 
 /* -------- PMC_PCER1 : (PMC Offset: 0x100) (/W 32) Peripheral Clock Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Enable               */
@@ -1484,6 +1617,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCER1_OFFSET                    (0x100)                                       /**<  (PMC_PCER1) Peripheral Clock Enable Register 1  Offset */
@@ -1572,6 +1706,7 @@ typedef union {
 
 /* -------- PMC_PCDR1 : (PMC Offset: 0x104) (/W 32) Peripheral Clock Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Disable              */
@@ -1610,6 +1745,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCDR1_OFFSET                    (0x104)                                       /**<  (PMC_PCDR1) Peripheral Clock Disable Register 1  Offset */
@@ -1698,6 +1834,7 @@ typedef union {
 
 /* -------- PMC_PCSR1 : (PMC Offset: 0x108) (R/ 32) Peripheral Clock Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Status               */
@@ -1736,6 +1873,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCSR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCSR1_OFFSET                    (0x108)                                       /**<  (PMC_PCSR1) Peripheral Clock Status Register 1  Offset */
@@ -1824,6 +1962,7 @@ typedef union {
 
 /* -------- PMC_PCR : (PMC Offset: 0x10c) (R/W 32) Peripheral Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID:7;                     /**< bit:   0..6  Peripheral ID                            */
@@ -1839,6 +1978,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCR_OFFSET                      (0x10C)                                       /**<  (PMC_PCR) Peripheral Control Register  Offset */
@@ -1877,6 +2017,7 @@ typedef union {
 
 /* -------- PMC_OCR : (PMC Offset: 0x110) (R/W 32) Oscillator Calibration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CAL4:7;                    /**< bit:   0..6  Main RC Oscillator Calibration Bits for 4 MHz */
@@ -1889,6 +2030,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_OCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_OCR_OFFSET                      (0x110)                                       /**<  (PMC_OCR) Oscillator Calibration Register  Offset */
@@ -1917,6 +2059,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ER0 : (PMC Offset: 0x114) (/W 32) SleepWalking Enable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -1952,6 +2095,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ER0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ER0_OFFSET                (0x114)                                       /**<  (PMC_SLPWK_ER0) SleepWalking Enable Register 0  Offset */
@@ -2040,6 +2184,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_DR0 : (PMC Offset: 0x118) (/W 32) SleepWalking Disable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2075,6 +2220,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_DR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_DR0_OFFSET                (0x118)                                       /**<  (PMC_SLPWK_DR0) SleepWalking Disable Register 0  Offset */
@@ -2163,6 +2309,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_SR0 : (PMC Offset: 0x11c) (R/ 32) SleepWalking Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2198,6 +2345,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_SR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_SR0_OFFSET                (0x11C)                                       /**<  (PMC_SLPWK_SR0) SleepWalking Status Register 0  Offset */
@@ -2286,6 +2434,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ASR0 : (PMC Offset: 0x120) (R/ 32) SleepWalking Activity Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2321,6 +2470,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ASR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ASR0_OFFSET               (0x120)                                       /**<  (PMC_SLPWK_ASR0) SleepWalking Activity Status Register 0  Offset */
@@ -2409,6 +2559,7 @@ typedef union {
 
 /* -------- PMC_PMMR : (PMC Offset: 0x130) (R/W 32) PLL Maximum Multiplier Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PLLA_MMAX:11;              /**< bit:  0..10  PLLA Maximum Allowed Multiplier Value    */
@@ -2416,6 +2567,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PMMR_OFFSET                     (0x130)                                       /**<  (PMC_PMMR) PLL Maximum Multiplier Value Register  Offset */
@@ -2429,6 +2581,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ER1 : (PMC Offset: 0x134) (/W 32) SleepWalking Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Enable        */
@@ -2467,6 +2620,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ER1_OFFSET                (0x134)                                       /**<  (PMC_SLPWK_ER1) SleepWalking Enable Register 1  Offset */
@@ -2555,6 +2709,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_DR1 : (PMC Offset: 0x138) (/W 32) SleepWalking Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Disable       */
@@ -2593,6 +2748,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_DR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_DR1_OFFSET                (0x138)                                       /**<  (PMC_SLPWK_DR1) SleepWalking Disable Register 1  Offset */
@@ -2681,6 +2837,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_SR1 : (PMC Offset: 0x13c) (R/ 32) SleepWalking Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Status        */
@@ -2719,6 +2876,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_SR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_SR1_OFFSET                (0x13C)                                       /**<  (PMC_SLPWK_SR1) SleepWalking Status Register 1  Offset */
@@ -2807,6 +2965,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ASR1 : (PMC Offset: 0x140) (R/ 32) SleepWalking Activity Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 Activity Status            */
@@ -2845,6 +3004,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ASR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ASR1_OFFSET               (0x140)                                       /**<  (PMC_SLPWK_ASR1) SleepWalking Activity Status Register 1  Offset */
@@ -2933,6 +3093,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_AIPR : (PMC Offset: 0x144) (R/ 32) SleepWalking Activity In Progress Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AIP:1;                     /**< bit:      0  Activity In Progress                     */
@@ -2940,6 +3101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_AIPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_AIPR_OFFSET               (0x144)                                       /**<  (PMC_SLPWK_AIPR) SleepWalking Activity In Progress Register  Offset */
@@ -2958,7 +3120,7 @@ typedef struct {
   __O  uint32_t PMC_SCER;       /**< (PMC Offset: 0x00) System Clock Enable Register */
   __O  uint32_t PMC_SCDR;       /**< (PMC Offset: 0x04) System Clock Disable Register */
   __I  uint32_t PMC_SCSR;       /**< (PMC Offset: 0x08) System Clock Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t PMC_PCER0;      /**< (PMC Offset: 0x10) Peripheral Clock Enable Register 0 */
   __O  uint32_t PMC_PCDR0;      /**< (PMC Offset: 0x14) Peripheral Clock Disable Register 0 */
   __I  uint32_t PMC_PCSR0;      /**< (PMC Offset: 0x18) Peripheral Clock Status Register 0 */
@@ -2966,11 +3128,11 @@ typedef struct {
   __IO uint32_t CKGR_MOR;       /**< (PMC Offset: 0x20) Main Oscillator Register */
   __IO uint32_t CKGR_MCFR;      /**< (PMC Offset: 0x24) Main Clock Frequency Register */
   __IO uint32_t CKGR_PLLAR;     /**< (PMC Offset: 0x28) PLLA Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t PMC_MCKR;       /**< (PMC Offset: 0x30) Master Clock Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __IO uint32_t PMC_USB;        /**< (PMC Offset: 0x38) USB Clock Register */
-  RoReg8  Reserved4[0x4];
+  __I  uint8_t                        Reserved4[4];
   __IO uint32_t PMC_PCK[8];     /**< (PMC Offset: 0x40) Programmable Clock Register */
   __O  uint32_t PMC_IER;        /**< (PMC Offset: 0x60) Interrupt Enable Register */
   __O  uint32_t PMC_IDR;        /**< (PMC Offset: 0x64) Interrupt Disable Register */
@@ -2979,10 +3141,10 @@ typedef struct {
   __IO uint32_t PMC_FSMR;       /**< (PMC Offset: 0x70) Fast Startup Mode Register */
   __IO uint32_t PMC_FSPR;       /**< (PMC Offset: 0x74) Fast Startup Polarity Register */
   __O  uint32_t PMC_FOCR;       /**< (PMC Offset: 0x78) Fault Output Clear Register */
-  RoReg8  Reserved5[0x68];
+  __I  uint8_t                        Reserved5[104];
   __IO uint32_t PMC_WPMR;       /**< (PMC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t PMC_WPSR;       /**< (PMC Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved6[0x14];
+  __I  uint8_t                        Reserved6[20];
   __O  uint32_t PMC_PCER1;      /**< (PMC Offset: 0x100) Peripheral Clock Enable Register 1 */
   __O  uint32_t PMC_PCDR1;      /**< (PMC Offset: 0x104) Peripheral Clock Disable Register 1 */
   __I  uint32_t PMC_PCSR1;      /**< (PMC Offset: 0x108) Peripheral Clock Status Register 1 */
@@ -2992,7 +3154,7 @@ typedef struct {
   __O  uint32_t PMC_SLPWK_DR0;  /**< (PMC Offset: 0x118) SleepWalking Disable Register 0 */
   __I  uint32_t PMC_SLPWK_SR0;  /**< (PMC Offset: 0x11C) SleepWalking Status Register 0 */
   __I  uint32_t PMC_SLPWK_ASR0; /**< (PMC Offset: 0x120) SleepWalking Activity Status Register 0 */
-  RoReg8  Reserved7[0xC];
+  __I  uint8_t                        Reserved7[12];
   __IO uint32_t PMC_PMMR;       /**< (PMC Offset: 0x130) PLL Maximum Multiplier Value Register */
   __O  uint32_t PMC_SLPWK_ER1;  /**< (PMC Offset: 0x134) SleepWalking Enable Register 1 */
   __O  uint32_t PMC_SLPWK_DR1;  /**< (PMC Offset: 0x138) SleepWalking Disable Register 1 */
@@ -3007,7 +3169,7 @@ typedef struct {
   __O  PMC_SCER_Type                  PMC_SCER;       /**< Offset: 0x00 ( /W  32) System Clock Enable Register */
   __O  PMC_SCDR_Type                  PMC_SCDR;       /**< Offset: 0x04 ( /W  32) System Clock Disable Register */
   __I  PMC_SCSR_Type                  PMC_SCSR;       /**< Offset: 0x08 (R/   32) System Clock Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  PMC_PCER0_Type                 PMC_PCER0;      /**< Offset: 0x10 ( /W  32) Peripheral Clock Enable Register 0 */
   __O  PMC_PCDR0_Type                 PMC_PCDR0;      /**< Offset: 0x14 ( /W  32) Peripheral Clock Disable Register 0 */
   __I  PMC_PCSR0_Type                 PMC_PCSR0;      /**< Offset: 0x18 (R/   32) Peripheral Clock Status Register 0 */
@@ -3015,11 +3177,11 @@ typedef struct {
   __IO CKGR_MOR_Type                  CKGR_MOR;       /**< Offset: 0x20 (R/W  32) Main Oscillator Register */
   __IO CKGR_MCFR_Type                 CKGR_MCFR;      /**< Offset: 0x24 (R/W  32) Main Clock Frequency Register */
   __IO CKGR_PLLAR_Type                CKGR_PLLAR;     /**< Offset: 0x28 (R/W  32) PLLA Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO PMC_MCKR_Type                  PMC_MCKR;       /**< Offset: 0x30 (R/W  32) Master Clock Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __IO PMC_USB_Type                   PMC_USB;        /**< Offset: 0x38 (R/W  32) USB Clock Register */
-  __I  uint32_t                       Reserved4[1];
+  __I  uint8_t                        Reserved4[4];
   __IO PMC_PCK_Type                   PMC_PCK[8];     /**< Offset: 0x40 (R/W  32) Programmable Clock Register */
   __O  PMC_IER_Type                   PMC_IER;        /**< Offset: 0x60 ( /W  32) Interrupt Enable Register */
   __O  PMC_IDR_Type                   PMC_IDR;        /**< Offset: 0x64 ( /W  32) Interrupt Disable Register */
@@ -3028,10 +3190,10 @@ typedef struct {
   __IO PMC_FSMR_Type                  PMC_FSMR;       /**< Offset: 0x70 (R/W  32) Fast Startup Mode Register */
   __IO PMC_FSPR_Type                  PMC_FSPR;       /**< Offset: 0x74 (R/W  32) Fast Startup Polarity Register */
   __O  PMC_FOCR_Type                  PMC_FOCR;       /**< Offset: 0x78 ( /W  32) Fault Output Clear Register */
-  __I  uint32_t                       Reserved5[26];
+  __I  uint8_t                        Reserved5[104];
   __IO PMC_WPMR_Type                  PMC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  PMC_WPSR_Type                  PMC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved6[5];
+  __I  uint8_t                        Reserved6[20];
   __O  PMC_PCER1_Type                 PMC_PCER1;      /**< Offset: 0x100 ( /W  32) Peripheral Clock Enable Register 1 */
   __O  PMC_PCDR1_Type                 PMC_PCDR1;      /**< Offset: 0x104 ( /W  32) Peripheral Clock Disable Register 1 */
   __I  PMC_PCSR1_Type                 PMC_PCSR1;      /**< Offset: 0x108 (R/   32) Peripheral Clock Status Register 1 */
@@ -3041,7 +3203,7 @@ typedef struct {
   __O  PMC_SLPWK_DR0_Type             PMC_SLPWK_DR0;  /**< Offset: 0x118 ( /W  32) SleepWalking Disable Register 0 */
   __I  PMC_SLPWK_SR0_Type             PMC_SLPWK_SR0;  /**< Offset: 0x11C (R/   32) SleepWalking Status Register 0 */
   __I  PMC_SLPWK_ASR0_Type            PMC_SLPWK_ASR0; /**< Offset: 0x120 (R/   32) SleepWalking Activity Status Register 0 */
-  __I  uint32_t                       Reserved7[3];
+  __I  uint8_t                        Reserved7[12];
   __IO PMC_PMMR_Type                  PMC_PMMR;       /**< Offset: 0x130 (R/W  32) PLL Maximum Multiplier Value Register */
   __O  PMC_SLPWK_ER1_Type             PMC_SLPWK_ER1;  /**< Offset: 0x134 ( /W  32) SleepWalking Enable Register 1 */
   __O  PMC_SLPWK_DR1_Type             PMC_SLPWK_DR1;  /**< Offset: 0x138 ( /W  32) SleepWalking Disable Register 1 */

--- a/asf/sam/include/same70/component/pwm.h
+++ b/asf/sam/include/same70/component/pwm.h
@@ -2743,7 +2743,7 @@ typedef struct {
   __I  uint8_t                        Reserved6[68];
        PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
-       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+       PwmChNum PWM_CH_NUM[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
   __I  uint8_t                        Reserved8[384];
   __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
   __I  uint8_t                        Reserved9[28];
@@ -2826,7 +2826,7 @@ typedef struct {
   __I  uint8_t                        Reserved6[68];
        PwmCmp                         PWM_CMP[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
-       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+       PwmChNum                       PWM_CH_NUM[4];    /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
   __I  uint8_t                        Reserved8[384];
   __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
   __I  uint8_t                        Reserved9[28];

--- a/asf/sam/include/same70/component/pwm.h
+++ b/asf/sam/include/same70/component/pwm.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PWM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- PWM_CMR : (PWM Offset: 0x00) (R/W 32) PWM Channel Mode Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRE:4;                    /**< bit:   0..3  Channel Pre-scaler                       */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMR_OFFSET                      (0x00)                                        /**<  (PWM_CMR) PWM Channel Mode Register (ch_num = 0)  Offset */
@@ -133,6 +137,7 @@ typedef union {
 
 /* -------- PWM_CDTY : (PWM Offset: 0x04) (R/W 32) PWM Channel Duty Cycle Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CDTY:24;                   /**< bit:  0..23  Channel Duty-Cycle                       */
@@ -140,6 +145,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CDTY_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CDTY_OFFSET                     (0x04)                                        /**<  (PWM_CDTY) PWM Channel Duty Cycle Register (ch_num = 0)  Offset */
@@ -153,6 +159,7 @@ typedef union {
 
 /* -------- PWM_CDTYUPD : (PWM Offset: 0x08) (/W 32) PWM Channel Duty Cycle Update Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CDTYUPD:24;                /**< bit:  0..23  Channel Duty-Cycle Update                */
@@ -160,6 +167,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CDTYUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CDTYUPD_OFFSET                  (0x08)                                        /**<  (PWM_CDTYUPD) PWM Channel Duty Cycle Update Register (ch_num = 0)  Offset */
@@ -173,6 +181,7 @@ typedef union {
 
 /* -------- PWM_CPRD : (PWM Offset: 0x0c) (R/W 32) PWM Channel Period Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRD:24;                   /**< bit:  0..23  Channel Period                           */
@@ -180,6 +189,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CPRD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CPRD_OFFSET                     (0x0C)                                        /**<  (PWM_CPRD) PWM Channel Period Register (ch_num = 0)  Offset */
@@ -193,6 +203,7 @@ typedef union {
 
 /* -------- PWM_CPRDUPD : (PWM Offset: 0x10) (/W 32) PWM Channel Period Update Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRDUPD:24;                /**< bit:  0..23  Channel Period Update                    */
@@ -200,6 +211,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CPRDUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CPRDUPD_OFFSET                  (0x10)                                        /**<  (PWM_CPRDUPD) PWM Channel Period Update Register (ch_num = 0)  Offset */
@@ -213,6 +225,7 @@ typedef union {
 
 /* -------- PWM_CCNT : (PWM Offset: 0x14) (R/ 32) PWM Channel Counter Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CNT:24;                    /**< bit:  0..23  Channel Counter Register                 */
@@ -220,6 +233,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CCNT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CCNT_OFFSET                     (0x14)                                        /**<  (PWM_CCNT) PWM Channel Counter Register (ch_num = 0)  Offset */
@@ -233,6 +247,7 @@ typedef union {
 
 /* -------- PWM_DT : (PWM Offset: 0x18) (R/W 32) PWM Channel Dead Time Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTH:16;                    /**< bit:  0..15  Dead-Time Value for PWMHx Output         */
@@ -240,6 +255,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DT_OFFSET                       (0x18)                                        /**<  (PWM_DT) PWM Channel Dead Time Register (ch_num = 0)  Offset */
@@ -256,6 +272,7 @@ typedef union {
 
 /* -------- PWM_DTUPD : (PWM Offset: 0x1c) (/W 32) PWM Channel Dead Time Update Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTHUPD:16;                 /**< bit:  0..15  Dead-Time Value Update for PWMHx Output  */
@@ -263,6 +280,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DTUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DTUPD_OFFSET                    (0x1C)                                        /**<  (PWM_DTUPD) PWM Channel Dead Time Update Register (ch_num = 0)  Offset */
@@ -279,6 +297,7 @@ typedef union {
 
 /* -------- PWM_CMPV : (PWM Offset: 0x00) (R/W 32) PWM Comparison 0 Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CV:24;                     /**< bit:  0..23  Comparison x Value                       */
@@ -287,6 +306,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPV_OFFSET                     (0x00)                                        /**<  (PWM_CMPV) PWM Comparison 0 Value Register  Offset */
@@ -303,6 +323,7 @@ typedef union {
 
 /* -------- PWM_CMPVUPD : (PWM Offset: 0x04) (/W 32) PWM Comparison 0 Value Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CVUPD:24;                  /**< bit:  0..23  Comparison x Value Update                */
@@ -311,6 +332,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPVUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPVUPD_OFFSET                  (0x04)                                        /**<  (PWM_CMPVUPD) PWM Comparison 0 Value Update Register  Offset */
@@ -327,6 +349,7 @@ typedef union {
 
 /* -------- PWM_CMPM : (PWM Offset: 0x08) (R/W 32) PWM Comparison 0 Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CEN:1;                     /**< bit:      0  Comparison x Enable                      */
@@ -340,6 +363,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPM_OFFSET                     (0x08)                                        /**<  (PWM_CMPM) PWM Comparison 0 Mode Register  Offset */
@@ -368,6 +392,7 @@ typedef union {
 
 /* -------- PWM_CMPMUPD : (PWM Offset: 0x0c) (/W 32) PWM Comparison 0 Mode Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CENUPD:1;                  /**< bit:      0  Comparison x Enable Update               */
@@ -380,6 +405,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPMUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPMUPD_OFFSET                  (0x0C)                                        /**<  (PWM_CMPMUPD) PWM Comparison 0 Mode Update Register  Offset */
@@ -402,6 +428,7 @@ typedef union {
 
 /* -------- PWM_CLK : (PWM Offset: 0x00) (R/W 32) PWM Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIVA:8;                    /**< bit:   0..7  CLKA Divide Factor                       */
@@ -413,6 +440,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CLK_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CLK_OFFSET                      (0x00)                                        /**<  (PWM_CLK) PWM Clock Register  Offset */
@@ -487,6 +515,7 @@ typedef union {
 
 /* -------- PWM_ENA : (PWM Offset: 0x04) (/W 32) PWM Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -501,6 +530,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ENA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ENA_OFFSET                      (0x04)                                        /**<  (PWM_ENA) PWM Enable Register  Offset */
@@ -526,6 +556,7 @@ typedef union {
 
 /* -------- PWM_DIS : (PWM Offset: 0x08) (/W 32) PWM Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -540,6 +571,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DIS_OFFSET                      (0x08)                                        /**<  (PWM_DIS) PWM Disable Register  Offset */
@@ -565,6 +597,7 @@ typedef union {
 
 /* -------- PWM_SR : (PWM Offset: 0x0c) (R/ 32) PWM Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -579,6 +612,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SR_OFFSET                       (0x0C)                                        /**<  (PWM_SR) PWM Status Register  Offset */
@@ -604,6 +638,7 @@ typedef union {
 
 /* -------- PWM_IER1 : (PWM Offset: 0x10) (/W 32) PWM Interrupt Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Enable */
@@ -625,6 +660,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IER1_OFFSET                     (0x10)                                        /**<  (PWM_IER1) PWM Interrupt Enable Register 1  Offset */
@@ -665,6 +701,7 @@ typedef union {
 
 /* -------- PWM_IDR1 : (PWM Offset: 0x14) (/W 32) PWM Interrupt Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Disable */
@@ -686,6 +723,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IDR1_OFFSET                     (0x14)                                        /**<  (PWM_IDR1) PWM Interrupt Disable Register 1  Offset */
@@ -726,6 +764,7 @@ typedef union {
 
 /* -------- PWM_IMR1 : (PWM Offset: 0x18) (R/ 32) PWM Interrupt Mask Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Mask */
@@ -747,6 +786,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IMR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IMR1_OFFSET                     (0x18)                                        /**<  (PWM_IMR1) PWM Interrupt Mask Register 1  Offset */
@@ -787,6 +827,7 @@ typedef union {
 
 /* -------- PWM_ISR1 : (PWM Offset: 0x1c) (R/ 32) PWM Interrupt Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0               */
@@ -808,6 +849,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ISR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ISR1_OFFSET                     (0x1C)                                        /**<  (PWM_ISR1) PWM Interrupt Status Register 1  Offset */
@@ -848,6 +890,7 @@ typedef union {
 
 /* -------- PWM_SCM : (PWM Offset: 0x20) (R/W 32) PWM Sync Channels Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SYNC0:1;                   /**< bit:      0  Synchronous Channel 0                    */
@@ -867,6 +910,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCM_OFFSET                      (0x20)                                        /**<  (PWM_SCM) PWM Sync Channels Mode Register  Offset */
@@ -907,6 +951,7 @@ typedef union {
 
 /* -------- PWM_DMAR : (PWM Offset: 0x24) (/W 32) PWM DMA Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DMADUTY:24;                /**< bit:  0..23  Duty-Cycle Holding Register for DMA Access */
@@ -914,6 +959,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DMAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DMAR_OFFSET                     (0x24)                                        /**<  (PWM_DMAR) PWM DMA Register  Offset */
@@ -927,6 +973,7 @@ typedef union {
 
 /* -------- PWM_SCUC : (PWM Offset: 0x28) (R/W 32) PWM Sync Channels Update Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPDULOCK:1;                /**< bit:      0  Synchronous Channels Update Unlock       */
@@ -934,6 +981,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUC_OFFSET                     (0x28)                                        /**<  (PWM_SCUC) PWM Sync Channels Update Control Register  Offset */
@@ -947,6 +995,7 @@ typedef union {
 
 /* -------- PWM_SCUP : (PWM Offset: 0x2c) (R/W 32) PWM Sync Channels Update Period Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPR:4;                     /**< bit:   0..3  Update Period                            */
@@ -955,6 +1004,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUP_OFFSET                     (0x2C)                                        /**<  (PWM_SCUP) PWM Sync Channels Update Period Register  Offset */
@@ -971,6 +1021,7 @@ typedef union {
 
 /* -------- PWM_SCUPUPD : (PWM Offset: 0x30) (/W 32) PWM Sync Channels Update Period Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPRUPD:4;                  /**< bit:   0..3  Update Period Update                     */
@@ -978,6 +1029,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUPUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUPUPD_OFFSET                  (0x30)                                        /**<  (PWM_SCUPUPD) PWM Sync Channels Update Period Update Register  Offset */
@@ -991,6 +1043,7 @@ typedef union {
 
 /* -------- PWM_IER2 : (PWM Offset: 0x34) (/W 32) PWM Interrupt Enable Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Enable */
@@ -1023,6 +1076,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IER2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IER2_OFFSET                     (0x34)                                        /**<  (PWM_IER2) PWM Interrupt Enable Register 2  Offset */
@@ -1093,6 +1147,7 @@ typedef union {
 
 /* -------- PWM_IDR2 : (PWM Offset: 0x38) (/W 32) PWM Interrupt Disable Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Disable */
@@ -1125,6 +1180,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IDR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IDR2_OFFSET                     (0x38)                                        /**<  (PWM_IDR2) PWM Interrupt Disable Register 2  Offset */
@@ -1195,6 +1251,7 @@ typedef union {
 
 /* -------- PWM_IMR2 : (PWM Offset: 0x3c) (R/ 32) PWM Interrupt Mask Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Mask */
@@ -1227,6 +1284,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IMR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IMR2_OFFSET                     (0x3C)                                        /**<  (PWM_IMR2) PWM Interrupt Mask Register 2  Offset */
@@ -1297,6 +1355,7 @@ typedef union {
 
 /* -------- PWM_ISR2 : (PWM Offset: 0x40) (R/ 32) PWM Interrupt Status Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update */
@@ -1329,6 +1388,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ISR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ISR2_OFFSET                     (0x40)                                        /**<  (PWM_ISR2) PWM Interrupt Status Register 2  Offset */
@@ -1399,6 +1459,7 @@ typedef union {
 
 /* -------- PWM_OOV : (PWM Offset: 0x44) (R/W 32) PWM Output Override Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OOVH0:1;                   /**< bit:      0  Output Override Value for PWMH output of the channel 0 */
@@ -1420,6 +1481,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OOV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OOV_OFFSET                      (0x44)                                        /**<  (PWM_OOV) PWM Output Override Value Register  Offset */
@@ -1460,6 +1522,7 @@ typedef union {
 
 /* -------- PWM_OS : (PWM Offset: 0x48) (R/W 32) PWM Output Selection Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSH0:1;                    /**< bit:      0  Output Selection for PWMH output of the channel 0 */
@@ -1481,6 +1544,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OS_OFFSET                       (0x48)                                        /**<  (PWM_OS) PWM Output Selection Register  Offset */
@@ -1521,6 +1585,7 @@ typedef union {
 
 /* -------- PWM_OSS : (PWM Offset: 0x4c) (/W 32) PWM Output Selection Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSSH0:1;                   /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
@@ -1542,6 +1607,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSS_OFFSET                      (0x4C)                                        /**<  (PWM_OSS) PWM Output Selection Set Register  Offset */
@@ -1582,6 +1648,7 @@ typedef union {
 
 /* -------- PWM_OSC : (PWM Offset: 0x50) (/W 32) PWM Output Selection Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSCH0:1;                   /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
@@ -1603,6 +1670,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSC_OFFSET                      (0x50)                                        /**<  (PWM_OSC) PWM Output Selection Clear Register  Offset */
@@ -1643,6 +1711,7 @@ typedef union {
 
 /* -------- PWM_OSSUPD : (PWM Offset: 0x54) (/W 32) PWM Output Selection Set Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSSUPH0:1;                 /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
@@ -1664,6 +1733,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSSUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSSUPD_OFFSET                   (0x54)                                        /**<  (PWM_OSSUPD) PWM Output Selection Set Update Register  Offset */
@@ -1704,6 +1774,7 @@ typedef union {
 
 /* -------- PWM_OSCUPD : (PWM Offset: 0x58) (/W 32) PWM Output Selection Clear Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSCUPH0:1;                 /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
@@ -1725,6 +1796,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSCUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSCUPD_OFFSET                   (0x58)                                        /**<  (PWM_OSCUPD) PWM Output Selection Clear Update Register  Offset */
@@ -1765,6 +1837,7 @@ typedef union {
 
 /* -------- PWM_FMR : (PWM Offset: 0x5c) (R/W 32) PWM Fault Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPOL:8;                    /**< bit:   0..7  Fault Polarity                           */
@@ -1774,6 +1847,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FMR_OFFSET                      (0x5C)                                        /**<  (PWM_FMR) PWM Fault Mode Register  Offset */
@@ -1793,6 +1867,7 @@ typedef union {
 
 /* -------- PWM_FSR : (PWM Offset: 0x60) (R/ 32) PWM Fault Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FIV:8;                     /**< bit:   0..7  Fault Input Value                        */
@@ -1801,6 +1876,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FSR_OFFSET                      (0x60)                                        /**<  (PWM_FSR) PWM Fault Status Register  Offset */
@@ -1817,6 +1893,7 @@ typedef union {
 
 /* -------- PWM_FCR : (PWM Offset: 0x64) (/W 32) PWM Fault Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCLR:8;                    /**< bit:   0..7  Fault Clear                              */
@@ -1824,6 +1901,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FCR_OFFSET                      (0x64)                                        /**<  (PWM_FCR) PWM Fault Clear Register  Offset */
@@ -1837,6 +1915,7 @@ typedef union {
 
 /* -------- PWM_FPV1 : (PWM Offset: 0x68) (R/W 32) PWM Fault Protection Value Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPVH0:1;                   /**< bit:      0  Fault Protection Value for PWMH output on channel 0 */
@@ -1858,6 +1937,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPV1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPV1_OFFSET                     (0x68)                                        /**<  (PWM_FPV1) PWM Fault Protection Value Register 1  Offset */
@@ -1898,6 +1978,7 @@ typedef union {
 
 /* -------- PWM_FPE : (PWM Offset: 0x6c) (R/W 32) PWM Fault Protection Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPE0:8;                    /**< bit:   0..7  Fault Protection Enable for channel 0    */
@@ -1907,6 +1988,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPE_OFFSET                      (0x6C)                                        /**<  (PWM_FPE) PWM Fault Protection Enable Register  Offset */
@@ -1929,6 +2011,7 @@ typedef union {
 
 /* -------- PWM_ELMR : (PWM Offset: 0x7c) (R/W 32) PWM Event Line 0 Mode Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL0:1;                   /**< bit:      0  Comparison 0 Selection                   */
@@ -1947,6 +2030,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ELMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ELMR_OFFSET                     (0x7C)                                        /**<  (PWM_ELMR) PWM Event Line 0 Mode Register 0  Offset */
@@ -1984,6 +2068,7 @@ typedef union {
 
 /* -------- PWM_SSPR : (PWM Offset: 0xa0) (R/W 32) PWM Spread Spectrum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPRD:24;                   /**< bit:  0..23  Spread Spectrum Limit Value              */
@@ -1992,6 +2077,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SSPR_OFFSET                     (0xA0)                                        /**<  (PWM_SSPR) PWM Spread Spectrum Register  Offset */
@@ -2008,6 +2094,7 @@ typedef union {
 
 /* -------- PWM_SSPUP : (PWM Offset: 0xa4) (/W 32) PWM Spread Spectrum Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPRDUP:24;                 /**< bit:  0..23  Spread Spectrum Limit Value Update       */
@@ -2015,6 +2102,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SSPUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SSPUP_OFFSET                    (0xA4)                                        /**<  (PWM_SSPUP) PWM Spread Spectrum Update Register  Offset */
@@ -2028,6 +2116,7 @@ typedef union {
 
 /* -------- PWM_SMMR : (PWM Offset: 0xb0) (R/W 32) PWM Stepper Motor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GCEN0:1;                   /**< bit:      0  Gray Count ENable                        */
@@ -2045,6 +2134,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SMMR_OFFSET                     (0xB0)                                        /**<  (PWM_SMMR) PWM Stepper Motor Mode Register  Offset */
@@ -2073,6 +2163,7 @@ typedef union {
 
 /* -------- PWM_FPV2 : (PWM Offset: 0xc0) (R/W 32) PWM Fault Protection Value 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPZH0:1;                   /**< bit:      0  Fault Protection to Hi-Z for PWMH output on channel 0 */
@@ -2094,6 +2185,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPV2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPV2_OFFSET                     (0xC0)                                        /**<  (PWM_FPV2) PWM Fault Protection Value 2 Register  Offset */
@@ -2134,6 +2226,7 @@ typedef union {
 
 /* -------- PWM_WPCR : (PWM Offset: 0xe4) (/W 32) PWM Write Protection Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPCMD:2;                   /**< bit:   0..1  Write Protection Command                 */
@@ -2152,6 +2245,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_WPCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_WPCR_OFFSET                     (0xE4)                                        /**<  (PWM_WPCR) PWM Write Protection Control Register  Offset */
@@ -2197,6 +2291,7 @@ typedef union {
 
 /* -------- PWM_WPSR : (PWM Offset: 0xe8) (R/ 32) PWM Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPSWS0:1;                  /**< bit:      0  Write Protect SW Status                  */
@@ -2224,6 +2319,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_WPSR_OFFSET                     (0xE8)                                        /**<  (PWM_WPSR) PWM Write Protection Status Register  Offset */
@@ -2282,6 +2378,7 @@ typedef union {
 
 /* -------- PWM_CMUPD0 : (PWM Offset: 0x400) (/W 32) PWM Channel Mode Update Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2292,6 +2389,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD0_OFFSET                   (0x400)                                       /**<  (PWM_CMUPD0) PWM Channel Mode Update Register (ch_num = 0)  Offset */
@@ -2308,6 +2406,7 @@ typedef union {
 
 /* -------- PWM_CMUPD1 : (PWM Offset: 0x420) (/W 32) PWM Channel Mode Update Register (ch_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2318,6 +2417,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD1_OFFSET                   (0x420)                                       /**<  (PWM_CMUPD1) PWM Channel Mode Update Register (ch_num = 1)  Offset */
@@ -2334,6 +2434,7 @@ typedef union {
 
 /* -------- PWM_ETRG1 : (PWM Offset: 0x42c) (R/W 32) PWM External Trigger Register (trg_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
@@ -2346,6 +2447,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ETRG1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ETRG1_OFFSET                    (0x42C)                                       /**<  (PWM_ETRG1) PWM External Trigger Register (trg_num = 1)  Offset */
@@ -2386,6 +2488,7 @@ typedef union {
 
 /* -------- PWM_LEBR1 : (PWM Offset: 0x430) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
@@ -2398,6 +2501,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_LEBR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_LEBR1_OFFSET                    (0x430)                                       /**<  (PWM_LEBR1) PWM Leading-Edge Blanking Register (trg_num = 1)  Offset */
@@ -2423,6 +2527,7 @@ typedef union {
 
 /* -------- PWM_CMUPD2 : (PWM Offset: 0x440) (/W 32) PWM Channel Mode Update Register (ch_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2433,6 +2538,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD2_OFFSET                   (0x440)                                       /**<  (PWM_CMUPD2) PWM Channel Mode Update Register (ch_num = 2)  Offset */
@@ -2449,6 +2555,7 @@ typedef union {
 
 /* -------- PWM_ETRG2 : (PWM Offset: 0x44c) (R/W 32) PWM External Trigger Register (trg_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
@@ -2461,6 +2568,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ETRG2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ETRG2_OFFSET                    (0x44C)                                       /**<  (PWM_ETRG2) PWM External Trigger Register (trg_num = 2)  Offset */
@@ -2501,6 +2609,7 @@ typedef union {
 
 /* -------- PWM_LEBR2 : (PWM Offset: 0x450) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
@@ -2513,6 +2622,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_LEBR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_LEBR2_OFFSET                    (0x450)                                       /**<  (PWM_LEBR2) PWM Leading-Edge Blanking Register (trg_num = 2)  Offset */
@@ -2538,6 +2648,7 @@ typedef union {
 
 /* -------- PWM_CMUPD3 : (PWM Offset: 0x460) (/W 32) PWM Channel Mode Update Register (ch_num = 3) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2548,6 +2659,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD3_OFFSET                   (0x460)                                       /**<  (PWM_CMUPD3) PWM Channel Mode Update Register (ch_num = 3)  Offset */
@@ -2616,35 +2728,35 @@ typedef struct {
   __O  uint32_t PWM_FCR;        /**< (PWM Offset: 0x64) PWM Fault Clear Register */
   __IO uint32_t PWM_FPV1;       /**< (PWM Offset: 0x68) PWM Fault Protection Value Register 1 */
   __IO uint32_t PWM_FPE;        /**< (PWM Offset: 0x6C) PWM Fault Protection Enable Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __IO uint32_t PWM_ELMR[2];    /**< (PWM Offset: 0x7C) PWM Event Line 0 Mode Register 0 */
-  RoReg8  Reserved2[0x1C];
+  __I  uint8_t                        Reserved2[28];
   __IO uint32_t PWM_SSPR;       /**< (PWM Offset: 0xA0) PWM Spread Spectrum Register */
   __O  uint32_t PWM_SSPUP;      /**< (PWM Offset: 0xA4) PWM Spread Spectrum Update Register */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __IO uint32_t PWM_SMMR;       /**< (PWM Offset: 0xB0) PWM Stepper Motor Mode Register */
-  RoReg8  Reserved4[0xC];
+  __I  uint8_t                        Reserved4[12];
   __IO uint32_t PWM_FPV2;       /**< (PWM Offset: 0xC0) PWM Fault Protection Value 2 Register */
-  RoReg8  Reserved5[0x20];
+  __I  uint8_t                        Reserved5[32];
   __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
   __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
-  RoReg8  Reserved6[0x44];
-       PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
-  RoReg8  Reserved7[0x50];
-       PwmChNum PWM_CH_NUM[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
-  RoReg8  Reserved8[0x180];
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+  __I  uint8_t                        Reserved8[384];
   __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
-  RoReg8  Reserved9[0x1C];
+  __I  uint8_t                        Reserved9[28];
   __O  uint32_t PWM_CMUPD1;     /**< (PWM Offset: 0x420) PWM Channel Mode Update Register (ch_num = 1) */
-  RoReg8  Reserved10[0x8];
+  __I  uint8_t                        Reserved10[8];
   __IO uint32_t PWM_ETRG1;      /**< (PWM Offset: 0x42C) PWM External Trigger Register (trg_num = 1) */
   __IO uint32_t PWM_LEBR1;      /**< (PWM Offset: 0x430) PWM Leading-Edge Blanking Register (trg_num = 1) */
-  RoReg8  Reserved11[0xC];
+  __I  uint8_t                        Reserved11[12];
   __O  uint32_t PWM_CMUPD2;     /**< (PWM Offset: 0x440) PWM Channel Mode Update Register (ch_num = 2) */
-  RoReg8  Reserved12[0x8];
+  __I  uint8_t                        Reserved12[8];
   __IO uint32_t PWM_ETRG2;      /**< (PWM Offset: 0x44C) PWM External Trigger Register (trg_num = 2) */
   __IO uint32_t PWM_LEBR2;      /**< (PWM Offset: 0x450) PWM Leading-Edge Blanking Register (trg_num = 2) */
-  RoReg8  Reserved13[0xC];
+  __I  uint8_t                        Reserved13[12];
   __O  uint32_t PWM_CMUPD3;     /**< (PWM Offset: 0x460) PWM Channel Mode Update Register (ch_num = 3) */
 } Pwm;
 
@@ -2699,35 +2811,35 @@ typedef struct {
   __O  PWM_FCR_Type                   PWM_FCR;        /**< Offset: 0x64 ( /W  32) PWM Fault Clear Register */
   __IO PWM_FPV1_Type                  PWM_FPV1;       /**< Offset: 0x68 (R/W  32) PWM Fault Protection Value Register 1 */
   __IO PWM_FPE_Type                   PWM_FPE;        /**< Offset: 0x6C (R/W  32) PWM Fault Protection Enable Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __IO PWM_ELMR_Type                  PWM_ELMR[2];    /**< Offset: 0x7C (R/W  32) PWM Event Line 0 Mode Register 0 */
-  __I  uint32_t                       Reserved2[7];
+  __I  uint8_t                        Reserved2[28];
   __IO PWM_SSPR_Type                  PWM_SSPR;       /**< Offset: 0xA0 (R/W  32) PWM Spread Spectrum Register */
   __O  PWM_SSPUP_Type                 PWM_SSPUP;      /**< Offset: 0xA4 ( /W  32) PWM Spread Spectrum Update Register */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __IO PWM_SMMR_Type                  PWM_SMMR;       /**< Offset: 0xB0 (R/W  32) PWM Stepper Motor Mode Register */
-  __I  uint32_t                       Reserved4[3];
+  __I  uint8_t                        Reserved4[12];
   __IO PWM_FPV2_Type                  PWM_FPV2;       /**< Offset: 0xC0 (R/W  32) PWM Fault Protection Value 2 Register */
-  __I  uint32_t                       Reserved5[8];
+  __I  uint8_t                        Reserved5[32];
   __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
   __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
-  __I  uint32_t                       Reserved6[17];
-       PwmCmp                         PWM_CMP[8];     /**< Offset: 0x130 PWM Comparison 0 Value Register */
-  __I  uint32_t                       Reserved7[20];
-       PwmChNum                       PWM_CH_NUM[4];  /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
-  __I  uint32_t                       Reserved8[96];
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
+  __I  uint8_t                        Reserved8[384];
   __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
-  __I  uint32_t                       Reserved9[7];
+  __I  uint8_t                        Reserved9[28];
   __O  PWM_CMUPD1_Type                PWM_CMUPD1;     /**< Offset: 0x420 ( /W  32) PWM Channel Mode Update Register (ch_num = 1) */
-  __I  uint32_t                       Reserved10[2];
+  __I  uint8_t                        Reserved10[8];
   __IO PWM_ETRG1_Type                 PWM_ETRG1;      /**< Offset: 0x42C (R/W  32) PWM External Trigger Register (trg_num = 1) */
   __IO PWM_LEBR1_Type                 PWM_LEBR1;      /**< Offset: 0x430 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 1) */
-  __I  uint32_t                       Reserved11[3];
+  __I  uint8_t                        Reserved11[12];
   __O  PWM_CMUPD2_Type                PWM_CMUPD2;     /**< Offset: 0x440 ( /W  32) PWM Channel Mode Update Register (ch_num = 2) */
-  __I  uint32_t                       Reserved12[2];
+  __I  uint8_t                        Reserved12[8];
   __IO PWM_ETRG2_Type                 PWM_ETRG2;      /**< Offset: 0x44C (R/W  32) PWM External Trigger Register (trg_num = 2) */
   __IO PWM_LEBR2_Type                 PWM_LEBR2;      /**< Offset: 0x450 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 2) */
-  __I  uint32_t                       Reserved13[3];
+  __I  uint8_t                        Reserved13[12];
   __O  PWM_CMUPD3_Type                PWM_CMUPD3;     /**< Offset: 0x460 ( /W  32) PWM Channel Mode Update Register (ch_num = 3) */
 } Pwm;
 

--- a/asf/sam/include/same70/component/pwm.h
+++ b/asf/sam/include/same70/component/pwm.h
@@ -2741,7 +2741,7 @@ typedef struct {
   __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
   __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
   __I  uint8_t                        Reserved6[68];
-       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+       PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
        PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
   __I  uint8_t                        Reserved8[384];
@@ -2824,7 +2824,7 @@ typedef struct {
   __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
   __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
   __I  uint8_t                        Reserved6[68];
-       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+       PwmCmp                         PWM_CMP[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
        PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
   __I  uint8_t                        Reserved8[384];

--- a/asf/sam/include/same70/component/qspi.h
+++ b/asf/sam/include/same70/component/qspi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for QSPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- QSPI_CR : (QSPI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QSPIEN:1;                  /**< bit:      0  QSPI Enable                              */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_CR_OFFSET                      (0x00)                                        /**<  (QSPI_CR) Control Register  Offset */
@@ -79,6 +83,7 @@ typedef union {
 
 /* -------- QSPI_MR : (QSPI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMM:1;                     /**< bit:      0  Serial Memory Mode                       */
@@ -94,6 +99,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_MR_OFFSET                      (0x04)                                        /**<  (QSPI_MR) Mode Register  Offset */
@@ -147,6 +153,7 @@ typedef union {
 
 /* -------- QSPI_RDR : (QSPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
@@ -154,6 +161,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_RDR_OFFSET                     (0x08)                                        /**<  (QSPI_RDR) Receive Data Register  Offset */
@@ -167,6 +175,7 @@ typedef union {
 
 /* -------- QSPI_TDR : (QSPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
@@ -174,6 +183,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_TDR_OFFSET                     (0x0C)                                        /**<  (QSPI_TDR) Transmit Data Register  Offset */
@@ -187,6 +197,7 @@ typedef union {
 
 /* -------- QSPI_SR : (QSPI Offset: 0x10) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
@@ -203,6 +214,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SR_OFFSET                      (0x10)                                        /**<  (QSPI_SR) Status Register  Offset */
@@ -237,6 +249,7 @@ typedef union {
 
 /* -------- QSPI_IER : (QSPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
@@ -251,6 +264,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IER_OFFSET                     (0x14)                                        /**<  (QSPI_IER) Interrupt Enable Register  Offset */
@@ -282,6 +296,7 @@ typedef union {
 
 /* -------- QSPI_IDR : (QSPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
@@ -296,6 +311,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IDR_OFFSET                     (0x18)                                        /**<  (QSPI_IDR) Interrupt Disable Register  Offset */
@@ -327,6 +343,7 @@ typedef union {
 
 /* -------- QSPI_IMR : (QSPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
@@ -341,6 +358,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IMR_OFFSET                     (0x1C)                                        /**<  (QSPI_IMR) Interrupt Mask Register  Offset */
@@ -372,6 +390,7 @@ typedef union {
 
 /* -------- QSPI_SCR : (QSPI Offset: 0x20) (R/W 32) Serial Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
@@ -383,6 +402,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SCR_OFFSET                     (0x20)                                        /**<  (QSPI_SCR) Serial Clock Register  Offset */
@@ -405,12 +425,14 @@ typedef union {
 
 /* -------- QSPI_IAR : (QSPI Offset: 0x30) (R/W 32) Instruction Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Address                                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IAR_OFFSET                     (0x30)                                        /**<  (QSPI_IAR) Instruction Address Register  Offset */
@@ -424,6 +446,7 @@ typedef union {
 
 /* -------- QSPI_ICR : (QSPI Offset: 0x34) (R/W 32) Instruction Code Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INST:8;                    /**< bit:   0..7  Instruction Code                         */
@@ -433,6 +456,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_ICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_ICR_OFFSET                     (0x34)                                        /**<  (QSPI_ICR) Instruction Code Register  Offset */
@@ -449,6 +473,7 @@ typedef union {
 
 /* -------- QSPI_IFR : (QSPI Offset: 0x38) (R/W 32) Instruction Frame Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WIDTH:3;                   /**< bit:   0..2  Width of Instruction Code, Address, Option Code and Data */
@@ -468,6 +493,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IFR_OFFSET                     (0x38)                                        /**<  (QSPI_IFR) Instruction Frame Register  Offset */
@@ -546,6 +572,7 @@ typedef union {
 
 /* -------- QSPI_SMR : (QSPI Offset: 0x40) (R/W 32) Scrambling Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCREN:1;                   /**< bit:      0  Scrambling/Unscrambling Enable           */
@@ -554,6 +581,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SMR_OFFSET                     (0x40)                                        /**<  (QSPI_SMR) Scrambling Mode Register  Offset */
@@ -574,12 +602,14 @@ typedef union {
 
 /* -------- QSPI_SKR : (QSPI Offset: 0x44) (/W 32) Scrambling Key Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USRK:32;                   /**< bit:  0..31  Scrambling User Key                      */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SKR_OFFSET                     (0x44)                                        /**<  (QSPI_SKR) Scrambling Key Register  Offset */
@@ -593,6 +623,7 @@ typedef union {
 
 /* -------- QSPI_WPMR : (QSPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -601,6 +632,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_WPMR_OFFSET                    (0xE4)                                        /**<  (QSPI_WPMR) Write Protection Mode Register  Offset */
@@ -619,6 +651,7 @@ typedef union {
 
 /* -------- QSPI_WPSR : (QSPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -628,6 +661,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_WPSR_OFFSET                    (0xE8)                                        /**<  (QSPI_WPSR) Write Protection Status Register  Offset */
@@ -655,14 +689,14 @@ typedef struct {
   __O  uint32_t QSPI_IDR;       /**< (QSPI Offset: 0x18) Interrupt Disable Register */
   __I  uint32_t QSPI_IMR;       /**< (QSPI Offset: 0x1C) Interrupt Mask Register */
   __IO uint32_t QSPI_SCR;       /**< (QSPI Offset: 0x20) Serial Clock Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __IO uint32_t QSPI_IAR;       /**< (QSPI Offset: 0x30) Instruction Address Register */
   __IO uint32_t QSPI_ICR;       /**< (QSPI Offset: 0x34) Instruction Code Register */
   __IO uint32_t QSPI_IFR;       /**< (QSPI Offset: 0x38) Instruction Frame Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t QSPI_SMR;       /**< (QSPI Offset: 0x40) Scrambling Mode Register */
   __O  uint32_t QSPI_SKR;       /**< (QSPI Offset: 0x44) Scrambling Key Register */
-  RoReg8  Reserved3[0x9C];
+  __I  uint8_t                        Reserved3[156];
   __IO uint32_t QSPI_WPMR;      /**< (QSPI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t QSPI_WPSR;      /**< (QSPI Offset: 0xE8) Write Protection Status Register */
 } Qspi;
@@ -679,14 +713,14 @@ typedef struct {
   __O  QSPI_IDR_Type                  QSPI_IDR;       /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
   __I  QSPI_IMR_Type                  QSPI_IMR;       /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
   __IO QSPI_SCR_Type                  QSPI_SCR;       /**< Offset: 0x20 (R/W  32) Serial Clock Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __IO QSPI_IAR_Type                  QSPI_IAR;       /**< Offset: 0x30 (R/W  32) Instruction Address Register */
   __IO QSPI_ICR_Type                  QSPI_ICR;       /**< Offset: 0x34 (R/W  32) Instruction Code Register */
   __IO QSPI_IFR_Type                  QSPI_IFR;       /**< Offset: 0x38 (R/W  32) Instruction Frame Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO QSPI_SMR_Type                  QSPI_SMR;       /**< Offset: 0x40 (R/W  32) Scrambling Mode Register */
   __O  QSPI_SKR_Type                  QSPI_SKR;       /**< Offset: 0x44 ( /W  32) Scrambling Key Register */
-  __I  uint32_t                       Reserved3[39];
+  __I  uint8_t                        Reserved3[156];
   __IO QSPI_WPMR_Type                 QSPI_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  QSPI_WPSR_Type                 QSPI_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Qspi;

--- a/asf/sam/include/same70/component/rstc.h
+++ b/asf/sam/include/same70/component/rstc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RSTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- RSTC_CR : (RSTC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PROCRST:1;                 /**< bit:      0  Processor Reset                          */
@@ -55,6 +58,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_CR_OFFSET                      (0x00)                                        /**<  (RSTC_CR) Control Register  Offset */
@@ -76,6 +80,7 @@ typedef union {
 
 /* -------- RSTC_SR : (RSTC Offset: 0x04) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URSTS:1;                   /**< bit:      0  User Reset Status                        */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_SR_OFFSET                      (0x04)                                        /**<  (RSTC_SR) Status Register  Offset */
@@ -120,6 +126,7 @@ typedef union {
 
 /* -------- RSTC_MR : (RSTC Offset: 0x08) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URSTEN:1;                  /**< bit:      0  User Reset Enable                        */
@@ -132,6 +139,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_MR_OFFSET                      (0x08)                                        /**<  (RSTC_MR) Mode Register  Offset */

--- a/asf/sam/include/same70/component/rswdt.h
+++ b/asf/sam/include/same70/component/rswdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RSWDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- RSWDT_CR : (RSWDT Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_CR_OFFSET                     (0x00)                                        /**<  (RSWDT_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- RSWDT_MR : (RSWDT Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
@@ -85,6 +90,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_MR_OFFSET                     (0x04)                                        /**<  (RSWDT_MR) Mode Register  Offset */
@@ -116,6 +122,7 @@ typedef union {
 
 /* -------- RSWDT_SR : (RSWDT Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow                       */
@@ -123,6 +130,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_SR_OFFSET                     (0x08)                                        /**<  (RSWDT_SR) Status Register  Offset */

--- a/asf/sam/include/same70/component/rtc.h
+++ b/asf/sam/include/same70/component/rtc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- RTC_CR : (RTC Offset: 0x00) (R/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPDTIM:1;                  /**< bit:      0  Update Request Time Register             */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CR_OFFSET                       (0x00)                                        /**<  (RTC_CR) Control Register  Offset */
@@ -93,6 +97,7 @@ typedef union {
 
 /* -------- RTC_MR : (RTC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HRMOD:1;                   /**< bit:      0  12-/24-hour Mode                         */
@@ -113,6 +118,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MR_OFFSET                       (0x04)                                        /**<  (RTC_MR) Mode Register  Offset */
@@ -206,6 +212,7 @@ typedef union {
 
 /* -------- RTC_TIMR : (RTC Offset: 0x08) (R/W 32) Time Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:7;                     /**< bit:   0..6  Current Second                           */
@@ -218,6 +225,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_TIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_TIMR_OFFSET                     (0x08)                                        /**<  (RTC_TIMR) Time Register  Offset */
@@ -240,6 +248,7 @@ typedef union {
 
 /* -------- RTC_CALR : (RTC Offset: 0x0c) (R/W 32) Calendar Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CENT:7;                    /**< bit:   0..6  Current Century                          */
@@ -252,6 +261,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CALR_OFFSET                     (0x0C)                                        /**<  (RTC_CALR) Calendar Register  Offset */
@@ -277,6 +287,7 @@ typedef union {
 
 /* -------- RTC_TIMALR : (RTC Offset: 0x10) (R/W 32) Time Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:7;                     /**< bit:   0..6  Second Alarm                             */
@@ -290,6 +301,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_TIMALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_TIMALR_OFFSET                   (0x10)                                        /**<  (RTC_TIMALR) Time Alarm Register  Offset */
@@ -321,6 +333,7 @@ typedef union {
 
 /* -------- RTC_CALALR : (RTC Offset: 0x14) (R/W 32) Calendar Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -333,6 +346,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CALALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CALALR_OFFSET                   (0x14)                                        /**<  (RTC_CALALR) Calendar Alarm Register  Offset */
@@ -355,6 +369,7 @@ typedef union {
 
 /* -------- RTC_SR : (RTC Offset: 0x18) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKUPD:1;                  /**< bit:      0  Acknowledge for Update                   */
@@ -367,6 +382,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_SR_OFFSET                       (0x18)                                        /**<  (RTC_SR) Status Register  Offset */
@@ -419,6 +435,7 @@ typedef union {
 
 /* -------- RTC_SCCR : (RTC Offset: 0x1c) (/W 32) Status Clear Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKCLR:1;                  /**< bit:      0  Acknowledge Clear                        */
@@ -431,6 +448,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_SCCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_SCCR_OFFSET                     (0x1C)                                        /**<  (RTC_SCCR) Status Clear Command Register  Offset */
@@ -459,6 +477,7 @@ typedef union {
 
 /* -------- RTC_IER : (RTC Offset: 0x20) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKEN:1;                   /**< bit:      0  Acknowledge Update Interrupt Enable      */
@@ -471,6 +490,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IER_OFFSET                      (0x20)                                        /**<  (RTC_IER) Interrupt Enable Register  Offset */
@@ -499,6 +519,7 @@ typedef union {
 
 /* -------- RTC_IDR : (RTC Offset: 0x24) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKDIS:1;                  /**< bit:      0  Acknowledge Update Interrupt Disable     */
@@ -511,6 +532,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IDR_OFFSET                      (0x24)                                        /**<  (RTC_IDR) Interrupt Disable Register  Offset */
@@ -539,6 +561,7 @@ typedef union {
 
 /* -------- RTC_IMR : (RTC Offset: 0x28) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACK:1;                     /**< bit:      0  Acknowledge Update Interrupt Mask        */
@@ -551,6 +574,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IMR_OFFSET                      (0x28)                                        /**<  (RTC_IMR) Interrupt Mask Register  Offset */
@@ -579,6 +603,7 @@ typedef union {
 
 /* -------- RTC_VER : (RTC Offset: 0x2c) (R/ 32) Valid Entry Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NVTIM:1;                   /**< bit:      0  Non-valid Time                           */
@@ -589,6 +614,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_VER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_VER_OFFSET                      (0x2C)                                        /**<  (RTC_VER) Valid Entry Register  Offset */
@@ -609,32 +635,6 @@ typedef union {
 #define RTC_VER_Msk                         _U_(0x0F)                                      /**< (RTC_VER) Register Mask  */
 
 
-/* -------- RTC_WPMR : (RTC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
-    uint32_t :7;                        /**< bit:   1..7  Reserved */
-    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} RTC_WPMR_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define RTC_WPMR_OFFSET                     (0xE4)                                        /**<  (RTC_WPMR) Write Protection Mode Register  Offset */
-
-#define RTC_WPMR_WPEN_Pos                   0                                              /**< (RTC_WPMR) Write Protection Enable Position */
-#define RTC_WPMR_WPEN_Msk                   (_U_(0x1) << RTC_WPMR_WPEN_Pos)                /**< (RTC_WPMR) Write Protection Enable Mask */
-#define RTC_WPMR_WPEN                       RTC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_WPMR_WPEN_Msk instead */
-#define RTC_WPMR_WPKEY_Pos                  8                                              /**< (RTC_WPMR) Write Protection Key Position */
-#define RTC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << RTC_WPMR_WPKEY_Pos)          /**< (RTC_WPMR) Write Protection Key Mask */
-#define RTC_WPMR_WPKEY(value)               (RTC_WPMR_WPKEY_Msk & ((value) << RTC_WPMR_WPKEY_Pos))
-#define   RTC_WPMR_WPKEY_PASSWD_Val         _U_(0x525443)                                  /**< (RTC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
-#define RTC_WPMR_WPKEY_PASSWD               (RTC_WPMR_WPKEY_PASSWD_Val << RTC_WPMR_WPKEY_Pos)  /**< (RTC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
-#define RTC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (RTC_WPMR) Register MASK  (Use RTC_WPMR_Msk instead)  */
-#define RTC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (RTC_WPMR) Register Mask  */
-
-
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief RTC hardware registers */
@@ -651,8 +651,6 @@ typedef struct {
   __O  uint32_t RTC_IDR;        /**< (RTC Offset: 0x24) Interrupt Disable Register */
   __I  uint32_t RTC_IMR;        /**< (RTC Offset: 0x28) Interrupt Mask Register */
   __I  uint32_t RTC_VER;        /**< (RTC Offset: 0x2C) Valid Entry Register */
-  RoReg8  Reserved1[0xB4];
-  __IO uint32_t RTC_WPMR;       /**< (RTC Offset: 0xE4) Write Protection Mode Register */
 } Rtc;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -670,8 +668,6 @@ typedef struct {
   __O  RTC_IDR_Type                   RTC_IDR;        /**< Offset: 0x24 ( /W  32) Interrupt Disable Register */
   __I  RTC_IMR_Type                   RTC_IMR;        /**< Offset: 0x28 (R/   32) Interrupt Mask Register */
   __I  RTC_VER_Type                   RTC_VER;        /**< Offset: 0x2C (R/   32) Valid Entry Register */
-  __I  uint32_t                       Reserved1[45];
-  __IO RTC_WPMR_Type                  RTC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Rtc;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70/component/rtt.h
+++ b/asf/sam/include/same70/component/rtt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RTT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- RTT_MR : (RTT Offset: 0x00) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RTPRES:16;                 /**< bit:  0..15  Real-time Timer Prescaler Value          */
@@ -59,6 +62,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_MR_OFFSET                       (0x00)                                        /**<  (RTT_MR) Mode Register  Offset */
@@ -87,12 +91,14 @@ typedef union {
 
 /* -------- RTT_AR : (RTT Offset: 0x04) (R/W 32) Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ALMV:32;                   /**< bit:  0..31  Alarm Value                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_AR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_AR_OFFSET                       (0x04)                                        /**<  (RTT_AR) Alarm Register  Offset */
@@ -106,12 +112,14 @@ typedef union {
 
 /* -------- RTT_VR : (RTT Offset: 0x08) (R/ 32) Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CRTV:32;                   /**< bit:  0..31  Current Real-time Value                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_VR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_VR_OFFSET                       (0x08)                                        /**<  (RTT_VR) Value Register  Offset */
@@ -125,6 +133,7 @@ typedef union {
 
 /* -------- RTT_SR : (RTT Offset: 0x0c) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ALMS:1;                    /**< bit:      0  Real-time Alarm Status (cleared on read) */
@@ -133,6 +142,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_SR_OFFSET                       (0x0C)                                        /**<  (RTT_SR) Status Register  Offset */

--- a/asf/sam/include/same70/component/sdramc.h
+++ b/asf/sam/include/same70/component/sdramc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SDRAMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- SDRAMC_MR : (SDRAMC Offset: 0x00) (R/W 32) SDRAMC Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MODE:3;                    /**< bit:   0..2  SDRAMC Command Mode                      */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_MR_OFFSET                    (0x00)                                        /**<  (SDRAMC_MR) SDRAMC Mode Register  Offset */
@@ -79,6 +83,7 @@ typedef union {
 
 /* -------- SDRAMC_TR : (SDRAMC Offset: 0x04) (R/W 32) SDRAMC Refresh Timer Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COUNT:12;                  /**< bit:  0..11  SDRAMC Refresh Timer Count               */
@@ -86,6 +91,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_TR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_TR_OFFSET                    (0x04)                                        /**<  (SDRAMC_TR) SDRAMC Refresh Timer Register  Offset */
@@ -99,6 +105,7 @@ typedef union {
 
 /* -------- SDRAMC_CR : (SDRAMC Offset: 0x08) (R/W 32) SDRAMC Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NC:2;                      /**< bit:   0..1  Number of Column Bits                    */
@@ -115,6 +122,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_CR_OFFSET                    (0x08)                                        /**<  (SDRAMC_CR) SDRAMC Configuration Register  Offset */
@@ -182,6 +190,7 @@ typedef union {
 
 /* -------- SDRAMC_LPR : (SDRAMC Offset: 0x10) (R/W 32) SDRAMC Low Power Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LPCB:2;                    /**< bit:   0..1  Low-power Configuration Bits             */
@@ -195,6 +204,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_LPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_LPR_OFFSET                   (0x10)                                        /**<  (SDRAMC_LPR) SDRAMC Low Power Register  Offset */
@@ -234,6 +244,7 @@ typedef union {
 
 /* -------- SDRAMC_IER : (SDRAMC Offset: 0x14) (/W 32) SDRAMC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
@@ -241,6 +252,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IER_OFFSET                   (0x14)                                        /**<  (SDRAMC_IER) SDRAMC Interrupt Enable Register  Offset */
@@ -254,6 +266,7 @@ typedef union {
 
 /* -------- SDRAMC_IDR : (SDRAMC Offset: 0x18) (/W 32) SDRAMC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
@@ -261,6 +274,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IDR_OFFSET                   (0x18)                                        /**<  (SDRAMC_IDR) SDRAMC Interrupt Disable Register  Offset */
@@ -274,6 +288,7 @@ typedef union {
 
 /* -------- SDRAMC_IMR : (SDRAMC Offset: 0x1c) (R/ 32) SDRAMC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
@@ -281,6 +296,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IMR_OFFSET                   (0x1C)                                        /**<  (SDRAMC_IMR) SDRAMC Interrupt Mask Register  Offset */
@@ -294,6 +310,7 @@ typedef union {
 
 /* -------- SDRAMC_ISR : (SDRAMC Offset: 0x20) (R/ 32) SDRAMC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES:1;                     /**< bit:      0  Refresh Error Status (cleared on read)   */
@@ -301,6 +318,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_ISR_OFFSET                   (0x20)                                        /**<  (SDRAMC_ISR) SDRAMC Interrupt Status Register  Offset */
@@ -314,6 +332,7 @@ typedef union {
 
 /* -------- SDRAMC_MDR : (SDRAMC Offset: 0x24) (R/W 32) SDRAMC Memory Device Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MD:2;                      /**< bit:   0..1  Memory Device Type                       */
@@ -321,6 +340,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_MDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_MDR_OFFSET                   (0x24)                                        /**<  (SDRAMC_MDR) SDRAMC Memory Device Register  Offset */
@@ -338,6 +358,7 @@ typedef union {
 
 /* -------- SDRAMC_CFR1 : (SDRAMC Offset: 0x28) (R/W 32) SDRAMC Configuration Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TMRD:4;                    /**< bit:   0..3  Load Mode Register Command to Active or Refresh Command */
@@ -347,6 +368,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_CFR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_CFR1_OFFSET                  (0x28)                                        /**<  (SDRAMC_CFR1) SDRAMC Configuration Register 1  Offset */
@@ -367,6 +389,7 @@ typedef union {
 
 /* -------- SDRAMC_OCMS : (SDRAMC Offset: 0x2c) (R/W 32) SDRAMC OCMS Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDR_SE:1;                  /**< bit:      0  SDRAM Memory Controller Scrambling Enable */
@@ -374,6 +397,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_OFFSET                  (0x2C)                                        /**<  (SDRAMC_OCMS) SDRAMC OCMS Register  Offset */
@@ -387,12 +411,14 @@ typedef union {
 
 /* -------- SDRAMC_OCMS_KEY1 : (SDRAMC Offset: 0x30) (/W 32) SDRAMC OCMS KEY1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY1:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 1 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_KEY1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_KEY1_OFFSET             (0x30)                                        /**<  (SDRAMC_OCMS_KEY1) SDRAMC OCMS KEY1 Register  Offset */
@@ -406,12 +432,14 @@ typedef union {
 
 /* -------- SDRAMC_OCMS_KEY2 : (SDRAMC Offset: 0x34) (/W 32) SDRAMC OCMS KEY2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY2:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 2 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_KEY2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_KEY2_OFFSET             (0x34)                                        /**<  (SDRAMC_OCMS_KEY2) SDRAMC OCMS KEY2 Register  Offset */
@@ -430,7 +458,7 @@ typedef struct {
   __IO uint32_t SDRAMC_MR;      /**< (SDRAMC Offset: 0x00) SDRAMC Mode Register */
   __IO uint32_t SDRAMC_TR;      /**< (SDRAMC Offset: 0x04) SDRAMC Refresh Timer Register */
   __IO uint32_t SDRAMC_CR;      /**< (SDRAMC Offset: 0x08) SDRAMC Configuration Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __IO uint32_t SDRAMC_LPR;     /**< (SDRAMC Offset: 0x10) SDRAMC Low Power Register */
   __O  uint32_t SDRAMC_IER;     /**< (SDRAMC Offset: 0x14) SDRAMC Interrupt Enable Register */
   __O  uint32_t SDRAMC_IDR;     /**< (SDRAMC Offset: 0x18) SDRAMC Interrupt Disable Register */
@@ -449,7 +477,7 @@ typedef struct {
   __IO SDRAMC_MR_Type                 SDRAMC_MR;      /**< Offset: 0x00 (R/W  32) SDRAMC Mode Register */
   __IO SDRAMC_TR_Type                 SDRAMC_TR;      /**< Offset: 0x04 (R/W  32) SDRAMC Refresh Timer Register */
   __IO SDRAMC_CR_Type                 SDRAMC_CR;      /**< Offset: 0x08 (R/W  32) SDRAMC Configuration Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __IO SDRAMC_LPR_Type                SDRAMC_LPR;     /**< Offset: 0x10 (R/W  32) SDRAMC Low Power Register */
   __O  SDRAMC_IER_Type                SDRAMC_IER;     /**< Offset: 0x14 ( /W  32) SDRAMC Interrupt Enable Register */
   __O  SDRAMC_IDR_Type                SDRAMC_IDR;     /**< Offset: 0x18 ( /W  32) SDRAMC Interrupt Disable Register */

--- a/asf/sam/include/same70/component/smc.h
+++ b/asf/sam/include/same70/component/smc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- SMC_SETUP : (SMC Offset: 0x00) (R/W 32) SMC Setup Register (CS_number = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_SETUP:6;               /**< bit:   0..5  NWE Setup Length                         */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_SETUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_SETUP_OFFSET                    (0x00)                                        /**<  (SMC_SETUP) SMC Setup Register (CS_number = 0)  Offset */
@@ -80,6 +84,7 @@ typedef union {
 
 /* -------- SMC_PULSE : (SMC Offset: 0x04) (R/W 32) SMC Pulse Register (CS_number = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_PULSE:7;               /**< bit:   0..6  NWE Pulse Length                         */
@@ -93,6 +98,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_PULSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_PULSE_OFFSET                    (0x04)                                        /**<  (SMC_PULSE) SMC Pulse Register (CS_number = 0)  Offset */
@@ -115,6 +121,7 @@ typedef union {
 
 /* -------- SMC_CYCLE : (SMC Offset: 0x08) (R/W 32) SMC Cycle Register (CS_number = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_CYCLE:9;               /**< bit:   0..8  Total Write Cycle Length                 */
@@ -124,6 +131,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_CYCLE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_CYCLE_OFFSET                    (0x08)                                        /**<  (SMC_CYCLE) SMC Cycle Register (CS_number = 0)  Offset */
@@ -140,6 +148,7 @@ typedef union {
 
 /* -------- SMC_MODE : (SMC Offset: 0x0c) (R/W 32) SMC MODE Register (CS_number = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t READ_MODE:1;               /**< bit:      0  Read Mode                                */
@@ -161,6 +170,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_MODE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_MODE_OFFSET                     (0x0C)                                        /**<  (SMC_MODE) SMC MODE Register (CS_number = 0)  Offset */
@@ -220,6 +230,7 @@ typedef union {
 
 /* -------- SMC_OCMS : (SMC Offset: 0x80) (R/W 32) SMC OCMS MODE Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMSE:1;                    /**< bit:      0  Static Memory Controller Scrambling Enable */
@@ -232,6 +243,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_OCMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_OCMS_OFFSET                     (0x80)                                        /**<  (SMC_OCMS) SMC OCMS MODE Register  Offset */
@@ -257,12 +269,14 @@ typedef union {
 
 /* -------- SMC_KEY1 : (SMC Offset: 0x84) (/W 32) SMC OCMS KEY1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY1:32;                   /**< bit:  0..31  Off Chip Memory Scrambling (OCMS) Key Part 1 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_KEY1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_KEY1_OFFSET                     (0x84)                                        /**<  (SMC_KEY1) SMC OCMS KEY1 Register  Offset */
@@ -276,12 +290,14 @@ typedef union {
 
 /* -------- SMC_KEY2 : (SMC Offset: 0x88) (/W 32) SMC OCMS KEY2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY2:32;                   /**< bit:  0..31  Off Chip Memory Scrambling (OCMS) Key Part 2 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_KEY2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_KEY2_OFFSET                     (0x88)                                        /**<  (SMC_KEY2) SMC OCMS KEY2 Register  Offset */
@@ -295,6 +311,7 @@ typedef union {
 
 /* -------- SMC_WPMR : (SMC Offset: 0xe4) (R/W 32) SMC Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
@@ -303,6 +320,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_WPMR_OFFSET                     (0xE4)                                        /**<  (SMC_WPMR) SMC Write Protection Mode Register  Offset */
@@ -321,6 +339,7 @@ typedef union {
 
 /* -------- SMC_WPSR : (SMC Offset: 0xe8) (R/ 32) SMC Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -330,6 +349,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_WPSR_OFFSET                     (0xE8)                                        /**<  (SMC_WPSR) SMC Write Protection Status Register  Offset */
@@ -357,12 +377,12 @@ typedef struct {
 #define SMCCSNUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
-  RoReg8  Reserved1[0x40];
+       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+  __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC OCMS MODE Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC OCMS KEY1 Register */
   __O  uint32_t SMC_KEY2;       /**< (SMC Offset: 0x88) SMC OCMS KEY2 Register */
-  RoReg8  Reserved2[0x58];
+  __I  uint8_t                        Reserved2[88];
   __IO uint32_t SMC_WPMR;       /**< (SMC Offset: 0xE4) SMC Write Protection Mode Register */
   __I  uint32_t SMC_WPSR;       /**< (SMC Offset: 0xE8) SMC Write Protection Status Register */
 } Smc;
@@ -378,12 +398,12 @@ typedef struct {
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
-  __I  uint32_t                       Reserved1[16];
+       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+  __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC OCMS MODE Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC OCMS KEY1 Register */
   __O  SMC_KEY2_Type                  SMC_KEY2;       /**< Offset: 0x88 ( /W  32) SMC OCMS KEY2 Register */
-  __I  uint32_t                       Reserved2[22];
+  __I  uint8_t                        Reserved2[88];
   __IO SMC_WPMR_Type                  SMC_WPMR;       /**< Offset: 0xE4 (R/W  32) SMC Write Protection Mode Register */
   __I  SMC_WPSR_Type                  SMC_WPSR;       /**< Offset: 0xE8 (R/   32) SMC Write Protection Status Register */
 } Smc;

--- a/asf/sam/include/same70/component/smc.h
+++ b/asf/sam/include/same70/component/smc.h
@@ -377,7 +377,7 @@ typedef struct {
 #define SMCCSNUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC OCMS MODE Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC OCMS KEY1 Register */
@@ -398,7 +398,7 @@ typedef struct {
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC OCMS MODE Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC OCMS KEY1 Register */

--- a/asf/sam/include/same70/component/spi.h
+++ b/asf/sam/include/same70/component/spi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- SPI_CR : (SPI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPIEN:1;                   /**< bit:      0  SPI Enable                               */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_CR_OFFSET                       (0x00)                                        /**<  (SPI_CR) Control Register  Offset */
@@ -101,6 +105,7 @@ typedef union {
 
 /* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MSTR:1;                    /**< bit:      0  Master/Slave Mode                        */
@@ -118,6 +123,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_MR_OFFSET                       (0x04)                                        /**<  (SPI_MR) Mode Register  Offset */
@@ -152,6 +158,7 @@ typedef union {
 
 /* -------- SPI_RDR : (SPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
@@ -160,6 +167,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_RDR_OFFSET                      (0x08)                                        /**<  (SPI_RDR) Receive Data Register  Offset */
@@ -176,6 +184,7 @@ typedef union {
 
 /* -------- SPI_TDR : (SPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
@@ -186,6 +195,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_TDR_OFFSET                      (0x0C)                                        /**<  (SPI_TDR) Transmit Data Register  Offset */
@@ -205,6 +215,7 @@ typedef union {
 
 /* -------- SPI_SR : (SPI Offset: 0x10) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
@@ -221,6 +232,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_SR_OFFSET                       (0x10)                                        /**<  (SPI_SR) Status Register  Offset */
@@ -255,6 +267,7 @@ typedef union {
 
 /* -------- SPI_IER : (SPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
@@ -269,6 +282,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IER_OFFSET                      (0x14)                                        /**<  (SPI_IER) Interrupt Enable Register  Offset */
@@ -300,6 +314,7 @@ typedef union {
 
 /* -------- SPI_IDR : (SPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
@@ -314,6 +329,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IDR_OFFSET                      (0x18)                                        /**<  (SPI_IDR) Interrupt Disable Register  Offset */
@@ -345,6 +361,7 @@ typedef union {
 
 /* -------- SPI_IMR : (SPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
@@ -359,6 +376,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IMR_OFFSET                      (0x1C)                                        /**<  (SPI_IMR) Interrupt Mask Register  Offset */
@@ -390,6 +408,7 @@ typedef union {
 
 /* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
@@ -403,6 +422,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_CSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_CSR_OFFSET                      (0x30)                                        /**<  (SPI_CSR) Chip Select Register 0  Offset */
@@ -455,6 +475,7 @@ typedef union {
 
 /* -------- SPI_WPMR : (SPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -463,6 +484,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPMR_OFFSET                     (0xE4)                                        /**<  (SPI_WPMR) Write Protection Mode Register  Offset */
@@ -481,6 +503,7 @@ typedef union {
 
 /* -------- SPI_WPSR : (SPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -490,6 +513,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPSR_OFFSET                     (0xE8)                                        /**<  (SPI_WPSR) Write Protection Status Register  Offset */
@@ -516,9 +540,9 @@ typedef struct {
   __O  uint32_t SPI_IER;        /**< (SPI Offset: 0x14) Interrupt Enable Register */
   __O  uint32_t SPI_IDR;        /**< (SPI Offset: 0x18) Interrupt Disable Register */
   __I  uint32_t SPI_IMR;        /**< (SPI Offset: 0x1C) Interrupt Mask Register */
-  RoReg8  Reserved1[0x10];
+  __I  uint8_t                        Reserved1[16];
   __IO uint32_t SPI_CSR[4];     /**< (SPI Offset: 0x30) Chip Select Register 0 */
-  RoReg8  Reserved2[0xA4];
+  __I  uint8_t                        Reserved2[164];
   __IO uint32_t SPI_WPMR;       /**< (SPI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t SPI_WPSR;       /**< (SPI Offset: 0xE8) Write Protection Status Register */
 } Spi;
@@ -534,9 +558,9 @@ typedef struct {
   __O  SPI_IER_Type                   SPI_IER;        /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
   __O  SPI_IDR_Type                   SPI_IDR;        /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
   __I  SPI_IMR_Type                   SPI_IMR;        /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
-  __I  uint32_t                       Reserved1[4];
+  __I  uint8_t                        Reserved1[16];
   __IO SPI_CSR_Type                   SPI_CSR[4];     /**< Offset: 0x30 (R/W  32) Chip Select Register 0 */
-  __I  uint32_t                       Reserved2[41];
+  __I  uint8_t                        Reserved2[164];
   __IO SPI_WPMR_Type                  SPI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  SPI_WPSR_Type                  SPI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Spi;

--- a/asf/sam/include/same70/component/ssc.h
+++ b/asf/sam/include/same70/component/ssc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SSC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- SSC_CR : (SSC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXEN:1;                    /**< bit:      0  Receive Enable                           */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_CR_OFFSET                       (0x00)                                        /**<  (SSC_CR) Control Register  Offset */
@@ -83,6 +87,7 @@ typedef union {
 
 /* -------- SSC_CMR : (SSC Offset: 0x04) (R/W 32) Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIV:12;                    /**< bit:  0..11  Clock Divider                            */
@@ -90,6 +95,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_CMR_OFFSET                      (0x04)                                        /**<  (SSC_CMR) Clock Mode Register  Offset */
@@ -103,6 +109,7 @@ typedef union {
 
 /* -------- SSC_RCMR : (SSC Offset: 0x10) (R/W 32) Receive Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CKS:2;                     /**< bit:   0..1  Receive Clock Selection                  */
@@ -117,6 +124,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RCMR_OFFSET                     (0x10)                                        /**<  (SSC_RCMR) Receive Clock Mode Register  Offset */
@@ -187,6 +195,7 @@ typedef union {
 
 /* -------- SSC_RFMR : (SSC Offset: 0x14) (R/W 32) Receive Frame Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
@@ -204,6 +213,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RFMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RFMR_OFFSET                     (0x14)                                        /**<  (SSC_RFMR) Receive Frame Mode Register  Offset */
@@ -254,6 +264,7 @@ typedef union {
 
 /* -------- SSC_TCMR : (SSC Offset: 0x18) (R/W 32) Transmit Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CKS:2;                     /**< bit:   0..1  Transmit Clock Selection                 */
@@ -267,6 +278,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TCMR_OFFSET                     (0x18)                                        /**<  (SSC_TCMR) Transmit Clock Mode Register  Offset */
@@ -332,6 +344,7 @@ typedef union {
 
 /* -------- SSC_TFMR : (SSC Offset: 0x1c) (R/W 32) Transmit Frame Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
@@ -349,6 +362,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TFMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TFMR_OFFSET                     (0x1C)                                        /**<  (SSC_TFMR) Transmit Frame Mode Register  Offset */
@@ -402,12 +416,14 @@ typedef union {
 
 /* -------- SSC_RHR : (SSC Offset: 0x20) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDAT:32;                   /**< bit:  0..31  Receive Data                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RHR_OFFSET                      (0x20)                                        /**<  (SSC_RHR) Receive Holding Register  Offset */
@@ -421,12 +437,14 @@ typedef union {
 
 /* -------- SSC_THR : (SSC Offset: 0x24) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TDAT:32;                   /**< bit:  0..31  Transmit Data                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_THR_OFFSET                      (0x24)                                        /**<  (SSC_THR) Transmit Holding Register  Offset */
@@ -440,6 +458,7 @@ typedef union {
 
 /* -------- SSC_RSHR : (SSC Offset: 0x30) (R/ 32) Receive Sync. Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RSDAT:16;                  /**< bit:  0..15  Receive Synchronization Data             */
@@ -447,6 +466,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RSHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RSHR_OFFSET                     (0x30)                                        /**<  (SSC_RSHR) Receive Sync. Holding Register  Offset */
@@ -460,6 +480,7 @@ typedef union {
 
 /* -------- SSC_TSHR : (SSC Offset: 0x34) (R/W 32) Transmit Sync. Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSDAT:16;                  /**< bit:  0..15  Transmit Synchronization Data            */
@@ -467,6 +488,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TSHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TSHR_OFFSET                     (0x34)                                        /**<  (SSC_TSHR) Transmit Sync. Holding Register  Offset */
@@ -480,6 +502,7 @@ typedef union {
 
 /* -------- SSC_RC0R : (SSC Offset: 0x38) (R/W 32) Receive Compare 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CP0:16;                    /**< bit:  0..15  Receive Compare Data 0                   */
@@ -487,6 +510,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RC0R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RC0R_OFFSET                     (0x38)                                        /**<  (SSC_RC0R) Receive Compare 0 Register  Offset */
@@ -500,6 +524,7 @@ typedef union {
 
 /* -------- SSC_RC1R : (SSC Offset: 0x3c) (R/W 32) Receive Compare 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CP1:16;                    /**< bit:  0..15  Receive Compare Data 1                   */
@@ -507,6 +532,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RC1R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RC1R_OFFSET                     (0x3C)                                        /**<  (SSC_RC1R) Receive Compare 1 Register  Offset */
@@ -520,6 +546,7 @@ typedef union {
 
 /* -------- SSC_SR : (SSC Offset: 0x40) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready                           */
@@ -544,6 +571,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_SR_OFFSET                       (0x40)                                        /**<  (SSC_SR) Status Register  Offset */
@@ -587,6 +615,7 @@ typedef union {
 
 /* -------- SSC_IER : (SSC Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Enable          */
@@ -608,6 +637,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IER_OFFSET                      (0x44)                                        /**<  (SSC_IER) Interrupt Enable Register  Offset */
@@ -645,6 +675,7 @@ typedef union {
 
 /* -------- SSC_IDR : (SSC Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Disable         */
@@ -666,6 +697,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IDR_OFFSET                      (0x48)                                        /**<  (SSC_IDR) Interrupt Disable Register  Offset */
@@ -703,6 +735,7 @@ typedef union {
 
 /* -------- SSC_IMR : (SSC Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Mask            */
@@ -724,6 +757,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IMR_OFFSET                      (0x4C)                                        /**<  (SSC_IMR) Interrupt Mask Register  Offset */
@@ -761,6 +795,7 @@ typedef union {
 
 /* -------- SSC_WPMR : (SSC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -769,6 +804,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_WPMR_OFFSET                     (0xE4)                                        /**<  (SSC_WPMR) Write Protection Mode Register  Offset */
@@ -787,6 +823,7 @@ typedef union {
 
 /* -------- SSC_WPSR : (SSC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -796,6 +833,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_WPSR_OFFSET                     (0xE8)                                        /**<  (SSC_WPSR) Write Protection Status Register  Offset */
@@ -816,14 +854,14 @@ typedef union {
 typedef struct {  
   __O  uint32_t SSC_CR;         /**< (SSC Offset: 0x00) Control Register */
   __IO uint32_t SSC_CMR;        /**< (SSC Offset: 0x04) Clock Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __IO uint32_t SSC_RCMR;       /**< (SSC Offset: 0x10) Receive Clock Mode Register */
   __IO uint32_t SSC_RFMR;       /**< (SSC Offset: 0x14) Receive Frame Mode Register */
   __IO uint32_t SSC_TCMR;       /**< (SSC Offset: 0x18) Transmit Clock Mode Register */
   __IO uint32_t SSC_TFMR;       /**< (SSC Offset: 0x1C) Transmit Frame Mode Register */
   __I  uint32_t SSC_RHR;        /**< (SSC Offset: 0x20) Receive Holding Register */
   __O  uint32_t SSC_THR;        /**< (SSC Offset: 0x24) Transmit Holding Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __I  uint32_t SSC_RSHR;       /**< (SSC Offset: 0x30) Receive Sync. Holding Register */
   __IO uint32_t SSC_TSHR;       /**< (SSC Offset: 0x34) Transmit Sync. Holding Register */
   __IO uint32_t SSC_RC0R;       /**< (SSC Offset: 0x38) Receive Compare 0 Register */
@@ -832,7 +870,7 @@ typedef struct {
   __O  uint32_t SSC_IER;        /**< (SSC Offset: 0x44) Interrupt Enable Register */
   __O  uint32_t SSC_IDR;        /**< (SSC Offset: 0x48) Interrupt Disable Register */
   __I  uint32_t SSC_IMR;        /**< (SSC Offset: 0x4C) Interrupt Mask Register */
-  RoReg8  Reserved3[0x94];
+  __I  uint8_t                        Reserved3[148];
   __IO uint32_t SSC_WPMR;       /**< (SSC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t SSC_WPSR;       /**< (SSC Offset: 0xE8) Write Protection Status Register */
 } Ssc;
@@ -842,14 +880,14 @@ typedef struct {
 typedef struct {  
   __O  SSC_CR_Type                    SSC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO SSC_CMR_Type                   SSC_CMR;        /**< Offset: 0x04 (R/W  32) Clock Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __IO SSC_RCMR_Type                  SSC_RCMR;       /**< Offset: 0x10 (R/W  32) Receive Clock Mode Register */
   __IO SSC_RFMR_Type                  SSC_RFMR;       /**< Offset: 0x14 (R/W  32) Receive Frame Mode Register */
   __IO SSC_TCMR_Type                  SSC_TCMR;       /**< Offset: 0x18 (R/W  32) Transmit Clock Mode Register */
   __IO SSC_TFMR_Type                  SSC_TFMR;       /**< Offset: 0x1C (R/W  32) Transmit Frame Mode Register */
   __I  SSC_RHR_Type                   SSC_RHR;        /**< Offset: 0x20 (R/   32) Receive Holding Register */
   __O  SSC_THR_Type                   SSC_THR;        /**< Offset: 0x24 ( /W  32) Transmit Holding Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __I  SSC_RSHR_Type                  SSC_RSHR;       /**< Offset: 0x30 (R/   32) Receive Sync. Holding Register */
   __IO SSC_TSHR_Type                  SSC_TSHR;       /**< Offset: 0x34 (R/W  32) Transmit Sync. Holding Register */
   __IO SSC_RC0R_Type                  SSC_RC0R;       /**< Offset: 0x38 (R/W  32) Receive Compare 0 Register */
@@ -858,7 +896,7 @@ typedef struct {
   __O  SSC_IER_Type                   SSC_IER;        /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
   __O  SSC_IDR_Type                   SSC_IDR;        /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
   __I  SSC_IMR_Type                   SSC_IMR;        /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
-  __I  uint32_t                       Reserved3[37];
+  __I  uint8_t                        Reserved3[148];
   __IO SSC_WPMR_Type                  SSC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  SSC_WPSR_Type                  SSC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Ssc;

--- a/asf/sam/include/same70/component/supc.h
+++ b/asf/sam/include/same70/component/supc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SUPC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- SUPC_CR : (SUPC Offset: 0x00) (/W 32) Supply Controller Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -55,6 +58,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_CR_OFFSET                      (0x00)                                        /**<  (SUPC_CR) Supply Controller Control Register  Offset */
@@ -84,6 +88,7 @@ typedef union {
 
 /* -------- SUPC_SMMR : (SUPC Offset: 0x04) (R/W 32) Supply Controller Supply Monitor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMTH:4;                    /**< bit:   0..3  Supply Monitor Threshold                 */
@@ -96,6 +101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_SMMR_OFFSET                    (0x04)                                        /**<  (SUPC_SMMR) Supply Controller Supply Monitor Mode Register  Offset */
@@ -136,6 +142,7 @@ typedef union {
 
 /* -------- SUPC_MR : (SUPC Offset: 0x08) (R/W 32) Supply Controller Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
@@ -151,6 +158,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_MR_OFFSET                      (0x08)                                        /**<  (SUPC_MR) Supply Controller Mode Register  Offset */
@@ -197,6 +205,7 @@ typedef union {
 
 /* -------- SUPC_WUMR : (SUPC Offset: 0x0c) (R/W 32) Supply Controller Wake-up Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -220,6 +229,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_WUMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_WUMR_OFFSET                    (0x0C)                                        /**<  (SUPC_WUMR) Supply Controller Wake-up Mode Register  Offset */
@@ -309,6 +319,7 @@ typedef union {
 
 /* -------- SUPC_WUIR : (SUPC Offset: 0x10) (R/W 32) Supply Controller Wake-up Inputs Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WKUPEN0:1;                 /**< bit:      0  Wake-up Input Enable 0 to 0              */
@@ -350,6 +361,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_WUIR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_WUIR_OFFSET                    (0x10)                                        /**<  (SUPC_WUIR) Supply Controller Wake-up Inputs Register  Offset */
@@ -562,6 +574,7 @@ typedef union {
 
 /* -------- SUPC_SR : (SUPC Offset: 0x14) (R/ 32) Supply Controller Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -601,6 +614,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_SR_OFFSET                      (0x14)                                        /**<  (SUPC_SR) Supply Controller Status Register  Offset */

--- a/asf/sam/include/same70/component/tc.h
+++ b/asf/sam/include/same70/component/tc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- TC_CCR : (TC Offset: 0x00) (/W 32) Channel Control Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLKEN:1;                   /**< bit:      0  Counter Clock Enable Command             */
@@ -54,6 +57,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CCR_OFFSET                       (0x00)                                        /**<  (TC_CCR) Channel Control Register (channel = 0)  Offset */
@@ -73,6 +77,7 @@ typedef union {
 
 /* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) Channel Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCCLKS:3;                  /**< bit:   0..2  Clock Selection                          */
@@ -92,6 +97,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CMR_OFFSET                       (0x04)                                        /**<  (TC_CMR) Channel Mode Register (channel = 0)  Offset */
@@ -190,92 +196,13 @@ typedef union {
 #define TC_CMR_SBSMPLR_FOURTH               (TC_CMR_SBSMPLR_FOURTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
 #define TC_CMR_SBSMPLR_EIGHTH               (TC_CMR_SBSMPLR_EIGHTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
 #define TC_CMR_SBSMPLR_SIXTEENTH            (TC_CMR_SBSMPLR_SIXTEENTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
-#define TC_CMR_CPCSTOP (0x1u << 6) /**< \brief (TC_CMR) Counter Clock Stopped with RC Compare */
-#define TC_CMR_CPCDIS (0x1u << 7) /**< \brief (TC_CMR) Counter Clock Disable with RC Compare */
-#define TC_CMR_EEVTEDG_Pos 8
-#define TC_CMR_EEVTEDG_Msk (0x3u << TC_CMR_EEVTEDG_Pos) /**< \brief (TC_CMR) External Event Edge Selection */
-#define TC_CMR_EEVTEDG(value) ((TC_CMR_EEVTEDG_Msk & ((value) << TC_CMR_EEVTEDG_Pos)))
-#define   TC_CMR_EEVTEDG_NONE (0x0u << 8) /**< \brief (TC_CMR) None */
-#define   TC_CMR_EEVTEDG_RISING (0x1u << 8) /**< \brief (TC_CMR) Rising edge */
-#define   TC_CMR_EEVTEDG_FALLING (0x2u << 8) /**< \brief (TC_CMR) Falling edge */
-#define   TC_CMR_EEVTEDG_EDGE (0x3u << 8) /**< \brief (TC_CMR) Each edge */
-#define TC_CMR_EEVT_Pos 10
-#define TC_CMR_EEVT_Msk (0x3u << TC_CMR_EEVT_Pos) /**< \brief (TC_CMR) External Event Selection */
-#define TC_CMR_EEVT(value) ((TC_CMR_EEVT_Msk & ((value) << TC_CMR_EEVT_Pos)))
-#define   TC_CMR_EEVT_TIOB (0x0u << 10) /**< \brief (TC_CMR) TIOB */
-#define   TC_CMR_EEVT_XC0 (0x1u << 10) /**< \brief (TC_CMR) XC0 */
-#define   TC_CMR_EEVT_XC1 (0x2u << 10) /**< \brief (TC_CMR) XC1 */
-#define   TC_CMR_EEVT_XC2 (0x3u << 10) /**< \brief (TC_CMR) XC2 */
-#define TC_CMR_ENETRG (0x1u << 12) /**< \brief (TC_CMR) External Event Trigger Enable */
-#define TC_CMR_WAVSEL_Pos 13
-#define TC_CMR_WAVSEL_Msk (0x3u << TC_CMR_WAVSEL_Pos) /**< \brief (TC_CMR) Waveform Selection */
-#define TC_CMR_WAVSEL(value) ((TC_CMR_WAVSEL_Msk & ((value) << TC_CMR_WAVSEL_Pos)))
-#define   TC_CMR_WAVSEL_UP (0x0u << 13) /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN (0x1u << 13) /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UP_RC (0x2u << 13) /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN_RC (0x3u << 13) /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
-#define TC_CMR_ACPA_Pos 16
-#define TC_CMR_ACPA_Msk (0x3u << TC_CMR_ACPA_Pos) /**< \brief (TC_CMR) RA Compare Effect on TIOA */
-#define TC_CMR_ACPA(value) ((TC_CMR_ACPA_Msk & ((value) << TC_CMR_ACPA_Pos)))
-#define   TC_CMR_ACPA_NONE (0x0u << 16) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ACPA_SET (0x1u << 16) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ACPA_CLEAR (0x2u << 16) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ACPA_TOGGLE (0x3u << 16) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_ACPC_Pos 18
-#define TC_CMR_ACPC_Msk (0x3u << TC_CMR_ACPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOA */
-#define TC_CMR_ACPC(value) ((TC_CMR_ACPC_Msk & ((value) << TC_CMR_ACPC_Pos)))
-#define   TC_CMR_ACPC_NONE (0x0u << 18) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ACPC_SET (0x1u << 18) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ACPC_CLEAR (0x2u << 18) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ACPC_TOGGLE (0x3u << 18) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_AEEVT_Pos 20
-#define TC_CMR_AEEVT_Msk (0x3u << TC_CMR_AEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOA */
-#define TC_CMR_AEEVT(value) ((TC_CMR_AEEVT_Msk & ((value) << TC_CMR_AEEVT_Pos)))
-#define   TC_CMR_AEEVT_NONE (0x0u << 20) /**< \brief (TC_CMR) None */
-#define   TC_CMR_AEEVT_SET (0x1u << 20) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_AEEVT_CLEAR (0x2u << 20) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_AEEVT_TOGGLE (0x3u << 20) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_ASWTRG_Pos 22
-#define TC_CMR_ASWTRG_Msk (0x3u << TC_CMR_ASWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOA */
-#define TC_CMR_ASWTRG(value) ((TC_CMR_ASWTRG_Msk & ((value) << TC_CMR_ASWTRG_Pos)))
-#define   TC_CMR_ASWTRG_NONE (0x0u << 22) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ASWTRG_SET (0x1u << 22) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ASWTRG_CLEAR (0x2u << 22) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ASWTRG_TOGGLE (0x3u << 22) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BCPB_Pos 24
-#define TC_CMR_BCPB_Msk (0x3u << TC_CMR_BCPB_Pos) /**< \brief (TC_CMR) RB Compare Effect on TIOB */
-#define TC_CMR_BCPB(value) ((TC_CMR_BCPB_Msk & ((value) << TC_CMR_BCPB_Pos)))
-#define   TC_CMR_BCPB_NONE (0x0u << 24) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BCPB_SET (0x1u << 24) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BCPB_CLEAR (0x2u << 24) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BCPB_TOGGLE (0x3u << 24) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BCPC_Pos 26
-#define TC_CMR_BCPC_Msk (0x3u << TC_CMR_BCPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOB */
-#define TC_CMR_BCPC(value) ((TC_CMR_BCPC_Msk & ((value) << TC_CMR_BCPC_Pos)))
-#define   TC_CMR_BCPC_NONE (0x0u << 26) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BCPC_SET (0x1u << 26) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BCPC_CLEAR (0x2u << 26) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BCPC_TOGGLE (0x3u << 26) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BEEVT_Pos 28
-#define TC_CMR_BEEVT_Msk (0x3u << TC_CMR_BEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOB */
-#define TC_CMR_BEEVT(value) ((TC_CMR_BEEVT_Msk & ((value) << TC_CMR_BEEVT_Pos)))
-#define   TC_CMR_BEEVT_NONE (0x0u << 28) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BEEVT_SET (0x1u << 28) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BEEVT_CLEAR (0x2u << 28) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BEEVT_TOGGLE (0x3u << 28) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BSWTRG_Pos 30
-#define TC_CMR_BSWTRG_Msk (0x3u << TC_CMR_BSWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOB */
-#define TC_CMR_BSWTRG(value) ((TC_CMR_BSWTRG_Msk & ((value) << TC_CMR_BSWTRG_Pos)))
-#define   TC_CMR_BSWTRG_NONE (0x0u << 30) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BSWTRG_SET (0x1u << 30) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BSWTRG_CLEAR (0x2u << 30) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BSWTRG_TOGGLE (0x3u << 30) /**< \brief (TC_CMR) Toggle */
 #define TC_CMR_MASK                         _U_(0x7FC7FF)                                  /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
 #define TC_CMR_Msk                          _U_(0x7FC7FF)                                  /**< (TC_CMR) Register Mask  */
 
 
 /* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) Stepper Motor Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GCEN:1;                    /**< bit:      0  Gray Count Enable                        */
@@ -284,6 +211,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SMMR_OFFSET                      (0x08)                                        /**<  (TC_SMMR) Stepper Motor Mode Register (channel = 0)  Offset */
@@ -300,12 +228,14 @@ typedef union {
 
 /* -------- TC_RAB : (TC Offset: 0x0c) (R/ 32) Register AB (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RAB:32;                    /**< bit:  0..31  Register A or Register B                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RAB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RAB_OFFSET                       (0x0C)                                        /**<  (TC_RAB) Register AB (channel = 0)  Offset */
@@ -319,12 +249,14 @@ typedef union {
 
 /* -------- TC_CV : (TC Offset: 0x10) (R/ 32) Counter Value (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CV:32;                     /**< bit:  0..31  Counter Value                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CV_OFFSET                        (0x10)                                        /**<  (TC_CV) Counter Value (channel = 0)  Offset */
@@ -338,12 +270,14 @@ typedef union {
 
 /* -------- TC_RA : (TC Offset: 0x14) (R/W 32) Register A (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RA:32;                     /**< bit:  0..31  Register A                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RA_OFFSET                        (0x14)                                        /**<  (TC_RA) Register A (channel = 0)  Offset */
@@ -357,12 +291,14 @@ typedef union {
 
 /* -------- TC_RB : (TC Offset: 0x18) (R/W 32) Register B (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RB:32;                     /**< bit:  0..31  Register B                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RB_OFFSET                        (0x18)                                        /**<  (TC_RB) Register B (channel = 0)  Offset */
@@ -376,12 +312,14 @@ typedef union {
 
 /* -------- TC_RC : (TC Offset: 0x1c) (R/W 32) Register C (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RC:32;                     /**< bit:  0..31  Register C                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RC_OFFSET                        (0x1C)                                        /**<  (TC_RC) Register C (channel = 0)  Offset */
@@ -395,6 +333,7 @@ typedef union {
 
 /* -------- TC_SR : (TC Offset: 0x20) (R/ 32) Status Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow Status (cleared on read) */
@@ -413,6 +352,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SR_OFFSET                        (0x20)                                        /**<  (TC_SR) Status Register (channel = 0)  Offset */
@@ -456,6 +396,7 @@ typedef union {
 
 /* -------- TC_IER : (TC Offset: 0x24) (/W 32) Interrupt Enable Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -470,6 +411,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IER_OFFSET                       (0x24)                                        /**<  (TC_IER) Interrupt Enable Register (channel = 0)  Offset */
@@ -504,6 +446,7 @@ typedef union {
 
 /* -------- TC_IDR : (TC Offset: 0x28) (/W 32) Interrupt Disable Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -518,6 +461,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IDR_OFFSET                       (0x28)                                        /**<  (TC_IDR) Interrupt Disable Register (channel = 0)  Offset */
@@ -552,6 +496,7 @@ typedef union {
 
 /* -------- TC_IMR : (TC Offset: 0x2c) (R/ 32) Interrupt Mask Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -566,6 +511,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IMR_OFFSET                       (0x2C)                                        /**<  (TC_IMR) Interrupt Mask Register (channel = 0)  Offset */
@@ -600,6 +546,7 @@ typedef union {
 
 /* -------- TC_EMR : (TC Offset: 0x30) (R/W 32) Extended Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRIGSRCA:2;                /**< bit:   0..1  Trigger Source for Input A               */
@@ -611,6 +558,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_EMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_EMR_OFFSET                       (0x30)                                        /**<  (TC_EMR) Extended Mode Register (channel = 0)  Offset */
@@ -638,6 +586,7 @@ typedef union {
 
 /* -------- TC_BCR : (TC Offset: 0xc0) (/W 32) Block Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SYNC:1;                    /**< bit:      0  Synchro Command                          */
@@ -645,6 +594,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_BCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BCR_OFFSET                       (0xC0)                                        /**<  (TC_BCR) Block Control Register  Offset */
@@ -658,6 +608,7 @@ typedef union {
 
 /* -------- TC_BMR : (TC Offset: 0xc4) (R/W 32) Block Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TC0XC0S:2;                 /**< bit:   0..1  External Clock Signal 0 Selection        */
@@ -680,6 +631,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_BMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BMR_OFFSET                       (0xC4)                                        /**<  (TC_BMR) Block Mode Register  Offset */
@@ -750,6 +702,7 @@ typedef union {
 
 /* -------- TC_QIER : (TC Offset: 0xc8) (/W 32) QDEC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
@@ -759,6 +712,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIER_OFFSET                      (0xC8)                                        /**<  (TC_QIER) QDEC Interrupt Enable Register  Offset */
@@ -778,6 +732,7 @@ typedef union {
 
 /* -------- TC_QIDR : (TC Offset: 0xcc) (/W 32) QDEC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
@@ -787,6 +742,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIDR_OFFSET                      (0xCC)                                        /**<  (TC_QIDR) QDEC Interrupt Disable Register  Offset */
@@ -806,6 +762,7 @@ typedef union {
 
 /* -------- TC_QIMR : (TC Offset: 0xd0) (R/ 32) QDEC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
@@ -815,6 +772,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIMR_OFFSET                      (0xD0)                                        /**<  (TC_QIMR) QDEC Interrupt Mask Register  Offset */
@@ -834,6 +792,7 @@ typedef union {
 
 /* -------- TC_QISR : (TC Offset: 0xd4) (R/ 32) QDEC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
@@ -845,6 +804,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QISR_OFFSET                      (0xD4)                                        /**<  (TC_QISR) QDEC Interrupt Status Register  Offset */
@@ -867,6 +827,7 @@ typedef union {
 
 /* -------- TC_FMR : (TC Offset: 0xd8) (R/W 32) Fault Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENCF0:1;                   /**< bit:      0  Enable Compare Fault Channel 0           */
@@ -879,6 +840,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } TC_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_FMR_OFFSET                       (0xD8)                                        /**<  (TC_FMR) Fault Mode Register  Offset */
@@ -898,6 +860,7 @@ typedef union {
 
 /* -------- TC_WPMR : (TC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -906,6 +869,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_WPMR_OFFSET                      (0xE4)                                        /**<  (TC_WPMR) Write Protection Mode Register  Offset */
@@ -939,13 +903,13 @@ typedef struct {
   __O  uint32_t TC_IDR;         /**< (TC_CHANNEL Offset: 0x28) Interrupt Disable Register (channel = 0) */
   __I  uint32_t TC_IMR;         /**< (TC_CHANNEL Offset: 0x2C) Interrupt Mask Register (channel = 0) */
   __IO uint32_t TC_EMR;         /**< (TC_CHANNEL Offset: 0x30) Extended Mode Register (channel = 0) */
-       RoReg8                         Reserved1[0x0C];
+  __I  uint8_t                        Reserved1[12];
 } TcChannel;
 
 #define TCCHANNEL_NUMBER 3
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel TC_CHANNEL[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
   __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
   __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
@@ -953,7 +917,7 @@ typedef struct {
   __I  uint32_t TC_QIMR;        /**< (TC Offset: 0xD0) QDEC Interrupt Mask Register */
   __I  uint32_t TC_QISR;        /**< (TC Offset: 0xD4) QDEC Interrupt Status Register */
   __IO uint32_t TC_FMR;         /**< (TC Offset: 0xD8) Fault Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __IO uint32_t TC_WPMR;        /**< (TC Offset: 0xE4) Write Protection Mode Register */
 } Tc;
 
@@ -973,12 +937,12 @@ typedef struct {
   __O  TC_IDR_Type                    TC_IDR;         /**< Offset: 0x28 ( /W  32) Interrupt Disable Register (channel = 0) */
   __I  TC_IMR_Type                    TC_IMR;         /**< Offset: 0x2C (R/   32) Interrupt Mask Register (channel = 0) */
   __IO TC_EMR_Type                    TC_EMR;         /**< Offset: 0x30 (R/W  32) Extended Mode Register (channel = 0) */
-       RoReg8                         Reserved1[0x0C];
+  __I  uint8_t                        Reserved1[12];
 } TcChannel;
 
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel                      TC_CHANNEL[3];  /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
   __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
   __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */
@@ -986,7 +950,7 @@ typedef struct {
   __I  TC_QIMR_Type                   TC_QIMR;        /**< Offset: 0xD0 (R/   32) QDEC Interrupt Mask Register */
   __I  TC_QISR_Type                   TC_QISR;        /**< Offset: 0xD4 (R/   32) QDEC Interrupt Status Register */
   __IO TC_FMR_Type                    TC_FMR;         /**< Offset: 0xD8 (R/W  32) Fault Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __IO TC_WPMR_Type                   TC_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Tc;
 

--- a/asf/sam/include/same70/component/tc.h
+++ b/asf/sam/include/same70/component/tc.h
@@ -909,7 +909,7 @@ typedef struct {
 #define TCCHANNEL_NUMBER 3
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel TC_CHANNEL[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
   __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
   __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
@@ -942,7 +942,7 @@ typedef struct {
 
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel                      TC_CHANNEL[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
   __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
   __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */

--- a/asf/sam/include/same70/component/trng.h
+++ b/asf/sam/include/same70/component/trng.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TRNG
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- TRNG_CR : (TRNG Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  Enables the TRNG to Provide Random Values */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_CR_OFFSET                      (0x00)                                        /**<  (TRNG_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- TRNG_IER : (TRNG Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
@@ -78,6 +83,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IER_OFFSET                     (0x10)                                        /**<  (TRNG_IER) Interrupt Enable Register  Offset */
@@ -91,6 +97,7 @@ typedef union {
 
 /* -------- TRNG_IDR : (TRNG Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
@@ -98,6 +105,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IDR_OFFSET                     (0x14)                                        /**<  (TRNG_IDR) Interrupt Disable Register  Offset */
@@ -111,6 +119,7 @@ typedef union {
 
 /* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
@@ -118,6 +127,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IMR_OFFSET                     (0x18)                                        /**<  (TRNG_IMR) Interrupt Mask Register  Offset */
@@ -131,6 +141,7 @@ typedef union {
 
 /* -------- TRNG_ISR : (TRNG Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready                               */
@@ -138,6 +149,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ISR_OFFSET                     (0x1C)                                        /**<  (TRNG_ISR) Interrupt Status Register  Offset */
@@ -151,12 +163,14 @@ typedef union {
 
 /* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/ 32) Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_ODATA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ODATA_OFFSET                   (0x50)                                        /**<  (TRNG_ODATA) Output Data Register  Offset */
@@ -173,12 +187,12 @@ typedef union {
 /** \brief TRNG hardware registers */
 typedef struct {  
   __O  uint32_t TRNG_CR;        /**< (TRNG Offset: 0x00) Control Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __O  uint32_t TRNG_IER;       /**< (TRNG Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t TRNG_IDR;       /**< (TRNG Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t TRNG_IMR;       /**< (TRNG Offset: 0x18) Interrupt Mask Register */
   __I  uint32_t TRNG_ISR;       /**< (TRNG Offset: 0x1C) Interrupt Status Register */
-  RoReg8  Reserved2[0x30];
+  __I  uint8_t                        Reserved2[48];
   __I  uint32_t TRNG_ODATA;     /**< (TRNG Offset: 0x50) Output Data Register */
 } Trng;
 
@@ -186,12 +200,12 @@ typedef struct {
 /** \brief TRNG hardware registers */
 typedef struct {  
   __O  TRNG_CR_Type                   TRNG_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __O  TRNG_IER_Type                  TRNG_IER;       /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  TRNG_IDR_Type                  TRNG_IDR;       /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  TRNG_IMR_Type                  TRNG_IMR;       /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
   __I  TRNG_ISR_Type                  TRNG_ISR;       /**< Offset: 0x1C (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[12];
+  __I  uint8_t                        Reserved2[48];
   __I  TRNG_ODATA_Type                TRNG_ODATA;     /**< Offset: 0x50 (R/   32) Output Data Register */
 } Trng;
 

--- a/asf/sam/include/same70/component/twihs.h
+++ b/asf/sam/include/same70/component/twihs.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TWIHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- TWIHS_CR : (TWIHS Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t START:1;                   /**< bit:      0  Send a START Condition                   */
@@ -76,6 +79,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_CR_OFFSET                     (0x00)                                        /**<  (TWIHS_CR) Control Register  Offset */
@@ -152,6 +156,7 @@ typedef union {
 
 /* -------- TWIHS_MMR : (TWIHS Offset: 0x04) (R/W 32) Master Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
@@ -164,6 +169,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_MMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_MMR_OFFSET                    (0x04)                                        /**<  (TWIHS_MMR) Master Mode Register  Offset */
@@ -191,6 +197,7 @@ typedef union {
 
 /* -------- TWIHS_SMR : (TWIHS Offset: 0x08) (R/W 32) Slave Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NACKEN:1;                  /**< bit:      0  Slave Receiver Data Phase NACK enable    */
@@ -211,6 +218,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SMR_OFFSET                    (0x08)                                        /**<  (TWIHS_SMR) Slave Mode Register  Offset */
@@ -250,6 +258,7 @@ typedef union {
 
 /* -------- TWIHS_IADR : (TWIHS Offset: 0x0c) (R/W 32) Internal Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IADR:24;                   /**< bit:  0..23  Internal Address                         */
@@ -257,6 +266,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IADR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IADR_OFFSET                   (0x0C)                                        /**<  (TWIHS_IADR) Internal Address Register  Offset */
@@ -270,6 +280,7 @@ typedef union {
 
 /* -------- TWIHS_CWGR : (TWIHS Offset: 0x10) (R/W 32) Clock Waveform Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLDIV:8;                   /**< bit:   0..7  Clock Low Divider                        */
@@ -281,6 +292,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_CWGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_CWGR_OFFSET                   (0x10)                                        /**<  (TWIHS_CWGR) Clock Waveform Generator Register  Offset */
@@ -303,6 +315,7 @@ typedef union {
 
 /* -------- TWIHS_SR : (TWIHS Offset: 0x20) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed (cleared by writing TWIHS_THR) */
@@ -331,6 +344,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SR_OFFSET                     (0x20)                                        /**<  (TWIHS_SR) Status Register  Offset */
@@ -398,6 +412,7 @@ typedef union {
 
 /* -------- TWIHS_IER : (TWIHS Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Enable  */
@@ -423,6 +438,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IER_OFFSET                    (0x24)                                        /**<  (TWIHS_IER) Interrupt Enable Register  Offset */
@@ -481,6 +497,7 @@ typedef union {
 
 /* -------- TWIHS_IDR : (TWIHS Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Disable */
@@ -506,6 +523,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IDR_OFFSET                    (0x28)                                        /**<  (TWIHS_IDR) Interrupt Disable Register  Offset */
@@ -564,6 +582,7 @@ typedef union {
 
 /* -------- TWIHS_IMR : (TWIHS Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Mask    */
@@ -589,6 +608,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IMR_OFFSET                    (0x2C)                                        /**<  (TWIHS_IMR) Interrupt Mask Register  Offset */
@@ -647,6 +667,7 @@ typedef union {
 
 /* -------- TWIHS_RHR : (TWIHS Offset: 0x30) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXDATA:8;                  /**< bit:   0..7  Master or Slave Receive Holding Data     */
@@ -654,6 +675,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_RHR_OFFSET                    (0x30)                                        /**<  (TWIHS_RHR) Receive Holding Register  Offset */
@@ -667,6 +689,7 @@ typedef union {
 
 /* -------- TWIHS_THR : (TWIHS Offset: 0x34) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXDATA:8;                  /**< bit:   0..7  Master or Slave Transmit Holding Data    */
@@ -674,6 +697,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_THR_OFFSET                    (0x34)                                        /**<  (TWIHS_THR) Transmit Holding Register  Offset */
@@ -687,6 +711,7 @@ typedef union {
 
 /* -------- TWIHS_SMBTR : (TWIHS Offset: 0x38) (R/W 32) SMBus Timing Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PRESC:4;                   /**< bit:   0..3  SMBus Clock Prescaler                    */
@@ -697,6 +722,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SMBTR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SMBTR_OFFSET                  (0x38)                                        /**<  (TWIHS_SMBTR) SMBus Timing Register  Offset */
@@ -719,6 +745,7 @@ typedef union {
 
 /* -------- TWIHS_FILTR : (TWIHS Offset: 0x44) (R/W 32) Filter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FILT:1;                    /**< bit:      0  RX Digital Filter                        */
@@ -730,6 +757,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_FILTR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_FILTR_OFFSET                  (0x44)                                        /**<  (TWIHS_FILTR) Filter Register  Offset */
@@ -752,6 +780,7 @@ typedef union {
 
 /* -------- TWIHS_SWMR : (TWIHS Offset: 0x4c) (R/W 32) SleepWalking Matching Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SADR1:7;                   /**< bit:   0..6  Slave Address 1                          */
@@ -764,6 +793,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SWMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SWMR_OFFSET                   (0x4C)                                        /**<  (TWIHS_SWMR) SleepWalking Matching Register  Offset */
@@ -786,6 +816,7 @@ typedef union {
 
 /* -------- TWIHS_WPMR : (TWIHS Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -794,6 +825,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_WPMR_OFFSET                   (0xE4)                                        /**<  (TWIHS_WPMR) Write Protection Mode Register  Offset */
@@ -812,6 +844,7 @@ typedef union {
 
 /* -------- TWIHS_WPSR : (TWIHS Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -820,6 +853,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_WPSR_OFFSET                   (0xE8)                                        /**<  (TWIHS_WPSR) Write Protection Status Register  Offset */
@@ -843,7 +877,7 @@ typedef struct {
   __IO uint32_t TWIHS_SMR;      /**< (TWIHS Offset: 0x08) Slave Mode Register */
   __IO uint32_t TWIHS_IADR;     /**< (TWIHS Offset: 0x0C) Internal Address Register */
   __IO uint32_t TWIHS_CWGR;     /**< (TWIHS Offset: 0x10) Clock Waveform Generator Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __I  uint32_t TWIHS_SR;       /**< (TWIHS Offset: 0x20) Status Register */
   __O  uint32_t TWIHS_IER;      /**< (TWIHS Offset: 0x24) Interrupt Enable Register */
   __O  uint32_t TWIHS_IDR;      /**< (TWIHS Offset: 0x28) Interrupt Disable Register */
@@ -851,11 +885,11 @@ typedef struct {
   __I  uint32_t TWIHS_RHR;      /**< (TWIHS Offset: 0x30) Receive Holding Register */
   __O  uint32_t TWIHS_THR;      /**< (TWIHS Offset: 0x34) Transmit Holding Register */
   __IO uint32_t TWIHS_SMBTR;    /**< (TWIHS Offset: 0x38) SMBus Timing Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __IO uint32_t TWIHS_FILTR;    /**< (TWIHS Offset: 0x44) Filter Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __IO uint32_t TWIHS_SWMR;     /**< (TWIHS Offset: 0x4C) SleepWalking Matching Register */
-  RoReg8  Reserved4[0x94];
+  __I  uint8_t                        Reserved4[148];
   __IO uint32_t TWIHS_WPMR;     /**< (TWIHS Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t TWIHS_WPSR;     /**< (TWIHS Offset: 0xE8) Write Protection Status Register */
 } Twihs;
@@ -868,7 +902,7 @@ typedef struct {
   __IO TWIHS_SMR_Type                 TWIHS_SMR;      /**< Offset: 0x08 (R/W  32) Slave Mode Register */
   __IO TWIHS_IADR_Type                TWIHS_IADR;     /**< Offset: 0x0C (R/W  32) Internal Address Register */
   __IO TWIHS_CWGR_Type                TWIHS_CWGR;     /**< Offset: 0x10 (R/W  32) Clock Waveform Generator Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __I  TWIHS_SR_Type                  TWIHS_SR;       /**< Offset: 0x20 (R/   32) Status Register */
   __O  TWIHS_IER_Type                 TWIHS_IER;      /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
   __O  TWIHS_IDR_Type                 TWIHS_IDR;      /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
@@ -876,11 +910,11 @@ typedef struct {
   __I  TWIHS_RHR_Type                 TWIHS_RHR;      /**< Offset: 0x30 (R/   32) Receive Holding Register */
   __O  TWIHS_THR_Type                 TWIHS_THR;      /**< Offset: 0x34 ( /W  32) Transmit Holding Register */
   __IO TWIHS_SMBTR_Type               TWIHS_SMBTR;    /**< Offset: 0x38 (R/W  32) SMBus Timing Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __IO TWIHS_FILTR_Type               TWIHS_FILTR;    /**< Offset: 0x44 (R/W  32) Filter Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __IO TWIHS_SWMR_Type                TWIHS_SWMR;     /**< Offset: 0x4C (R/W  32) SleepWalking Matching Register */
-  __I  uint32_t                       Reserved4[37];
+  __I  uint8_t                        Reserved4[148];
   __IO TWIHS_WPMR_Type                TWIHS_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  TWIHS_WPSR_Type                TWIHS_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Twihs;

--- a/asf/sam/include/same70/component/uart.h
+++ b/asf/sam/include/same70/component/uart.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for UART
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- UART_CR : (UART Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -61,6 +64,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_CR_OFFSET                      (0x00)                                        /**<  (UART_CR) Control Register  Offset */
@@ -95,6 +99,7 @@ typedef union {
 
 /* -------- UART_MR : (UART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -108,6 +113,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_MR_OFFSET                      (0x04)                                        /**<  (UART_MR) Mode Register  Offset */
@@ -156,6 +162,7 @@ typedef union {
 
 /* -------- UART_IER : (UART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Enable RXRDY Interrupt                   */
@@ -172,6 +179,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IER_OFFSET                     (0x08)                                        /**<  (UART_IER) Interrupt Enable Register  Offset */
@@ -203,6 +211,7 @@ typedef union {
 
 /* -------- UART_IDR : (UART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Disable RXRDY Interrupt                  */
@@ -219,6 +228,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IDR_OFFSET                     (0x0C)                                        /**<  (UART_IDR) Interrupt Disable Register  Offset */
@@ -250,6 +260,7 @@ typedef union {
 
 /* -------- UART_IMR : (UART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Mask RXRDY Interrupt                     */
@@ -266,6 +277,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IMR_OFFSET                     (0x10)                                        /**<  (UART_IMR) Interrupt Mask Register  Offset */
@@ -297,6 +309,7 @@ typedef union {
 
 /* -------- UART_SR : (UART Offset: 0x14) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready                           */
@@ -313,6 +326,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_SR_OFFSET                      (0x14)                                        /**<  (UART_SR) Status Register  Offset */
@@ -344,6 +358,7 @@ typedef union {
 
 /* -------- UART_RHR : (UART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXCHR:8;                   /**< bit:   0..7  Received Character                       */
@@ -351,6 +366,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_RHR_OFFSET                     (0x18)                                        /**<  (UART_RHR) Receive Holding Register  Offset */
@@ -364,6 +380,7 @@ typedef union {
 
 /* -------- UART_THR : (UART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCHR:8;                   /**< bit:   0..7  Character to be Transmitted              */
@@ -371,6 +388,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_THR_OFFSET                     (0x1C)                                        /**<  (UART_THR) Transmit Holding Register  Offset */
@@ -384,6 +402,7 @@ typedef union {
 
 /* -------- UART_BRGR : (UART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CD:16;                     /**< bit:  0..15  Clock Divisor                            */
@@ -391,6 +410,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_BRGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_BRGR_OFFSET                    (0x20)                                        /**<  (UART_BRGR) Baud Rate Generator Register  Offset */
@@ -404,6 +424,7 @@ typedef union {
 
 /* -------- UART_CMPR : (UART Offset: 0x24) (R/W 32) Comparison Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VAL1:8;                    /**< bit:   0..7  First Comparison Value for Received Character */
@@ -417,6 +438,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_CMPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_CMPR_OFFSET                    (0x24)                                        /**<  (UART_CMPR) Comparison Register  Offset */
@@ -443,6 +465,7 @@ typedef union {
 
 /* -------- UART_WPMR : (UART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -451,6 +474,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_WPMR_OFFSET                    (0xE4)                                        /**<  (UART_WPMR) Write Protection Mode Register  Offset */
@@ -481,7 +505,7 @@ typedef struct {
   __O  uint32_t UART_THR;       /**< (UART Offset: 0x1C) Transmit Holding Register */
   __IO uint32_t UART_BRGR;      /**< (UART Offset: 0x20) Baud Rate Generator Register */
   __IO uint32_t UART_CMPR;      /**< (UART Offset: 0x24) Comparison Register */
-  RoReg8  Reserved1[0xBC];
+  __I  uint8_t                        Reserved1[188];
   __IO uint32_t UART_WPMR;      /**< (UART Offset: 0xE4) Write Protection Mode Register */
 } Uart;
 
@@ -498,7 +522,7 @@ typedef struct {
   __O  UART_THR_Type                  UART_THR;       /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
   __IO UART_BRGR_Type                 UART_BRGR;      /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
   __IO UART_CMPR_Type                 UART_CMPR;      /**< Offset: 0x24 (R/W  32) Comparison Register */
-  __I  uint32_t                       Reserved1[47];
+  __I  uint8_t                        Reserved1[188];
   __IO UART_WPMR_Type                 UART_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Uart;
 

--- a/asf/sam/include/same70/component/usart.h
+++ b/asf/sam/include/same70/component/usart.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for USART
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- US_CR : (USART Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -72,6 +75,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_CR_OFFSET                        (0x00)                                        /**<  (US_CR) Control Register  Offset */
@@ -142,6 +146,7 @@ typedef union {
 
 /* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USART_MODE:4;              /**< bit:   0..3  USART Mode of Operation                  */
@@ -166,8 +171,14 @@ typedef union {
     uint32_t MODSYNC:1;                 /**< bit:     30  Manchester Synchronization Mode          */
     uint32_t ONEBIT:1;                  /**< bit:     31  Start Frame Delimiter Selector           */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :17;                       /**< bit:  0..16  Reserved */
+    uint32_t MODE:1;                    /**< bit:     17  9-bit Character Length                   */
+    uint32_t :14;                       /**< bit: 18..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } US_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MR_OFFSET                        (0x04)                                        /**<  (US_MR) Mode Register  Offset */
@@ -297,9 +308,13 @@ typedef union {
 #define US_MR_MASK                          _U_(0xF7FFFFFF)                                /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
 #define US_MR_Msk                           _U_(0xF7FFFFFF)                                /**< (US_MR) Register Mask  */
 
+#define US_MR_MODE_Pos                      17                                             /**< (US_MR Position) 9-bit Character Length */
+#define US_MR_MODE_Msk                      (_U_(0x1) << US_MR_MODE_Pos)                   /**< (US_MR Mask) MODE */
+#define US_MR_MODE(value)                   (US_MR_MODE_Msk & ((value) << US_MR_MODE_Pos))  
 
 /* -------- US_IER : (USART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Enable                   */
@@ -325,6 +340,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IER_OFFSET                       (0x08)                                        /**<  (US_IER) Interrupt Enable Register  Offset */
@@ -380,6 +396,7 @@ typedef union {
 
 /* -------- US_IDR : (USART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Disable                  */
@@ -405,6 +422,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDR_OFFSET                       (0x0C)                                        /**<  (US_IDR) Interrupt Disable Register  Offset */
@@ -460,6 +478,7 @@ typedef union {
 
 /* -------- US_IMR : (USART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Mask                     */
@@ -485,6 +504,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IMR_OFFSET                       (0x10)                                        /**<  (US_IMR) Interrupt Mask Register  Offset */
@@ -540,6 +560,7 @@ typedef union {
 
 /* -------- US_CSR : (USART Offset: 0x14) (R/ 32) Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready (cleared by reading US_RHR) */
@@ -568,6 +589,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_CSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_CSR_OFFSET                       (0x14)                                        /**<  (US_CSR) Channel Status Register  Offset */
@@ -635,6 +657,7 @@ typedef union {
 
 /* -------- US_RHR : (USART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXCHR:9;                   /**< bit:   0..8  Received Character                       */
@@ -644,6 +667,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_RHR_OFFSET                       (0x18)                                        /**<  (US_RHR) Receive Holding Register  Offset */
@@ -660,6 +684,7 @@ typedef union {
 
 /* -------- US_THR : (USART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCHR:9;                   /**< bit:   0..8  Character to be Transmitted              */
@@ -669,6 +694,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_THR_OFFSET                       (0x1C)                                        /**<  (US_THR) Transmit Holding Register  Offset */
@@ -685,6 +711,7 @@ typedef union {
 
 /* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CD:16;                     /**< bit:  0..15  Clock Divider                            */
@@ -693,6 +720,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_BRGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_BRGR_OFFSET                      (0x20)                                        /**<  (US_BRGR) Baud Rate Generator Register  Offset */
@@ -709,6 +737,7 @@ typedef union {
 
 /* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Time-out Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TO:17;                     /**< bit:  0..16  Time-out Value                           */
@@ -716,6 +745,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_RTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_RTOR_OFFSET                      (0x24)                                        /**<  (US_RTOR) Receiver Time-out Register  Offset */
@@ -729,6 +759,7 @@ typedef union {
 
 /* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TG:8;                      /**< bit:   0..7  Timeguard Value                          */
@@ -736,6 +767,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_TTGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_TTGR_OFFSET                      (0x28)                                        /**<  (US_TTGR) Transmitter Timeguard Register  Offset */
@@ -749,6 +781,7 @@ typedef union {
 
 /* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FI_DI_RATIO:16;            /**< bit:  0..15  FI Over DI Ratio Value                   */
@@ -756,6 +789,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_FIDI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_FIDI_OFFSET                      (0x40)                                        /**<  (US_FIDI) FI DI Ratio Register  Offset */
@@ -769,6 +803,7 @@ typedef union {
 
 /* -------- US_NER : (USART Offset: 0x44) (R/ 32) Number of Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NB_ERRORS:8;               /**< bit:   0..7  Number of Errors                         */
@@ -776,6 +811,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_NER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_NER_OFFSET                       (0x44)                                        /**<  (US_NER) Number of Errors Register  Offset */
@@ -789,6 +825,7 @@ typedef union {
 
 /* -------- US_IF : (USART Offset: 0x4c) (R/W 32) IrDA Filter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IRDA_FILTER:8;             /**< bit:   0..7  IrDA Filter                              */
@@ -796,6 +833,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IF_OFFSET                        (0x4C)                                        /**<  (US_IF) IrDA Filter Register  Offset */
@@ -809,6 +847,7 @@ typedef union {
 
 /* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TX_PL:4;                   /**< bit:   0..3  Transmitter Preamble Length              */
@@ -828,6 +867,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_MAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MAN_OFFSET                       (0x50)                                        /**<  (US_MAN) Manchester Configuration Register  Offset */
@@ -881,6 +921,7 @@ typedef union {
 
 /* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NACT:2;                    /**< bit:   0..1  LIN Node Action                          */
@@ -897,6 +938,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINMR_OFFSET                     (0x54)                                        /**<  (US_LINMR) LIN Mode Register  Offset */
@@ -943,6 +985,7 @@ typedef union {
 
 /* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDCHR:8;                   /**< bit:   0..7  Identifier Character                     */
@@ -950,6 +993,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINIR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINIR_OFFSET                     (0x58)                                        /**<  (US_LINIR) LIN Identifier Register  Offset */
@@ -963,6 +1007,7 @@ typedef union {
 
 /* -------- US_LINBRR : (USART Offset: 0x5c) (R/ 32) LIN Baud Rate Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LINCD:16;                  /**< bit:  0..15  Clock Divider after Synchronization      */
@@ -971,6 +1016,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINBRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINBRR_OFFSET                    (0x5C)                                        /**<  (US_LINBRR) LIN Baud Rate Register  Offset */
@@ -987,6 +1033,7 @@ typedef union {
 
 /* -------- US_LONMR : (USART Offset: 0x60) (R/W 32) LON Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COMMT:1;                   /**< bit:      0  LON comm_type Parameter Value            */
@@ -1001,6 +1048,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONMR_OFFSET                     (0x60)                                        /**<  (US_LONMR) LON Mode Register  Offset */
@@ -1032,6 +1080,7 @@ typedef union {
 
 /* -------- US_LONPR : (USART Offset: 0x64) (R/W 32) LON Preamble Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONPL:14;                  /**< bit:  0..13  LON Preamble Length                      */
@@ -1039,6 +1088,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONPR_OFFSET                     (0x64)                                        /**<  (US_LONPR) LON Preamble Register  Offset */
@@ -1052,6 +1102,7 @@ typedef union {
 
 /* -------- US_LONDL : (USART Offset: 0x68) (R/W 32) LON Data Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONDL:8;                   /**< bit:   0..7  LON Data Length                          */
@@ -1059,6 +1110,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONDL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONDL_OFFSET                     (0x68)                                        /**<  (US_LONDL) LON Data Length Register  Offset */
@@ -1072,6 +1124,7 @@ typedef union {
 
 /* -------- US_LONL2HDR : (USART Offset: 0x6c) (R/W 32) LON L2HDR Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BLI:6;                     /**< bit:   0..5  LON Backlog Increment                    */
@@ -1081,6 +1134,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONL2HDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONL2HDR_OFFSET                  (0x6C)                                        /**<  (US_LONL2HDR) LON L2HDR Register  Offset */
@@ -1100,6 +1154,7 @@ typedef union {
 
 /* -------- US_LONBL : (USART Offset: 0x70) (R/ 32) LON Backlog Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONBL:6;                   /**< bit:   0..5  LON Node Backlog Value                   */
@@ -1107,6 +1162,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONBL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONBL_OFFSET                     (0x70)                                        /**<  (US_LONBL) LON Backlog Register  Offset */
@@ -1120,6 +1176,7 @@ typedef union {
 
 /* -------- US_LONB1TX : (USART Offset: 0x74) (R/W 32) LON Beta1 Tx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BETA1TX:24;                /**< bit:  0..23  LON Beta1 Length after Transmission      */
@@ -1127,6 +1184,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONB1TX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONB1TX_OFFSET                   (0x74)                                        /**<  (US_LONB1TX) LON Beta1 Tx Register  Offset */
@@ -1140,6 +1198,7 @@ typedef union {
 
 /* -------- US_LONB1RX : (USART Offset: 0x78) (R/W 32) LON Beta1 Rx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BETA1RX:24;                /**< bit:  0..23  LON Beta1 Length after Reception         */
@@ -1147,6 +1206,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONB1RX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONB1RX_OFFSET                   (0x78)                                        /**<  (US_LONB1RX) LON Beta1 Rx Register  Offset */
@@ -1160,6 +1220,7 @@ typedef union {
 
 /* -------- US_LONPRIO : (USART Offset: 0x7c) (R/W 32) LON Priority Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PSNB:7;                    /**< bit:   0..6  LON Priority Slot Number                 */
@@ -1169,6 +1230,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONPRIO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONPRIO_OFFSET                   (0x7C)                                        /**<  (US_LONPRIO) LON Priority Register  Offset */
@@ -1185,6 +1247,7 @@ typedef union {
 
 /* -------- US_IDTTX : (USART Offset: 0x80) (R/W 32) LON IDT Tx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDTTX:24;                  /**< bit:  0..23  LON Indeterminate Time after Transmission (comm_type = 1 mode only) */
@@ -1192,6 +1255,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDTTX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDTTX_OFFSET                     (0x80)                                        /**<  (US_IDTTX) LON IDT Tx Register  Offset */
@@ -1205,6 +1269,7 @@ typedef union {
 
 /* -------- US_IDTRX : (USART Offset: 0x84) (R/W 32) LON IDT Rx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDTRX:24;                  /**< bit:  0..23  LON Indeterminate Time after Reception (comm_type = 1 mode only) */
@@ -1212,6 +1277,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDTRX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDTRX_OFFSET                     (0x84)                                        /**<  (US_IDTRX) LON IDT Rx Register  Offset */
@@ -1225,6 +1291,7 @@ typedef union {
 
 /* -------- US_ICDIFF : (USART Offset: 0x88) (R/W 32) IC DIFF Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ICDIFF:4;                  /**< bit:   0..3  IC Differentiator Number                 */
@@ -1232,6 +1299,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_ICDIFF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_ICDIFF_OFFSET                    (0x88)                                        /**<  (US_ICDIFF) IC DIFF Register  Offset */
@@ -1245,6 +1313,7 @@ typedef union {
 
 /* -------- US_WPMR : (USART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1253,6 +1322,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPMR_OFFSET                      (0xE4)                                        /**<  (US_WPMR) Write Protection Mode Register  Offset */
@@ -1271,6 +1341,7 @@ typedef union {
 
 /* -------- US_WPSR : (USART Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1280,6 +1351,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPSR_OFFSET                      (0xE8)                                        /**<  (US_WPSR) Write Protection Status Register  Offset */
@@ -1309,10 +1381,10 @@ typedef struct {
   __IO uint32_t US_BRGR;        /**< (USART Offset: 0x20) Baud Rate Generator Register */
   __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Time-out Register */
   __IO uint32_t US_TTGR;        /**< (USART Offset: 0x28) Transmitter Timeguard Register */
-  RoReg8  Reserved1[0x14];
+  __I  uint8_t                        Reserved1[20];
   __IO uint32_t US_FIDI;        /**< (USART Offset: 0x40) FI DI Ratio Register */
   __I  uint32_t US_NER;         /**< (USART Offset: 0x44) Number of Errors Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t US_IF;          /**< (USART Offset: 0x4C) IrDA Filter Register */
   __IO uint32_t US_MAN;         /**< (USART Offset: 0x50) Manchester Configuration Register */
   __IO uint32_t US_LINMR;       /**< (USART Offset: 0x54) LIN Mode Register */
@@ -1329,7 +1401,7 @@ typedef struct {
   __IO uint32_t US_IDTTX;       /**< (USART Offset: 0x80) LON IDT Tx Register */
   __IO uint32_t US_IDTRX;       /**< (USART Offset: 0x84) LON IDT Rx Register */
   __IO uint32_t US_ICDIFF;      /**< (USART Offset: 0x88) IC DIFF Register */
-  RoReg8  Reserved3[0x58];
+  __I  uint8_t                        Reserved3[88];
   __IO uint32_t US_WPMR;        /**< (USART Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t US_WPSR;        /**< (USART Offset: 0xE8) Write Protection Status Register */
 } Usart;
@@ -1348,10 +1420,10 @@ typedef struct {
   __IO US_BRGR_Type                   US_BRGR;        /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
   __IO US_RTOR_Type                   US_RTOR;        /**< Offset: 0x24 (R/W  32) Receiver Time-out Register */
   __IO US_TTGR_Type                   US_TTGR;        /**< Offset: 0x28 (R/W  32) Transmitter Timeguard Register */
-  __I  uint32_t                       Reserved1[5];
+  __I  uint8_t                        Reserved1[20];
   __IO US_FIDI_Type                   US_FIDI;        /**< Offset: 0x40 (R/W  32) FI DI Ratio Register */
   __I  US_NER_Type                    US_NER;         /**< Offset: 0x44 (R/   32) Number of Errors Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO US_IF_Type                     US_IF;          /**< Offset: 0x4C (R/W  32) IrDA Filter Register */
   __IO US_MAN_Type                    US_MAN;         /**< Offset: 0x50 (R/W  32) Manchester Configuration Register */
   __IO US_LINMR_Type                  US_LINMR;       /**< Offset: 0x54 (R/W  32) LIN Mode Register */
@@ -1368,7 +1440,7 @@ typedef struct {
   __IO US_IDTTX_Type                  US_IDTTX;       /**< Offset: 0x80 (R/W  32) LON IDT Tx Register */
   __IO US_IDTRX_Type                  US_IDTRX;       /**< Offset: 0x84 (R/W  32) LON IDT Rx Register */
   __IO US_ICDIFF_Type                 US_ICDIFF;      /**< Offset: 0x88 (R/W  32) IC DIFF Register */
-  __I  uint32_t                       Reserved3[22];
+  __I  uint8_t                        Reserved3[88];
   __IO US_WPMR_Type                   US_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  US_WPSR_Type                   US_WPSR;        /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Usart;

--- a/asf/sam/include/same70/component/usbhs.h
+++ b/asf/sam/include/same70/component/usbhs.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for USBHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,12 +47,14 @@
 
 /* -------- USBHS_DEVDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Device DMA Channel Next Descriptor Address Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMANXTDSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_DEVDMANXTDSC) Device DMA Channel Next Descriptor Address Register (n = 1)  Offset */
@@ -64,12 +68,14 @@ typedef union {
 
 /* -------- USBHS_DEVDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Device DMA Channel Address Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMAADDRESS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_DEVDMAADDRESS) Device DMA Channel Address Register (n = 1)  Offset */
@@ -83,6 +89,7 @@ typedef union {
 
 /* -------- USBHS_DEVDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Device DMA Channel Control Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
@@ -98,6 +105,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMACONTROL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_DEVDMACONTROL) Device DMA Channel Control Register (n = 1)  Offset */
@@ -135,6 +143,7 @@ typedef union {
 
 /* -------- USBHS_DEVDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Device DMA Channel Status Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
@@ -148,6 +157,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMASTATUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_DEVDMASTATUS) Device DMA Channel Status Register (n = 1)  Offset */
@@ -176,12 +186,14 @@ typedef union {
 
 /* -------- USBHS_HSTDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Host DMA Channel Next Descriptor Address Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMANXTDSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_HSTDMANXTDSC) Host DMA Channel Next Descriptor Address Register (n = 1)  Offset */
@@ -195,12 +207,14 @@ typedef union {
 
 /* -------- USBHS_HSTDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Host DMA Channel Address Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMAADDRESS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_HSTDMAADDRESS) Host DMA Channel Address Register (n = 1)  Offset */
@@ -214,6 +228,7 @@ typedef union {
 
 /* -------- USBHS_HSTDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Host DMA Channel Control Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
@@ -229,6 +244,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMACONTROL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_HSTDMACONTROL) Host DMA Channel Control Register (n = 1)  Offset */
@@ -266,6 +282,7 @@ typedef union {
 
 /* -------- USBHS_HSTDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Host DMA Channel Status Register (n = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
@@ -279,6 +296,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMASTATUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_HSTDMASTATUS) Host DMA Channel Status Register (n = 1)  Offset */
@@ -307,6 +325,7 @@ typedef union {
 
 /* -------- USBHS_DEVCTRL : (USBHS Offset: 0x00) (R/W 32) Device General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UADD:7;                    /**< bit:   0..6  USB Address                              */
@@ -321,8 +340,14 @@ typedef union {
     uint32_t OPMODE2:1;                 /**< bit:     16  Specific Operational mode                */
     uint32_t :15;                       /**< bit: 17..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t OPMODE:1;                  /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVCTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVCTRL_OFFSET                (0x00)                                        /**<  (USBHS_DEVCTRL) Device General Control Register  Offset */
@@ -364,9 +389,13 @@ typedef union {
 #define USBHS_DEVCTRL_MASK                  _U_(0x1FFFF)                                   /**< \deprecated (USBHS_DEVCTRL) Register MASK  (Use USBHS_DEVCTRL_Msk instead)  */
 #define USBHS_DEVCTRL_Msk                   _U_(0x1FFFF)                                   /**< (USBHS_DEVCTRL) Register Mask  */
 
+#define USBHS_DEVCTRL_OPMODE_Pos            16                                             /**< (USBHS_DEVCTRL Position) Specific Operational mode */
+#define USBHS_DEVCTRL_OPMODE_Msk            (_U_(0x1) << USBHS_DEVCTRL_OPMODE_Pos)         /**< (USBHS_DEVCTRL Mask) OPMODE */
+#define USBHS_DEVCTRL_OPMODE(value)         (USBHS_DEVCTRL_OPMODE_Msk & ((value) << USBHS_DEVCTRL_OPMODE_Pos))  
 
 /* -------- USBHS_DEVISR : (USBHS Offset: 0x04) (R/ 32) Device Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSP:1;                    /**< bit:      0  Suspend Interrupt                        */
@@ -406,6 +435,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVISR_OFFSET                 (0x04)                                        /**<  (USBHS_DEVISR) Device Global Interrupt Status Register  Offset */
@@ -500,6 +530,7 @@ typedef union {
 
 /* -------- USBHS_DEVICR : (USBHS Offset: 0x08) (/W 32) Device Global Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPC:1;                   /**< bit:      0  Suspend Interrupt Clear                  */
@@ -513,6 +544,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVICR_OFFSET                 (0x08)                                        /**<  (USBHS_DEVICR) Device Global Interrupt Clear Register  Offset */
@@ -544,6 +576,7 @@ typedef union {
 
 /* -------- USBHS_DEVIFR : (USBHS Offset: 0x0c) (/W 32) Device Global Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPS:1;                   /**< bit:      0  Suspend Interrupt Set                    */
@@ -568,6 +601,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIFR_OFFSET                 (0x0C)                                        /**<  (USBHS_DEVIFR) Device Global Interrupt Set Register  Offset */
@@ -623,6 +657,7 @@ typedef union {
 
 /* -------- USBHS_DEVIMR : (USBHS Offset: 0x10) (R/ 32) Device Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPE:1;                   /**< bit:      0  Suspend Interrupt Mask                   */
@@ -662,6 +697,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIMR_OFFSET                 (0x10)                                        /**<  (USBHS_DEVIMR) Device Global Interrupt Mask Register  Offset */
@@ -756,6 +792,7 @@ typedef union {
 
 /* -------- USBHS_DEVIDR : (USBHS Offset: 0x14) (/W 32) Device Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPEC:1;                  /**< bit:      0  Suspend Interrupt Disable                */
@@ -795,6 +832,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIDR_OFFSET                 (0x14)                                        /**<  (USBHS_DEVIDR) Device Global Interrupt Disable Register  Offset */
@@ -889,6 +927,7 @@ typedef union {
 
 /* -------- USBHS_DEVIER : (USBHS Offset: 0x18) (/W 32) Device Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPES:1;                  /**< bit:      0  Suspend Interrupt Enable                 */
@@ -928,6 +967,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIER_OFFSET                 (0x18)                                        /**<  (USBHS_DEVIER) Device Global Interrupt Enable Register  Offset */
@@ -1022,6 +1062,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPT : (USBHS Offset: 0x1c) (R/W 32) Device Endpoint Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EPEN0:1;                   /**< bit:      0  Endpoint 0 Enable                        */
@@ -1055,6 +1096,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPT_OFFSET                 (0x1C)                                        /**<  (USBHS_DEVEPT) Device Endpoint Register  Offset */
@@ -1131,6 +1173,7 @@ typedef union {
 
 /* -------- USBHS_DEVFNUM : (USBHS Offset: 0x20) (R/ 32) Device Frame Number Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
@@ -1141,6 +1184,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVFNUM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVFNUM_OFFSET                (0x20)                                        /**<  (USBHS_DEVFNUM) Device Frame Number Register  Offset */
@@ -1160,6 +1204,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTCFG : (USBHS Offset: 0x100) (R/W 32) Device Endpoint Configuration Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -1176,6 +1221,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTCFG_OFFSET              (0x100)                                       /**<  (USBHS_DEVEPTCFG) Device Endpoint Configuration Register (n = 0) 0  Offset */
@@ -1249,6 +1295,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTISR : (USBHS Offset: 0x130) (R/ 32) Device Endpoint Status Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINI:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
@@ -1272,6 +1319,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTISR_OFFSET              (0x130)                                       /**<  (USBHS_DEVEPTISR) Device Endpoint Status Register (n = 0) 0  Offset */
@@ -1349,6 +1397,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTICR : (USBHS Offset: 0x160) (/W 32) Device Endpoint Clear Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINIC:1;                  /**< bit:      0  Transmitted IN Data Interrupt Clear      */
@@ -1363,6 +1412,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTICR_OFFSET              (0x160)                                       /**<  (USBHS_DEVEPTICR) Device Endpoint Clear Register (n = 0) 0  Offset */
@@ -1397,6 +1447,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTIFR : (USBHS Offset: 0x190) (/W 32) Device Endpoint Set Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINIS:1;                  /**< bit:      0  Transmitted IN Data Interrupt Set        */
@@ -1413,6 +1464,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTIFR_OFFSET              (0x190)                                       /**<  (USBHS_DEVEPTIFR) Device Endpoint Set Register (n = 0) 0  Offset */
@@ -1450,6 +1502,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTIMR : (USBHS Offset: 0x1c0) (R/ 32) Device Endpoint Mask Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINE:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
@@ -1473,6 +1526,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTIMR_OFFSET              (0x1C0)                                       /**<  (USBHS_DEVEPTIMR) Device Endpoint Mask Register (n = 0) 0  Offset */
@@ -1528,6 +1582,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTIER : (USBHS Offset: 0x1f0) (/W 32) Device Endpoint Enable Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINES:1;                  /**< bit:      0  Transmitted IN Data Interrupt Enable     */
@@ -1551,6 +1606,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTIER_OFFSET              (0x1F0)                                       /**<  (USBHS_DEVEPTIER) Device Endpoint Enable Register (n = 0) 0  Offset */
@@ -1606,6 +1662,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPTIDR : (USBHS Offset: 0x220) (/W 32) Device Endpoint Disable Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINEC:1;                  /**< bit:      0  Transmitted IN Interrupt Clear           */
@@ -1629,6 +1686,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPTIDR_OFFSET              (0x220)                                       /**<  (USBHS_DEVEPTIDR) Device Endpoint Disable Register (n = 0) 0  Offset */
@@ -1678,6 +1736,7 @@ typedef union {
 
 /* -------- USBHS_HSTCTRL : (USBHS Offset: 0x400) (R/W 32) Host General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
@@ -1690,6 +1749,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTCTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTCTRL_OFFSET                (0x400)                                       /**<  (USBHS_HSTCTRL) Host General Control Register  Offset */
@@ -1716,6 +1776,7 @@ typedef union {
 
 /* -------- USBHS_HSTISR : (USBHS Offset: 0x404) (R/ 32) Host Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNI:1;                  /**< bit:      0  Device Connection Interrupt              */
@@ -1755,6 +1816,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTISR_OFFSET                 (0x404)                                       /**<  (USBHS_HSTISR) Host Global Interrupt Status Register  Offset */
@@ -1849,6 +1911,7 @@ typedef union {
 
 /* -------- USBHS_HSTICR : (USBHS Offset: 0x408) (/W 32) Host Global Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIC:1;                 /**< bit:      0  Device Connection Interrupt Clear        */
@@ -1862,6 +1925,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTICR_OFFSET                 (0x408)                                       /**<  (USBHS_HSTICR) Host Global Interrupt Clear Register  Offset */
@@ -1893,6 +1957,7 @@ typedef union {
 
 /* -------- USBHS_HSTIFR : (USBHS Offset: 0x40c) (/W 32) Host Global Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIS:1;                 /**< bit:      0  Device Connection Interrupt Set          */
@@ -1917,6 +1982,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIFR_OFFSET                 (0x40C)                                       /**<  (USBHS_HSTIFR) Host Global Interrupt Set Register  Offset */
@@ -1972,6 +2038,7 @@ typedef union {
 
 /* -------- USBHS_HSTIMR : (USBHS Offset: 0x410) (R/ 32) Host Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIE:1;                 /**< bit:      0  Device Connection Interrupt Enable       */
@@ -2011,6 +2078,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIMR_OFFSET                 (0x410)                                       /**<  (USBHS_HSTIMR) Host Global Interrupt Mask Register  Offset */
@@ -2105,6 +2173,7 @@ typedef union {
 
 /* -------- USBHS_HSTIDR : (USBHS Offset: 0x414) (/W 32) Host Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIEC:1;                /**< bit:      0  Device Connection Interrupt Disable      */
@@ -2144,6 +2213,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIDR_OFFSET                 (0x414)                                       /**<  (USBHS_HSTIDR) Host Global Interrupt Disable Register  Offset */
@@ -2238,6 +2308,7 @@ typedef union {
 
 /* -------- USBHS_HSTIER : (USBHS Offset: 0x418) (/W 32) Host Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIES:1;                /**< bit:      0  Device Connection Interrupt Enable       */
@@ -2277,6 +2348,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIER_OFFSET                 (0x418)                                       /**<  (USBHS_HSTIER) Host Global Interrupt Enable Register  Offset */
@@ -2371,6 +2443,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIP : (USBHS Offset: 0x41c) (R/W 32) Host Pipe Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PEN0:1;                    /**< bit:      0  Pipe 0 Enable                            */
@@ -2402,6 +2475,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIP_OFFSET                 (0x41C)                                       /**<  (USBHS_HSTPIP) Host Pipe Register  Offset */
@@ -2472,6 +2546,7 @@ typedef union {
 
 /* -------- USBHS_HSTFNUM : (USBHS Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
@@ -2482,6 +2557,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTFNUM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTFNUM_OFFSET                (0x420)                                       /**<  (USBHS_HSTFNUM) Host Frame Number Register  Offset */
@@ -2501,6 +2577,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR1 : (USBHS Offset: 0x424) (R/W 32) Host Address 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP0:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2514,6 +2591,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR1_OFFSET               (0x424)                                       /**<  (USBHS_HSTADDR1) Host Address 1 Register  Offset */
@@ -2536,6 +2614,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR2 : (USBHS Offset: 0x428) (R/W 32) Host Address 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP4:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2549,6 +2628,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR2_OFFSET               (0x428)                                       /**<  (USBHS_HSTADDR2) Host Address 2 Register  Offset */
@@ -2571,6 +2651,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR3 : (USBHS Offset: 0x42c) (R/W 32) Host Address 3 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP8:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2580,6 +2661,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR3_OFFSET               (0x42C)                                       /**<  (USBHS_HSTADDR3) Host Address 3 Register  Offset */
@@ -2596,6 +2678,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPCFG : (USBHS Offset: 0x500) (R/W 32) Host Pipe Configuration Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -2614,6 +2697,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPCFG_OFFSET              (0x500)                                       /**<  (USBHS_HSTPIPCFG) Host Pipe Configuration Register (n = 0) 0  Offset */
@@ -2684,6 +2768,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPISR : (USBHS Offset: 0x530) (R/ 32) Host Pipe Status Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINI:1;                   /**< bit:      0  Received IN Data Interrupt               */
@@ -2707,6 +2792,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPISR_OFFSET              (0x530)                                       /**<  (USBHS_HSTPIPISR) Host Pipe Status Register (n = 0) 0  Offset */
@@ -2777,6 +2863,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPICR : (USBHS Offset: 0x560) (/W 32) Host Pipe Clear Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINIC:1;                  /**< bit:      0  Received IN Data Interrupt Clear         */
@@ -2791,6 +2878,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPICR_OFFSET              (0x560)                                       /**<  (USBHS_HSTPIPICR) Host Pipe Clear Register (n = 0) 0  Offset */
@@ -2822,6 +2910,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPIFR : (USBHS Offset: 0x590) (/W 32) Host Pipe Set Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINIS:1;                  /**< bit:      0  Received IN Data Interrupt Set           */
@@ -2838,6 +2927,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPIFR_OFFSET              (0x590)                                       /**<  (USBHS_HSTPIPIFR) Host Pipe Set Register (n = 0) 0  Offset */
@@ -2875,6 +2965,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPIMR : (USBHS Offset: 0x5c0) (R/ 32) Host Pipe Mask Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINE:1;                   /**< bit:      0  Received IN Data Interrupt Enable        */
@@ -2897,6 +2988,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPIMR_OFFSET              (0x5C0)                                       /**<  (USBHS_HSTPIPIMR) Host Pipe Mask Register (n = 0) 0  Offset */
@@ -2946,6 +3038,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPIER : (USBHS Offset: 0x5f0) (/W 32) Host Pipe Enable Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINES:1;                  /**< bit:      0  Received IN Data Interrupt Enable        */
@@ -2966,6 +3059,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPIER_OFFSET              (0x5F0)                                       /**<  (USBHS_HSTPIPIER) Host Pipe Enable Register (n = 0) 0  Offset */
@@ -3012,6 +3106,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPIDR : (USBHS Offset: 0x620) (/W 32) Host Pipe Disable Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINEC:1;                  /**< bit:      0  Received IN Data Interrupt Disable       */
@@ -3033,6 +3128,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPIDR_OFFSET              (0x620)                                       /**<  (USBHS_HSTPIPIDR) Host Pipe Disable Register (n = 0) 0  Offset */
@@ -3079,6 +3175,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPINRQ : (USBHS Offset: 0x650) (R/W 32) Host Pipe IN Request Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INRQ:8;                    /**< bit:   0..7  IN Request Number before Freeze          */
@@ -3087,6 +3184,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPINRQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPINRQ_OFFSET             (0x650)                                       /**<  (USBHS_HSTPIPINRQ) Host Pipe IN Request Register (n = 0) 0  Offset */
@@ -3103,6 +3201,7 @@ typedef union {
 
 /* -------- USBHS_HSTPIPERR : (USBHS Offset: 0x680) (R/W 32) Host Pipe Error Register (n = 0) 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATATGL:1;                 /**< bit:      0  Data Toggle Error                        */
@@ -3113,8 +3212,14 @@ typedef union {
     uint32_t COUNTER:2;                 /**< bit:   5..6  Error Counter                            */
     uint32_t :25;                       /**< bit:  7..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CRC:1;                     /**< bit:      4  CRCx6 Error                              */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPERR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIPERR_OFFSET              (0x680)                                       /**<  (USBHS_HSTPIPERR) Host Pipe Error Register (n = 0) 0  Offset */
@@ -3140,9 +3245,13 @@ typedef union {
 #define USBHS_HSTPIPERR_MASK                _U_(0x7F)                                      /**< \deprecated (USBHS_HSTPIPERR) Register MASK  (Use USBHS_HSTPIPERR_Msk instead)  */
 #define USBHS_HSTPIPERR_Msk                 _U_(0x7F)                                      /**< (USBHS_HSTPIPERR) Register Mask  */
 
+#define USBHS_HSTPIPERR_CRC_Pos             4                                              /**< (USBHS_HSTPIPERR Position) CRCx6 Error */
+#define USBHS_HSTPIPERR_CRC_Msk             (_U_(0x1) << USBHS_HSTPIPERR_CRC_Pos)          /**< (USBHS_HSTPIPERR Mask) CRC */
+#define USBHS_HSTPIPERR_CRC(value)          (USBHS_HSTPIPERR_CRC_Msk & ((value) << USBHS_HSTPIPERR_CRC_Pos))  
 
 /* -------- USBHS_CTRL : (USBHS Offset: 0x800) (R/W 32) General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3158,6 +3267,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_CTRL_OFFSET                   (0x800)                                       /**<  (USBHS_CTRL) General Control Register  Offset */
@@ -3187,6 +3297,7 @@ typedef union {
 
 /* -------- USBHS_SR : (USBHS Offset: 0x804) (R/ 32) General Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3198,6 +3309,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SR_OFFSET                     (0x804)                                       /**<  (USBHS_SR) General Status Register  Offset */
@@ -3223,6 +3335,7 @@ typedef union {
 
 /* -------- USBHS_SCR : (USBHS Offset: 0x808) (/W 32) General Status Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3231,6 +3344,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SCR_OFFSET                    (0x808)                                       /**<  (USBHS_SCR) General Status Clear Register  Offset */
@@ -3244,6 +3358,7 @@ typedef union {
 
 /* -------- USBHS_SFR : (USBHS Offset: 0x80c) (/W 32) General Status Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3254,6 +3369,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SFR_OFFSET                    (0x80C)                                       /**<  (USBHS_SFR) General Status Set Register  Offset */
@@ -3299,23 +3415,23 @@ typedef struct {
   __O  uint32_t USBHS_DEVIER;   /**< (USBHS Offset: 0x18) Device Global Interrupt Enable Register */
   __IO uint32_t USBHS_DEVEPT;   /**< (USBHS Offset: 0x1C) Device Endpoint Register */
   __I  uint32_t USBHS_DEVFNUM;  /**< (USBHS Offset: 0x20) Device Frame Number Register */
-  RoReg8  Reserved1[0xDC];
+  __I  uint8_t                        Reserved1[220];
   __IO uint32_t USBHS_DEVEPTCFG[10]; /**< (USBHS Offset: 0x100) Device Endpoint Configuration Register (n = 0) 0 */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __I  uint32_t USBHS_DEVEPTISR[10]; /**< (USBHS Offset: 0x130) Device Endpoint Status Register (n = 0) 0 */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __O  uint32_t USBHS_DEVEPTICR[10]; /**< (USBHS Offset: 0x160) Device Endpoint Clear Register (n = 0) 0 */
-  RoReg8  Reserved4[0x8];
+  __I  uint8_t                        Reserved4[8];
   __O  uint32_t USBHS_DEVEPTIFR[10]; /**< (USBHS Offset: 0x190) Device Endpoint Set Register (n = 0) 0 */
-  RoReg8  Reserved5[0x8];
+  __I  uint8_t                        Reserved5[8];
   __I  uint32_t USBHS_DEVEPTIMR[10]; /**< (USBHS Offset: 0x1C0) Device Endpoint Mask Register (n = 0) 0 */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __O  uint32_t USBHS_DEVEPTIER[10]; /**< (USBHS Offset: 0x1F0) Device Endpoint Enable Register (n = 0) 0 */
-  RoReg8  Reserved7[0x8];
+  __I  uint8_t                        Reserved7[8];
   __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Disable Register (n = 0) 0 */
-  RoReg8  Reserved8[0xC8];
-       UsbhsDevdma USBHS_DEVDMA[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
-  RoReg8  Reserved9[0x80];
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved9[128];
   __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
   __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
   __O  uint32_t USBHS_HSTICR;   /**< (USBHS Offset: 0x408) Host Global Interrupt Clear Register */
@@ -3328,27 +3444,27 @@ typedef struct {
   __IO uint32_t USBHS_HSTADDR1; /**< (USBHS Offset: 0x424) Host Address 1 Register */
   __IO uint32_t USBHS_HSTADDR2; /**< (USBHS Offset: 0x428) Host Address 2 Register */
   __IO uint32_t USBHS_HSTADDR3; /**< (USBHS Offset: 0x42C) Host Address 3 Register */
-  RoReg8  Reserved10[0xD0];
+  __I  uint8_t                        Reserved10[208];
   __IO uint32_t USBHS_HSTPIPCFG[10]; /**< (USBHS Offset: 0x500) Host Pipe Configuration Register (n = 0) 0 */
-  RoReg8  Reserved11[0x8];
+  __I  uint8_t                        Reserved11[8];
   __I  uint32_t USBHS_HSTPIPISR[10]; /**< (USBHS Offset: 0x530) Host Pipe Status Register (n = 0) 0 */
-  RoReg8  Reserved12[0x8];
+  __I  uint8_t                        Reserved12[8];
   __O  uint32_t USBHS_HSTPIPICR[10]; /**< (USBHS Offset: 0x560) Host Pipe Clear Register (n = 0) 0 */
-  RoReg8  Reserved13[0x8];
+  __I  uint8_t                        Reserved13[8];
   __O  uint32_t USBHS_HSTPIPIFR[10]; /**< (USBHS Offset: 0x590) Host Pipe Set Register (n = 0) 0 */
-  RoReg8  Reserved14[0x8];
+  __I  uint8_t                        Reserved14[8];
   __I  uint32_t USBHS_HSTPIPIMR[10]; /**< (USBHS Offset: 0x5C0) Host Pipe Mask Register (n = 0) 0 */
-  RoReg8  Reserved15[0x8];
+  __I  uint8_t                        Reserved15[8];
   __O  uint32_t USBHS_HSTPIPIER[10]; /**< (USBHS Offset: 0x5F0) Host Pipe Enable Register (n = 0) 0 */
-  RoReg8  Reserved16[0x8];
+  __I  uint8_t                        Reserved16[8];
   __O  uint32_t USBHS_HSTPIPIDR[10]; /**< (USBHS Offset: 0x620) Host Pipe Disable Register (n = 0) 0 */
-  RoReg8  Reserved17[0x8];
+  __I  uint8_t                        Reserved17[8];
   __IO uint32_t USBHS_HSTPIPINRQ[10]; /**< (USBHS Offset: 0x650) Host Pipe IN Request Register (n = 0) 0 */
-  RoReg8  Reserved18[0x8];
+  __I  uint8_t                        Reserved18[8];
   __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register (n = 0) 0 */
-  RoReg8  Reserved19[0x68];
-       UsbhsHstdma USBHS_HSTDMA[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
-  RoReg8  Reserved20[0x80];
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved20[128];
   __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
   __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
   __O  uint32_t USBHS_SCR;      /**< (USBHS Offset: 0x808) General Status Clear Register */
@@ -3383,23 +3499,23 @@ typedef struct {
   __O  USBHS_DEVIER_Type              USBHS_DEVIER;   /**< Offset: 0x18 ( /W  32) Device Global Interrupt Enable Register */
   __IO USBHS_DEVEPT_Type              USBHS_DEVEPT;   /**< Offset: 0x1C (R/W  32) Device Endpoint Register */
   __I  USBHS_DEVFNUM_Type             USBHS_DEVFNUM;  /**< Offset: 0x20 (R/   32) Device Frame Number Register */
-  __I  uint32_t                       Reserved1[55];
+  __I  uint8_t                        Reserved1[220];
   __IO USBHS_DEVEPTCFG_Type           USBHS_DEVEPTCFG[10]; /**< Offset: 0x100 (R/W  32) Device Endpoint Configuration Register (n = 0) 0 */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __I  USBHS_DEVEPTISR_Type           USBHS_DEVEPTISR[10]; /**< Offset: 0x130 (R/   32) Device Endpoint Status Register (n = 0) 0 */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __O  USBHS_DEVEPTICR_Type           USBHS_DEVEPTICR[10]; /**< Offset: 0x160 ( /W  32) Device Endpoint Clear Register (n = 0) 0 */
-  __I  uint32_t                       Reserved4[2];
+  __I  uint8_t                        Reserved4[8];
   __O  USBHS_DEVEPTIFR_Type           USBHS_DEVEPTIFR[10]; /**< Offset: 0x190 ( /W  32) Device Endpoint Set Register (n = 0) 0 */
-  __I  uint32_t                       Reserved5[2];
+  __I  uint8_t                        Reserved5[8];
   __I  USBHS_DEVEPTIMR_Type           USBHS_DEVEPTIMR[10]; /**< Offset: 0x1C0 (R/   32) Device Endpoint Mask Register (n = 0) 0 */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __O  USBHS_DEVEPTIER_Type           USBHS_DEVEPTIER[10]; /**< Offset: 0x1F0 ( /W  32) Device Endpoint Enable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved7[2];
+  __I  uint8_t                        Reserved7[8];
   __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Disable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved8[50];
-       UsbhsDevdma                    USBHS_DEVDMA[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
-  __I  uint32_t                       Reserved9[32];
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved9[128];
   __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
   __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */
   __O  USBHS_HSTICR_Type              USBHS_HSTICR;   /**< Offset: 0x408 ( /W  32) Host Global Interrupt Clear Register */
@@ -3412,27 +3528,27 @@ typedef struct {
   __IO USBHS_HSTADDR1_Type            USBHS_HSTADDR1; /**< Offset: 0x424 (R/W  32) Host Address 1 Register */
   __IO USBHS_HSTADDR2_Type            USBHS_HSTADDR2; /**< Offset: 0x428 (R/W  32) Host Address 2 Register */
   __IO USBHS_HSTADDR3_Type            USBHS_HSTADDR3; /**< Offset: 0x42C (R/W  32) Host Address 3 Register */
-  __I  uint32_t                       Reserved10[52];
+  __I  uint8_t                        Reserved10[208];
   __IO USBHS_HSTPIPCFG_Type           USBHS_HSTPIPCFG[10]; /**< Offset: 0x500 (R/W  32) Host Pipe Configuration Register (n = 0) 0 */
-  __I  uint32_t                       Reserved11[2];
+  __I  uint8_t                        Reserved11[8];
   __I  USBHS_HSTPIPISR_Type           USBHS_HSTPIPISR[10]; /**< Offset: 0x530 (R/   32) Host Pipe Status Register (n = 0) 0 */
-  __I  uint32_t                       Reserved12[2];
+  __I  uint8_t                        Reserved12[8];
   __O  USBHS_HSTPIPICR_Type           USBHS_HSTPIPICR[10]; /**< Offset: 0x560 ( /W  32) Host Pipe Clear Register (n = 0) 0 */
-  __I  uint32_t                       Reserved13[2];
+  __I  uint8_t                        Reserved13[8];
   __O  USBHS_HSTPIPIFR_Type           USBHS_HSTPIPIFR[10]; /**< Offset: 0x590 ( /W  32) Host Pipe Set Register (n = 0) 0 */
-  __I  uint32_t                       Reserved14[2];
+  __I  uint8_t                        Reserved14[8];
   __I  USBHS_HSTPIPIMR_Type           USBHS_HSTPIPIMR[10]; /**< Offset: 0x5C0 (R/   32) Host Pipe Mask Register (n = 0) 0 */
-  __I  uint32_t                       Reserved15[2];
+  __I  uint8_t                        Reserved15[8];
   __O  USBHS_HSTPIPIER_Type           USBHS_HSTPIPIER[10]; /**< Offset: 0x5F0 ( /W  32) Host Pipe Enable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved16[2];
+  __I  uint8_t                        Reserved16[8];
   __O  USBHS_HSTPIPIDR_Type           USBHS_HSTPIPIDR[10]; /**< Offset: 0x620 ( /W  32) Host Pipe Disable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved17[2];
+  __I  uint8_t                        Reserved17[8];
   __IO USBHS_HSTPIPINRQ_Type          USBHS_HSTPIPINRQ[10]; /**< Offset: 0x650 (R/W  32) Host Pipe IN Request Register (n = 0) 0 */
-  __I  uint32_t                       Reserved18[2];
+  __I  uint8_t                        Reserved18[8];
   __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register (n = 0) 0 */
-  __I  uint32_t                       Reserved19[26];
-       UsbhsHstdma                    USBHS_HSTDMA[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
-  __I  uint32_t                       Reserved20[32];
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+  __I  uint8_t                        Reserved20[128];
   __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
   __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */
   __O  USBHS_SCR_Type                 USBHS_SCR;      /**< Offset: 0x808 ( /W  32) General Status Clear Register */

--- a/asf/sam/include/same70/component/usbhs.h
+++ b/asf/sam/include/same70/component/usbhs.h
@@ -3463,7 +3463,7 @@ typedef struct {
   __I  uint8_t                        Reserved18[8];
   __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register (n = 0) 0 */
   __I  uint8_t                        Reserved19[104];
-       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+       UsbhsHstdma USBHS_HSTDMA[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
   __I  uint8_t                        Reserved20[128];
   __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
   __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
@@ -3547,7 +3547,7 @@ typedef struct {
   __I  uint8_t                        Reserved18[8];
   __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register (n = 0) 0 */
   __I  uint8_t                        Reserved19[104];
-       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
+       UsbhsHstdma                    USBHS_HSTDMA[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
   __I  uint8_t                        Reserved20[128];
   __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
   __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */

--- a/asf/sam/include/same70/component/usbhs.h
+++ b/asf/sam/include/same70/component/usbhs.h
@@ -3430,7 +3430,7 @@ typedef struct {
   __I  uint8_t                        Reserved7[8];
   __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Disable Register (n = 0) 0 */
   __I  uint8_t                        Reserved8[200];
-       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+       UsbhsDevdma USBHS_DEVDMA[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
   __I  uint8_t                        Reserved9[128];
   __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
   __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
@@ -3514,7 +3514,7 @@ typedef struct {
   __I  uint8_t                        Reserved7[8];
   __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Disable Register (n = 0) 0 */
   __I  uint8_t                        Reserved8[200];
-       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
+       UsbhsDevdma                    USBHS_DEVDMA[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
   __I  uint8_t                        Reserved9[128];
   __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
   __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */

--- a/asf/sam/include/same70/component/utmi.h
+++ b/asf/sam/include/same70/component/utmi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for UTMI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- UTMI_OHCIICR : (UTMI Offset: 0x10) (R/W 32) OHCI Interrupt Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES0:1;                    /**< bit:      0  USB PORTx Reset                          */
@@ -55,8 +58,13 @@ typedef union {
     uint32_t UDPPUDIS:1;                /**< bit:     23  USB Device Pull-up Disable               */
     uint32_t :8;                        /**< bit: 24..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :31;                       /**< bit:  1..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } UTMI_OHCIICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UTMI_OHCIICR_OFFSET                 (0x10)                                        /**<  (UTMI_OHCIICR) OHCI Interrupt Configuration Register  Offset */
@@ -76,9 +84,13 @@ typedef union {
 #define UTMI_OHCIICR_MASK                   _U_(0x800031)                                  /**< \deprecated (UTMI_OHCIICR) Register MASK  (Use UTMI_OHCIICR_Msk instead)  */
 #define UTMI_OHCIICR_Msk                    _U_(0x800031)                                  /**< (UTMI_OHCIICR) Register Mask  */
 
+#define UTMI_OHCIICR_RES_Pos                0                                              /**< (UTMI_OHCIICR Position) USB PORTx Reset */
+#define UTMI_OHCIICR_RES_Msk                (_U_(0x1) << UTMI_OHCIICR_RES_Pos)             /**< (UTMI_OHCIICR Mask) RES */
+#define UTMI_OHCIICR_RES(value)             (UTMI_OHCIICR_RES_Msk & ((value) << UTMI_OHCIICR_RES_Pos))  
 
 /* -------- UTMI_CKTRIM : (UTMI Offset: 0x30) (R/W 32) UTMI Clock Trimming Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FREQ:2;                    /**< bit:   0..1  UTMI Reference Clock Frequency           */
@@ -86,6 +98,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UTMI_CKTRIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UTMI_CKTRIM_OFFSET                  (0x30)                                        /**<  (UTMI_CKTRIM) UTMI Clock Trimming Register  Offset */
@@ -105,18 +118,18 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief UTMI hardware registers */
 typedef struct {  
-  RoReg8  Reserved1[0x10];
+  __I  uint8_t                        Reserved1[16];
   __IO uint32_t UTMI_OHCIICR;   /**< (UTMI Offset: 0x10) OHCI Interrupt Configuration Register */
-  RoReg8  Reserved2[0x1C];
+  __I  uint8_t                        Reserved2[28];
   __IO uint32_t UTMI_CKTRIM;    /**< (UTMI Offset: 0x30) UTMI Clock Trimming Register */
 } Utmi;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief UTMI hardware registers */
 typedef struct {  
-  __I  uint32_t                       Reserved1[4];
+  __I  uint8_t                        Reserved1[16];
   __IO UTMI_OHCIICR_Type              UTMI_OHCIICR;   /**< Offset: 0x10 (R/W  32) OHCI Interrupt Configuration Register */
-  __I  uint32_t                       Reserved2[7];
+  __I  uint8_t                        Reserved2[28];
   __IO UTMI_CKTRIM_Type               UTMI_CKTRIM;    /**< Offset: 0x30 (R/W  32) UTMI Clock Trimming Register */
 } Utmi;
 

--- a/asf/sam/include/same70/component/wdt.h
+++ b/asf/sam/include/same70/component/wdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for WDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- WDT_CR : (WDT Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CR_OFFSET                       (0x00)                                        /**<  (WDT_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- WDT_MR : (WDT Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
@@ -85,6 +90,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_MR_OFFSET                       (0x04)                                        /**<  (WDT_MR) Mode Register  Offset */
@@ -116,6 +122,7 @@ typedef union {
 
 /* -------- WDT_SR : (WDT Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow (cleared on read)     */
@@ -124,6 +131,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_SR_OFFSET                       (0x08)                                        /**<  (WDT_SR) Status Register  Offset */

--- a/asf/sam/include/same70/component/xdmac.h
+++ b/asf/sam/include/same70/component/xdmac.h
@@ -2461,7 +2461,7 @@ typedef struct {
   __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
   __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
   __I  uint8_t                        Reserved1[12];
-       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+       XdmacChid XDMAC_CHID[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
 } Xdmac;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -2504,7 +2504,7 @@ typedef struct {
   __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
   __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
   __I  uint8_t                        Reserved1[12];
-       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+       XdmacChid                      XDMAC_CHID[24];  /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
 } Xdmac;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70/component/xdmac.h
+++ b/asf/sam/include/same70/component/xdmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for XDMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,7 @@
 
 /* -------- XDMAC_CIE : (XDMAC Offset: 0x00) (/W 32) Channel Interrupt Enable Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIE:1;                     /**< bit:      0  End of Block Interrupt Enable Bit        */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CIE_OFFSET                    (0x00)                                        /**<  (XDMAC_CIE) Channel Interrupt Enable Register (chid = 0)  Offset */
@@ -89,6 +93,7 @@ typedef union {
 
 /* -------- XDMAC_CID : (XDMAC Offset: 0x04) (/W 32) Channel Interrupt Disable Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BID:1;                     /**< bit:      0  End of Block Interrupt Disable Bit       */
@@ -102,6 +107,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CID_OFFSET                    (0x04)                                        /**<  (XDMAC_CID) Channel Interrupt Disable Register (chid = 0)  Offset */
@@ -133,6 +139,7 @@ typedef union {
 
 /* -------- XDMAC_CIM : (XDMAC Offset: 0x08) (R/ 32) Channel Interrupt Mask Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIM:1;                     /**< bit:      0  End of Block Interrupt Mask Bit          */
@@ -146,6 +153,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CIM_OFFSET                    (0x08)                                        /**<  (XDMAC_CIM) Channel Interrupt Mask Register (chid = 0)  Offset */
@@ -177,6 +185,7 @@ typedef union {
 
 /* -------- XDMAC_CIS : (XDMAC Offset: 0x0c) (R/ 32) Channel Interrupt Status Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIS:1;                     /**< bit:      0  End of Block Interrupt Status Bit        */
@@ -190,6 +199,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CIS_OFFSET                    (0x0C)                                        /**<  (XDMAC_CIS) Channel Interrupt Status Register (chid = 0)  Offset */
@@ -221,12 +231,14 @@ typedef union {
 
 /* -------- XDMAC_CSA : (XDMAC Offset: 0x10) (R/W 32) Channel Source Address Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SA:32;                     /**< bit:  0..31  Channel x Source Address                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CSA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CSA_OFFSET                    (0x10)                                        /**<  (XDMAC_CSA) Channel Source Address Register (chid = 0)  Offset */
@@ -240,12 +252,14 @@ typedef union {
 
 /* -------- XDMAC_CDA : (XDMAC Offset: 0x14) (R/W 32) Channel Destination Address Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DA:32;                     /**< bit:  0..31  Channel x Destination Address            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CDA_OFFSET                    (0x14)                                        /**<  (XDMAC_CDA) Channel Destination Address Register (chid = 0)  Offset */
@@ -259,6 +273,7 @@ typedef union {
 
 /* -------- XDMAC_CNDA : (XDMAC Offset: 0x18) (R/W 32) Channel Next Descriptor Address Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NDAIF:1;                   /**< bit:      0  Channel x Next Descriptor Interface      */
@@ -267,6 +282,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CNDA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CNDA_OFFSET                   (0x18)                                        /**<  (XDMAC_CNDA) Channel Next Descriptor Address Register (chid = 0)  Offset */
@@ -283,6 +299,7 @@ typedef union {
 
 /* -------- XDMAC_CNDC : (XDMAC Offset: 0x1c) (R/W 32) Channel Next Descriptor Control Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NDE:1;                     /**< bit:      0  Channel x Next Descriptor Enable         */
@@ -293,6 +310,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CNDC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CNDC_OFFSET                   (0x1C)                                        /**<  (XDMAC_CNDC) Channel Next Descriptor Control Register (chid = 0)  Offset */
@@ -335,6 +353,7 @@ typedef union {
 
 /* -------- XDMAC_CUBC : (XDMAC Offset: 0x20) (R/W 32) Channel Microblock Control Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UBLEN:24;                  /**< bit:  0..23  Channel x Microblock Length              */
@@ -342,6 +361,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CUBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CUBC_OFFSET                   (0x20)                                        /**<  (XDMAC_CUBC) Channel Microblock Control Register (chid = 0)  Offset */
@@ -355,6 +375,7 @@ typedef union {
 
 /* -------- XDMAC_CBC : (XDMAC Offset: 0x24) (R/W 32) Channel Block Control Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BLEN:12;                   /**< bit:  0..11  Channel x Block Length                   */
@@ -362,6 +383,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CBC_OFFSET                    (0x24)                                        /**<  (XDMAC_CBC) Channel Block Control Register (chid = 0)  Offset */
@@ -375,6 +397,7 @@ typedef union {
 
 /* -------- XDMAC_CC : (XDMAC Offset: 0x28) (R/W 32) Channel Configuration Register (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TYPE:1;                    /**< bit:      0  Channel x Transfer Type                  */
@@ -400,6 +423,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CC_OFFSET                     (0x28)                                        /**<  (XDMAC_CC) Channel Configuration Register (chid = 0)  Offset */
@@ -531,6 +555,7 @@ typedef union {
 
 /* -------- XDMAC_CDS_MSP : (XDMAC Offset: 0x2c) (R/W 32) Channel Data Stride Memory Set Pattern (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDS_MSP:16;                /**< bit:  0..15  Channel x Source Data stride or Memory Set Pattern */
@@ -538,6 +563,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDS_MSP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CDS_MSP_OFFSET                (0x2C)                                        /**<  (XDMAC_CDS_MSP) Channel Data Stride Memory Set Pattern (chid = 0)  Offset */
@@ -554,6 +580,7 @@ typedef union {
 
 /* -------- XDMAC_CSUS : (XDMAC Offset: 0x30) (R/W 32) Channel Source Microblock Stride (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUBS:24;                   /**< bit:  0..23  Channel x Source Microblock Stride       */
@@ -561,6 +588,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CSUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CSUS_OFFSET                   (0x30)                                        /**<  (XDMAC_CSUS) Channel Source Microblock Stride (chid = 0)  Offset */
@@ -574,6 +602,7 @@ typedef union {
 
 /* -------- XDMAC_CDUS : (XDMAC Offset: 0x34) (R/W 32) Channel Destination Microblock Stride (chid = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DUBS:24;                   /**< bit:  0..23  Channel x Destination Microblock Stride  */
@@ -581,6 +610,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_CDUS_OFFSET                   (0x34)                                        /**<  (XDMAC_CDUS) Channel Destination Microblock Stride (chid = 0)  Offset */
@@ -594,6 +624,7 @@ typedef union {
 
 /* -------- XDMAC_GTYPE : (XDMAC Offset: 0x00) (R/ 32) Global Type Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NB_CH:5;                   /**< bit:   0..4  Number of Channels Minus One             */
@@ -603,6 +634,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GTYPE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GTYPE_OFFSET                  (0x00)                                        /**<  (XDMAC_GTYPE) Global Type Register  Offset */
@@ -622,6 +654,7 @@ typedef union {
 
 /* -------- XDMAC_GCFG : (XDMAC Offset: 0x04) (R/W 32) Global Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CGDISREG:1;                /**< bit:      0  Configuration Registers Clock Gating Disable */
@@ -634,6 +667,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GCFG_OFFSET                   (0x04)                                        /**<  (XDMAC_GCFG) Global Configuration Register  Offset */
@@ -659,6 +693,7 @@ typedef union {
 
 /* -------- XDMAC_GWAC : (XDMAC Offset: 0x08) (R/W 32) Global Weighted Arbiter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PW0:4;                     /**< bit:   0..3  Pool Weight 0                            */
@@ -669,6 +704,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GWAC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GWAC_OFFSET                   (0x08)                                        /**<  (XDMAC_GWAC) Global Weighted Arbiter Configuration Register  Offset */
@@ -691,6 +727,7 @@ typedef union {
 
 /* -------- XDMAC_GIE : (XDMAC Offset: 0x0c) (/W 32) Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IE0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Enable Bit     */
@@ -725,6 +762,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIE_OFFSET                    (0x0C)                                        /**<  (XDMAC_GIE) Global Interrupt Enable Register  Offset */
@@ -810,6 +848,7 @@ typedef union {
 
 /* -------- XDMAC_GID : (XDMAC Offset: 0x10) (/W 32) Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ID0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Disable Bit    */
@@ -844,6 +883,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GID_OFFSET                    (0x10)                                        /**<  (XDMAC_GID) Global Interrupt Disable Register  Offset */
@@ -929,6 +969,7 @@ typedef union {
 
 /* -------- XDMAC_GIM : (XDMAC Offset: 0x14) (R/ 32) Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IM0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Mask Bit       */
@@ -963,6 +1004,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIM_OFFSET                    (0x14)                                        /**<  (XDMAC_GIM) Global Interrupt Mask Register  Offset */
@@ -1048,6 +1090,7 @@ typedef union {
 
 /* -------- XDMAC_GIS : (XDMAC Offset: 0x18) (R/ 32) Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Status Bit     */
@@ -1082,6 +1125,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIS_OFFSET                    (0x18)                                        /**<  (XDMAC_GIS) Global Interrupt Status Register  Offset */
@@ -1167,6 +1211,7 @@ typedef union {
 
 /* -------- XDMAC_GE : (XDMAC Offset: 0x1c) (/W 32) Global Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EN0:1;                     /**< bit:      0  XDMAC Channel 0 Enable Bit               */
@@ -1201,6 +1246,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GE_OFFSET                     (0x1C)                                        /**<  (XDMAC_GE) Global Channel Enable Register  Offset */
@@ -1286,6 +1332,7 @@ typedef union {
 
 /* -------- XDMAC_GD : (XDMAC Offset: 0x20) (/W 32) Global Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DI0:1;                     /**< bit:      0  XDMAC Channel 0 Disable Bit              */
@@ -1320,6 +1367,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GD_OFFSET                     (0x20)                                        /**<  (XDMAC_GD) Global Channel Disable Register  Offset */
@@ -1405,6 +1453,7 @@ typedef union {
 
 /* -------- XDMAC_GS : (XDMAC Offset: 0x24) (R/ 32) Global Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ST0:1;                     /**< bit:      0  XDMAC Channel 0 Status Bit               */
@@ -1439,6 +1488,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GS_OFFSET                     (0x24)                                        /**<  (XDMAC_GS) Global Channel Status Register  Offset */
@@ -1524,6 +1574,7 @@ typedef union {
 
 /* -------- XDMAC_GRS : (XDMAC Offset: 0x28) (R/W 32) Global Channel Read Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RS0:1;                     /**< bit:      0  XDMAC Channel 0 Read Suspend Bit         */
@@ -1558,6 +1609,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRS_OFFSET                    (0x28)                                        /**<  (XDMAC_GRS) Global Channel Read Suspend Register  Offset */
@@ -1643,6 +1695,7 @@ typedef union {
 
 /* -------- XDMAC_GWS : (XDMAC Offset: 0x2c) (R/W 32) Global Channel Write Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WS0:1;                     /**< bit:      0  XDMAC Channel 0 Write Suspend Bit        */
@@ -1677,6 +1730,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GWS_OFFSET                    (0x2C)                                        /**<  (XDMAC_GWS) Global Channel Write Suspend Register  Offset */
@@ -1762,6 +1816,7 @@ typedef union {
 
 /* -------- XDMAC_GRWS : (XDMAC Offset: 0x30) (/W 32) Global Channel Read Write Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RWS0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Suspend Bit   */
@@ -1796,6 +1851,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRWS_OFFSET                   (0x30)                                        /**<  (XDMAC_GRWS) Global Channel Read Write Suspend Register  Offset */
@@ -1881,6 +1937,7 @@ typedef union {
 
 /* -------- XDMAC_GRWR : (XDMAC Offset: 0x34) (/W 32) Global Channel Read Write Resume Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RWR0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Resume Bit    */
@@ -1915,6 +1972,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRWR_OFFSET                   (0x34)                                        /**<  (XDMAC_GRWR) Global Channel Read Write Resume Register  Offset */
@@ -2000,6 +2058,7 @@ typedef union {
 
 /* -------- XDMAC_GSWR : (XDMAC Offset: 0x38) (/W 32) Global Channel Software Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWREQ0:1;                  /**< bit:      0  XDMAC Channel 0 Software Request Bit     */
@@ -2034,6 +2093,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWR_OFFSET                   (0x38)                                        /**<  (XDMAC_GSWR) Global Channel Software Request Register  Offset */
@@ -2119,6 +2179,7 @@ typedef union {
 
 /* -------- XDMAC_GSWS : (XDMAC Offset: 0x3c) (R/ 32) Global Channel Software Request Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRS0:1;                   /**< bit:      0  XDMAC Channel 0 Software Request Status Bit */
@@ -2153,6 +2214,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWS_OFFSET                   (0x3C)                                        /**<  (XDMAC_GSWS) Global Channel Software Request Status Register  Offset */
@@ -2238,6 +2300,7 @@ typedef union {
 
 /* -------- XDMAC_GSWF : (XDMAC Offset: 0x40) (/W 32) Global Channel Software Flush Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWF0:1;                    /**< bit:      0  XDMAC Channel 0 Software Flush Request Bit */
@@ -2272,6 +2335,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWF_OFFSET                   (0x40)                                        /**<  (XDMAC_GSWF) Global Channel Software Flush Request Register  Offset */
@@ -2373,7 +2437,7 @@ typedef struct {
   __IO uint32_t XDMAC_CDS_MSP;  /**< (XDMAC_CHID Offset: 0x2C) Channel Data Stride Memory Set Pattern (chid = 0) */
   __IO uint32_t XDMAC_CSUS;     /**< (XDMAC_CHID Offset: 0x30) Channel Source Microblock Stride (chid = 0) */
   __IO uint32_t XDMAC_CDUS;     /**< (XDMAC_CHID Offset: 0x34) Channel Destination Microblock Stride (chid = 0) */
-       RoReg8                         Reserved1[0x08];
+  __I  uint8_t                        Reserved1[8];
 } XdmacChid;
 
 #define XDMACCHID_NUMBER 24
@@ -2396,8 +2460,8 @@ typedef struct {
   __O  uint32_t XDMAC_GSWR;     /**< (XDMAC Offset: 0x38) Global Channel Software Request Register */
   __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
   __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
-  RoReg8  Reserved1[0x0C];
-       XdmacChid XDMAC_CHID[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
 } Xdmac;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -2417,7 +2481,7 @@ typedef struct {
   __IO XDMAC_CDS_MSP_Type             XDMAC_CDS_MSP;  /**< Offset: 0x2C (R/W  32) Channel Data Stride Memory Set Pattern (chid = 0) */
   __IO XDMAC_CSUS_Type                XDMAC_CSUS;     /**< Offset: 0x30 (R/W  32) Channel Source Microblock Stride (chid = 0) */
   __IO XDMAC_CDUS_Type                XDMAC_CDUS;     /**< Offset: 0x34 (R/W  32) Channel Destination Microblock Stride (chid = 0) */
-       RoReg8                         Reserved1[0x08];
+  __I  uint8_t                        Reserved1[8];
 } XdmacChid;
 
 /** \brief XDMAC hardware registers */
@@ -2439,8 +2503,8 @@ typedef struct {
   __O  XDMAC_GSWR_Type                XDMAC_GSWR;     /**< Offset: 0x38 ( /W  32) Global Channel Software Request Register */
   __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
   __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
-  __I  uint32_t                       Reserved1[3];
-       XdmacChid                      XDMAC_CHID[24]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
 } Xdmac;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70/instance/acc.h
+++ b/asf/sam/include/same70/instance/acc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +59,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ACC peripheral ========== */
-#define ACC_INSTANCE_ID                          33        
+#define ACC_INSTANCE_ID                          33         
 
 #endif /* _SAME70_ACC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/aes.h
+++ b/asf/sam/include/same70/instance/aes.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AES
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,8 +137,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AES peripheral ========== */
-#define AES_INSTANCE_ID                          56        
-#define AES_DMAC_ID_TX                           37        
-#define AES_DMAC_ID_RX                           38        
+#define AES_DMAC_ID_TX                           37         
+#define AES_DMAC_ID_RX                           38         
+#define AES_INSTANCE_ID                          56         
 
 #endif /* _SAME70_AES_INSTANCE_ */

--- a/asf/sam/include/same70/instance/afec0.h
+++ b/asf/sam/include/same70/instance/afec0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AFEC0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +99,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AFEC0 peripheral ========== */
-#define AFEC0_INSTANCE_ID                        29        
-#define AFEC0_DMAC_ID_RX                         35        
+#define AFEC0_DMAC_ID_RX                         35         
+#define AFEC0_INSTANCE_ID                        29         
 
 #endif /* _SAME70_AFEC0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/afec1.h
+++ b/asf/sam/include/same70/instance/afec1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AFEC1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +99,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AFEC1 peripheral ========== */
-#define AFEC1_INSTANCE_ID                        40        
-#define AFEC1_DMAC_ID_RX                         36        
+#define AFEC1_DMAC_ID_RX                         36         
+#define AFEC1_INSTANCE_ID                        40         
 
 #endif /* _SAME70_AFEC1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/chipid.h
+++ b/asf/sam/include/same70/instance/chipid.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for CHIPID
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/instance/dacc.h
+++ b/asf/sam/include/same70/instance/dacc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for DACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +73,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for DACC peripheral ========== */
-#define DACC_INSTANCE_ID                         30        
-#define DACC_DMAC_ID_TX                          30        
+#define DACC_DMAC_ID_TX                          30         
+#define DACC_INSTANCE_ID                         30         
 
 #endif /* _SAME70_DACC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/efc.h
+++ b/asf/sam/include/same70/instance/efc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for EFC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +51,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for EFC peripheral ========== */
-#define EFC_FLASH_SIZE                           2097152   
-#define EFC_INSTANCE_ID                          6         
-#define EFC_PAGES_PR_REGION                      32        
-#define EFC_PAGE_SIZE                            512       
+#define EFC_FLASH_SIZE                           2097152    
+#define EFC_PAGE_SIZE                            512        
+#define EFC_INSTANCE_ID                          6          
+#define EFC_PAGES_PR_REGION                      32         
 
 #endif /* _SAME70_EFC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/gmac.h
+++ b/asf/sam/include/same70/instance/gmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for GMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -431,6 +433,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for GMAC peripheral ========== */
-#define GMAC_INSTANCE_ID                         39        
+#define GMAC_INSTANCE_ID                         39         
 
 #endif /* _SAME70_GMAC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/gpbr.h
+++ b/asf/sam/include/same70/instance/gpbr.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for GPBR
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/instance/hsmci.h
+++ b/asf/sam/include/same70/instance/hsmci.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for HSMCI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -599,8 +601,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for HSMCI peripheral ========== */
-#define HSMCI_INSTANCE_ID                        18        
-#define HSMCI_DMAC_ID_TX                         0         
-#define HSMCI_DMAC_ID_RX                         0         
+#define HSMCI_DMAC_ID_RX                         0          
+#define HSMCI_DMAC_ID_TX                         0          
+#define HSMCI_INSTANCE_ID                        18         
 
 #endif /* _SAME70_HSMCI_INSTANCE_ */

--- a/asf/sam/include/same70/instance/icm.h
+++ b/asf/sam/include/same70/instance/icm.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ICM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +79,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ICM peripheral ========== */
-#define ICM_INSTANCE_ID                          32        
+#define ICM_INSTANCE_ID                          32         
 
 #endif /* _SAME70_ICM_INSTANCE_ */

--- a/asf/sam/include/same70/instance/isi.h
+++ b/asf/sam/include/same70/instance/isi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ISI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +91,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ISI peripheral ========== */
-#define ISI_INSTANCE_ID                          59        
+#define ISI_INSTANCE_ID                          59         
 
 #endif /* _SAME70_ISI_INSTANCE_ */

--- a/asf/sam/include/same70/instance/matrix.h
+++ b/asf/sam/include/same70/instance/matrix.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MATRIX
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/instance/mcan0.h
+++ b/asf/sam/include/same70/instance/mcan0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MCAN0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +129,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for MCAN0 peripheral ========== */
-#define MCAN0_INSTANCE_ID                        35        
+#define MCAN0_INSTANCE_ID                        35         
 
 #endif /* _SAME70_MCAN0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/mcan1.h
+++ b/asf/sam/include/same70/instance/mcan1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MCAN1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +129,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for MCAN1 peripheral ========== */
-#define MCAN1_INSTANCE_ID                        37        
+#define MCAN1_INSTANCE_ID                        37         
 
 #endif /* _SAME70_MCAN1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pioa.h
+++ b/asf/sam/include/same70/instance/pioa.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOA
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +153,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOA peripheral ========== */
-#define PIOA_INSTANCE_ID                         10        
-#define PIOA_DMAC_ID_RX                          34        
+#define PIOA_DMAC_ID_RX                          34         
+#define PIOA_INSTANCE_ID                         10         
 
 #endif /* _SAME70_PIOA_INSTANCE_ */

--- a/asf/sam/include/same70/instance/piob.h
+++ b/asf/sam/include/same70/instance/piob.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOB
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +153,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOB peripheral ========== */
-#define PIOB_INSTANCE_ID                         11        
+#define PIOB_INSTANCE_ID                         11         
 
 #endif /* _SAME70_PIOB_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pioc.h
+++ b/asf/sam/include/same70/instance/pioc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +153,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOC peripheral ========== */
-#define PIOC_INSTANCE_ID                         12        
+#define PIOC_INSTANCE_ID                         12         
 
 #endif /* _SAME70_PIOC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/piod.h
+++ b/asf/sam/include/same70/instance/piod.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOD
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +153,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOD peripheral ========== */
-#define PIOD_INSTANCE_ID                         16        
+#define PIOD_INSTANCE_ID                         16         
 
 #endif /* _SAME70_PIOD_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pioe.h
+++ b/asf/sam/include/same70/instance/pioe.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOE
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,6 +153,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOE peripheral ========== */
-#define PIOE_INSTANCE_ID                         17        
+#define PIOE_INSTANCE_ID                         17         
 
 #endif /* _SAME70_PIOE_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pmc.h
+++ b/asf/sam/include/same70/instance/pmc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,6 +131,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PMC peripheral ========== */
-#define PMC_INSTANCE_ID                          5         
+#define PMC_INSTANCE_ID                          5          
 
 #endif /* _SAME70_PMC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pwm0.h
+++ b/asf/sam/include/same70/instance/pwm0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PWM0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,7 +259,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PWM0 peripheral ========== */
-#define PWM0_INSTANCE_ID                         31        
-#define PWM0_DMAC_ID_TX                          13        
+#define PWM0_DMAC_ID_TX                          13         
+#define PWM0_INSTANCE_ID                         31         
 
 #endif /* _SAME70_PWM0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/pwm1.h
+++ b/asf/sam/include/same70/instance/pwm1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PWM1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -257,7 +259,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PWM1 peripheral ========== */
-#define PWM1_INSTANCE_ID                         60        
-#define PWM1_DMAC_ID_TX                          39        
+#define PWM1_DMAC_ID_TX                          39         
+#define PWM1_INSTANCE_ID                         60         
 
 #endif /* _SAME70_PWM1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/qspi.h
+++ b/asf/sam/include/same70/instance/qspi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for QSPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +73,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for QSPI peripheral ========== */
-#define QSPI_INSTANCE_ID                         43        
-#define QSPI_DMAC_ID_TX                          5         
-#define QSPI_DMAC_ID_RX                          6         
+#define QSPI_DMAC_ID_RX                          6          
+#define QSPI_DMAC_ID_TX                          5          
+#define QSPI_INSTANCE_ID                         43         
 
 #endif /* _SAME70_QSPI_INSTANCE_ */

--- a/asf/sam/include/same70/instance/rstc.h
+++ b/asf/sam/include/same70/instance/rstc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RSTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RSTC peripheral ========== */
-#define RSTC_INSTANCE_ID                         1         
+#define RSTC_INSTANCE_ID                         1          
 
 #endif /* _SAME70_RSTC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/rswdt.h
+++ b/asf/sam/include/same70/instance/rswdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RSWDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RSWDT peripheral ========== */
-#define RSWDT_INSTANCE_ID                        63        
+#define RSWDT_INSTANCE_ID                        63         
 
 #endif /* _SAME70_RSWDT_INSTANCE_ */

--- a/asf/sam/include/same70/instance/rtc.h
+++ b/asf/sam/include/same70/instance/rtc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +46,6 @@
 #define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
-#define REG_RTC_WPMR            (0x400E1944) /**< (RTC) Write Protection Mode Register */
 
 #else
 
@@ -60,11 +61,10 @@
 #define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
-#define REG_RTC_WPMR            (*(__IO uint32_t*)0x400E1944U) /**< (RTC) Write Protection Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2         
+#define RTC_INSTANCE_ID                          2          
 
 #endif /* _SAME70_RTC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/rtt.h
+++ b/asf/sam/include/same70/instance/rtt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RTT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +49,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTT peripheral ========== */
-#define RTT_INSTANCE_ID                          3         
+#define RTT_INSTANCE_ID                          3          
 
 #endif /* _SAME70_RTT_INSTANCE_ */

--- a/asf/sam/include/same70/instance/sdramc.h
+++ b/asf/sam/include/same70/instance/sdramc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SDRAMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +67,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SDRAMC peripheral ========== */
-#define SDRAMC_INSTANCE_ID                       62        
+#define SDRAMC_INSTANCE_ID                       62         
 
 #endif /* _SAME70_SDRAMC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/smc.h
+++ b/asf/sam/include/same70/instance/smc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +83,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SMC peripheral ========== */
-#define SMC_INSTANCE_ID                          9         
+#define SMC_INSTANCE_ID                          9          
 
 #endif /* _SAME70_SMC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/spi0.h
+++ b/asf/sam/include/same70/instance/spi0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SPI0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +71,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SPI0 peripheral ========== */
-#define SPI0_INSTANCE_ID                         21        
-#define SPI0_DMAC_ID_TX                          1         
-#define SPI0_DMAC_ID_RX                          2         
+#define SPI0_DMAC_ID_RX                          2          
+#define SPI0_DMAC_ID_TX                          1          
+#define SPI0_INSTANCE_ID                         21         
 
 #endif /* _SAME70_SPI0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/spi1.h
+++ b/asf/sam/include/same70/instance/spi1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SPI1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +71,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SPI1 peripheral ========== */
-#define SPI1_INSTANCE_ID                         42        
-#define SPI1_DMAC_ID_TX                          3         
-#define SPI1_DMAC_ID_RX                          4         
+#define SPI1_DMAC_ID_RX                          4          
+#define SPI1_DMAC_ID_TX                          3          
+#define SPI1_INSTANCE_ID                         42         
 
 #endif /* _SAME70_SPI1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/ssc.h
+++ b/asf/sam/include/same70/instance/ssc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SSC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,8 +77,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SSC peripheral ========== */
-#define SSC_INSTANCE_ID                          22        
-#define SSC_DMAC_ID_TX                           32        
-#define SSC_DMAC_ID_RX                           33        
+#define SSC_DMAC_ID_RX                           33         
+#define SSC_DMAC_ID_TX                           32         
+#define SSC_INSTANCE_ID                          22         
 
 #endif /* _SAME70_SSC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/supc.h
+++ b/asf/sam/include/same70/instance/supc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SUPC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +53,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SUPC peripheral ========== */
-#define SUPC_INSTANCE_ID                         0         
+#define SUPC_INSTANCE_ID                         0          
 
 #endif /* _SAME70_SUPC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/tc0.h
+++ b/asf/sam/include/same70/instance/tc0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,9 +135,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC0 peripheral ========== */
-#define TC0_INSTANCE_ID_CHANNEL1                 24        
-#define TC0_INSTANCE_ID_CHANNEL0                 23        
-#define TC0_INSTANCE_ID_CHANNEL2                 25        
-#define TC0_DMAC_ID_RX                           40        
+#define TC0_DMAC_ID_RX                           40         
+#define TC0_INSTANCE_ID_CHANNEL0                 23         
+#define TC0_INSTANCE_ID_CHANNEL1                 24         
+#define TC0_INSTANCE_ID_CHANNEL2                 25         
 
 #endif /* _SAME70_TC0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/tc1.h
+++ b/asf/sam/include/same70/instance/tc1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,9 +135,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC1 peripheral ========== */
-#define TC1_INSTANCE_ID_CHANNEL1                 27        
-#define TC1_INSTANCE_ID_CHANNEL0                 26        
-#define TC1_INSTANCE_ID_CHANNEL2                 28        
-#define TC1_DMAC_ID_RX                           41        
+#define TC1_DMAC_ID_RX                           41         
+#define TC1_INSTANCE_ID_CHANNEL0                 26         
+#define TC1_INSTANCE_ID_CHANNEL1                 27         
+#define TC1_INSTANCE_ID_CHANNEL2                 28         
 
 #endif /* _SAME70_TC1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/tc2.h
+++ b/asf/sam/include/same70/instance/tc2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,9 +135,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC2 peripheral ========== */
-#define TC2_INSTANCE_ID_CHANNEL1                 48        
-#define TC2_INSTANCE_ID_CHANNEL0                 47        
-#define TC2_INSTANCE_ID_CHANNEL2                 49        
-#define TC2_DMAC_ID_RX                           42        
+#define TC2_DMAC_ID_RX                           42         
+#define TC2_INSTANCE_ID_CHANNEL0                 47         
+#define TC2_INSTANCE_ID_CHANNEL1                 48         
+#define TC2_INSTANCE_ID_CHANNEL2                 49         
 
 #endif /* _SAME70_TC2_INSTANCE_ */

--- a/asf/sam/include/same70/instance/tc3.h
+++ b/asf/sam/include/same70/instance/tc3.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC3
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,9 +135,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC3 peripheral ========== */
-#define TC3_INSTANCE_ID_CHANNEL1                 51        
-#define TC3_INSTANCE_ID_CHANNEL0                 50        
-#define TC3_INSTANCE_ID_CHANNEL2                 52        
-#define TC3_DMAC_ID_RX                           43        
+#define TC3_DMAC_ID_RX                           43         
+#define TC3_INSTANCE_ID_CHANNEL0                 50         
+#define TC3_INSTANCE_ID_CHANNEL1                 51         
+#define TC3_INSTANCE_ID_CHANNEL2                 52         
 
 #endif /* _SAME70_TC3_INSTANCE_ */

--- a/asf/sam/include/same70/instance/trng.h
+++ b/asf/sam/include/same70/instance/trng.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TRNG
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +53,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TRNG peripheral ========== */
-#define TRNG_INSTANCE_ID                         57        
+#define TRNG_INSTANCE_ID                         57         
 
 #endif /* _SAME70_TRNG_INSTANCE_ */

--- a/asf/sam/include/same70/instance/twihs0.h
+++ b/asf/sam/include/same70/instance/twihs0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +73,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS0 peripheral ========== */
-#define TWIHS0_INSTANCE_ID                       19        
-#define TWIHS0_DMAC_ID_TX                        14        
-#define TWIHS0_DMAC_ID_RX                        15        
+#define TWIHS0_DMAC_ID_RX                        15         
+#define TWIHS0_DMAC_ID_TX                        14         
+#define TWIHS0_INSTANCE_ID                       19         
 
 #endif /* _SAME70_TWIHS0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/twihs1.h
+++ b/asf/sam/include/same70/instance/twihs1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +73,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS1 peripheral ========== */
-#define TWIHS1_INSTANCE_ID                       20        
-#define TWIHS1_DMAC_ID_TX                        16        
-#define TWIHS1_DMAC_ID_RX                        17        
+#define TWIHS1_DMAC_ID_RX                        17         
+#define TWIHS1_DMAC_ID_TX                        16         
+#define TWIHS1_INSTANCE_ID                       20         
 
 #endif /* _SAME70_TWIHS1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/twihs2.h
+++ b/asf/sam/include/same70/instance/twihs2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +73,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS2 peripheral ========== */
-#define TWIHS2_INSTANCE_ID                       41        
-#define TWIHS2_DMAC_ID_TX                        18        
-#define TWIHS2_DMAC_ID_RX                        19        
+#define TWIHS2_DMAC_ID_RX                        19         
+#define TWIHS2_DMAC_ID_TX                        18         
+#define TWIHS2_INSTANCE_ID                       41         
 
 #endif /* _SAME70_TWIHS2_INSTANCE_ */

--- a/asf/sam/include/same70/instance/uart0.h
+++ b/asf/sam/include/same70/instance/uart0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +63,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART0 peripheral ========== */
-#define UART0_INSTANCE_ID                        7         
-#define UART0_DMAC_ID_TX                         20        
-#define UART0_DMAC_ID_RX                         21        
+#define UART0_DMAC_ID_RX                         21         
+#define UART0_DMAC_ID_TX                         20         
+#define UART0_INSTANCE_ID                        7          
 
 #endif /* _SAME70_UART0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/uart1.h
+++ b/asf/sam/include/same70/instance/uart1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +63,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART1 peripheral ========== */
-#define UART1_INSTANCE_ID                        8         
-#define UART1_DMAC_ID_TX                         22        
-#define UART1_DMAC_ID_RX                         23        
+#define UART1_DMAC_ID_RX                         23         
+#define UART1_DMAC_ID_TX                         22         
+#define UART1_INSTANCE_ID                        8          
 
 #endif /* _SAME70_UART1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/uart2.h
+++ b/asf/sam/include/same70/instance/uart2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +63,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART2 peripheral ========== */
-#define UART2_INSTANCE_ID                        44        
-#define UART2_DMAC_ID_TX                         24        
-#define UART2_DMAC_ID_RX                         25        
+#define UART2_DMAC_ID_RX                         25         
+#define UART2_DMAC_ID_TX                         24         
+#define UART2_INSTANCE_ID                        44         
 
 #endif /* _SAME70_UART2_INSTANCE_ */

--- a/asf/sam/include/same70/instance/uart3.h
+++ b/asf/sam/include/same70/instance/uart3.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART3
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +63,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART3 peripheral ========== */
-#define UART3_INSTANCE_ID                        45        
-#define UART3_DMAC_ID_TX                         26        
-#define UART3_DMAC_ID_RX                         27        
+#define UART3_DMAC_ID_RX                         27         
+#define UART3_DMAC_ID_TX                         26         
+#define UART3_INSTANCE_ID                        45         
 
 #endif /* _SAME70_UART3_INSTANCE_ */

--- a/asf/sam/include/same70/instance/uart4.h
+++ b/asf/sam/include/same70/instance/uart4.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART4
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,8 +63,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART4 peripheral ========== */
-#define UART4_INSTANCE_ID                        46        
-#define UART4_DMAC_ID_TX                         28        
-#define UART4_DMAC_ID_RX                         29        
+#define UART4_DMAC_ID_RX                         29         
+#define UART4_DMAC_ID_TX                         28         
+#define UART4_INSTANCE_ID                        46         
 
 #endif /* _SAME70_UART4_INSTANCE_ */

--- a/asf/sam/include/same70/instance/usart0.h
+++ b/asf/sam/include/same70/instance/usart0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +103,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART0 peripheral ========== */
-#define USART0_INSTANCE_ID                       13        
-#define USART0_DMAC_ID_TX                        7         
-#define USART0_DMAC_ID_RX                        8         
+#define USART0_DMAC_ID_RX                        8          
+#define USART0_DMAC_ID_TX                        7          
+#define USART0_INSTANCE_ID                       13         
 
 #endif /* _SAME70_USART0_INSTANCE_ */

--- a/asf/sam/include/same70/instance/usart1.h
+++ b/asf/sam/include/same70/instance/usart1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +103,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART1 peripheral ========== */
-#define USART1_INSTANCE_ID                       14        
-#define USART1_DMAC_ID_TX                        9         
-#define USART1_DMAC_ID_RX                        10        
+#define USART1_DMAC_ID_RX                        10         
+#define USART1_DMAC_ID_TX                        9          
+#define USART1_INSTANCE_ID                       14         
 
 #endif /* _SAME70_USART1_INSTANCE_ */

--- a/asf/sam/include/same70/instance/usart2.h
+++ b/asf/sam/include/same70/instance/usart2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +103,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART2 peripheral ========== */
-#define USART2_INSTANCE_ID                       15        
-#define USART2_DMAC_ID_TX                        11        
-#define USART2_DMAC_ID_RX                        12        
+#define USART2_DMAC_ID_RX                        12         
+#define USART2_DMAC_ID_TX                        11         
+#define USART2_INSTANCE_ID                       15         
 
 #endif /* _SAME70_USART2_INSTANCE_ */

--- a/asf/sam/include/same70/instance/usbhs.h
+++ b/asf/sam/include/same70/instance/usbhs.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USBHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -553,6 +555,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USBHS peripheral ========== */
-#define USBHS_INSTANCE_ID                        34        
+#define USBHS_INSTANCE_ID                        34         
 
 #endif /* _SAME70_USBHS_INSTANCE_ */

--- a/asf/sam/include/same70/instance/utmi.h
+++ b/asf/sam/include/same70/instance/utmi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UTMI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/instance/wdt.h
+++ b/asf/sam/include/same70/instance/wdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for WDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for WDT peripheral ========== */
-#define WDT_INSTANCE_ID                          4         
+#define WDT_INSTANCE_ID                          4          
 
 #endif /* _SAME70_WDT_INSTANCE_ */

--- a/asf/sam/include/same70/instance/xdmac.h
+++ b/asf/sam/include/same70/instance/xdmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for XDMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -745,6 +747,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for XDMAC peripheral ========== */
-#define XDMAC_INSTANCE_ID                        58        
+#define XDMAC_INSTANCE_ID                        58         
 
 #endif /* _SAME70_XDMAC_INSTANCE_ */

--- a/asf/sam/include/same70/pio/same70j19.h
+++ b/asf/sam/include/same70/pio/same70j19.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -834,34 +836,6 @@
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
 #define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
 #define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
-
-#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
-#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
-#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
-
-#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
-#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
-#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
-
-#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
-#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
-#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
-
-#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
-#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
-#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
-
-#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
-#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
-#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
-
-#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
-#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
-#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
 
 #define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
 #define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */

--- a/asf/sam/include/same70/pio/same70j20.h
+++ b/asf/sam/include/same70/pio/same70j20.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -834,34 +836,6 @@
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
 #define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
 #define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
-
-#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
-#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
-#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
-
-#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
-#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
-#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
-
-#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
-#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
-#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
-
-#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
-#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
-#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
-
-#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
-#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
-#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
-
-#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
-#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
-#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
 
 #define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
 #define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */

--- a/asf/sam/include/same70/pio/same70j21.h
+++ b/asf/sam/include/same70/pio/same70j21.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -834,34 +836,6 @@
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
 #define MUX_PA4B_TC0_TCLK0                         _L_(1)       /**< TC0 signal line function value: TCLK0 */
 #define PIO_PA4B_TC0_TCLK0                         (_UL_(1) << 4)
-
-#define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
-#define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
-#define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
-
-#define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
-#define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */
-#define PIO_PA0B_TC0_TIOA0                         (_UL_(1) << 0)
-
-#define PIN_PA15B_TC0_TIOA1                        _L_(15)      /**< TC0 signal: TIOA1 on PA15 mux B*/
-#define MUX_PA15B_TC0_TIOA1                        _L_(1)       /**< TC0 signal line function value: TIOA1 */
-#define PIO_PA15B_TC0_TIOA1                        (_UL_(1) << 15)
-
-#define PIN_PA26B_TC0_TIOA2                        _L_(26)      /**< TC0 signal: TIOA2 on PA26 mux B*/
-#define MUX_PA26B_TC0_TIOA2                        _L_(1)       /**< TC0 signal line function value: TIOA2 */
-#define PIO_PA26B_TC0_TIOA2                        (_UL_(1) << 26)
-
-#define PIN_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal: TIOB0 on PA1 mux B*/
-#define MUX_PA1B_TC0_TIOB0                         _L_(1)       /**< TC0 signal line function value: TIOB0 */
-#define PIO_PA1B_TC0_TIOB0                         (_UL_(1) << 1)
-
-#define PIN_PA16B_TC0_TIOB1                        _L_(16)      /**< TC0 signal: TIOB1 on PA16 mux B*/
-#define MUX_PA16B_TC0_TIOB1                        _L_(1)       /**< TC0 signal line function value: TIOB1 */
-#define PIO_PA16B_TC0_TIOB1                        (_UL_(1) << 16)
 
 #define PIN_PA27B_TC0_TIOB2                        _L_(27)      /**< TC0 signal: TIOB2 on PA27 mux B*/
 #define MUX_PA27B_TC0_TIOB2                        _L_(1)       /**< TC0 signal line function value: TIOB2 */

--- a/asf/sam/include/same70/pio/same70n19.h
+++ b/asf/sam/include/same70/pio/same70n19.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -905,10 +907,6 @@
 #define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
 #define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
 #define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
 
 #define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
 #define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */

--- a/asf/sam/include/same70/pio/same70n20.h
+++ b/asf/sam/include/same70/pio/same70n20.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -905,10 +907,6 @@
 #define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
 #define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
 #define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
 
 #define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
 #define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */

--- a/asf/sam/include/same70/pio/same70n21.h
+++ b/asf/sam/include/same70/pio/same70n21.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -905,10 +907,6 @@
 #define PIN_PA28B_TC0_TCLK1                        _L_(28)      /**< TC0 signal: TCLK1 on PA28 mux B*/
 #define MUX_PA28B_TC0_TCLK1                        _L_(1)       /**< TC0 signal line function value: TCLK1 */
 #define PIO_PA28B_TC0_TCLK1                        (_UL_(1) << 28)
-
-#define PIN_PA29B_TC0_TCLK2                        _L_(29)      /**< TC0 signal: TCLK2 on PA29 mux B*/
-#define MUX_PA29B_TC0_TCLK2                        _L_(1)       /**< TC0 signal line function value: TCLK2 */
-#define PIO_PA29B_TC0_TCLK2                        (_UL_(1) << 29)
 
 #define PIN_PA0B_TC0_TIOA0                         _L_(0)       /**< TC0 signal: TIOA0 on PA0 mux B*/
 #define MUX_PA0B_TC0_TIOA0                         _L_(1)       /**< TC0 signal line function value: TIOA0 */

--- a/asf/sam/include/same70/pio/same70q19.h
+++ b/asf/sam/include/same70/pio/same70q19.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/pio/same70q20.h
+++ b/asf/sam/include/same70/pio/same70q20.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/pio/same70q21.h
+++ b/asf/sam/include/same70/pio/same70q21.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/asf/sam/include/same70/same70j19.h
+++ b/asf/sam/include/same70/same70j19.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J19 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70J19 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70J19 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J19 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J19 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J19 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J19 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J19 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J19 Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J19 Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J19 Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J19 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J19 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J19 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J19 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70J19 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70J19 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70J19 Timer Counter (TC3)       */
@@ -165,13 +173,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J19 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J19 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J19 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J19 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J19 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J19 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J19 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J19 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J19 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J19 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J19 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J19 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -198,6 +204,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J19 Supply Controller (SUPC) */
@@ -226,9 +233,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J19 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70J19 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70J19 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J19 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70J19 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70J19 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J19 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J19 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J19 Pulse Width Modulation Controller (PWM0) */
@@ -247,9 +254,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J19 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J19 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70J19 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70J19 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70J19 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70J19 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70J19 Timer Counter (TC3)  */
@@ -261,15 +268,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J19 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J19 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J19 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J19 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J19 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J19 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J19 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J19 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J19 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J19 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J19 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J19 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -295,8 +309,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -326,6 +338,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -339,6 +357,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -359,7 +385,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -448,6 +474,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -490,6 +518,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -501,6 +532,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -570,6 +604,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -679,9 +715,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -789,6 +827,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70j20.h
+++ b/asf/sam/include/same70/same70j20.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J20 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70J20 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70J20 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J20 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J20 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J20 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J20 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J20 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J20 Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J20 Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J20 Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J20 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J20 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J20 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J20 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70J20 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70J20 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70J20 Timer Counter (TC3)       */
@@ -165,13 +173,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J20 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J20 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J20 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J20 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J20 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J20 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J20 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J20 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J20 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J20 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J20 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J20 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -198,6 +204,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J20 Supply Controller (SUPC) */
@@ -226,9 +233,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J20 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70J20 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70J20 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J20 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70J20 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70J20 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J20 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J20 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J20 Pulse Width Modulation Controller (PWM0) */
@@ -247,9 +254,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J20 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J20 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70J20 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70J20 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70J20 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70J20 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70J20 Timer Counter (TC3)  */
@@ -261,15 +268,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J20 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J20 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J20 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J20 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J20 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J20 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J20 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J20 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J20 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J20 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J20 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J20 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -295,8 +309,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -326,6 +338,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -339,6 +357,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -359,7 +385,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -448,6 +474,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -490,6 +518,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -501,6 +532,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -570,6 +604,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -679,9 +715,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -789,6 +827,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70j21.h
+++ b/asf/sam/include/same70/same70j21.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J21 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70J21 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70J21 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J21 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J21 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J21 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J21 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J21 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J21 Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J21 Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J21 Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J21 Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J21 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J21 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J21 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70J21 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70J21 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70J21 Timer Counter (TC3)       */
@@ -165,13 +173,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J21 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J21 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J21 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J21 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J21 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J21 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J21 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J21 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J21 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J21 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J21 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J21 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -198,6 +204,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J21 Supply Controller (SUPC) */
@@ -226,9 +233,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J21 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70J21 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70J21 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J21 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70J21 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70J21 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J21 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J21 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J21 Pulse Width Modulation Controller (PWM0) */
@@ -247,9 +254,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J21 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J21 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70J21 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70J21 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70J21 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70J21 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70J21 Timer Counter (TC3)  */
@@ -261,15 +268,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J21 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J21 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J21 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J21 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J21 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J21 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J21 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J21 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J21 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J21 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J21 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J21 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -295,8 +309,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -326,6 +338,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -339,6 +357,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -359,7 +385,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -448,6 +474,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -490,6 +518,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -501,6 +532,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -570,6 +604,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -679,9 +715,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -787,6 +825,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70n19.h
+++ b/asf/sam/include/same70/same70n19.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N19 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70N19 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70N19 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N19 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N19 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N19 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N19 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N19 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N19 Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N19 Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N19 Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N19 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N19 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N19 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N19 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70N19 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70N19 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70N19 Timer Counter (TC3)       */
@@ -173,13 +181,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N19 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N19 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N19 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N19 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N19 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N19 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N19 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N19 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N19 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N19 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N19 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N19 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -206,6 +212,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N19 Supply Controller (SUPC) */
@@ -234,9 +241,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N19 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70N19 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70N19 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N19 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70N19 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70N19 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N19 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N19 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N19 Pulse Width Modulation Controller (PWM0) */
@@ -255,9 +262,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N19 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N19 Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N19 Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N19 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70N19 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70N19 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70N19 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70N19 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70N19 Timer Counter (TC3)  */
@@ -269,15 +276,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N19 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N19 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N19 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N19 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N19 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N19 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N19 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N19 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N19 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N19 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N19 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N19 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -303,8 +317,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -338,6 +350,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -355,6 +373,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -375,7 +401,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -469,6 +495,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -518,6 +546,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -533,6 +564,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -605,6 +639,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -727,9 +763,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -841,6 +879,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70n20.h
+++ b/asf/sam/include/same70/same70n20.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N20 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70N20 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70N20 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N20 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N20 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N20 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N20 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N20 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N20 Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N20 Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N20 Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N20 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N20 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N20 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N20 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70N20 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70N20 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70N20 Timer Counter (TC3)       */
@@ -173,13 +181,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N20 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N20 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N20 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N20 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N20 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N20 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N20 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N20 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N20 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N20 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N20 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N20 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -206,6 +212,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N20 Supply Controller (SUPC) */
@@ -234,9 +241,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N20 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70N20 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70N20 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N20 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70N20 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70N20 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N20 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N20 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N20 Pulse Width Modulation Controller (PWM0) */
@@ -255,9 +262,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N20 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N20 Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N20 Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N20 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70N20 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70N20 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70N20 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70N20 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70N20 Timer Counter (TC3)  */
@@ -269,15 +276,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N20 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N20 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N20 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N20 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N20 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N20 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N20 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N20 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N20 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N20 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N20 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N20 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -303,8 +317,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -338,6 +350,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -355,6 +373,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -375,7 +401,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -469,6 +495,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -518,6 +546,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -533,6 +564,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -605,6 +639,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -727,9 +763,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -841,6 +879,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70n21.h
+++ b/asf/sam/include/same70/same70n21.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N21 Timer Counter (TC0)       */
   TC1_IRQn                  = 24 , /**< 24  SAME70N21 Timer Counter (TC0)       */
   TC2_IRQn                  = 25 , /**< 25  SAME70N21 Timer Counter (TC0)       */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N21 Timer Counter (TC1)       */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N21 Timer Counter (TC1)       */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N21 Timer Counter (TC1)       */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N21 Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N21 Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N21 Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N21 Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N21 Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N21 Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N21 Timer Counter (TC2)       */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N21 Timer Counter (TC2)       */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N21 Timer Counter (TC2)       */
   TC9_IRQn                  = 50 , /**< 50  SAME70N21 Timer Counter (TC3)       */
   TC10_IRQn                 = 51 , /**< 51  SAME70N21 Timer Counter (TC3)       */
   TC11_IRQn                 = 52 , /**< 52  SAME70N21 Timer Counter (TC3)       */
@@ -173,13 +181,11 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N21 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N21 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N21 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N21 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N21 Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N21 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N21 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N21 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N21 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N21 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N21 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N21 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -206,6 +212,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N21 Supply Controller (SUPC) */
@@ -234,9 +241,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N21 Timer Counter (TC0)  */
   void* pfnTC1_Handler;                          /* 24  SAME70N21 Timer Counter (TC0)  */
   void* pfnTC2_Handler;                          /* 25  SAME70N21 Timer Counter (TC0)  */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N21 Timer Counter (TC1)  */
+  void* pfnTC4_Handler;                          /* 27  SAME70N21 Timer Counter (TC1)  */
+  void* pfnTC5_Handler;                          /* 28  SAME70N21 Timer Counter (TC1)  */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N21 Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N21 Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N21 Pulse Width Modulation Controller (PWM0) */
@@ -255,9 +262,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N21 Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N21 Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N21 Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N21 Timer Counter (TC2)  */
+  void* pfnTC7_Handler;                          /* 48  SAME70N21 Timer Counter (TC2)  */
+  void* pfnTC8_Handler;                          /* 49  SAME70N21 Timer Counter (TC2)  */
   void* pfnTC9_Handler;                          /* 50  SAME70N21 Timer Counter (TC3)  */
   void* pfnTC10_Handler;                         /* 51  SAME70N21 Timer Counter (TC3)  */
   void* pfnTC11_Handler;                         /* 52  SAME70N21 Timer Counter (TC3)  */
@@ -269,15 +276,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N21 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N21 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N21 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N21 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N21 Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N21 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N21 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N21 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N21 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N21 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N21 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N21 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -303,8 +317,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -338,6 +350,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -355,6 +373,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -375,7 +401,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -469,6 +495,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -518,6 +546,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -533,6 +564,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -605,6 +639,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -727,9 +763,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -841,6 +879,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70q19.h
+++ b/asf/sam/include/same70/same70q19.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q19
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,12 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q19 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q19 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q19 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q19 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q19 Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q19 SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q19 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q19 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q19 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q19 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q19 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q19 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q19 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -216,6 +216,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q19 Supply Controller (SUPC) */
@@ -279,15 +280,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q19 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q19 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q19 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q19 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q19 Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q19 SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q19 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q19 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q19 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q19 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q19 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q19 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q19 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -313,8 +321,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -375,6 +381,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -395,7 +409,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -909,6 +923,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70q20.h
+++ b/asf/sam/include/same70/same70q20.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q20
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,12 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q20 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q20 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q20 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q20 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q20 Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q20 SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q20 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q20 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q20 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q20 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q20 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q20 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q20 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -216,6 +216,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q20 Supply Controller (SUPC) */
@@ -279,15 +280,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q20 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q20 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q20 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q20 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q20 Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q20 SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q20 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q20 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q20 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q20 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q20 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q20 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q20 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -313,8 +321,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -375,6 +381,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -395,7 +409,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -909,6 +923,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70/same70q21.h
+++ b/asf/sam/include/same70/same70q21.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q21
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,12 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q21 Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q21 Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q21 Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q21 Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q21 Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q21 SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q21 Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q21 System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q21 System Control Registers (SystemControl) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q21 Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q21 Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q21 Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q21 Floating Point Unit (FPU) */
 
   PERIPH_COUNT_IRQn        = 69  /**< Number of peripheral IDs */
 } IRQn_Type;
@@ -216,6 +216,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q21 Supply Controller (SUPC) */
@@ -279,15 +280,22 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q21 Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q21 Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q21 Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q21 Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q21 Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q21 SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q21 Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q21 System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q21 System Control Registers (SystemControl) */
+  void* pvReserved64;
+  void* pvReserved65;
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q21 Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q21 Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q21 Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q21 Floating Point Unit (FPU) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -313,8 +321,6 @@ void ACC_Handler                   ( void );
 void AES_Handler                   ( void );
 void AFEC0_Handler                 ( void );
 void AFEC1_Handler                 ( void );
-void CCF_Handler                   ( void );
-void CCW_Handler                   ( void );
 void DACC_Handler                  ( void );
 void EFC_Handler                   ( void );
 void FPU_Handler                   ( void );
@@ -375,6 +381,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -395,7 +409,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -593,18 +607,18 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 /*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAME70Q21 */
 /* ************************************************************************** */
-#define ID_TC0                   ID_TC0_CHANNEL0
-#define ID_TC1                   ID_TC0_CHANNEL1
-#define ID_TC2                   ID_TC0_CHANNEL2
-#define ID_TC3                   ID_TC1_CHANNEL0
-#define ID_TC4                   ID_TC1_CHANNEL1
-#define ID_TC5                   ID_TC1_CHANNEL2
-#define ID_TC6                   ID_TC2_CHANNEL0
-#define ID_TC7                   ID_TC2_CHANNEL1
-#define ID_TC8                   ID_TC2_CHANNEL2
-#define ID_TC9                   ID_TC3_CHANNEL0
-#define ID_TC10                  ID_TC3_CHANNEL1
-#define ID_TC11                  ID_TC3_CHANNEL2
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
 /** @}  end of Legacy Peripheral Ids Definitions */
 
 /** \addtogroup SAME70Q21_base Peripheral Base Address Definitions
@@ -909,6 +923,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -40,4 +40,5 @@ Patch List:
    * Fix XDMAC_CHID register name.
    * Fix TC_CHANNEL register name.
    * Fix USBHS_DEVDMA register name.
+   * Fix USBHS_HSTDMA register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -39,4 +39,5 @@ Patch List:
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.
    * Fix TC_CHANNEL register name.
+   * Fix USBHS_DEVDMA register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -34,3 +34,6 @@ License:
 
 License Link:
    https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix GMAC_SA register name.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -41,4 +41,5 @@ Patch List:
    * Fix TC_CHANNEL register name.
    * Fix USBHS_DEVDMA register name.
    * Fix USBHS_HSTDMA register name.
+   * Fix MATRIX_PR register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -44,4 +44,5 @@ Patch List:
    * Fix MATRIX_PR register name.
    * Fix PWM_CMP register name.
    * Fix PWM_CH_NUM register name.
+   * Fix SMC_CS_NUMBER register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -43,4 +43,5 @@ Patch List:
    * Fix USBHS_HSTDMA register name.
    * Fix MATRIX_PR register name.
    * Fix PWM_CMP register name.
+   * Fix PWM_CH_NUM register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -37,4 +37,5 @@ License Link:
 
 Patch List:
    * Fix GMAC_SA register name.
+   * Fix XDMAC_CHID register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -38,4 +38,5 @@ License Link:
 Patch List:
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.
+   * Fix TC_CHANNEL register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix GMAC_SA register name.
+   * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -42,4 +42,5 @@ Patch List:
    * Fix USBHS_DEVDMA register name.
    * Fix USBHS_HSTDMA register name.
    * Fix MATRIX_PR register name.
+   * Fix PWM_CMP register name.
    * Add old USART definitions for compatibility.

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -5,11 +5,11 @@ Origin:
    Microchip Packs Repository
    http://packs.download.atmel.com/
 
-   Atmel SAME70 Series Device Support (2.3.98)
-   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.3.98.atpack
+   Atmel SAME70 Series Device Support (2.4.166)
+   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.4.166.atpack
 
 Status:
-   version 2.3.98
+   version 2.4.166
 
 Purpose:
    Official package for SAM E70B.
@@ -21,7 +21,7 @@ Description:
 
 URL:
    http://packs.download.atmel.com/
-   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.3.98.atpack
+   http://packs.download.atmel.com/Atmel.SAME70_DFP.2.4.166.atpack
 
 commit:
   n/a
@@ -34,11 +34,3 @@ License:
 
 License Link:
    https://www.apache.org/licenses/LICENSE-2.0
-
-Patch Lst:
-   * Add missing header files symbols for Atmel SAM E70
-      Several missing symbols for same70q21b SoC are added:
-      - TC Channel Mode Register: Waveform Mode definitions
-      - Legacy peripheral IDs definitions
-   * Fix the GMAC priority queues related register to match the
-     datasheet.

--- a/asf/sam/include/same70b/component-version.h
+++ b/asf/sam/include/same70b/component-version.h
@@ -3,7 +3,7 @@
  *
  * \brief Component version header file
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
  *
  * \license_start
  *
@@ -29,7 +29,7 @@
 #define _COMPONENT_VERSION_H_INCLUDED
 
 #define COMPONENT_VERSION_MAJOR 2
-#define COMPONENT_VERSION_MINOR 3
+#define COMPONENT_VERSION_MINOR 4
 
 //
 // The COMPONENT_VERSION define is composed of the major and the minor version number.
@@ -37,18 +37,18 @@
 // The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
 // The rest of the COMPONENT_VERSION is the major version.
 //
-#define COMPONENT_VERSION 20003
+#define COMPONENT_VERSION 20004
 
 //
 // The build number does not refer to the component, but to the build number
 // of the device pack that provides the component.
 //
-#define BUILD_NUMBER 98
+#define BUILD_NUMBER 166
 
 //
 // The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
 //
-#define COMPONENT_VERSION_STRING "2.3"
+#define COMPONENT_VERSION_STRING "2.4"
 
 //
 // The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
@@ -58,7 +58,7 @@
 //     "%Y-%m-%d %H:%M:%S"
 //
 //
-#define COMPONENT_DATE_STRING "2018-01-30 13:59:17"
+#define COMPONENT_DATE_STRING "2019-02-18 11:43:38"
 
 #endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
 

--- a/asf/sam/include/same70b/component/acc.h
+++ b/asf/sam/include/same70b/component/acc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ACC_COMPONENT_H_
 #define _SAME70_ACC_COMPONENT_H_
 #define _SAME70_ACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define ACC_6490                       /**< (ACC) Module ID */
-#define REV_ACC H                      /**< (ACC) Module revision */
+#define REV_ACC J                      /**< (ACC) Module revision */
 
 /* -------- ACC_CR : (ACC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_CR_OFFSET                       (0x00)                                        /**<  (ACC_CR) Control Register  Offset */
@@ -65,6 +69,7 @@ typedef union {
 
 /* -------- ACC_MR : (ACC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SELMINUS:3;                /**< bit:   0..2  Selection for Minus Comparator Input     */
@@ -81,6 +86,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_MR_OFFSET                       (0x04)                                        /**<  (ACC_MR) Mode Register  Offset */
@@ -166,6 +172,7 @@ typedef union {
 
 /* -------- ACC_IER : (ACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -173,6 +180,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IER_OFFSET                      (0x24)                                        /**<  (ACC_IER) Interrupt Enable Register  Offset */
@@ -186,6 +194,7 @@ typedef union {
 
 /* -------- ACC_IDR : (ACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -193,6 +202,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IDR_OFFSET                      (0x28)                                        /**<  (ACC_IDR) Interrupt Disable Register  Offset */
@@ -206,6 +216,7 @@ typedef union {
 
 /* -------- ACC_IMR : (ACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge                          */
@@ -213,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_IMR_OFFSET                      (0x2C)                                        /**<  (ACC_IMR) Interrupt Mask Register  Offset */
@@ -226,6 +238,7 @@ typedef union {
 
 /* -------- ACC_ISR : (ACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CE:1;                      /**< bit:      0  Comparison Edge (cleared on read)        */
@@ -235,6 +248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_ISR_OFFSET                      (0x30)                                        /**<  (ACC_ISR) Interrupt Status Register  Offset */
@@ -253,6 +267,7 @@ typedef union {
 
 /* -------- ACC_ACR : (ACC Offset: 0x94) (R/W 32) Analog Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ISEL:1;                    /**< bit:      0  Current Selection                        */
@@ -261,6 +276,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_ACR_OFFSET                      (0x94)                                        /**<  (ACC_ACR) Analog Control Register  Offset */
@@ -281,6 +297,7 @@ typedef union {
 
 /* -------- ACC_WPMR : (ACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -289,6 +306,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_WPMR_OFFSET                     (0xE4)                                        /**<  (ACC_WPMR) Write Protection Mode Register  Offset */
@@ -307,6 +325,7 @@ typedef union {
 
 /* -------- ACC_WPSR : (ACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -314,6 +333,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ACC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ACC_WPSR_OFFSET                     (0xE8)                                        /**<  (ACC_WPSR) Write Protection Status Register  Offset */
@@ -331,14 +351,14 @@ typedef union {
 typedef struct {  
   __O  uint32_t ACC_CR;         /**< (ACC Offset: 0x00) Control Register */
   __IO uint32_t ACC_MR;         /**< (ACC Offset: 0x04) Mode Register */
-  RoReg8  Reserved1[0x1C];
+  __I  uint8_t                        Reserved1[28];
   __O  uint32_t ACC_IER;        /**< (ACC Offset: 0x24) Interrupt Enable Register */
   __O  uint32_t ACC_IDR;        /**< (ACC Offset: 0x28) Interrupt Disable Register */
   __I  uint32_t ACC_IMR;        /**< (ACC Offset: 0x2C) Interrupt Mask Register */
   __I  uint32_t ACC_ISR;        /**< (ACC Offset: 0x30) Interrupt Status Register */
-  RoReg8  Reserved2[0x60];
+  __I  uint8_t                        Reserved2[96];
   __IO uint32_t ACC_ACR;        /**< (ACC Offset: 0x94) Analog Control Register */
-  RoReg8  Reserved3[0x4C];
+  __I  uint8_t                        Reserved3[76];
   __IO uint32_t ACC_WPMR;       /**< (ACC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t ACC_WPSR;       /**< (ACC Offset: 0xE8) Write Protection Status Register */
 } Acc;
@@ -348,14 +368,14 @@ typedef struct {
 typedef struct {  
   __O  ACC_CR_Type                    ACC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO ACC_MR_Type                    ACC_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
-  __I  uint32_t                       Reserved1[7];
+  __I  uint8_t                        Reserved1[28];
   __O  ACC_IER_Type                   ACC_IER;        /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
   __O  ACC_IDR_Type                   ACC_IDR;        /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
   __I  ACC_IMR_Type                   ACC_IMR;        /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
   __I  ACC_ISR_Type                   ACC_ISR;        /**< Offset: 0x30 (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[24];
+  __I  uint8_t                        Reserved2[96];
   __IO ACC_ACR_Type                   ACC_ACR;        /**< Offset: 0x94 (R/W  32) Analog Control Register */
-  __I  uint32_t                       Reserved3[19];
+  __I  uint8_t                        Reserved3[76];
   __IO ACC_WPMR_Type                  ACC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  ACC_WPSR_Type                  ACC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Acc;

--- a/asf/sam/include/same70b/component/aes.h
+++ b/asf/sam/include/same70b/component/aes.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for AES
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_AES_COMPONENT_H_
 #define _SAME70_AES_COMPONENT_H_
 #define _SAME70_AES_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,15 +47,19 @@
 
 /* -------- AES_CR : (AES Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t START:1;                   /**< bit:      0  Start Processing                         */
     uint32_t :7;                        /**< bit:   1..7  Reserved */
     uint32_t SWRST:1;                   /**< bit:      8  Software Reset                           */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t LOADSEED:1;                /**< bit:     16  Random Number Generator Seed Loading     */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CR_OFFSET                       (0x00)                                        /**<  (AES_CR) Control Register  Offset */
@@ -64,12 +70,16 @@ typedef union {
 #define AES_CR_SWRST_Pos                    8                                              /**< (AES_CR) Software Reset Position */
 #define AES_CR_SWRST_Msk                    (_U_(0x1) << AES_CR_SWRST_Pos)                 /**< (AES_CR) Software Reset Mask */
 #define AES_CR_SWRST                        AES_CR_SWRST_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_SWRST_Msk instead */
-#define AES_CR_MASK                         _U_(0x101)                                     /**< \deprecated (AES_CR) Register MASK  (Use AES_CR_Msk instead)  */
-#define AES_CR_Msk                          _U_(0x101)                                     /**< (AES_CR) Register Mask  */
+#define AES_CR_LOADSEED_Pos                 16                                             /**< (AES_CR) Random Number Generator Seed Loading Position */
+#define AES_CR_LOADSEED_Msk                 (_U_(0x1) << AES_CR_LOADSEED_Pos)              /**< (AES_CR) Random Number Generator Seed Loading Mask */
+#define AES_CR_LOADSEED                     AES_CR_LOADSEED_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use AES_CR_LOADSEED_Msk instead */
+#define AES_CR_MASK                         _U_(0x10101)                                   /**< \deprecated (AES_CR) Register MASK  (Use AES_CR_Msk instead)  */
+#define AES_CR_Msk                          _U_(0x10101)                                   /**< (AES_CR) Register Mask  */
 
 
 /* -------- AES_MR : (AES Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CIPHER:1;                  /**< bit:      0  Processing Mode                          */
@@ -88,6 +98,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_MR_OFFSET                       (0x04)                                        /**<  (AES_MR) Mode Register  Offset */
@@ -168,6 +179,7 @@ typedef union {
 
 /* -------- AES_IER : (AES Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
@@ -179,6 +191,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IER_OFFSET                      (0x10)                                        /**<  (AES_IER) Interrupt Enable Register  Offset */
@@ -198,6 +211,7 @@ typedef union {
 
 /* -------- AES_IDR : (AES Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
@@ -209,6 +223,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IDR_OFFSET                      (0x14)                                        /**<  (AES_IDR) Interrupt Disable Register  Offset */
@@ -228,6 +243,7 @@ typedef union {
 
 /* -------- AES_IMR : (AES Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
@@ -239,6 +255,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_IMR_OFFSET                      (0x18)                                        /**<  (AES_IMR) Interrupt Mask Register  Offset */
@@ -258,6 +275,7 @@ typedef union {
 
 /* -------- AES_ISR : (AES Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready (cleared by setting bit START or bit SWRST in AES_CR or by reading AES_ODATARx) */
@@ -270,6 +288,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_ISR_OFFSET                      (0x1C)                                        /**<  (AES_ISR) Interrupt Status Register  Offset */
@@ -302,17 +321,19 @@ typedef union {
 #define AES_ISR_Msk                         _U_(0x1F101)                                   /**< (AES_ISR) Register Mask  */
 
 
-/* -------- AES_KEYWR : (AES Offset: 0x20) (/W 32) Key Word Register 0 -------- */
+/* -------- AES_KEYWR : (AES Offset: 0x20) (/W 32) Key Word Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEYW:32;                   /**< bit:  0..31  Key Word                                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_KEYWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_KEYWR_OFFSET                    (0x20)                                        /**<  (AES_KEYWR) Key Word Register 0  Offset */
+#define AES_KEYWR_OFFSET                    (0x20)                                        /**<  (AES_KEYWR) Key Word Register  Offset */
 
 #define AES_KEYWR_KEYW_Pos                  0                                              /**< (AES_KEYWR) Key Word Position */
 #define AES_KEYWR_KEYW_Msk                  (_U_(0xFFFFFFFF) << AES_KEYWR_KEYW_Pos)        /**< (AES_KEYWR) Key Word Mask */
@@ -321,17 +342,19 @@ typedef union {
 #define AES_KEYWR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_KEYWR) Register Mask  */
 
 
-/* -------- AES_IDATAR : (AES Offset: 0x40) (/W 32) Input Data Register 0 -------- */
+/* -------- AES_IDATAR : (AES Offset: 0x40) (/W 32) Input Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDATA:32;                  /**< bit:  0..31  Input Data Word                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IDATAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_IDATAR_OFFSET                   (0x40)                                        /**<  (AES_IDATAR) Input Data Register 0  Offset */
+#define AES_IDATAR_OFFSET                   (0x40)                                        /**<  (AES_IDATAR) Input Data Register  Offset */
 
 #define AES_IDATAR_IDATA_Pos                0                                              /**< (AES_IDATAR) Input Data Word Position */
 #define AES_IDATAR_IDATA_Msk                (_U_(0xFFFFFFFF) << AES_IDATAR_IDATA_Pos)      /**< (AES_IDATAR) Input Data Word Mask */
@@ -340,17 +363,19 @@ typedef union {
 #define AES_IDATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_IDATAR) Register Mask  */
 
 
-/* -------- AES_ODATAR : (AES Offset: 0x50) (R/ 32) Output Data Register 0 -------- */
+/* -------- AES_ODATAR : (AES Offset: 0x50) (R/ 32) Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_ODATAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_ODATAR_OFFSET                   (0x50)                                        /**<  (AES_ODATAR) Output Data Register 0  Offset */
+#define AES_ODATAR_OFFSET                   (0x50)                                        /**<  (AES_ODATAR) Output Data Register  Offset */
 
 #define AES_ODATAR_ODATA_Pos                0                                              /**< (AES_ODATAR) Output Data Position */
 #define AES_ODATAR_ODATA_Msk                (_U_(0xFFFFFFFF) << AES_ODATAR_ODATA_Pos)      /**< (AES_ODATAR) Output Data Mask */
@@ -359,17 +384,19 @@ typedef union {
 #define AES_ODATAR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_ODATAR) Register Mask  */
 
 
-/* -------- AES_IVR : (AES Offset: 0x60) (/W 32) Initialization Vector Register 0 -------- */
+/* -------- AES_IVR : (AES Offset: 0x60) (/W 32) Initialization Vector Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IV:32;                     /**< bit:  0..31  Initialization Vector                    */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_IVR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_IVR_OFFSET                      (0x60)                                        /**<  (AES_IVR) Initialization Vector Register 0  Offset */
+#define AES_IVR_OFFSET                      (0x60)                                        /**<  (AES_IVR) Initialization Vector Register  Offset */
 
 #define AES_IVR_IV_Pos                      0                                              /**< (AES_IVR) Initialization Vector Position */
 #define AES_IVR_IV_Msk                      (_U_(0xFFFFFFFF) << AES_IVR_IV_Pos)            /**< (AES_IVR) Initialization Vector Mask */
@@ -380,12 +407,14 @@ typedef union {
 
 /* -------- AES_AADLENR : (AES Offset: 0x70) (R/W 32) Additional Authenticated Data Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AADLEN:32;                 /**< bit:  0..31  Additional Authenticated Data Length     */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_AADLENR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_AADLENR_OFFSET                  (0x70)                                        /**<  (AES_AADLENR) Additional Authenticated Data Length Register  Offset */
@@ -399,12 +428,14 @@ typedef union {
 
 /* -------- AES_CLENR : (AES Offset: 0x74) (R/W 32) Plaintext/Ciphertext Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLEN:32;                   /**< bit:  0..31  Plaintext/Ciphertext Length              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CLENR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CLENR_OFFSET                    (0x74)                                        /**<  (AES_CLENR) Plaintext/Ciphertext Length Register  Offset */
@@ -416,17 +447,19 @@ typedef union {
 #define AES_CLENR_Msk                       _U_(0xFFFFFFFF)                                /**< (AES_CLENR) Register Mask  */
 
 
-/* -------- AES_GHASHR : (AES Offset: 0x78) (R/W 32) GCM Intermediate Hash Word Register 0 -------- */
+/* -------- AES_GHASHR : (AES Offset: 0x78) (R/W 32) GCM Intermediate Hash Word Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GHASH:32;                  /**< bit:  0..31  Intermediate GCM Hash Word x             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_GHASHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_GHASHR_OFFSET                   (0x78)                                        /**<  (AES_GHASHR) GCM Intermediate Hash Word Register 0  Offset */
+#define AES_GHASHR_OFFSET                   (0x78)                                        /**<  (AES_GHASHR) GCM Intermediate Hash Word Register  Offset */
 
 #define AES_GHASHR_GHASH_Pos                0                                              /**< (AES_GHASHR) Intermediate GCM Hash Word x Position */
 #define AES_GHASHR_GHASH_Msk                (_U_(0xFFFFFFFF) << AES_GHASHR_GHASH_Pos)      /**< (AES_GHASHR) Intermediate GCM Hash Word x Mask */
@@ -435,17 +468,19 @@ typedef union {
 #define AES_GHASHR_Msk                      _U_(0xFFFFFFFF)                                /**< (AES_GHASHR) Register Mask  */
 
 
-/* -------- AES_TAGR : (AES Offset: 0x88) (R/ 32) GCM Authentication Tag Word Register 0 -------- */
+/* -------- AES_TAGR : (AES Offset: 0x88) (R/ 32) GCM Authentication Tag Word Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TAG:32;                    /**< bit:  0..31  GCM Authentication Tag x                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_TAGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_TAGR_OFFSET                     (0x88)                                        /**<  (AES_TAGR) GCM Authentication Tag Word Register 0  Offset */
+#define AES_TAGR_OFFSET                     (0x88)                                        /**<  (AES_TAGR) GCM Authentication Tag Word Register  Offset */
 
 #define AES_TAGR_TAG_Pos                    0                                              /**< (AES_TAGR) GCM Authentication Tag x Position */
 #define AES_TAGR_TAG_Msk                    (_U_(0xFFFFFFFF) << AES_TAGR_TAG_Pos)          /**< (AES_TAGR) GCM Authentication Tag x Mask */
@@ -456,12 +491,14 @@ typedef union {
 
 /* -------- AES_CTRR : (AES Offset: 0x98) (R/ 32) GCM Encryption Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CTR:32;                    /**< bit:  0..31  GCM Encryption Counter                   */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_CTRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AES_CTRR_OFFSET                     (0x98)                                        /**<  (AES_CTRR) GCM Encryption Counter Value Register  Offset */
@@ -473,17 +510,19 @@ typedef union {
 #define AES_CTRR_Msk                        _U_(0xFFFFFFFF)                                /**< (AES_CTRR) Register Mask  */
 
 
-/* -------- AES_GCMHR : (AES Offset: 0x9c) (R/W 32) GCM H Word Register 0 -------- */
+/* -------- AES_GCMHR : (AES Offset: 0x9c) (R/W 32) GCM H Word Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t H:32;                      /**< bit:  0..31  GCM H Word x                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AES_GCMHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define AES_GCMHR_OFFSET                    (0x9C)                                        /**<  (AES_GCMHR) GCM H Word Register 0  Offset */
+#define AES_GCMHR_OFFSET                    (0x9C)                                        /**<  (AES_GCMHR) GCM H Word Register  Offset */
 
 #define AES_GCMHR_H_Pos                     0                                              /**< (AES_GCMHR) GCM H Word x Position */
 #define AES_GCMHR_H_Msk                     (_U_(0xFFFFFFFF) << AES_GCMHR_H_Pos)           /**< (AES_GCMHR) GCM H Word x Mask */
@@ -498,21 +537,21 @@ typedef union {
 typedef struct {  
   __O  uint32_t AES_CR;         /**< (AES Offset: 0x00) Control Register */
   __IO uint32_t AES_MR;         /**< (AES Offset: 0x04) Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __O  uint32_t AES_IER;        /**< (AES Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t AES_IDR;        /**< (AES Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t AES_IMR;        /**< (AES Offset: 0x18) Interrupt Mask Register */
   __I  uint32_t AES_ISR;        /**< (AES Offset: 0x1C) Interrupt Status Register */
-  __O  uint32_t AES_KEYWR[8];   /**< (AES Offset: 0x20) Key Word Register 0 */
-  __O  uint32_t AES_IDATAR[4];  /**< (AES Offset: 0x40) Input Data Register 0 */
-  __I  uint32_t AES_ODATAR[4];  /**< (AES Offset: 0x50) Output Data Register 0 */
-  __O  uint32_t AES_IVR[4];     /**< (AES Offset: 0x60) Initialization Vector Register 0 */
+  __O  uint32_t AES_KEYWR[8];   /**< (AES Offset: 0x20) Key Word Register */
+  __O  uint32_t AES_IDATAR[4];  /**< (AES Offset: 0x40) Input Data Register */
+  __I  uint32_t AES_ODATAR[4];  /**< (AES Offset: 0x50) Output Data Register */
+  __O  uint32_t AES_IVR[4];     /**< (AES Offset: 0x60) Initialization Vector Register */
   __IO uint32_t AES_AADLENR;    /**< (AES Offset: 0x70) Additional Authenticated Data Length Register */
   __IO uint32_t AES_CLENR;      /**< (AES Offset: 0x74) Plaintext/Ciphertext Length Register */
-  __IO uint32_t AES_GHASHR[4];  /**< (AES Offset: 0x78) GCM Intermediate Hash Word Register 0 */
-  __I  uint32_t AES_TAGR[4];    /**< (AES Offset: 0x88) GCM Authentication Tag Word Register 0 */
+  __IO uint32_t AES_GHASHR[4];  /**< (AES Offset: 0x78) GCM Intermediate Hash Word Register */
+  __I  uint32_t AES_TAGR[4];    /**< (AES Offset: 0x88) GCM Authentication Tag Word Register */
   __I  uint32_t AES_CTRR;       /**< (AES Offset: 0x98) GCM Encryption Counter Value Register */
-  __IO uint32_t AES_GCMHR[4];   /**< (AES Offset: 0x9C) GCM H Word Register 0 */
+  __IO uint32_t AES_GCMHR[4];   /**< (AES Offset: 0x9C) GCM H Word Register */
 } Aes;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -520,21 +559,21 @@ typedef struct {
 typedef struct {  
   __O  AES_CR_Type                    AES_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO AES_MR_Type                    AES_MR;         /**< Offset: 0x04 (R/W  32) Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __O  AES_IER_Type                   AES_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  AES_IDR_Type                   AES_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  AES_IMR_Type                   AES_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
   __I  AES_ISR_Type                   AES_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
-  __O  AES_KEYWR_Type                 AES_KEYWR[8];   /**< Offset: 0x20 ( /W  32) Key Word Register 0 */
-  __O  AES_IDATAR_Type                AES_IDATAR[4];  /**< Offset: 0x40 ( /W  32) Input Data Register 0 */
-  __I  AES_ODATAR_Type                AES_ODATAR[4];  /**< Offset: 0x50 (R/   32) Output Data Register 0 */
-  __O  AES_IVR_Type                   AES_IVR[4];     /**< Offset: 0x60 ( /W  32) Initialization Vector Register 0 */
+  __O  AES_KEYWR_Type                 AES_KEYWR[8];   /**< Offset: 0x20 ( /W  32) Key Word Register */
+  __O  AES_IDATAR_Type                AES_IDATAR[4];  /**< Offset: 0x40 ( /W  32) Input Data Register */
+  __I  AES_ODATAR_Type                AES_ODATAR[4];  /**< Offset: 0x50 (R/   32) Output Data Register */
+  __O  AES_IVR_Type                   AES_IVR[4];     /**< Offset: 0x60 ( /W  32) Initialization Vector Register */
   __IO AES_AADLENR_Type               AES_AADLENR;    /**< Offset: 0x70 (R/W  32) Additional Authenticated Data Length Register */
   __IO AES_CLENR_Type                 AES_CLENR;      /**< Offset: 0x74 (R/W  32) Plaintext/Ciphertext Length Register */
-  __IO AES_GHASHR_Type                AES_GHASHR[4];  /**< Offset: 0x78 (R/W  32) GCM Intermediate Hash Word Register 0 */
-  __I  AES_TAGR_Type                  AES_TAGR[4];    /**< Offset: 0x88 (R/   32) GCM Authentication Tag Word Register 0 */
+  __IO AES_GHASHR_Type                AES_GHASHR[4];  /**< Offset: 0x78 (R/W  32) GCM Intermediate Hash Word Register */
+  __I  AES_TAGR_Type                  AES_TAGR[4];    /**< Offset: 0x88 (R/   32) GCM Authentication Tag Word Register */
   __I  AES_CTRR_Type                  AES_CTRR;       /**< Offset: 0x98 (R/   32) GCM Encryption Counter Value Register */
-  __IO AES_GCMHR_Type                 AES_GCMHR[4];   /**< Offset: 0x9C (R/W  32) GCM H Word Register 0 */
+  __IO AES_GCMHR_Type                 AES_GCMHR[4];   /**< Offset: 0x9C (R/W  32) GCM H Word Register */
 } Aes;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70b/component/afec.h
+++ b/asf/sam/include/same70b/component/afec.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for AFEC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_AFEC_COMPONENT_H_
 #define _SAME70_AFEC_COMPONENT_H_
 #define _SAME70_AFEC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- AFEC_CR : (AFEC Offset: 0x00) (/W 32) AFEC Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CR_OFFSET                      (0x00)                                        /**<  (AFEC_CR) AFEC Control Register  Offset */
@@ -69,6 +73,7 @@ typedef union {
 
 /* -------- AFEC_MR : (AFEC Offset: 0x04) (R/W 32) AFEC Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRGEN:1;                   /**< bit:      0  Trigger Enable                           */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_MR_OFFSET                      (0x04)                                        /**<  (AFEC_MR) AFEC Mode Register  Offset */
@@ -197,6 +203,7 @@ typedef union {
 
 /* -------- AFEC_EMR : (AFEC Offset: 0x08) (R/W 32) AFEC Extended Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMPMODE:2;                 /**< bit:   0..1  Comparison Mode                          */
@@ -217,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_EMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_EMR_OFFSET                     (0x08)                                        /**<  (AFEC_EMR) AFEC Extended Mode Register  Offset */
@@ -277,6 +285,7 @@ typedef union {
 
 /* -------- AFEC_SEQ1R : (AFEC Offset: 0x0c) (R/W 32) AFEC Channel Sequence 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USCH0:4;                   /**< bit:   0..3  User Sequence Number 0                   */
@@ -290,6 +299,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SEQ1R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SEQ1R_OFFSET                   (0x0C)                                        /**<  (AFEC_SEQ1R) AFEC Channel Sequence 1 Register  Offset */
@@ -324,6 +334,7 @@ typedef union {
 
 /* -------- AFEC_SEQ2R : (AFEC Offset: 0x10) (R/W 32) AFEC Channel Sequence 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USCH8:4;                   /**< bit:   0..3  User Sequence Number 8                   */
@@ -334,6 +345,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SEQ2R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SEQ2R_OFFSET                   (0x10)                                        /**<  (AFEC_SEQ2R) AFEC Channel Sequence 2 Register  Offset */
@@ -356,6 +368,7 @@ typedef union {
 
 /* -------- AFEC_CHER : (AFEC Offset: 0x14) (/W 32) AFEC Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
@@ -378,6 +391,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHER_OFFSET                    (0x14)                                        /**<  (AFEC_CHER) AFEC Channel Enable Register  Offset */
@@ -427,6 +441,7 @@ typedef union {
 
 /* -------- AFEC_CHDR : (AFEC Offset: 0x18) (/W 32) AFEC Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
@@ -449,6 +464,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHDR_OFFSET                    (0x18)                                        /**<  (AFEC_CHDR) AFEC Channel Disable Register  Offset */
@@ -498,6 +514,7 @@ typedef union {
 
 /* -------- AFEC_CHSR : (AFEC Offset: 0x1c) (R/ 32) AFEC Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
@@ -520,6 +537,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CHSR_OFFSET                    (0x1C)                                        /**<  (AFEC_CHSR) AFEC Channel Status Register  Offset */
@@ -569,6 +587,7 @@ typedef union {
 
 /* -------- AFEC_LCDR : (AFEC Offset: 0x20) (R/ 32) AFEC Last Converted Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LDATA:16;                  /**< bit:  0..15  Last Data Converted                      */
@@ -578,6 +597,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_LCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_LCDR_OFFSET                    (0x20)                                        /**<  (AFEC_LCDR) AFEC Last Converted Data Register  Offset */
@@ -594,6 +614,7 @@ typedef union {
 
 /* -------- AFEC_IER : (AFEC Offset: 0x24) (/W 32) AFEC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Enable 0     */
@@ -622,6 +643,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IER_OFFSET                     (0x24)                                        /**<  (AFEC_IER) AFEC Interrupt Enable Register  Offset */
@@ -683,6 +705,7 @@ typedef union {
 
 /* -------- AFEC_IDR : (AFEC Offset: 0x28) (/W 32) AFEC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Disable 0    */
@@ -711,6 +734,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IDR_OFFSET                     (0x28)                                        /**<  (AFEC_IDR) AFEC Interrupt Disable Register  Offset */
@@ -772,6 +796,7 @@ typedef union {
 
 /* -------- AFEC_IMR : (AFEC Offset: 0x2c) (R/ 32) AFEC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion Interrupt Mask 0       */
@@ -800,6 +825,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_IMR_OFFSET                     (0x2C)                                        /**<  (AFEC_IMR) AFEC Interrupt Mask Register  Offset */
@@ -861,6 +887,7 @@ typedef union {
 
 /* -------- AFEC_ISR : (AFEC Offset: 0x30) (R/ 32) AFEC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EOC0:1;                    /**< bit:      0  End of Conversion 0 (cleared by reading AFEC_CDRx) */
@@ -889,6 +916,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_ISR_OFFSET                     (0x30)                                        /**<  (AFEC_ISR) AFEC Interrupt Status Register  Offset */
@@ -950,6 +978,7 @@ typedef union {
 
 /* -------- AFEC_OVER : (AFEC Offset: 0x4c) (R/ 32) AFEC Overrun Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OVRE0:1;                   /**< bit:      0  Overrun Error 0                          */
@@ -972,6 +1001,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_OVER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_OVER_OFFSET                    (0x4C)                                        /**<  (AFEC_OVER) AFEC Overrun Status Register  Offset */
@@ -1021,6 +1051,7 @@ typedef union {
 
 /* -------- AFEC_CWR : (AFEC Offset: 0x50) (R/W 32) AFEC Compare Window Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LOWTHRES:16;               /**< bit:  0..15  Low Threshold                            */
@@ -1028,6 +1059,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CWR_OFFSET                     (0x50)                                        /**<  (AFEC_CWR) AFEC Compare Window Register  Offset */
@@ -1044,6 +1076,7 @@ typedef union {
 
 /* -------- AFEC_CGR : (AFEC Offset: 0x54) (R/W 32) AFEC Channel Gain Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GAIN0:2;                   /**< bit:   0..1  Gain for Channel 0                       */
@@ -1062,6 +1095,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CGR_OFFSET                     (0x54)                                        /**<  (AFEC_CGR) AFEC Channel Gain Register  Offset */
@@ -1108,6 +1142,7 @@ typedef union {
 
 /* -------- AFEC_DIFFR : (AFEC Offset: 0x60) (R/W 32) AFEC Channel Differential Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIFF0:1;                   /**< bit:      0  Differential inputs for channel 0        */
@@ -1130,6 +1165,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_DIFFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_DIFFR_OFFSET                   (0x60)                                        /**<  (AFEC_DIFFR) AFEC Channel Differential Register  Offset */
@@ -1179,6 +1215,7 @@ typedef union {
 
 /* -------- AFEC_CSELR : (AFEC Offset: 0x64) (R/W 32) AFEC Channel Selection Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL:4;                    /**< bit:   0..3  Channel Selection                        */
@@ -1186,6 +1223,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CSELR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CSELR_OFFSET                   (0x64)                                        /**<  (AFEC_CSELR) AFEC Channel Selection Register  Offset */
@@ -1199,6 +1237,7 @@ typedef union {
 
 /* -------- AFEC_CDR : (AFEC Offset: 0x68) (R/ 32) AFEC Channel Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:16;                   /**< bit:  0..15  Converted Data                           */
@@ -1206,6 +1245,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CDR_OFFSET                     (0x68)                                        /**<  (AFEC_CDR) AFEC Channel Data Register  Offset */
@@ -1219,6 +1259,7 @@ typedef union {
 
 /* -------- AFEC_COCR : (AFEC Offset: 0x6c) (R/W 32) AFEC Channel Offset Compensation Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AOFF:10;                   /**< bit:   0..9  Analog Offset                            */
@@ -1226,6 +1267,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_COCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_COCR_OFFSET                    (0x6C)                                        /**<  (AFEC_COCR) AFEC Channel Offset Compensation Register  Offset */
@@ -1239,6 +1281,7 @@ typedef union {
 
 /* -------- AFEC_TEMPMR : (AFEC Offset: 0x70) (R/W 32) AFEC Temperature Sensor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RTCT:1;                    /**< bit:      0  Temperature Sensor RTC Trigger Mode      */
@@ -1248,6 +1291,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_TEMPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_TEMPMR_OFFSET                  (0x70)                                        /**<  (AFEC_TEMPMR) AFEC Temperature Sensor Mode Register  Offset */
@@ -1272,6 +1316,7 @@ typedef union {
 
 /* -------- AFEC_TEMPCWR : (AFEC Offset: 0x74) (R/W 32) AFEC Temperature Compare Window Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TLOWTHRES:16;              /**< bit:  0..15  Temperature Low Threshold                */
@@ -1279,6 +1324,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_TEMPCWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_TEMPCWR_OFFSET                 (0x74)                                        /**<  (AFEC_TEMPCWR) AFEC Temperature Compare Window Register  Offset */
@@ -1295,6 +1341,7 @@ typedef union {
 
 /* -------- AFEC_ACR : (AFEC Offset: 0x94) (R/W 32) AFEC Analog Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1306,6 +1353,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_ACR_OFFSET                     (0x94)                                        /**<  (AFEC_ACR) AFEC Analog Control Register  Offset */
@@ -1325,6 +1373,7 @@ typedef union {
 
 /* -------- AFEC_SHMR : (AFEC Offset: 0xa0) (R/W 32) AFEC Sample & Hold Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DUAL0:1;                   /**< bit:      0  Dual Sample & Hold for channel 0         */
@@ -1347,6 +1396,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_SHMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_SHMR_OFFSET                    (0xA0)                                        /**<  (AFEC_SHMR) AFEC Sample & Hold Mode Register  Offset */
@@ -1396,6 +1446,7 @@ typedef union {
 
 /* -------- AFEC_COSR : (AFEC Offset: 0xd0) (R/W 32) AFEC Correction Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL:1;                    /**< bit:      0  Sample & Hold unit Correction Select     */
@@ -1403,6 +1454,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_COSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_COSR_OFFSET                    (0xD0)                                        /**<  (AFEC_COSR) AFEC Correction Select Register  Offset */
@@ -1416,6 +1468,7 @@ typedef union {
 
 /* -------- AFEC_CVR : (AFEC Offset: 0xd4) (R/W 32) AFEC Correction Values Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFFSETCORR:16;             /**< bit:  0..15  Offset Correction                        */
@@ -1423,6 +1476,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CVR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CVR_OFFSET                     (0xD4)                                        /**<  (AFEC_CVR) AFEC Correction Values Register  Offset */
@@ -1439,6 +1493,7 @@ typedef union {
 
 /* -------- AFEC_CECR : (AFEC Offset: 0xd8) (R/W 32) AFEC Channel Error Correction Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ECORR0:1;                  /**< bit:      0  Error Correction Enable for channel 0    */
@@ -1461,6 +1516,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_CECR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_CECR_OFFSET                    (0xD8)                                        /**<  (AFEC_CECR) AFEC Channel Error Correction Register  Offset */
@@ -1510,6 +1566,7 @@ typedef union {
 
 /* -------- AFEC_WPMR : (AFEC Offset: 0xe4) (R/W 32) AFEC Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1518,6 +1575,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_WPMR_OFFSET                    (0xE4)                                        /**<  (AFEC_WPMR) AFEC Write Protection Mode Register  Offset */
@@ -1536,6 +1594,7 @@ typedef union {
 
 /* -------- AFEC_WPSR : (AFEC Offset: 0xe8) (R/ 32) AFEC Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protect Violation Status           */
@@ -1545,6 +1604,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } AFEC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define AFEC_WPSR_OFFSET                    (0xE8)                                        /**<  (AFEC_WPSR) AFEC Write Protection Status Register  Offset */
@@ -1576,26 +1636,26 @@ typedef struct {
   __O  uint32_t AFEC_IDR;       /**< (AFEC Offset: 0x28) AFEC Interrupt Disable Register */
   __I  uint32_t AFEC_IMR;       /**< (AFEC Offset: 0x2C) AFEC Interrupt Mask Register */
   __I  uint32_t AFEC_ISR;       /**< (AFEC Offset: 0x30) AFEC Interrupt Status Register */
-  RoReg8  Reserved1[0x18];
+  __I  uint8_t                        Reserved1[24];
   __I  uint32_t AFEC_OVER;      /**< (AFEC Offset: 0x4C) AFEC Overrun Status Register */
   __IO uint32_t AFEC_CWR;       /**< (AFEC Offset: 0x50) AFEC Compare Window Register */
   __IO uint32_t AFEC_CGR;       /**< (AFEC Offset: 0x54) AFEC Channel Gain Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __IO uint32_t AFEC_DIFFR;     /**< (AFEC Offset: 0x60) AFEC Channel Differential Register */
   __IO uint32_t AFEC_CSELR;     /**< (AFEC Offset: 0x64) AFEC Channel Selection Register */
   __I  uint32_t AFEC_CDR;       /**< (AFEC Offset: 0x68) AFEC Channel Data Register */
   __IO uint32_t AFEC_COCR;      /**< (AFEC Offset: 0x6C) AFEC Channel Offset Compensation Register */
   __IO uint32_t AFEC_TEMPMR;    /**< (AFEC Offset: 0x70) AFEC Temperature Sensor Mode Register */
   __IO uint32_t AFEC_TEMPCWR;   /**< (AFEC Offset: 0x74) AFEC Temperature Compare Window Register */
-  RoReg8  Reserved3[0x1C];
+  __I  uint8_t                        Reserved3[28];
   __IO uint32_t AFEC_ACR;       /**< (AFEC Offset: 0x94) AFEC Analog Control Register */
-  RoReg8  Reserved4[0x8];
+  __I  uint8_t                        Reserved4[8];
   __IO uint32_t AFEC_SHMR;      /**< (AFEC Offset: 0xA0) AFEC Sample & Hold Mode Register */
-  RoReg8  Reserved5[0x2C];
+  __I  uint8_t                        Reserved5[44];
   __IO uint32_t AFEC_COSR;      /**< (AFEC Offset: 0xD0) AFEC Correction Select Register */
   __IO uint32_t AFEC_CVR;       /**< (AFEC Offset: 0xD4) AFEC Correction Values Register */
   __IO uint32_t AFEC_CECR;      /**< (AFEC Offset: 0xD8) AFEC Channel Error Correction Register */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __IO uint32_t AFEC_WPMR;      /**< (AFEC Offset: 0xE4) AFEC Write Protection Mode Register */
   __I  uint32_t AFEC_WPSR;      /**< (AFEC Offset: 0xE8) AFEC Write Protection Status Register */
 } Afec;
@@ -1616,26 +1676,26 @@ typedef struct {
   __O  AFEC_IDR_Type                  AFEC_IDR;       /**< Offset: 0x28 ( /W  32) AFEC Interrupt Disable Register */
   __I  AFEC_IMR_Type                  AFEC_IMR;       /**< Offset: 0x2C (R/   32) AFEC Interrupt Mask Register */
   __I  AFEC_ISR_Type                  AFEC_ISR;       /**< Offset: 0x30 (R/   32) AFEC Interrupt Status Register */
-  __I  uint32_t                       Reserved1[6];
+  __I  uint8_t                        Reserved1[24];
   __I  AFEC_OVER_Type                 AFEC_OVER;      /**< Offset: 0x4C (R/   32) AFEC Overrun Status Register */
   __IO AFEC_CWR_Type                  AFEC_CWR;       /**< Offset: 0x50 (R/W  32) AFEC Compare Window Register */
   __IO AFEC_CGR_Type                  AFEC_CGR;       /**< Offset: 0x54 (R/W  32) AFEC Channel Gain Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __IO AFEC_DIFFR_Type                AFEC_DIFFR;     /**< Offset: 0x60 (R/W  32) AFEC Channel Differential Register */
   __IO AFEC_CSELR_Type                AFEC_CSELR;     /**< Offset: 0x64 (R/W  32) AFEC Channel Selection Register */
   __I  AFEC_CDR_Type                  AFEC_CDR;       /**< Offset: 0x68 (R/   32) AFEC Channel Data Register */
   __IO AFEC_COCR_Type                 AFEC_COCR;      /**< Offset: 0x6C (R/W  32) AFEC Channel Offset Compensation Register */
   __IO AFEC_TEMPMR_Type               AFEC_TEMPMR;    /**< Offset: 0x70 (R/W  32) AFEC Temperature Sensor Mode Register */
   __IO AFEC_TEMPCWR_Type              AFEC_TEMPCWR;   /**< Offset: 0x74 (R/W  32) AFEC Temperature Compare Window Register */
-  __I  uint32_t                       Reserved3[7];
+  __I  uint8_t                        Reserved3[28];
   __IO AFEC_ACR_Type                  AFEC_ACR;       /**< Offset: 0x94 (R/W  32) AFEC Analog Control Register */
-  __I  uint32_t                       Reserved4[2];
+  __I  uint8_t                        Reserved4[8];
   __IO AFEC_SHMR_Type                 AFEC_SHMR;      /**< Offset: 0xA0 (R/W  32) AFEC Sample & Hold Mode Register */
-  __I  uint32_t                       Reserved5[11];
+  __I  uint8_t                        Reserved5[44];
   __IO AFEC_COSR_Type                 AFEC_COSR;      /**< Offset: 0xD0 (R/W  32) AFEC Correction Select Register */
   __IO AFEC_CVR_Type                  AFEC_CVR;       /**< Offset: 0xD4 (R/W  32) AFEC Correction Values Register */
   __IO AFEC_CECR_Type                 AFEC_CECR;      /**< Offset: 0xD8 (R/W  32) AFEC Channel Error Correction Register */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __IO AFEC_WPMR_Type                 AFEC_WPMR;      /**< Offset: 0xE4 (R/W  32) AFEC Write Protection Mode Register */
   __I  AFEC_WPSR_Type                 AFEC_WPSR;      /**< Offset: 0xE8 (R/   32) AFEC Write Protection Status Register */
 } Afec;

--- a/asf/sam/include/same70b/component/chipid.h
+++ b/asf/sam/include/same70b/component/chipid.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for CHIPID
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_CHIPID_COMPONENT_H_
 #define _SAME70_CHIPID_COMPONENT_H_
 #define _SAME70_CHIPID_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- CHIPID_CIDR : (CHIPID Offset: 0x00) (R/ 32) Chip ID Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VERSION:5;                 /**< bit:   0..4  Version of the Device                    */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CHIPID_CIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_CIDR_OFFSET                  (0x00)                                        /**<  (CHIPID_CIDR) Chip ID Register  Offset */
@@ -200,12 +204,14 @@ typedef union {
 
 /* -------- CHIPID_EXID : (CHIPID Offset: 0x04) (R/ 32) Chip ID Extension Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EXID:32;                   /**< bit:  0..31  Chip ID Extension                        */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CHIPID_EXID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CHIPID_EXID_OFFSET                  (0x04)                                        /**<  (CHIPID_EXID) Chip ID Extension Register  Offset */

--- a/asf/sam/include/same70b/component/dacc.h
+++ b/asf/sam/include/same70b/component/dacc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for DACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_DACC_COMPONENT_H_
 #define _SAME70_DACC_COMPONENT_H_
 #define _SAME70_DACC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- DACC_CR : (DACC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRST:1;                   /**< bit:      0  Software Reset                           */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CR_OFFSET                      (0x00)                                        /**<  (DACC_CR) Control Register  Offset */
@@ -65,6 +69,7 @@ typedef union {
 
 /* -------- DACC_MR : (DACC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXS0:1;                   /**< bit:      0  Max Speed Mode for Channel 0             */
@@ -83,6 +88,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_MR_OFFSET                      (0x04)                                        /**<  (DACC_MR) Mode Register  Offset */
@@ -130,6 +136,7 @@ typedef union {
 
 /* -------- DACC_TRIGR : (DACC Offset: 0x08) (R/W 32) Trigger Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRGEN0:1;                  /**< bit:      0  Trigger Enable of Channel 0              */
@@ -150,6 +157,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_TRIGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_TRIGR_OFFSET                   (0x08)                                        /**<  (DACC_TRIGR) Trigger Register  Offset */
@@ -171,41 +179,41 @@ typedef union {
 #define DACC_TRIGR_TRGSEL0_Pos              4                                              /**< (DACC_TRIGR) Trigger Selection of Channel 0 Position */
 #define DACC_TRIGR_TRGSEL0_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL0_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 0 Mask */
 #define DACC_TRIGR_TRGSEL0(value)           (DACC_TRIGR_TRGSEL0_Msk & ((value) << DACC_TRIGR_TRGSEL0_Pos))
-#define   DACC_TRIGR_TRGSEL0_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DATRG  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 output  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC1 output  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC2 output  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 event 0  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 event 1  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 event 0  */
-#define   DACC_TRIGR_TRGSEL0_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 event 1  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL0          (DACC_TRIGR_TRGSEL0_TRGSEL0_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) DATRG Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL1          (DACC_TRIGR_TRGSEL0_TRGSEL1_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 output Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL2          (DACC_TRIGR_TRGSEL0_TRGSEL2_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC1 output Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL3          (DACC_TRIGR_TRGSEL0_TRGSEL3_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC2 output Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL4          (DACC_TRIGR_TRGSEL0_TRGSEL4_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 event 0 Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL5          (DACC_TRIGR_TRGSEL0_TRGSEL5_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 event 1 Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL6          (DACC_TRIGR_TRGSEL0_TRGSEL6_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 event 0 Position  */
-#define DACC_TRIGR_TRGSEL0_TRGSEL7          (DACC_TRIGR_TRGSEL0_TRGSEL7_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 event 1 Position  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DAC External Trigger Input (DATRG)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2)  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 Event Line 1  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL0_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 Event Line 1  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL0          (DACC_TRIGR_TRGSEL0_TRGSEL0_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) DAC External Trigger Input (DATRG) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL1          (DACC_TRIGR_TRGSEL0_TRGSEL1_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL2          (DACC_TRIGR_TRGSEL0_TRGSEL2_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL3          (DACC_TRIGR_TRGSEL0_TRGSEL3_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2) Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL4          (DACC_TRIGR_TRGSEL0_TRGSEL4_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL5          (DACC_TRIGR_TRGSEL0_TRGSEL5_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 1 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL6          (DACC_TRIGR_TRGSEL0_TRGSEL6_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL0_TRGSEL7          (DACC_TRIGR_TRGSEL0_TRGSEL7_Val << DACC_TRIGR_TRGSEL0_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 1 Position  */
 #define DACC_TRIGR_TRGSEL1_Pos              8                                              /**< (DACC_TRIGR) Trigger Selection of Channel 1 Position */
 #define DACC_TRIGR_TRGSEL1_Msk              (_U_(0x7) << DACC_TRIGR_TRGSEL1_Pos)           /**< (DACC_TRIGR) Trigger Selection of Channel 1 Mask */
 #define DACC_TRIGR_TRGSEL1(value)           (DACC_TRIGR_TRGSEL1_Msk & ((value) << DACC_TRIGR_TRGSEL1_Pos))
-#define   DACC_TRIGR_TRGSEL1_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DATRG  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 output  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC1 output  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC2 output  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 event 0  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 event 1  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 event 0  */
-#define   DACC_TRIGR_TRGSEL1_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 event 1  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL0          (DACC_TRIGR_TRGSEL1_TRGSEL0_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) DATRG Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL1          (DACC_TRIGR_TRGSEL1_TRGSEL1_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 output Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL2          (DACC_TRIGR_TRGSEL1_TRGSEL2_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC1 output Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL3          (DACC_TRIGR_TRGSEL1_TRGSEL3_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC2 output Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL4          (DACC_TRIGR_TRGSEL1_TRGSEL4_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 event 0 Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL5          (DACC_TRIGR_TRGSEL1_TRGSEL5_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 event 1 Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL6          (DACC_TRIGR_TRGSEL1_TRGSEL6_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 event 0 Position  */
-#define DACC_TRIGR_TRGSEL1_TRGSEL7          (DACC_TRIGR_TRGSEL1_TRGSEL7_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 event 1 Position  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL0_Val    _U_(0x0)                                       /**< (DACC_TRIGR) DAC External Trigger Input (DATRG)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL1_Val    _U_(0x1)                                       /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL2_Val    _U_(0x2)                                       /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL3_Val    _U_(0x3)                                       /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2)  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL4_Val    _U_(0x4)                                       /**< (DACC_TRIGR) PWM0 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL5_Val    _U_(0x5)                                       /**< (DACC_TRIGR) PWM0 Event Line 1  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL6_Val    _U_(0x6)                                       /**< (DACC_TRIGR) PWM1 Event Line 0  */
+#define   DACC_TRIGR_TRGSEL1_TRGSEL7_Val    _U_(0x7)                                       /**< (DACC_TRIGR) PWM1 Event Line 1  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL0          (DACC_TRIGR_TRGSEL1_TRGSEL0_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) DAC External Trigger Input (DATRG) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL1          (DACC_TRIGR_TRGSEL1_TRGSEL1_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 0 Output (TIOA0) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL2          (DACC_TRIGR_TRGSEL1_TRGSEL2_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 1 Output (TIOA1) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL3          (DACC_TRIGR_TRGSEL1_TRGSEL3_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) TC0 Channel 2 Output (TIOA2) Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL4          (DACC_TRIGR_TRGSEL1_TRGSEL4_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL5          (DACC_TRIGR_TRGSEL1_TRGSEL5_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM0 Event Line 1 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL6          (DACC_TRIGR_TRGSEL1_TRGSEL6_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 0 Position  */
+#define DACC_TRIGR_TRGSEL1_TRGSEL7          (DACC_TRIGR_TRGSEL1_TRGSEL7_Val << DACC_TRIGR_TRGSEL1_Pos)  /**< (DACC_TRIGR) PWM1 Event Line 1 Position  */
 #define DACC_TRIGR_OSR0_Pos                 16                                             /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Position */
 #define DACC_TRIGR_OSR0_Msk                 (_U_(0x7) << DACC_TRIGR_OSR0_Pos)              /**< (DACC_TRIGR) Over Sampling Ratio of Channel 0 Mask */
 #define DACC_TRIGR_OSR0(value)              (DACC_TRIGR_OSR0_Msk & ((value) << DACC_TRIGR_OSR0_Pos))
@@ -245,6 +253,7 @@ typedef union {
 
 /* -------- DACC_CHER : (DACC Offset: 0x10) (/W 32) Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Enable                         */
@@ -257,6 +266,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHER_OFFSET                    (0x10)                                        /**<  (DACC_CHER) Channel Enable Register  Offset */
@@ -276,6 +286,7 @@ typedef union {
 
 /* -------- DACC_CHDR : (DACC Offset: 0x14) (/W 32) Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Disable                        */
@@ -288,6 +299,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHDR_OFFSET                    (0x14)                                        /**<  (DACC_CHDR) Channel Disable Register  Offset */
@@ -307,6 +319,7 @@ typedef union {
 
 /* -------- DACC_CHSR : (DACC Offset: 0x18) (R/ 32) Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CH0:1;                     /**< bit:      0  Channel 0 Status                         */
@@ -324,6 +337,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CHSR_OFFSET                    (0x18)                                        /**<  (DACC_CHSR) Channel Status Register  Offset */
@@ -352,6 +366,7 @@ typedef union {
 
 /* -------- DACC_CDR : (DACC Offset: 0x1c) (/W 32) Conversion Data Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA0:16;                  /**< bit:  0..15  Data to Convert for channel 0            */
@@ -359,6 +374,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_CDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_CDR_OFFSET                     (0x1C)                                        /**<  (DACC_CDR) Conversion Data Register 0  Offset */
@@ -375,6 +391,7 @@ typedef union {
 
 /* -------- DACC_IER : (DACC Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Enable of channel 0 */
@@ -392,6 +409,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IER_OFFSET                     (0x24)                                        /**<  (DACC_IER) Interrupt Enable Register  Offset */
@@ -420,6 +438,7 @@ typedef union {
 
 /* -------- DACC_IDR : (DACC Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Disable of channel 0 */
@@ -437,6 +456,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IDR_OFFSET                     (0x28)                                        /**<  (DACC_IDR) Interrupt Disable Register  Offset */
@@ -465,6 +485,7 @@ typedef union {
 
 /* -------- DACC_IMR : (DACC Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Mask of channel 0 */
@@ -482,6 +503,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_IMR_OFFSET                     (0x2C)                                        /**<  (DACC_IMR) Interrupt Mask Register  Offset */
@@ -510,6 +532,7 @@ typedef union {
 
 /* -------- DACC_ISR : (DACC Offset: 0x30) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY0:1;                  /**< bit:      0  Transmit Ready Interrupt Flag of channel 0 */
@@ -527,6 +550,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_ISR_OFFSET                     (0x30)                                        /**<  (DACC_ISR) Interrupt Status Register  Offset */
@@ -555,6 +579,7 @@ typedef union {
 
 /* -------- DACC_ACR : (DACC Offset: 0x94) (R/W 32) Analog Current Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IBCTLCH0:2;                /**< bit:   0..1  Analog Output Current Control            */
@@ -563,6 +588,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_ACR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_ACR_OFFSET                     (0x94)                                        /**<  (DACC_ACR) Analog Current Register  Offset */
@@ -579,6 +605,7 @@ typedef union {
 
 /* -------- DACC_WPMR : (DACC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -587,6 +614,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPMR_OFFSET                    (0xE4)                                        /**<  (DACC_WPMR) Write Protection Mode Register  Offset */
@@ -605,6 +633,7 @@ typedef union {
 
 /* -------- DACC_WPSR : (DACC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -614,6 +643,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } DACC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define DACC_WPSR_OFFSET                    (0xE8)                                        /**<  (DACC_WPSR) Write Protection Status Register  Offset */
@@ -635,7 +665,7 @@ typedef struct {
   __O  uint32_t DACC_CR;        /**< (DACC Offset: 0x00) Control Register */
   __IO uint32_t DACC_MR;        /**< (DACC Offset: 0x04) Mode Register */
   __IO uint32_t DACC_TRIGR;     /**< (DACC Offset: 0x08) Trigger Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t DACC_CHER;      /**< (DACC Offset: 0x10) Channel Enable Register */
   __O  uint32_t DACC_CHDR;      /**< (DACC Offset: 0x14) Channel Disable Register */
   __I  uint32_t DACC_CHSR;      /**< (DACC Offset: 0x18) Channel Status Register */
@@ -644,9 +674,9 @@ typedef struct {
   __O  uint32_t DACC_IDR;       /**< (DACC Offset: 0x28) Interrupt Disable Register */
   __I  uint32_t DACC_IMR;       /**< (DACC Offset: 0x2C) Interrupt Mask Register */
   __I  uint32_t DACC_ISR;       /**< (DACC Offset: 0x30) Interrupt Status Register */
-  RoReg8  Reserved2[0x60];
+  __I  uint8_t                        Reserved2[96];
   __IO uint32_t DACC_ACR;       /**< (DACC Offset: 0x94) Analog Current Register */
-  RoReg8  Reserved3[0x4C];
+  __I  uint8_t                        Reserved3[76];
   __IO uint32_t DACC_WPMR;      /**< (DACC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t DACC_WPSR;      /**< (DACC Offset: 0xE8) Write Protection Status Register */
 } Dacc;
@@ -657,7 +687,7 @@ typedef struct {
   __O  DACC_CR_Type                   DACC_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
   __IO DACC_MR_Type                   DACC_MR;        /**< Offset: 0x04 (R/W  32) Mode Register */
   __IO DACC_TRIGR_Type                DACC_TRIGR;     /**< Offset: 0x08 (R/W  32) Trigger Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  DACC_CHER_Type                 DACC_CHER;      /**< Offset: 0x10 ( /W  32) Channel Enable Register */
   __O  DACC_CHDR_Type                 DACC_CHDR;      /**< Offset: 0x14 ( /W  32) Channel Disable Register */
   __I  DACC_CHSR_Type                 DACC_CHSR;      /**< Offset: 0x18 (R/   32) Channel Status Register */
@@ -666,9 +696,9 @@ typedef struct {
   __O  DACC_IDR_Type                  DACC_IDR;       /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
   __I  DACC_IMR_Type                  DACC_IMR;       /**< Offset: 0x2C (R/   32) Interrupt Mask Register */
   __I  DACC_ISR_Type                  DACC_ISR;       /**< Offset: 0x30 (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[24];
+  __I  uint8_t                        Reserved2[96];
   __IO DACC_ACR_Type                  DACC_ACR;       /**< Offset: 0x94 (R/W  32) Analog Current Register */
-  __I  uint32_t                       Reserved3[19];
+  __I  uint8_t                        Reserved3[76];
   __IO DACC_WPMR_Type                 DACC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  DACC_WPSR_Type                 DACC_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Dacc;

--- a/asf/sam/include/same70b/component/deprecated/tc.h
+++ b/asf/sam/include/same70b/component/deprecated/tc.h
@@ -1,0 +1,63 @@
+/**
+ * \file
+ * \brief This file is for deprecated macro constants
+ *
+ *  Used to mark macro constants as deprecate.
+ *  Uses a macro 'DEPRECTAED' to give warnings during compilation (GCC >= 4.8)
+ *
+ *  \remark To use, add defines and put a DEPRECATED statement between the macro name and the value
+ *
+ *  \note This file is manually maintained
+ */
+
+#ifndef _SAME70_TC_COMPONENT_DEPRECATED_H_
+#define _SAME70_TC_COMPONENT_DEPRECATED_H_
+
+#ifndef DEPRECATED
+#define _DEP_STRING(X) #X
+
+/** \hideinitializer
+ * \brief Macro deprecation mark
+ *
+ * Putting this in a macro definition will emit deprecation warning when given
+ * macro is used (GCC 4.8)
+ *
+ *  \code{.c}
+ *  #define OLD_MACRO DEPRECATED(OLD_MACRO, "deprecated <or any other text>") <value>
+ *  \endcode
+ *
+ *  \warning Using these macros in #if statements will not work
+ */
+#if defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 408
+#define DEPRECATED(macro, message) _Pragma (_DEP_STRING(GCC warning message))
+#else
+#define DEPRECATED(macro, message)
+#endif
+#endif
+
+/* deprecated defines added below here */
+#define TC_CMR_ABETRG_Msk DEPRECATED(TC_CMR_ABETRG_Msk, "Using deprecated macro TC_CMR_ABETRG_Msk") (_U_(0x1) << TC_CMR_ABETRG_Pos) /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_ABETRG_Pos DEPRECATED(TC_CMR_ABETRG_Pos, "Using deprecated macro TC_CMR_ABETRG_Pos") 10 /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_ABETRG DEPRECATED(TC_CMR_ABETRG, "Using deprecated macro TC_CMR_ABETRG") TC_CMR_ABETRG_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_ABETRG_Msk instead */
+#define TC_CMR_CPCTRG_Msk DEPRECATED(TC_CMR_CPCTRG_Msk, "Using deprecated macro TC_CMR_CPCTRG_Msk") (_U_(0x1) << TC_CMR_CPCTRG_Pos) /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CPCTRG_Pos DEPRECATED(TC_CMR_CPCTRG_Pos, "Using deprecated macro TC_CMR_CPCTRG_Pos") 14 /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CPCTRG DEPRECATED(TC_CMR_CPCTRG, "Using deprecated macro TC_CMR_CPCTRG") TC_CMR_CPCTRG_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CPCTRG_Msk instead */
+#define TC_CMR_ETRGEDG_Msk DEPRECATED(TC_CMR_ETRGEDG_Msk, "Using deprecated macro TC_CMR_ETRGEDG_Msk") (_U_(0x3) << TC_CMR_ETRGEDG_Pos) /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_ETRGEDG_Pos DEPRECATED(TC_CMR_ETRGEDG_Pos, "Using deprecated macro TC_CMR_ETRGEDG_Pos") 8 /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_ETRGEDG(value) DEPRECATED(TC_CMR_ETRGEDG, "Using deprecated macro TC_CMR_ETRGEDG") (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
+#define TC_CMR_LDBDIS_Msk DEPRECATED(TC_CMR_LDBDIS_Msk, "Using deprecated macro TC_CMR_LDBDIS_Msk") (_U_(0x1) << TC_CMR_LDBDIS_Pos) /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_LDBDIS_Pos DEPRECATED(TC_CMR_LDBDIS_Pos, "Using deprecated macro TC_CMR_LDBDIS_Pos") 7 /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_LDBDIS DEPRECATED(TC_CMR_LDBDIS, "Using deprecated macro TC_CMR_LDBDIS") TC_CMR_LDBDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBDIS_Msk instead */
+#define TC_CMR_LDBSTOP_Msk DEPRECATED(TC_CMR_LDBSTOP_Msk, "Using deprecated macro TC_CMR_LDBSTOP_Msk") (_U_(0x1) << TC_CMR_LDBSTOP_Pos) /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_LDBSTOP_Pos DEPRECATED(TC_CMR_LDBSTOP_Pos, "Using deprecated macro TC_CMR_LDBSTOP_Pos") 6 /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_LDBSTOP DEPRECATED(TC_CMR_LDBSTOP, "Using deprecated macro TC_CMR_LDBSTOP") TC_CMR_LDBSTOP_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBSTOP_Msk instead */
+#define TC_CMR_LDRA_Msk DEPRECATED(TC_CMR_LDRA_Msk, "Using deprecated macro TC_CMR_LDRA_Msk") (_U_(0x3) << TC_CMR_LDRA_Pos) /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_LDRA_Pos DEPRECATED(TC_CMR_LDRA_Pos, "Using deprecated macro TC_CMR_LDRA_Pos") 16 /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_LDRA(value) DEPRECATED(TC_CMR_LDRA, "Using deprecated macro TC_CMR_LDRA") (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
+#define TC_CMR_LDRB_Msk DEPRECATED(TC_CMR_LDRB_Msk, "Using deprecated macro TC_CMR_LDRB_Msk") (_U_(0x3) << TC_CMR_LDRB_Pos) /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_LDRB_Pos DEPRECATED(TC_CMR_LDRB_Pos, "Using deprecated macro TC_CMR_LDRB_Pos") 18 /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_LDRB(value) DEPRECATED(TC_CMR_LDRB, "Using deprecated macro TC_CMR_LDRB") (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
+#define TC_CMR_SBSMPLR_Msk DEPRECATED(TC_CMR_SBSMPLR_Msk, "Using deprecated macro TC_CMR_SBSMPLR_Msk") (_U_(0x7) << TC_CMR_SBSMPLR_Pos) /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_SBSMPLR_Pos DEPRECATED(TC_CMR_SBSMPLR_Pos, "Using deprecated macro TC_CMR_SBSMPLR_Pos") 20 /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_SBSMPLR(value) DEPRECATED(TC_CMR_SBSMPLR, "Using deprecated macro TC_CMR_SBSMPLR") (TC_CMR_SBSMPLR_Msk & ((value) << TC_CMR_SBSMPLR_Pos))
+#endif

--- a/asf/sam/include/same70b/component/deprecated/template.h
+++ b/asf/sam/include/same70b/component/deprecated/template.h
@@ -1,0 +1,41 @@
+/**
+ * \file
+ * \brief This file is for deprecated macro constants
+ *
+ *  Used to mark macro constants as deprecate.
+ *  Uses a macro 'DEPRECTAED' to give warnings during compilation (GCC >= 4.8)
+ *
+ *  \remark To use, add defines and put a DEPRECATED statement between the macro name and the value
+ *
+ *  \note This file is manually maintained
+ */
+
+#ifndef _<DEVICE>_<MODULE>_COMPONENT_DEPRECATED_H_
+#define _<DEVICE>_<MODULE>_COMPONENT_DEPRECATED_H_
+
+#ifndef DEPRECATED
+#define _DEP_STRING(X) #X
+
+/** \hideinitializer
+ * \brief Macro deprecation mark
+ *
+ * Putting this in a macro definition will emit deprecation warning when given
+ * macro is used (GCC 4.8)
+ *
+ *  \code{.c}
+ *  #define OLD_MACRO DEPRECATED(OLD_MACRO, "deprecated <or any other text>") <value>
+ *  \endcode
+ *
+ *  \warning Using these macros in #if statements will not work
+ */
+#if defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 408
+#define DEPRECATED(macro, message) _Pragma (_DEP_STRING(GCC warning message))
+#else
+#define DEPRECATED(macro, message)
+#endif
+#endif
+
+/* deprecated defines added below here */
+#define <MODULE>_OLD_MACRO DEPRECATED(<MODULE>_OLD_MACRO, "deprecated") <value>
+
+#endif

--- a/asf/sam/include/same70b/component/deprecated/usart.h
+++ b/asf/sam/include/same70b/component/deprecated/usart.h
@@ -1,0 +1,250 @@
+/**
+ * \file
+ * \brief This file is for deprecated macro constants
+ *
+ *  Used to mark macro constants as deprecate.
+ *  Uses a macro 'DEPRECTAED' to give warnings during compilation (GCC >= 4.8)
+ *
+ *  \remark To use, add defines and put a DEPRECATED statement between the macro name and the value
+ *
+ *  \note This file is manually maintained
+ */
+
+#ifndef _SAME70_USART_COMPONENT_DEPRECATED_H_
+#define _SAME70_USART_COMPONENT_DEPRECATED_H_
+
+#ifndef DEPRECATED
+#define _DEP_STRING(X) #X
+
+/** \hideinitializer
+ * \brief Macro deprecation mark
+ *
+ * Putting this in a macro definition will emit deprecation warning when given
+ * macro is used (GCC 4.8)
+ *
+ *  \code{.c}
+ *  #define OLD_MACRO DEPRECATED(OLD_MACRO, "deprecated <or any other text>") <value>
+ *  \endcode
+ *
+ *  \warning Using these macros in #if statements will not work
+ */
+#if defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 408
+#define DEPRECATED(macro, message) _Pragma (_DEP_STRING(GCC warning message))
+#else
+#define DEPRECATED(macro, message)
+#endif
+#endif
+
+/* deprecated defines added below here */
+#define US_CR_DTRDIS_Msk DEPRECATED(US_CR_DTRDIS_Msk, "Using deprecated macro US_CR_DTRDIS_Msk") (_U_(0x1) << US_CR_DTRDIS_Pos) /**< (US_CR) Data Terminal Ready Disable Mask */
+#define US_CR_DTRDIS_Pos DEPRECATED(US_CR_DTRDIS_Pos, "Using deprecated macro US_CR_DTRDIS_Pos") 17 /**< (US_CR) Data Terminal Ready Disable Position */
+#define US_CR_DTRDIS DEPRECATED(US_CR_DTRDIS, "Using deprecated macro US_CR_DTRDIS") US_CR_DTRDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTRDIS_Msk instead */
+#define US_CR_DTREN_Msk DEPRECATED(US_CR_DTREN_Msk, "Using deprecated macro US_CR_DTREN_Msk") (_U_(0x1) << US_CR_DTREN_Pos) /**< (US_CR) Data Terminal Ready Enable Mask */
+#define US_CR_DTREN_Pos DEPRECATED(US_CR_DTREN_Pos, "Using deprecated macro US_CR_DTREN_Pos") 16 /**< (US_CR) Data Terminal Ready Enable Position */
+#define US_CR_DTREN DEPRECATED(US_CR_DTREN, "Using deprecated macro US_CR_DTREN") US_CR_DTREN_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTREN_Msk instead */
+#define US_CR_LINABT_Msk DEPRECATED(US_CR_LINABT_Msk, "Using deprecated macro US_CR_LINABT_Msk") (_U_(0x1) << US_CR_LINABT_Pos) /**< (US_CR) Abort LIN Transmission Mask */
+#define US_CR_LINABT_Pos DEPRECATED(US_CR_LINABT_Pos, "Using deprecated macro US_CR_LINABT_Pos") 20 /**< (US_CR) Abort LIN Transmission Position */
+#define US_CR_LINABT DEPRECATED(US_CR_LINABT, "Using deprecated macro US_CR_LINABT") US_CR_LINABT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINABT_Msk instead */
+#define US_CR_LINWKUP_Msk DEPRECATED(US_CR_LINWKUP_Msk, "Using deprecated macro US_CR_LINWKUP_Msk") (_U_(0x1) << US_CR_LINWKUP_Pos) /**< (US_CR) Send LIN Wakeup Signal Mask */
+#define US_CR_LINWKUP_Pos DEPRECATED(US_CR_LINWKUP_Pos, "Using deprecated macro US_CR_LINWKUP_Pos") 21 /**< (US_CR) Send LIN Wakeup Signal Position */
+#define US_CR_LINWKUP DEPRECATED(US_CR_LINWKUP, "Using deprecated macro US_CR_LINWKUP") US_CR_LINWKUP_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINWKUP_Msk instead */
+#define US_CR_RETTO_Msk DEPRECATED(US_CR_RETTO_Msk, "Using deprecated macro US_CR_RETTO_Msk") (_U_(0x1) << US_CR_RETTO_Pos) /**< (US_CR) Start Time-out Immediately Mask */
+#define US_CR_RETTO_Pos DEPRECATED(US_CR_RETTO_Pos, "Using deprecated macro US_CR_RETTO_Pos") 15 /**< (US_CR) Start Time-out Immediately Position */
+#define US_CR_RETTO DEPRECATED(US_CR_RETTO, "Using deprecated macro US_CR_RETTO") US_CR_RETTO_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RETTO_Msk instead */
+#define US_CR_RSTIT_Msk DEPRECATED(US_CR_RSTIT_Msk, "Using deprecated macro US_CR_RSTIT_Msk") (_U_(0x1) << US_CR_RSTIT_Pos) /**< (US_CR) Reset Iterations Mask */
+#define US_CR_RSTIT_Pos DEPRECATED(US_CR_RSTIT_Pos, "Using deprecated macro US_CR_RSTIT_Pos") 13 /**< (US_CR) Reset Iterations Position */
+#define US_CR_RSTIT DEPRECATED(US_CR_RSTIT, "Using deprecated macro US_CR_RSTIT") US_CR_RSTIT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTIT_Msk instead */
+#define US_CR_RSTNACK_Msk DEPRECATED(US_CR_RSTNACK_Msk, "Using deprecated macro US_CR_RSTNACK_Msk") (_U_(0x1) << US_CR_RSTNACK_Pos) /**< (US_CR) Reset Non Acknowledge Mask */
+#define US_CR_RSTNACK_Pos DEPRECATED(US_CR_RSTNACK_Pos, "Using deprecated macro US_CR_RSTNACK_Pos") 14 /**< (US_CR) Reset Non Acknowledge Position */
+#define US_CR_RSTNACK DEPRECATED(US_CR_RSTNACK, "Using deprecated macro US_CR_RSTNACK") US_CR_RSTNACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTNACK_Msk instead */
+#define US_CR_RTSDIS_Msk DEPRECATED(US_CR_RTSDIS_Msk, "Using deprecated macro US_CR_RTSDIS_Msk") (_U_(0x1) << US_CR_RTSDIS_Pos) /**< (US_CR) Request to Send Pin Control Mask */
+#define US_CR_RTSDIS_Pos DEPRECATED(US_CR_RTSDIS_Pos, "Using deprecated macro US_CR_RTSDIS_Pos") 19 /**< (US_CR) Request to Send Pin Control Position */
+#define US_CR_RTSDIS DEPRECATED(US_CR_RTSDIS, "Using deprecated macro US_CR_RTSDIS") US_CR_RTSDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSDIS_Msk instead */
+#define US_CR_RTSEN_Msk DEPRECATED(US_CR_RTSEN_Msk, "Using deprecated macro US_CR_RTSEN_Msk") (_U_(0x1) << US_CR_RTSEN_Pos) /**< (US_CR) Request to Send Pin Control Mask */
+#define US_CR_RTSEN_Pos DEPRECATED(US_CR_RTSEN_Pos, "Using deprecated macro US_CR_RTSEN_Pos") 18 /**< (US_CR) Request to Send Pin Control Position */
+#define US_CR_RTSEN DEPRECATED(US_CR_RTSEN, "Using deprecated macro US_CR_RTSEN") US_CR_RTSEN_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSEN_Msk instead */
+#define US_CR_SENDA_Msk DEPRECATED(US_CR_SENDA_Msk, "Using deprecated macro US_CR_SENDA_Msk") (_U_(0x1) << US_CR_SENDA_Pos) /**< (US_CR) Send Address Mask */
+#define US_CR_SENDA_Pos DEPRECATED(US_CR_SENDA_Pos, "Using deprecated macro US_CR_SENDA_Pos") 12 /**< (US_CR) Send Address Position */
+#define US_CR_SENDA DEPRECATED(US_CR_SENDA, "Using deprecated macro US_CR_SENDA") US_CR_SENDA_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SENDA_Msk instead */
+#define US_CR_STPBRK_Msk DEPRECATED(US_CR_STPBRK_Msk, "Using deprecated macro US_CR_STPBRK_Msk") (_U_(0x1) << US_CR_STPBRK_Pos) /**< (US_CR) Stop Break Mask */
+#define US_CR_STPBRK_Pos DEPRECATED(US_CR_STPBRK_Pos, "Using deprecated macro US_CR_STPBRK_Pos") 10 /**< (US_CR) Stop Break Position */
+#define US_CR_STPBRK DEPRECATED(US_CR_STPBRK, "Using deprecated macro US_CR_STPBRK") US_CR_STPBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STPBRK_Msk instead */
+#define US_CR_STTBRK_Msk DEPRECATED(US_CR_STTBRK_Msk, "Using deprecated macro US_CR_STTBRK_Msk") (_U_(0x1) << US_CR_STTBRK_Pos) /**< (US_CR) Start Break Mask */
+#define US_CR_STTBRK_Pos DEPRECATED(US_CR_STTBRK_Pos, "Using deprecated macro US_CR_STTBRK_Pos") 9 /**< (US_CR) Start Break Position */
+#define US_CR_STTBRK DEPRECATED(US_CR_STTBRK, "Using deprecated macro US_CR_STTBRK") US_CR_STTBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTBRK_Msk instead */
+#define US_CR_STTTO_Msk DEPRECATED(US_CR_STTTO_Msk, "Using deprecated macro US_CR_STTTO_Msk") (_U_(0x1) << US_CR_STTTO_Pos) /**< (US_CR) Clear TIMEOUT Flag and Start Time-out After Next Character Received Mask */
+#define US_CR_STTTO_Pos DEPRECATED(US_CR_STTTO_Pos, "Using deprecated macro US_CR_STTTO_Pos") 11 /**< (US_CR) Clear TIMEOUT Flag and Start Time-out After Next Character Received Position */
+#define US_CR_STTTO DEPRECATED(US_CR_STTTO, "Using deprecated macro US_CR_STTTO") US_CR_STTTO_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTTO_Msk instead */
+#define US_CSR_CTSIC_Msk DEPRECATED(US_CSR_CTSIC_Msk, "Using deprecated macro US_CSR_CTSIC_Msk") (_U_(0x1) << US_CSR_CTSIC_Pos) /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_CTSIC_Pos DEPRECATED(US_CSR_CTSIC_Pos, "Using deprecated macro US_CSR_CTSIC_Pos") 19 /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_CTSIC DEPRECATED(US_CSR_CTSIC, "Using deprecated macro US_CSR_CTSIC") US_CSR_CTSIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTSIC_Msk instead */
+#define US_CSR_CTS_Msk DEPRECATED(US_CSR_CTS_Msk, "Using deprecated macro US_CSR_CTS_Msk") (_U_(0x1) << US_CSR_CTS_Pos) /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_CTS_Pos DEPRECATED(US_CSR_CTS_Pos, "Using deprecated macro US_CSR_CTS_Pos") 23 /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_CTS DEPRECATED(US_CSR_CTS, "Using deprecated macro US_CSR_CTS") US_CSR_CTS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTS_Msk instead */
+#define US_CSR_DCD_Msk DEPRECATED(US_CSR_DCD_Msk, "Using deprecated macro US_CSR_DCD_Msk") (_U_(0x1) << US_CSR_DCD_Pos) /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_DCD_Pos DEPRECATED(US_CSR_DCD_Pos, "Using deprecated macro US_CSR_DCD_Pos") 22 /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_DCD DEPRECATED(US_CSR_DCD, "Using deprecated macro US_CSR_DCD") US_CSR_DCD_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCD_Msk instead */
+#define US_CSR_DSR_Msk DEPRECATED(US_CSR_DSR_Msk, "Using deprecated macro US_CSR_DSR_Msk") (_U_(0x1) << US_CSR_DSR_Pos) /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_DSR_Pos DEPRECATED(US_CSR_DSR_Pos, "Using deprecated macro US_CSR_DSR_Pos") 21 /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_DSR DEPRECATED(US_CSR_DSR, "Using deprecated macro US_CSR_DSR") US_CSR_DSR_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSR_Msk instead */
+#define US_CSR_FRAME_Msk DEPRECATED(US_CSR_FRAME_Msk, "Using deprecated macro US_CSR_FRAME_Msk") (_U_(0x1) << US_CSR_FRAME_Pos) /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_FRAME_Pos DEPRECATED(US_CSR_FRAME_Pos, "Using deprecated macro US_CSR_FRAME_Pos") 6 /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_FRAME DEPRECATED(US_CSR_FRAME, "Using deprecated macro US_CSR_FRAME") US_CSR_FRAME_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_FRAME_Msk instead */
+#define US_CSR_ITER_Msk DEPRECATED(US_CSR_ITER_Msk, "Using deprecated macro US_CSR_ITER_Msk") (_U_(0x1) << US_CSR_ITER_Pos) /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_ITER_Pos DEPRECATED(US_CSR_ITER_Pos, "Using deprecated macro US_CSR_ITER_Pos") 10 /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_ITER DEPRECATED(US_CSR_ITER, "Using deprecated macro US_CSR_ITER") US_CSR_ITER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_ITER_Msk instead */
+#define US_CSR_MANERR_Msk DEPRECATED(US_CSR_MANERR_Msk, "Using deprecated macro US_CSR_MANERR_Msk") (_U_(0x1) << US_CSR_MANERR_Pos) /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_MANERR_Pos DEPRECATED(US_CSR_MANERR_Pos, "Using deprecated macro US_CSR_MANERR_Pos") 24 /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_MANERR DEPRECATED(US_CSR_MANERR, "Using deprecated macro US_CSR_MANERR") US_CSR_MANERR_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_MANERR_Msk instead */
+#define US_CSR_NACK_Msk DEPRECATED(US_CSR_NACK_Msk, "Using deprecated macro US_CSR_NACK_Msk") (_U_(0x1) << US_CSR_NACK_Pos) /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_NACK_Pos DEPRECATED(US_CSR_NACK_Pos, "Using deprecated macro US_CSR_NACK_Pos") 13 /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_NACK DEPRECATED(US_CSR_NACK, "Using deprecated macro US_CSR_NACK") US_CSR_NACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_NACK_Msk instead */
+#define US_CSR_PARE_Msk DEPRECATED(US_CSR_PARE_Msk, "Using deprecated macro US_CSR_PARE_Msk") (_U_(0x1) << US_CSR_PARE_Pos) /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_PARE_Pos DEPRECATED(US_CSR_PARE_Pos, "Using deprecated macro US_CSR_PARE_Pos") 7 /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_PARE DEPRECATED(US_CSR_PARE, "Using deprecated macro US_CSR_PARE") US_CSR_PARE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_PARE_Msk instead */
+#define US_CSR_RI_Msk DEPRECATED(US_CSR_RI_Msk, "Using deprecated macro US_CSR_RI_Msk") (_U_(0x1) << US_CSR_RI_Pos) /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_RI_Pos DEPRECATED(US_CSR_RI_Pos, "Using deprecated macro US_CSR_RI_Pos") 20 /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_RI DEPRECATED(US_CSR_RI, "Using deprecated macro US_CSR_RI") US_CSR_RI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RI_Msk instead */
+#define US_CSR_RXBRK_Msk DEPRECATED(US_CSR_RXBRK_Msk, "Using deprecated macro US_CSR_RXBRK_Msk") (_U_(0x1) << US_CSR_RXBRK_Pos) /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_RXBRK_Pos DEPRECATED(US_CSR_RXBRK_Pos, "Using deprecated macro US_CSR_RXBRK_Pos") 2 /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_RXBRK DEPRECATED(US_CSR_RXBRK, "Using deprecated macro US_CSR_RXBRK") US_CSR_RXBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXBRK_Msk instead */
+#define US_CSR_TIMEOUT_Msk DEPRECATED(US_CSR_TIMEOUT_Msk, "Using deprecated macro US_CSR_TIMEOUT_Msk") (_U_(0x1) << US_CSR_TIMEOUT_Pos) /**< (US_CSR) Receiver Time-out (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_TIMEOUT_Pos DEPRECATED(US_CSR_TIMEOUT_Pos, "Using deprecated macro US_CSR_TIMEOUT_Pos") 8 /**< (US_CSR) Receiver Time-out (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_TIMEOUT DEPRECATED(US_CSR_TIMEOUT, "Using deprecated macro US_CSR_TIMEOUT") US_CSR_TIMEOUT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TIMEOUT_Msk instead */
+#define US_FIDI_FI_DI_RATIO_Msk DEPRECATED(US_FIDI_FI_DI_RATIO_Msk, "Using deprecated macro US_FIDI_FI_DI_RATIO_Msk") (_U_(0xFFFF) << US_FIDI_FI_DI_RATIO_Pos) /**< (US_FIDI) FI Over DI Ratio Value Mask */
+#define US_FIDI_FI_DI_RATIO_Pos DEPRECATED(US_FIDI_FI_DI_RATIO_Pos, "Using deprecated macro US_FIDI_FI_DI_RATIO_Pos") 0 /**< (US_FIDI) FI Over DI Ratio Value Position */
+#define US_FIDI_FI_DI_RATIO(value) DEPRECATED(US_FIDI_FI_DI_RATIO, "Using deprecated macro US_FIDI_FI_DI_RATIO") (US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos))
+#define US_IDR_CTSIC_Msk DEPRECATED(US_IDR_CTSIC_Msk, "Using deprecated macro US_IDR_CTSIC_Msk") (_U_(0x1) << US_IDR_CTSIC_Pos) /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_CTSIC_Pos DEPRECATED(US_IDR_CTSIC_Pos, "Using deprecated macro US_IDR_CTSIC_Pos") 19 /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_CTSIC DEPRECATED(US_IDR_CTSIC, "Using deprecated macro US_IDR_CTSIC") US_IDR_CTSIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_CTSIC_Msk instead */
+#define US_IDR_FRAME_Msk DEPRECATED(US_IDR_FRAME_Msk, "Using deprecated macro US_IDR_FRAME_Msk") (_U_(0x1) << US_IDR_FRAME_Pos) /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_FRAME_Pos DEPRECATED(US_IDR_FRAME_Pos, "Using deprecated macro US_IDR_FRAME_Pos") 6 /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_FRAME DEPRECATED(US_IDR_FRAME, "Using deprecated macro US_IDR_FRAME") US_IDR_FRAME_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_FRAME_Msk instead */
+#define US_IDR_ITER_Msk DEPRECATED(US_IDR_ITER_Msk, "Using deprecated macro US_IDR_ITER_Msk") (_U_(0x1) << US_IDR_ITER_Pos) /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_ITER_Pos DEPRECATED(US_IDR_ITER_Pos, "Using deprecated macro US_IDR_ITER_Pos") 10 /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_ITER DEPRECATED(US_IDR_ITER, "Using deprecated macro US_IDR_ITER") US_IDR_ITER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_ITER_Msk instead */
+#define US_IDR_MANE_Msk DEPRECATED(US_IDR_MANE_Msk, "Using deprecated macro US_IDR_MANE_Msk") (_U_(0x1) << US_IDR_MANE_Pos) /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_MANE_Pos DEPRECATED(US_IDR_MANE_Pos, "Using deprecated macro US_IDR_MANE_Pos") 24 /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_MANE DEPRECATED(US_IDR_MANE, "Using deprecated macro US_IDR_MANE") US_IDR_MANE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_MANE_Msk instead */
+#define US_IDR_NACK_Msk DEPRECATED(US_IDR_NACK_Msk, "Using deprecated macro US_IDR_NACK_Msk") (_U_(0x1) << US_IDR_NACK_Pos) /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_NACK_Pos DEPRECATED(US_IDR_NACK_Pos, "Using deprecated macro US_IDR_NACK_Pos") 13 /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_NACK DEPRECATED(US_IDR_NACK, "Using deprecated macro US_IDR_NACK") US_IDR_NACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_NACK_Msk instead */
+#define US_IDR_PARE_Msk DEPRECATED(US_IDR_PARE_Msk, "Using deprecated macro US_IDR_PARE_Msk") (_U_(0x1) << US_IDR_PARE_Pos) /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_PARE_Pos DEPRECATED(US_IDR_PARE_Pos, "Using deprecated macro US_IDR_PARE_Pos") 7 /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_PARE DEPRECATED(US_IDR_PARE, "Using deprecated macro US_IDR_PARE") US_IDR_PARE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_PARE_Msk instead */
+#define US_IDR_RXBRK_Msk DEPRECATED(US_IDR_RXBRK_Msk, "Using deprecated macro US_IDR_RXBRK_Msk") (_U_(0x1) << US_IDR_RXBRK_Pos) /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_RXBRK_Pos DEPRECATED(US_IDR_RXBRK_Pos, "Using deprecated macro US_IDR_RXBRK_Pos") 2 /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_RXBRK DEPRECATED(US_IDR_RXBRK, "Using deprecated macro US_IDR_RXBRK") US_IDR_RXBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXBRK_Msk instead */
+#define US_IDR_TIMEOUT_Msk DEPRECATED(US_IDR_TIMEOUT_Msk, "Using deprecated macro US_IDR_TIMEOUT_Msk") (_U_(0x1) << US_IDR_TIMEOUT_Pos) /**< (US_IDR) Time-out Interrupt Disable Mask */
+#define US_IDR_TIMEOUT_Pos DEPRECATED(US_IDR_TIMEOUT_Pos, "Using deprecated macro US_IDR_TIMEOUT_Pos") 8 /**< (US_IDR) Time-out Interrupt Disable Position */
+#define US_IDR_TIMEOUT DEPRECATED(US_IDR_TIMEOUT, "Using deprecated macro US_IDR_TIMEOUT") US_IDR_TIMEOUT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TIMEOUT_Msk instead */
+#define US_IER_CTSIC_Msk DEPRECATED(US_IER_CTSIC_Msk, "Using deprecated macro US_IER_CTSIC_Msk") (_U_(0x1) << US_IER_CTSIC_Pos) /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_CTSIC_Pos DEPRECATED(US_IER_CTSIC_Pos, "Using deprecated macro US_IER_CTSIC_Pos") 19 /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_CTSIC DEPRECATED(US_IER_CTSIC, "Using deprecated macro US_IER_CTSIC") US_IER_CTSIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_CTSIC_Msk instead */
+#define US_IER_DCDIC_Msk DEPRECATED(US_IER_DCDIC_Msk, "Using deprecated macro US_IER_DCDIC_Msk") (_U_(0x1) << US_IER_DCDIC_Pos) /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_DCDIC_Pos DEPRECATED(US_IER_DCDIC_Pos, "Using deprecated macro US_IER_DCDIC_Pos") 18 /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_DCDIC DEPRECATED(US_IER_DCDIC, "Using deprecated macro US_IER_DCDIC") US_IER_DCDIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DCDIC_Msk instead */
+#define US_IER_DSRIC_Msk DEPRECATED(US_IER_DSRIC_Msk, "Using deprecated macro US_IER_DSRIC_Msk") (_U_(0x1) << US_IER_DSRIC_Pos) /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_DSRIC_Pos DEPRECATED(US_IER_DSRIC_Pos, "Using deprecated macro US_IER_DSRIC_Pos") 17 /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_DSRIC DEPRECATED(US_IER_DSRIC, "Using deprecated macro US_IER_DSRIC") US_IER_DSRIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DSRIC_Msk instead */
+#define US_IER_FRAME_Msk DEPRECATED(US_IER_FRAME_Msk, "Using deprecated macro US_IER_FRAME_Msk") (_U_(0x1) << US_IER_FRAME_Pos) /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_FRAME_Pos DEPRECATED(US_IER_FRAME_Pos, "Using deprecated macro US_IER_FRAME_Pos") 6 /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_FRAME DEPRECATED(US_IER_FRAME, "Using deprecated macro US_IER_FRAME") US_IER_FRAME_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_FRAME_Msk instead */
+#define US_IER_ITER_Msk DEPRECATED(US_IER_ITER_Msk, "Using deprecated macro US_IER_ITER_Msk") (_U_(0x1) << US_IER_ITER_Pos) /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_ITER_Pos DEPRECATED(US_IER_ITER_Pos, "Using deprecated macro US_IER_ITER_Pos") 10 /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_ITER DEPRECATED(US_IER_ITER, "Using deprecated macro US_IER_ITER") US_IER_ITER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_ITER_Msk instead */
+#define US_IER_MANE_Msk DEPRECATED(US_IER_MANE_Msk, "Using deprecated macro US_IER_MANE_Msk") (_U_(0x1) << US_IER_MANE_Pos) /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_MANE_Pos DEPRECATED(US_IER_MANE_Pos, "Using deprecated macro US_IER_MANE_Po") 24 /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_MANE DEPRECATED(US_IER_MANE, "Using deprecated macro US_IER_MANE") US_IER_MANE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_MANE_Msk instead */
+#define US_IER_NACK_Msk DEPRECATED(US_IER_NACK_Msk, "Using deprecated macro US_IER_NACK_Msk") (_U_(0x1) << US_IER_NACK_Pos) /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_NACK_Pos DEPRECATED(US_IER_NACK_Pos, "Using deprecated macro US_IER_NACK_Pos") 13 /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_NACK DEPRECATED(US_IER_NACK, "Using deprecated macro US_IER_NAC") US_IER_NACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_NACK_Msk instead */
+#define US_IER_PARE_Msk DEPRECATED(US_IER_PARE_Msk, "Using deprecated macro US_IER_PARE_Msk") (_U_(0x1) << US_IER_PARE_Pos) /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_PARE_Pos DEPRECATED(US_IER_PARE_Pos, "Using deprecated macro US_IER_PARE_Pos") 7 /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_PARE DEPRECATED(US_IER_PARE, "Using deprecated macro US_IER_PARE") US_IER_PARE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_PARE_Msk instead */
+#define US_IER_RIIC_Msk DEPRECATED(US_IER_RIIC_Msk, "Using deprecated macro US_IER_RIIC_Msk") (_U_(0x1) << US_IER_RIIC_Pos) /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_RIIC_Pos DEPRECATED(US_IER_RIIC_Pos, "Using deprecated macro US_IER_RIIC_Pos") 16 /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_RIIC DEPRECATED(US_IER_RIIC, "Using deprecated macro US_IER_RIIC") US_IER_RIIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RIIC_Msk instead */
+#define US_IER_RXBRK_Msk DEPRECATED(US_IER_RXBRK_Msk, "Using deprecated macro US_IER_RXBRK_Msk") (_U_(0x1) << US_IER_RXBRK_Pos) /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_RXBRK_Pos DEPRECATED(US_IER_RXBRK_Pos, "Using deprecated macro US_IER_RXBRK_Pos") 2 /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_RXBRK DEPRECATED(US_IER_RXBRK, "Using deprecated macro US_IER_RXBRK") US_IER_RXBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXBRK_Msk instead */
+#define US_IER_TIMEOUT_Msk DEPRECATED(US_IER_TIMEOUT_Msk, "Using deprecated macro US_IER_TIMEOUT_Msk") (_U_(0x1) << US_IER_TIMEOUT_Pos) /**< (US_IER) Time-out Interrupt Enable Mask */
+#define US_IER_TIMEOUT_Pos DEPRECATED(US_IER_TIMEOUT_Pos, "Using deprecated macro US_IER_TIMEOUT_Pos") 8 /**< (US_IER) Time-out Interrupt Enable Position */
+#define US_IER_TIMEOUT DEPRECATED(US_IER_TIMEOUT, "Using deprecated macro US_IER_TIMEOUT") US_IER_TIMEOUT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TIMEOUT_Msk instead */
+#define US_IMR_CTSIC_Msk DEPRECATED(US_IMR_CTSIC_Msk, "Using deprecated macro US_IMR_CTSIC_Msk") (_U_(0x1) << US_IMR_CTSIC_Pos) /**< (US_IMR) Clear to Send Input Change Interrupt Mask Mask */
+#define US_IMR_CTSIC_Pos DEPRECATED(US_IMR_CTSIC_Pos, "Using deprecated macro US_IMR_CTSIC_Pos") 19 /**< (US_IMR) Clear to Send Input Change Interrupt Mask Position */
+#define US_IMR_CTSIC DEPRECATED(US_IMR_CTSIC, "Using deprecated macro US_IMR_CTSIC") US_IMR_CTSIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_CTSIC_Msk instead */
+#define US_IMR_FRAME_Msk DEPRECATED(US_IMR_FRAME_Msk, "Using deprecated macro US_IMR_FRAME_Msk") (_U_(0x1) << US_IMR_FRAME_Pos) /**< (US_IMR) Framing Error Interrupt Mask Mask */
+#define US_IMR_FRAME_Pos DEPRECATED(US_IMR_FRAME_Pos, "Using deprecated macro US_IMR_FRAME_Pos") 6 /**< (US_IMR) Framing Error Interrupt Mask Position */
+#define US_IMR_FRAME DEPRECATED(US_IMR_FRAME, "Using deprecated macro US_IMR_FRAME") US_IMR_FRAME_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_FRAME_Msk instead */
+#define US_IMR_ITER_Msk DEPRECATED(US_IMR_ITER_Msk, "Using deprecated macro US_IMR_ITER_Msk") (_U_(0x1) << US_IMR_ITER_Pos) /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Mask */
+#define US_IMR_ITER_Pos DEPRECATED(US_IMR_ITER_Pos, "Using deprecated macro US_IMR_ITER_Pos") 10 /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Position */
+#define US_IMR_ITER DEPRECATED(US_IMR_ITER, "Using deprecated macro US_IMR_ITER") US_IMR_ITER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_ITER_Msk instead */
+#define US_IMR_MANE_Msk DEPRECATED(US_IMR_MANE_Msk, "Using deprecated macro US_IMR_MANE_Msk") (_U_(0x1) << US_IMR_MANE_Pos) /**< (US_IMR) Manchester Error Interrupt Mask Mask */
+#define US_IMR_MANE_Pos DEPRECATED(US_IMR_MANE_Pos, "Using deprecated macro US_IMR_MANE_Pos") 24 /**< (US_IMR) Manchester Error Interrupt Mask Position */
+#define US_IMR_MANE DEPRECATED(US_IMR_MANE, "Using deprecated macro US_IMR_MANE") US_IMR_MANE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_MANE_Msk instead */
+#define US_IMR_NACK_Msk DEPRECATED(US_IMR_NACK_Msk, "Using deprecated macro US_IMR_NACK_Msk") (_U_(0x1) << US_IMR_NACK_Pos) /**< (US_IMR) Non Acknowledge Interrupt Mask Mask */
+#define US_IMR_NACK_Pos DEPRECATED(US_IMR_NACK_Pos, "Using deprecated macro US_IMR_NACK_Pos") 13 /**< (US_IMR) Non Acknowledge Interrupt Mask Position */
+#define US_IMR_NACK DEPRECATED(US_IMR_NACK, "Using deprecated macro US_IMR_NACK") US_IMR_NACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_NACK_Msk instead */
+#define US_IMR_PARE_Msk DEPRECATED(US_IMR_PARE_Msk, "Using deprecated macro US_IMR_PARE_Msk") (_U_(0x1) << US_IMR_PARE_Pos) /**< (US_IMR) Parity Error Interrupt Mask Mask */
+#define US_IMR_PARE_Pos DEPRECATED(US_IMR_PARE_Pos, "Using deprecated macro US_IMR_PARE_Pos") 7 /**< (US_IMR) Parity Error Interrupt Mask Position */
+#define US_IMR_PARE DEPRECATED(US_IMR_PARE, "Using deprecated macro US_IMR_PARE") US_IMR_PARE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_PARE_Msk instead */
+#define US_IMR_RXBRK_Msk DEPRECATED(US_IMR_RXBRK_Msk, "Using deprecated macro US_IMR_RXBRK_Msk") (_U_(0x1) << US_IMR_RXBRK_Pos) /**< (US_IMR) Receiver Break Interrupt Mask Mask */
+#define US_IMR_RXBRK_Pos DEPRECATED(US_IMR_RXBRK_Pos, "Using deprecated macro US_IMR_RXBRK_Pos") 2 /**< (US_IMR) Receiver Break Interrupt Mask Position */
+#define US_IMR_RXBRK DEPRECATED(US_IMR_RXBRK, "Using deprecated macro US_IMR_RXBRK") US_IMR_RXBRK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RXBRK_Msk instead */
+#define US_IMR_TIMEOUT_Msk DEPRECATED(US_IMR_TIMEOUT_Msk, "Using deprecated macro US_IMR_TIMEOUT_Msk") (_U_(0x1) << US_IMR_TIMEOUT_Pos) /**< (US_IMR) Time-out Interrupt Mask Mask */
+#define US_IMR_TIMEOUT_Pos DEPRECATED(US_IMR_TIMEOUT_Pos, "Using deprecated macro US_IMR_TIMEOUT_Pos") 8 /**< (US_IMR) Time-out Interrupt Mask Position */
+#define US_IMR_TIMEOUT DEPRECATED(US_IMR_TIMEOUT, "Using deprecated macro US_IMR_TIMEOUT") US_IMR_TIMEOUT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TIMEOUT_Msk instead */
+#define US_MR_CHMODE_Msk DEPRECATED(US_MR_CHMODE_Msk, "Using deprecated macro US_MR_CHMODE_Msk") (_U_(0x3) << US_MR_CHMODE_Pos) /**< (US_MR) Channel Mode Mask */
+#define US_MR_CHMODE_Pos DEPRECATED(US_MR_CHMODE_Pos, "Using deprecated macro US_MR_CHMODE_Pos") 14 /**< (US_MR) Channel Mode Position */
+#define US_MR_CHMODE(value) DEPRECATED(US_MR_CHMODE, "Using deprecated macro US_MR_CHMODE") (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
+#define US_MR_DSNACK_Msk DEPRECATED(US_MR_DSNACK_Msk, "Using deprecated macro US_MR_DSNACK_Msk") (_U_(0x1) << US_MR_DSNACK_Pos) /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_DSNACK_Pos DEPRECATED(US_MR_DSNACK_Pos, "Using deprecated macro US_MR_DSNACK_Pos") 21 /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_DSNACK DEPRECATED(US_MR_DSNACK, "Using deprecated macro US_MR_DSNACK") US_MR_DSNACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_DSNACK_Msk instead */
+#define US_MR_FILTER_Msk DEPRECATED(US_MR_FILTER_Msk, "Using deprecated macro US_MR_FILTER_Msk") (_U_(0x1) << US_MR_FILTER_Pos) /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_FILTER_Pos DEPRECATED(US_MR_FILTER_Pos, "Using deprecated macro US_MR_FILTER_Pos") 28 /**< (US_MR) Receive Line Filter Position */
+#define US_MR_FILTER DEPRECATED(US_MR_FILTER, "Using deprecated macro US_MR_FILTER") US_MR_FILTER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_FILTER_Msk instead */
+#define US_MR_INACK_Msk DEPRECATED(US_MR_INACK_Msk, "Using deprecated macro US_MR_INACK_Msk") (_U_(0x1) << US_MR_INACK_Pos) /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_INACK_Pos DEPRECATED(US_MR_INACK_Pos, "Using deprecated macro US_MR_INACK_Pos") 20 /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_INACK DEPRECATED(US_MR_INACK, "Using deprecated macro US_MR_INACK") US_MR_INACK_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INACK_Msk instead */
+#define US_MR_INVDATA_Msk DEPRECATED(US_MR_INVDATA_Msk, "Using deprecated macro US_MR_INVDATA_Msk") (_U_(0x1) << US_MR_INVDATA_Pos) /**< (US_MR) Inverted Data Mask */
+#define US_MR_INVDATA_Pos DEPRECATED(US_MR_INVDATA_Pos, "Using deprecated macro US_MR_INVDATA_Pos") 23 /**< (US_MR) Inverted Data Position */
+#define US_MR_INVDATA DEPRECATED(US_MR_INVDATA, "Using deprecated macro US_MR_INVDATA") US_MR_INVDATA_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INVDATA_Msk instead */
+#define US_MR_MAN_Msk DEPRECATED(US_MR_MAN_Msk, "Using deprecated macro US_MR_MAN_Msk") (_U_(0x1) << US_MR_MAN_Pos) /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_MAN_Pos DEPRECATED(US_MR_MAN_Pos, "Using deprecated macro US_MR_MAN_Pos") 29 /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_MAN DEPRECATED(US_MR_MAN, "Using deprecated macro US_MR_MAN") US_MR_MAN_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MAN_Msk instead */
+#define US_MR_MAX_ITERATION_Msk DEPRECATED(US_MR_MAX_ITERATION_Msk, "Using deprecated macro US_MR_MAX_ITERATION_Msk") (_U_(0x7) << US_MR_MAX_ITERATION_Pos) /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_MAX_ITERATION_Pos DEPRECATED(US_MR_MAX_ITERATION_Pos, "Using deprecated macro US_MR_MAX_ITERATION_Pos") 24 /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_MAX_ITERATION(value) DEPRECATED(US_MR_MAX_ITERATION, "Using deprecated macro US_MR_MAX_ITERATION") (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
+#define US_MR_MODE9_Msk DEPRECATED(US_MR_MODE9_Msk, "Using deprecated macro US_MR_MODE9_Msk") (_U_(0x1) << US_MR_MODE9_Pos) /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_MODE9_Pos DEPRECATED(US_MR_MODE9_Pos, "Using deprecated macro US_MR_MODE9_Pos") 17 /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_MODE9 DEPRECATED(US_MR_MODE9, "Using deprecated macro US_MR_MODE9") US_MR_MODE9_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODE9_Msk instead */
+#define US_MR_MODSYNC_Msk DEPRECATED(US_MR_MODSYNC_Msk, "Using deprecated macro US_MR_MODSYNC_Msk") (_U_(0x1) << US_MR_MODSYNC_Pos) /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_MODSYNC_Pos DEPRECATED(US_MR_MODSYNC_Pos, "Using deprecated macro US_MR_MODSYNC_Pos") 30 /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_MODSYNC DEPRECATED(US_MR_MODSYNC, "Using deprecated macro US_MR_MODSYNC") US_MR_MODSYNC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODSYNC_Msk instead */
+#define US_MR_MSBF_Msk DEPRECATED(US_MR_MSBF_Msk, "Using deprecated macro US_MR_MSBF_Msk") (_U_(0x1) << US_MR_MSBF_Pos) /**< (US_MR) Bit Order Mask */
+#define US_MR_MSBF_Pos DEPRECATED(US_MR_MSBF_Pos, "Using deprecated macro US_MR_MSBF_Pos") 16 /**< (US_MR) Bit Order Position */
+#define US_MR_MSBF DEPRECATED(US_MR_MSBF, "Using deprecated macro US_MR_MSBF") US_MR_MSBF_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MSBF_Msk instead */
+#define US_MR_NBSTOP_Msk DEPRECATED(US_MR_NBSTOP_Msk, "Using deprecated macro US_MR_NBSTOP_Msk") (_U_(0x3) << US_MR_NBSTOP_Pos) /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_NBSTOP_Pos DEPRECATED(US_MR_NBSTOP_Pos, "Using deprecated macro US_MR_NBSTOP_Pos") 12 /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_NBSTOP(value) DEPRECATED(US_MR_NBSTOP, "Using deprecated macro US_MR_NBSTOP") (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
+#define US_MR_ONEBIT_Msk DEPRECATED(US_MR_ONEBIT_Msk, "Using deprecated macro US_MR_ONEBIT_Msk") (_U_(0x1) << US_MR_ONEBIT_Pos) /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_ONEBIT_Pos DEPRECATED(US_MR_ONEBIT_Pos, "Using deprecated macro US_MR_ONEBIT_Pos") 31 /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_ONEBIT DEPRECATED(US_MR_ONEBIT, "Using deprecated macro US_MR_ONEBIT") US_MR_ONEBIT_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_ONEBIT_Msk instead */
+#define US_MR_OVER_Msk DEPRECATED(US_MR_OVER_Msk, "Using deprecated macro US_MR_OVER_Msk") (_U_(0x1) << US_MR_OVER_Pos) /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_OVER_Pos DEPRECATED(US_MR_OVER_Pos, "Using deprecated macro US_MR_OVER_Pos") 19 /**< (US_MR) Oversampling Mode Position */
+#define US_MR_OVER DEPRECATED(US_MR_OVER, "Using deprecated macro US_MR_OVER") US_MR_OVER_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_OVER_Msk instead */
+#define US_MR_PAR_Msk DEPRECATED(US_MR_PAR_Msk, "Using deprecated macro US_MR_PAR_Msk") (_U_(0x7) << US_MR_PAR_Pos) /**< (US_MR) Parity Type Mask */
+#define US_MR_PAR_Pos DEPRECATED(US_MR_PAR_Pos, "Using deprecated macro US_MR_PAR_Pos") 9 /**< (US_MR) Parity Type Position */
+#define US_MR_PAR(value) DEPRECATED(US_MR_PAR, "Using deprecated macro US_MR_PAR") (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos))
+#define US_MR_SYNC_Msk DEPRECATED(US_MR_SYNC_Msk, "Using deprecated macro US_MR_SYNC_Msk") (_U_(0x1) << US_MR_SYNC_Pos) /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_SYNC_Pos DEPRECATED(US_MR_SYNC_Pos, "Using deprecated macro US_MR_SYNC_Pos") 8 /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_SYNC DEPRECATED(US_MR_SYNC, "Using deprecated macro US_MR_SYNC") US_MR_SYNC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SYNC_Msk instead */
+#define US_MR_VAR_SYNC_Msk DEPRECATED(US_MR_VAR_SYNC_Msk, "Using deprecated macro US_MR_VAR_SYNC_Msk") (_U_(0x1) << US_MR_VAR_SYNC_Pos) /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_VAR_SYNC_Pos DEPRECATED(US_MR_VAR_SYNC_Pos, "Using deprecated macro US_MR_VAR_SYNC_Pos") 22 /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_VAR_SYNC DEPRECATED(US_MR_VAR_SYNC, "Using deprecated macro US_MR_VAR_SYNC") US_MR_VAR_SYNC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_VAR_SYNC_Msk instead */
+#define US_TTGR_TG_Msk DEPRECATED(US_TTGR_TG_Msk, "Using deprecated macro US_TTGR_TG_Msk") (_U_(0xFF) << US_TTGR_TG_Pos) /**< (US_TTGR) Timeguard Value Mask */
+#define US_TTGR_TG_Pos DEPRECATED(US_TTGR_TG_Pos, "Using deprecated macro US_TTGR_TG_Pos") 0 /**< (US_TTGR) Timeguard Value Position */
+#define US_TTGR_TG(value) DEPRECATED(US_TTGR_TG, "Using deprecated macro US_TTGR_TG") (US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos))
+
+#endif

--- a/asf/sam/include/same70b/component/deprecated/usbhs.h
+++ b/asf/sam/include/same70b/component/deprecated/usbhs.h
@@ -1,0 +1,184 @@
+/**
+ * \file
+ * \brief This file is for deprecated macro constants
+ *
+ *  Used to mark macro constants as deprecate.
+ *  Uses a macro 'DEPRECTAED' to give warnings during compilation (GCC >= 4.8)
+ *
+ *  \remark To use, add defines and put a DEPRECATED statement between the macro name and the value
+ *
+ *  \note This file is manually maintained
+ */
+
+#ifndef _SAME70_USBHS_COMPONENT_DEPRECATED_H_
+#define _SAME70_USBHS_COMPONENT_DEPRECATED_H_
+
+#ifndef DEPRECATED
+#define _DEP_STRING(X) #X
+
+/** \hideinitializer
+ * \brief Macro deprecation mark
+ *
+ * Putting this in a macro definition will emit deprecation warning when given
+ * macro is used (GCC 4.8)
+ *
+ *  \code{.c}
+ *  #define OLD_MACRO DEPRECATED(OLD_MACRO, "deprecated <or any other text>") <value>
+ *  \endcode
+ *
+ *  \warning Using these macros in #if statements will not work
+ */
+#if defined(__GNUC__) && __GNUC__*100 + __GNUC_MINOR__ >= 408
+#define DEPRECATED(macro, message) _Pragma (_DEP_STRING(GCC warning message))
+#else
+#define DEPRECATED(macro, message)
+#endif
+#endif
+
+/* deprecated defines added below here */
+#define USBHS_DEVEPTICR_NAKINIC_Msk DEPRECATED(USBHS_DEVEPTICR_NAKINIC_Msk, "Using deprecated macro USBHS_DEVEPTICR_NAKINIC_Msk") (_U_(0x1) << USBHS_DEVEPTICR_NAKINIC_Pos) /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_NAKINIC_Pos DEPRECATED(USBHS_DEVEPTICR_NAKINIC_Pos, "Using deprecated macro USBHS_DEVEPTICR_NAKINIC_Pos") 4 /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_NAKINIC DEPRECATED(USBHS_DEVEPTICR_NAKINIC, "Using deprecated macro USBHS_DEVEPTICR_NAKINIC") USBHS_DEVEPTICR_NAKINIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_NAKOUTIC_Msk DEPRECATED(USBHS_DEVEPTICR_NAKOUTIC_Msk, "Using deprecated macro USBHS_DEVEPTICR_NAKOUTIC_Msk") (_U_(0x1) << USBHS_DEVEPTICR_NAKOUTIC_Pos) /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_NAKOUTIC_Pos DEPRECATED(USBHS_DEVEPTICR_NAKOUTIC_Pos, "Using deprecated macro USBHS_DEVEPTICR_NAKOUTIC_Pos") 3 /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_NAKOUTIC DEPRECATED(USBHS_DEVEPTICR_NAKOUTIC, "Using deprecated macro USBHS_DEVEPTICR_NAKOUTIC") USBHS_DEVEPTICR_NAKOUTIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_RXSTPIC_Msk DEPRECATED(USBHS_DEVEPTICR_RXSTPIC_Msk, "Using deprecated macro USBHS_DEVEPTICR_RXSTPIC_Msk") (_U_(0x1) << USBHS_DEVEPTICR_RXSTPIC_Pos) /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_RXSTPIC_Pos DEPRECATED(USBHS_DEVEPTICR_RXSTPIC_Pos, "Using deprecated macro USBHS_DEVEPTICR_RXSTPIC_Pos") 2 /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_RXSTPIC DEPRECATED(USBHS_DEVEPTICR_RXSTPIC, "Using deprecated macro USBHS_DEVEPTICR_RXSTPIC") USBHS_DEVEPTICR_RXSTPIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_STALLEDIC_Msk DEPRECATED(USBHS_DEVEPTICR_STALLEDIC_Msk, "Using deprecated macro USBHS_DEVEPTICR_STALLEDIC_Msk") (_U_(0x1) << USBHS_DEVEPTICR_STALLEDIC_Pos) /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_STALLEDIC_Pos DEPRECATED(USBHS_DEVEPTICR_STALLEDIC_Pos, "Using deprecated macro USBHS_DEVEPTICR_STALLEDIC_Pos") 6 /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_STALLEDIC DEPRECATED(USBHS_DEVEPTICR_STALLEDIC, "Using deprecated macro USBHS_DEVEPTICR_STALLEDIC") USBHS_DEVEPTICR_STALLEDIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTIDR_NAKINEC_Msk DEPRECATED(USBHS_DEVEPTIDR_NAKINEC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_NAKINEC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_NAKINEC_Pos) /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NAKINEC_Pos DEPRECATED(USBHS_DEVEPTIDR_NAKINEC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_NAKINEC_Pos") 4 /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NAKINEC DEPRECATED(USBHS_DEVEPTIDR_NAKINEC, "Using deprecated macro USBHS_DEVEPTIDR_NAKINEC") USBHS_DEVEPTIDR_NAKINEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_NAKOUTEC_Msk DEPRECATED(USBHS_DEVEPTIDR_NAKOUTEC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_NAKOUTEC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_NAKOUTEC_Pos) /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_NAKOUTEC_Pos DEPRECATED(USBHS_DEVEPTIDR_NAKOUTEC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_NAKOUTEC_Pos") 3 /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_NAKOUTEC DEPRECATED(USBHS_DEVEPTIDR_NAKOUTEC, "Using deprecated macro USBHS_DEVEPTIDR_NAKOUTEC") USBHS_DEVEPTIDR_NAKOUTEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_NYETDISC_Msk DEPRECATED(USBHS_DEVEPTIDR_NYETDISC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_NYETDISC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_NYETDISC_Pos) /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_NYETDISC_Pos DEPRECATED(USBHS_DEVEPTIDR_NYETDISC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_NYETDISC_Pos") 17 /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_NYETDISC DEPRECATED(USBHS_DEVEPTIDR_NYETDISC, "Using deprecated macro USBHS_DEVEPTIDR_NYETDISC") USBHS_DEVEPTIDR_NYETDISC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_RXSTPEC_Msk DEPRECATED(USBHS_DEVEPTIDR_RXSTPEC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_RXSTPEC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_RXSTPEC_Pos) /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_RXSTPEC_Pos DEPRECATED(USBHS_DEVEPTIDR_RXSTPEC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_RXSTPEC_Pos") 2 /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_RXSTPEC DEPRECATED(USBHS_DEVEPTIDR_RXSTPEC, "Using deprecated macro USBHS_DEVEPTIDR_RXSTPEC") USBHS_DEVEPTIDR_RXSTPEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_STALLEDEC_Msk DEPRECATED(USBHS_DEVEPTIDR_STALLEDEC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_STALLEDEC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_STALLEDEC_Pos) /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_STALLEDEC_Pos DEPRECATED(USBHS_DEVEPTIDR_STALLEDEC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_STALLEDEC_Pos") 6 /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_STALLEDEC DEPRECATED(USBHS_DEVEPTIDR_STALLEDEC, "Using deprecated macro USBHS_DEVEPTIDR_STALLEDEC") USBHS_DEVEPTIDR_STALLEDEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_STALLRQC_Msk DEPRECATED(USBHS_DEVEPTIDR_STALLRQC_Msk, "Using deprecated macro USBHS_DEVEPTIDR_STALLRQC_Msk") (_U_(0x1) << USBHS_DEVEPTIDR_STALLRQC_Pos) /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_STALLRQC_Pos DEPRECATED(USBHS_DEVEPTIDR_STALLRQC_Pos, "Using deprecated macro USBHS_DEVEPTIDR_STALLRQC_Pos") 19 /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_STALLRQC DEPRECATED(USBHS_DEVEPTIDR_STALLRQC, "Using deprecated macro USBHS_DEVEPTIDR_STALLRQC") USBHS_DEVEPTIDR_STALLRQC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIER_NAKINES_Msk DEPRECATED(USBHS_DEVEPTIER_NAKINES_Msk, "Using deprecated macro USBHS_DEVEPTIER_NAKINES_Msk") (_U_(0x1) << USBHS_DEVEPTIER_NAKINES_Pos) /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NAKINES_Pos DEPRECATED(USBHS_DEVEPTIER_NAKINES_Pos, "Using deprecated macro USBHS_DEVEPTIER_NAKINES_Pos") 4 /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NAKINES DEPRECATED(USBHS_DEVEPTIER_NAKINES, "Using deprecated macro USBHS_DEVEPTIER_NAKINES") USBHS_DEVEPTIER_NAKINES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_NAKOUTES_Msk DEPRECATED(USBHS_DEVEPTIER_NAKOUTES_Msk, "Using deprecated macro USBHS_DEVEPTIER_NAKOUTES_Msk") (_U_(0x1) << USBHS_DEVEPTIER_NAKOUTES_Pos) /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_NAKOUTES_Pos DEPRECATED(USBHS_DEVEPTIER_NAKOUTES_Pos, "Using deprecated macro USBHS_DEVEPTIER_NAKOUTES_Pos") 3 /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_NAKOUTES DEPRECATED(USBHS_DEVEPTIER_NAKOUTES, "Using deprecated macro USBHS_DEVEPTIER_NAKOUTES") USBHS_DEVEPTIER_NAKOUTES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_NYETDISS_Msk DEPRECATED(USBHS_DEVEPTIER_NYETDISS_Msk, "Using deprecated macro USBHS_DEVEPTIER_NYETDISS_Msk") (_U_(0x1) << USBHS_DEVEPTIER_NYETDISS_Pos) /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_NYETDISS_Pos DEPRECATED(USBHS_DEVEPTIER_NYETDISS_Pos, "Using deprecated macro USBHS_DEVEPTIER_NYETDISS_Pos") 17 /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_NYETDISS DEPRECATED(USBHS_DEVEPTIER_NYETDISS, "Using deprecated macro USBHS_DEVEPTIER_NYETDISS") USBHS_DEVEPTIER_NYETDISS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_RXSTPES_Msk DEPRECATED(USBHS_DEVEPTIER_RXSTPES_Msk, "Using deprecated macro USBHS_DEVEPTIER_RXSTPES_Msk") (_U_(0x1) << USBHS_DEVEPTIER_RXSTPES_Pos) /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_RXSTPES_Pos DEPRECATED(USBHS_DEVEPTIER_RXSTPES_Pos, "Using deprecated macro USBHS_DEVEPTIER_RXSTPES_Pos") 2 /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_RXSTPES DEPRECATED(USBHS_DEVEPTIER_RXSTPES, "Using deprecated macro USBHS_DEVEPTIER_RXSTPES") USBHS_DEVEPTIER_RXSTPES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_STALLEDES_Msk DEPRECATED(USBHS_DEVEPTIER_STALLEDES_Msk, "Using deprecated macro USBHS_DEVEPTIER_STALLEDES_Msk") (_U_(0x1) << USBHS_DEVEPTIER_STALLEDES_Pos) /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_STALLEDES_Pos DEPRECATED(USBHS_DEVEPTIER_STALLEDES_Pos, "Using deprecated macro USBHS_DEVEPTIER_STALLEDES_Pos") 6 /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_STALLEDES DEPRECATED(USBHS_DEVEPTIER_STALLEDES, "Using deprecated macro USBHS_DEVEPTIER_STALLEDES") USBHS_DEVEPTIER_STALLEDES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_STALLRQS_Msk DEPRECATED(USBHS_DEVEPTIER_STALLRQS_Msk, "Using deprecated macro USBHS_DEVEPTIER_STALLRQS_Msk") (_U_(0x1) << USBHS_DEVEPTIER_STALLRQS_Pos) /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_STALLRQS_Pos DEPRECATED(USBHS_DEVEPTIER_STALLRQS_Pos, "Using deprecated macro USBHS_DEVEPTIER_STALLRQS_Pos") 19 /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_STALLRQS DEPRECATED(USBHS_DEVEPTIER_STALLRQS, "Using deprecated macro USBHS_DEVEPTIER_STALLRQS") USBHS_DEVEPTIER_STALLRQS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIFR_NAKINIS_Msk DEPRECATED(USBHS_DEVEPTIFR_NAKINIS_Msk, "Using deprecated macro USBHS_DEVEPTIFR_NAKINIS_Msk") (_U_(0x1) << USBHS_DEVEPTIFR_NAKINIS_Pos) /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NAKINIS_Pos DEPRECATED(USBHS_DEVEPTIFR_NAKINIS_Pos, "Using deprecated macro USBHS_DEVEPTIFR_NAKINIS_Pos") 4 /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NAKINIS DEPRECATED(USBHS_DEVEPTIFR_NAKINIS, "Using deprecated macro USBHS_DEVEPTIFR_NAKINIS") USBHS_DEVEPTIFR_NAKINIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_NAKOUTIS_Msk DEPRECATED(USBHS_DEVEPTIFR_NAKOUTIS_Msk, "Using deprecated macro USBHS_DEVEPTIFR_NAKOUTIS_Msk") (_U_(0x1) << USBHS_DEVEPTIFR_NAKOUTIS_Pos) /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_NAKOUTIS_Pos DEPRECATED(USBHS_DEVEPTIFR_NAKOUTIS_Pos, "Using deprecated macro USBHS_DEVEPTIFR_NAKOUTIS_Pos") 3 /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_NAKOUTIS DEPRECATED(USBHS_DEVEPTIFR_NAKOUTIS, "Using deprecated macro USBHS_DEVEPTIFR_NAKOUTIS") USBHS_DEVEPTIFR_NAKOUTIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_RXSTPIS_Msk DEPRECATED(USBHS_DEVEPTIFR_RXSTPIS_Msk, "Using deprecated macro USBHS_DEVEPTIFR_RXSTPIS_Msk") (_U_(0x1) << USBHS_DEVEPTIFR_RXSTPIS_Pos) /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_RXSTPIS_Pos DEPRECATED(USBHS_DEVEPTIFR_RXSTPIS_Pos, "Using deprecated macro USBHS_DEVEPTIFR_RXSTPIS_Pos") 2 /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_RXSTPIS DEPRECATED(USBHS_DEVEPTIFR_RXSTPIS, "Using deprecated macro USBHS_DEVEPTIFR_RXSTPIS") USBHS_DEVEPTIFR_RXSTPIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_STALLEDIS_Msk DEPRECATED(USBHS_DEVEPTIFR_STALLEDIS_Msk, "Using deprecated macro USBHS_DEVEPTIFR_STALLEDIS_Msk") (_U_(0x1) << USBHS_DEVEPTIFR_STALLEDIS_Pos) /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_STALLEDIS_Pos DEPRECATED(USBHS_DEVEPTIFR_STALLEDIS_Pos, "Using deprecated macro USBHS_DEVEPTIFR_STALLEDIS_Pos") 6 /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_STALLEDIS DEPRECATED(USBHS_DEVEPTIFR_STALLEDIS, "Using deprecated macro USBHS_DEVEPTIFR_STALLEDIS") USBHS_DEVEPTIFR_STALLEDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIMR_NAKINE_Msk DEPRECATED(USBHS_DEVEPTIMR_NAKINE_Msk, "Using deprecated macro USBHS_DEVEPTIMR_NAKINE_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_NAKINE_Pos) /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_NAKINE_Pos DEPRECATED(USBHS_DEVEPTIMR_NAKINE_Pos, "Using deprecated macro USBHS_DEVEPTIMR_NAKINE_Pos") 4 /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_NAKINE DEPRECATED(USBHS_DEVEPTIMR_NAKINE, "Using deprecated macro USBHS_DEVEPTIMR_NAKINE") USBHS_DEVEPTIMR_NAKINE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_NAKOUTE_Msk DEPRECATED(USBHS_DEVEPTIMR_NAKOUTE_Msk, "Using deprecated macro USBHS_DEVEPTIMR_NAKOUTE_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_NAKOUTE_Pos) /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_NAKOUTE_Pos DEPRECATED(USBHS_DEVEPTIMR_NAKOUTE_Pos, "Using deprecated macro USBHS_DEVEPTIMR_NAKOUTE_Pos") 3 /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_NAKOUTE DEPRECATED(USBHS_DEVEPTIMR_NAKOUTE, "Using deprecated macro USBHS_DEVEPTIMR_NAKOUTE") USBHS_DEVEPTIMR_NAKOUTE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_NYETDIS_Msk DEPRECATED(USBHS_DEVEPTIMR_NYETDIS_Msk, "Using deprecated macro USBHS_DEVEPTIMR_NYETDIS_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_NYETDIS_Pos) /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_NYETDIS_Pos DEPRECATED(USBHS_DEVEPTIMR_NYETDIS_Pos, "Using deprecated macro USBHS_DEVEPTIMR_NYETDIS_Pos") 17 /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_NYETDIS DEPRECATED(USBHS_DEVEPTIMR_NYETDIS, "Using deprecated macro USBHS_DEVEPTIMR_NYETDIS") USBHS_DEVEPTIMR_NYETDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_RXSTPE_Msk DEPRECATED(USBHS_DEVEPTIMR_RXSTPE_Msk, "Using deprecated macro USBHS_DEVEPTIMR_RXSTPE_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_RXSTPE_Pos) /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_RXSTPE_Pos DEPRECATED(USBHS_DEVEPTIMR_RXSTPE_Pos, "Using deprecated macro USBHS_DEVEPTIMR_RXSTPE_Pos") 2 /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_RXSTPE DEPRECATED(USBHS_DEVEPTIMR_RXSTPE, "Using deprecated macro USBHS_DEVEPTIMR_RXSTPE") USBHS_DEVEPTIMR_RXSTPE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_STALLEDE_Msk DEPRECATED(USBHS_DEVEPTIMR_STALLEDE_Msk, "Using deprecated macro USBHS_DEVEPTIMR_STALLEDE_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_STALLEDE_Pos) /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_STALLEDE_Pos DEPRECATED(USBHS_DEVEPTIMR_STALLEDE_Pos, "Using deprecated macro USBHS_DEVEPTIMR_STALLEDE_Pos") 6 /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_STALLEDE DEPRECATED(USBHS_DEVEPTIMR_STALLEDE, "Using deprecated macro USBHS_DEVEPTIMR_STALLEDE") USBHS_DEVEPTIMR_STALLEDE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_STALLRQ_Msk DEPRECATED(USBHS_DEVEPTIMR_STALLRQ_Msk, "Using deprecated macro USBHS_DEVEPTIMR_STALLRQ_Msk") (_U_(0x1) << USBHS_DEVEPTIMR_STALLRQ_Pos) /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_STALLRQ_Pos DEPRECATED(USBHS_DEVEPTIMR_STALLRQ_Pos, "Using deprecated macro USBHS_DEVEPTIMR_STALLRQ_Pos") 19 /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_STALLRQ DEPRECATED(USBHS_DEVEPTIMR_STALLRQ, "Using deprecated macro USBHS_DEVEPTIMR_STALLRQ") USBHS_DEVEPTIMR_STALLRQ_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLRQ_Msk instead */
+#define USBHS_DEVEPTISR_CTRLDIR_Msk DEPRECATED(USBHS_DEVEPTISR_CTRLDIR_Msk, "Using deprecated macro USBHS_DEVEPTISR_CTRLDIR_Msk") (_U_(0x1) << USBHS_DEVEPTISR_CTRLDIR_Pos) /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_CTRLDIR_Pos DEPRECATED(USBHS_DEVEPTISR_CTRLDIR_Pos, "Using deprecated macro USBHS_DEVEPTISR_CTRLDIR_Pos") 17 /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_CTRLDIR DEPRECATED(USBHS_DEVEPTISR_CTRLDIR, "Using deprecated macro USBHS_DEVEPTISR_CTRLDIR") USBHS_DEVEPTISR_CTRLDIR_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_NAKINI_Msk DEPRECATED(USBHS_DEVEPTISR_NAKINI_Msk, "Using deprecated macro USBHS_DEVEPTISR_NAKINI_Msk") (_U_(0x1) << USBHS_DEVEPTISR_NAKINI_Pos) /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_NAKINI_Pos DEPRECATED(USBHS_DEVEPTISR_NAKINI_Pos, "Using deprecated macro USBHS_DEVEPTISR_NAKINI_Pos") 4 /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_NAKINI DEPRECATED(USBHS_DEVEPTISR_NAKINI, "Using deprecated macro USBHS_DEVEPTISR_NAKINI") USBHS_DEVEPTISR_NAKINI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_NAKOUTI_Msk DEPRECATED(USBHS_DEVEPTISR_NAKOUTI_Msk, "Using deprecated macro USBHS_DEVEPTISR_NAKOUTI_Msk") (_U_(0x1) << USBHS_DEVEPTISR_NAKOUTI_Pos) /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_NAKOUTI_Pos DEPRECATED(USBHS_DEVEPTISR_NAKOUTI_Pos, "Using deprecated macro USBHS_DEVEPTISR_NAKOUTI_Pos") 3 /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_NAKOUTI DEPRECATED(USBHS_DEVEPTISR_NAKOUTI, "Using deprecated macro USBHS_DEVEPTISR_NAKOUTI") USBHS_DEVEPTISR_NAKOUTI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_RXSTPI_Msk DEPRECATED(USBHS_DEVEPTISR_RXSTPI_Msk, "Using deprecated macro USBHS_DEVEPTISR_RXSTPI_Msk") (_U_(0x1) << USBHS_DEVEPTISR_RXSTPI_Pos) /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_RXSTPI_Pos DEPRECATED(USBHS_DEVEPTISR_RXSTPI_Pos, "Using deprecated macro USBHS_DEVEPTISR_RXSTPI_Pos") 2 /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_RXSTPI DEPRECATED(USBHS_DEVEPTISR_RXSTPI, "Using deprecated macro USBHS_DEVEPTISR_RXSTPI") USBHS_DEVEPTISR_RXSTPI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_STALLEDI_Msk DEPRECATED(USBHS_DEVEPTISR_STALLEDI_Msk, "Using deprecated macro USBHS_DEVEPTISR_STALLEDI_Msk") (_U_(0x1) << USBHS_DEVEPTISR_STALLEDI_Pos) /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_STALLEDI_Pos DEPRECATED(USBHS_DEVEPTISR_STALLEDI_Pos, "Using deprecated macro USBHS_DEVEPTISR_STALLEDI_Pos") 6 /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_STALLEDI DEPRECATED(USBHS_DEVEPTISR_STALLEDI, "Using deprecated macro USBHS_DEVEPTISR_STALLEDI") USBHS_DEVEPTISR_STALLEDI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_STALLEDI_Msk instead */
+#define USBHS_HSTIDR_DMA_7_Msk DEPRECATED(USBHS_HSTIDR_DMA_7_Msk, "Using deprecated macro USBHS_HSTIDR_DMA_7_Msk") (_U_(0x1) << USBHS_HSTIDR_DMA_7_Pos) /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_7_Pos DEPRECATED(USBHS_HSTIDR_DMA_7_Pos, "Using deprecated macro USBHS_HSTIDR_DMA_7_Pos") 31 /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_7 DEPRECATED(USBHS_HSTIDR_DMA_7, "Using deprecated macro USBHS_HSTIDR_DMA_7") USBHS_HSTIDR_DMA_7_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_7_Msk instead */
+#define USBHS_HSTIER_DMA_7_Msk DEPRECATED(USBHS_HSTIER_DMA_7_Msk, "Using deprecated macro USBHS_HSTIER_DMA_7_Msk") (_U_(0x1) << USBHS_HSTIER_DMA_7_Pos) /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_7_Pos DEPRECATED(USBHS_HSTIER_DMA_7_Pos, "Using deprecated macro USBHS_HSTIER_DMA_7_Pos") 31 /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_7 DEPRECATED(USBHS_HSTIER_DMA_7, "Using deprecated macro USBHS_HSTIER_DMA_7") USBHS_HSTIER_DMA_7_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_7_Msk instead */
+#define USBHS_HSTIFR_DMA_7_Msk DEPRECATED(USBHS_HSTIFR_DMA_7_Msk, "Using deprecated macro USBHS_HSTIFR_DMA_7_Msk") (_U_(0x1) << USBHS_HSTIFR_DMA_7_Pos) /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_7_Pos DEPRECATED(USBHS_HSTIFR_DMA_7_Pos, "Using deprecated macro USBHS_HSTIFR_DMA_7_Pos") 31 /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_7 DEPRECATED(USBHS_HSTIFR_DMA_7, "Using deprecated macro USBHS_HSTIFR_DMA_7") USBHS_HSTIFR_DMA_7_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_7_Msk instead */
+#define USBHS_HSTIMR_DMA_7_Msk DEPRECATED(USBHS_HSTIMR_DMA_7_Msk, "Using deprecated macro USBHS_HSTIMR_DMA_7_Msk") (_U_(0x1) << USBHS_HSTIMR_DMA_7_Pos) /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_7_Pos DEPRECATED(USBHS_HSTIMR_DMA_7_Pos, "Using deprecated macro USBHS_HSTIMR_DMA_7_Pos") 31 /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_7 DEPRECATED(USBHS_HSTIMR_DMA_7, "Using deprecated macro USBHS_HSTIMR_DMA_7") USBHS_HSTIMR_DMA_7_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_7_Msk instead */
+#define USBHS_HSTISR_DMA_7_Msk DEPRECATED(USBHS_HSTISR_DMA_7_Msk, "Using deprecated macro USBHS_HSTISR_DMA_7_Msk") (_U_(0x1) << USBHS_HSTISR_DMA_7_Pos) /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Mask */
+#define USBHS_HSTISR_DMA_7_Pos DEPRECATED(USBHS_HSTISR_DMA_7_Pos, "Using deprecated macro USBHS_HSTISR_DMA_7_Pos") 31 /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Position */
+#define USBHS_HSTISR_DMA_7 DEPRECATED(USBHS_HSTISR_DMA_7, "Using deprecated macro USBHS_HSTISR_DMA_7") USBHS_HSTISR_DMA_7_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_7_Msk instead */
+#define USBHS_HSTPIPICR_RXSTALLDIC_Msk DEPRECATED(USBHS_HSTPIPICR_RXSTALLDIC_Msk, "Using deprecated macro USBHS_HSTPIPICR_RXSTALLDIC_Msk") (_U_(0x1) << USBHS_HSTPIPICR_RXSTALLDIC_Pos) /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_RXSTALLDIC_Pos DEPRECATED(USBHS_HSTPIPICR_RXSTALLDIC_Pos, "Using deprecated macro USBHS_HSTPIPICR_RXSTALLDIC_Pos") 6 /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_RXSTALLDIC DEPRECATED(USBHS_HSTPIPICR_RXSTALLDIC, "Using deprecated macro USBHS_HSTPIPICR_RXSTALLDIC") USBHS_HSTPIPICR_RXSTALLDIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_TXSTPIC_Msk DEPRECATED(USBHS_HSTPIPICR_TXSTPIC_Msk, "Using deprecated macro USBHS_HSTPIPICR_TXSTPIC_Msk") (_U_(0x1) << USBHS_HSTPIPICR_TXSTPIC_Pos) /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_TXSTPIC_Pos DEPRECATED(USBHS_HSTPIPICR_TXSTPIC_Pos, "Using deprecated macro USBHS_HSTPIPICR_TXSTPIC_Pos") 2 /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_TXSTPIC DEPRECATED(USBHS_HSTPIPICR_TXSTPIC, "Using deprecated macro USBHS_HSTPIPICR_TXSTPIC") USBHS_HSTPIPICR_TXSTPIC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPIDR_RXSTALLDEC_Msk DEPRECATED(USBHS_HSTPIPIDR_RXSTALLDEC_Msk, "Using deprecated macro USBHS_HSTPIPIDR_RXSTALLDEC_Msk") (_U_(0x1) << USBHS_HSTPIPIDR_RXSTALLDEC_Pos) /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_RXSTALLDEC_Pos DEPRECATED(USBHS_HSTPIPIDR_RXSTALLDEC_Pos, "Using deprecated macro USBHS_HSTPIPIDR_RXSTALLDEC_Pos") 6 /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_RXSTALLDEC DEPRECATED(USBHS_HSTPIPIDR_RXSTALLDEC, "Using deprecated macro USBHS_HSTPIPIDR_RXSTALLDEC") USBHS_HSTPIPIDR_RXSTALLDEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_TXSTPEC_Msk DEPRECATED(USBHS_HSTPIPIDR_TXSTPEC_Msk, "Using deprecated macro USBHS_HSTPIPIDR_TXSTPEC_Msk") (_U_(0x1) << USBHS_HSTPIPIDR_TXSTPEC_Pos) /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_TXSTPEC_Pos DEPRECATED(USBHS_HSTPIPIDR_TXSTPEC_Pos, "Using deprecated macro USBHS_HSTPIPIDR_TXSTPEC_Pos") 2 /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_TXSTPEC DEPRECATED(USBHS_HSTPIPIDR_TXSTPEC, "Using deprecated macro USBHS_HSTPIPIDR_TXSTPEC") USBHS_HSTPIPIDR_TXSTPEC_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIER_RXSTALLDES_Msk DEPRECATED(USBHS_HSTPIPIER_RXSTALLDES_Msk, "Using deprecated macro USBHS_HSTPIPIER_RXSTALLDES_Msk") (_U_(0x1) << USBHS_HSTPIPIER_RXSTALLDES_Pos) /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_RXSTALLDES_Pos DEPRECATED(USBHS_HSTPIPIER_RXSTALLDES_Pos, "Using deprecated macro USBHS_HSTPIPIER_RXSTALLDES_Pos") 6 /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_RXSTALLDES DEPRECATED(USBHS_HSTPIPIER_RXSTALLDES, "Using deprecated macro USBHS_HSTPIPIER_RXSTALLDES") USBHS_HSTPIPIER_RXSTALLDES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_TXSTPES_Msk DEPRECATED(USBHS_HSTPIPIER_TXSTPES_Msk, "Using deprecated macro USBHS_HSTPIPIER_TXSTPES_Msk") (_U_(0x1) << USBHS_HSTPIPIER_TXSTPES_Pos) /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_TXSTPES_Pos DEPRECATED(USBHS_HSTPIPIER_TXSTPES_Pos, "Using deprecated macro USBHS_HSTPIPIER_TXSTPES_Pos") 2 /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_TXSTPES DEPRECATED(USBHS_HSTPIPIER_TXSTPES, "Using deprecated macro USBHS_HSTPIPIER_TXSTPES") USBHS_HSTPIPIER_TXSTPES_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIFR_RXSTALLDIS_Msk DEPRECATED(USBHS_HSTPIPIFR_RXSTALLDIS_Msk, "Using deprecated macro USBHS_HSTPIPIFR_RXSTALLDIS_Msk") (_U_(0x1) << USBHS_HSTPIPIFR_RXSTALLDIS_Pos) /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_RXSTALLDIS_Pos DEPRECATED(USBHS_HSTPIPIFR_RXSTALLDIS_Pos, "Using deprecated macro USBHS_HSTPIPIFR_RXSTALLDIS_Pos") 6 /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_RXSTALLDIS DEPRECATED(USBHS_HSTPIPIFR_RXSTALLDIS, "Using deprecated macro USBHS_HSTPIPIFR_RXSTALLDIS") USBHS_HSTPIPIFR_RXSTALLDIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_TXSTPIS_Msk DEPRECATED(USBHS_HSTPIPIFR_TXSTPIS_Msk, "Using deprecated macro USBHS_HSTPIPIFR_TXSTPIS_Msk") (_U_(0x1) << USBHS_HSTPIPIFR_TXSTPIS_Pos) /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_TXSTPIS_Pos DEPRECATED(USBHS_HSTPIPIFR_TXSTPIS_Pos, "Using deprecated macro USBHS_HSTPIPIFR_TXSTPIS_Pos") 2 /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_TXSTPIS DEPRECATED(USBHS_HSTPIPIFR_TXSTPIS, "Using deprecated macro USBHS_HSTPIPIFR_TXSTPIS") USBHS_HSTPIPIFR_TXSTPIS_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIMR_RXSTALLDE_Msk DEPRECATED(USBHS_HSTPIPIMR_RXSTALLDE_Msk, "Using deprecated macro USBHS_HSTPIPIMR_RXSTALLDE_Msk") (_U_(0x1) << USBHS_HSTPIPIMR_RXSTALLDE_Pos) /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_RXSTALLDE_Pos DEPRECATED(USBHS_HSTPIPIMR_RXSTALLDE_Pos, "Using deprecated macro USBHS_HSTPIPIMR_RXSTALLDE_Pos") 6 /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_RXSTALLDE DEPRECATED(USBHS_HSTPIPIMR_RXSTALLDE, "Using deprecated macro USBHS_HSTPIPIMR_RXSTALLDE") USBHS_HSTPIPIMR_RXSTALLDE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_TXSTPE_Msk DEPRECATED(USBHS_HSTPIPIMR_TXSTPE_Msk, "Using deprecated macro USBHS_HSTPIPIMR_TXSTPE_Msk") (_U_(0x1) << USBHS_HSTPIPIMR_TXSTPE_Pos) /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_TXSTPE_Pos DEPRECATED(USBHS_HSTPIPIMR_TXSTPE_Pos, "Using deprecated macro USBHS_HSTPIPIMR_TXSTPE_Pos") 2 /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_TXSTPE DEPRECATED(USBHS_HSTPIPIMR_TXSTPE, "Using deprecated macro USBHS_HSTPIPIMR_TXSTPE") USBHS_HSTPIPIMR_TXSTPE_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXSTPE_Msk instead */
+#define USBHS_HSTPIPISR_RXSTALLDI_Msk DEPRECATED(USBHS_HSTPIPISR_RXSTALLDI_Msk, "Using deprecated macro USBHS_HSTPIPISR_RXSTALLDI_Msk") (_U_(0x1) << USBHS_HSTPIPISR_RXSTALLDI_Pos) /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_RXSTALLDI_Pos DEPRECATED(USBHS_HSTPIPISR_RXSTALLDI_Pos, "Using deprecated macro USBHS_HSTPIPISR_RXSTALLDI_Pos") 6 /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_RXSTALLDI DEPRECATED(USBHS_HSTPIPISR_RXSTALLDI, "Using deprecated macro USBHS_HSTPIPISR_RXSTALLDI") USBHS_HSTPIPISR_RXSTALLDI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_TXSTPI_Msk DEPRECATED(USBHS_HSTPIPISR_TXSTPI_Msk, "Using deprecated macro USBHS_HSTPIPISR_TXSTPI_Msk") (_U_(0x1) << USBHS_HSTPIPISR_TXSTPI_Pos) /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_TXSTPI_Pos DEPRECATED(USBHS_HSTPIPISR_TXSTPI_Pos, "Using deprecated macro USBHS_HSTPIPISR_TXSTPI_Pos") 2 /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_TXSTPI DEPRECATED(USBHS_HSTPIPISR_TXSTPI, "Using deprecated macro USBHS_HSTPIPISR_TXSTPI") USBHS_HSTPIPISR_TXSTPI_Msk /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXSTPI_Msk instead */
+
+#endif

--- a/asf/sam/include/same70b/component/efc.h
+++ b/asf/sam/include/same70b/component/efc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for EFC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_EFC_COMPONENT_H_
 #define _SAME70_EFC_COMPONENT_H_
 #define _SAME70_EFC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define EFC_6450                       /**< (EFC) Module ID */
-#define REV_EFC X                      /**< (EFC) Module revision */
+#define REV_EFC Y                      /**< (EFC) Module revision */
 
 /* -------- EEFC_FMR : (EFC Offset: 0x00) (R/W 32) EEFC Flash Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Interrupt Enable             */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FMR_OFFSET                     (0x00)                                        /**<  (EEFC_FMR) EEFC Flash Mode Register  Offset */
@@ -80,6 +84,7 @@ typedef union {
 
 /* -------- EEFC_FCR : (EFC Offset: 0x04) (/W 32) EEFC Flash Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCMD:8;                    /**< bit:   0..7  Flash Command                            */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FCR_OFFSET                     (0x04)                                        /**<  (EEFC_FCR) EEFC Flash Command Register  Offset */
@@ -151,6 +157,7 @@ typedef union {
 
 /* -------- EEFC_FSR : (EFC Offset: 0x08) (R/ 32) EEFC Flash Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRDY:1;                    /**< bit:      0  Flash Ready Status (cleared when Flash is busy) */
@@ -166,6 +173,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FSR_OFFSET                     (0x08)                                        /**<  (EEFC_FSR) EEFC Flash Status Register  Offset */
@@ -200,12 +208,14 @@ typedef union {
 
 /* -------- EEFC_FRR : (EFC Offset: 0x0c) (R/ 32) EEFC Flash Result Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FVALUE:32;                 /**< bit:  0..31  Flash Result Value                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_FRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_FRR_OFFSET                     (0x0C)                                        /**<  (EEFC_FRR) EEFC Flash Result Register  Offset */
@@ -219,6 +229,7 @@ typedef union {
 
 /* -------- EEFC_WPMR : (EFC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -227,6 +238,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } EEFC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define EEFC_WPMR_OFFSET                    (0xE4)                                        /**<  (EEFC_WPMR) Write Protection Mode Register  Offset */
@@ -251,7 +263,7 @@ typedef struct {
   __O  uint32_t EEFC_FCR;       /**< (EFC Offset: 0x04) EEFC Flash Command Register */
   __I  uint32_t EEFC_FSR;       /**< (EFC Offset: 0x08) EEFC Flash Status Register */
   __I  uint32_t EEFC_FRR;       /**< (EFC Offset: 0x0C) EEFC Flash Result Register */
-  RoReg8  Reserved1[0xD4];
+  __I  uint8_t                        Reserved1[212];
   __IO uint32_t EEFC_WPMR;      /**< (EFC Offset: 0xE4) Write Protection Mode Register */
 } Efc;
 
@@ -262,7 +274,7 @@ typedef struct {
   __O  EEFC_FCR_Type                  EEFC_FCR;       /**< Offset: 0x04 ( /W  32) EEFC Flash Command Register */
   __I  EEFC_FSR_Type                  EEFC_FSR;       /**< Offset: 0x08 (R/   32) EEFC Flash Status Register */
   __I  EEFC_FRR_Type                  EEFC_FRR;       /**< Offset: 0x0C (R/   32) EEFC Flash Result Register */
-  __I  uint32_t                       Reserved1[53];
+  __I  uint8_t                        Reserved1[212];
   __IO EEFC_WPMR_Type                 EEFC_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Efc;
 

--- a/asf/sam/include/same70b/component/gmac.h
+++ b/asf/sam/include/same70b/component/gmac.h
@@ -3616,7 +3616,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -3767,7 +3767,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GMAC_SA[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */

--- a/asf/sam/include/same70b/component/gmac.h
+++ b/asf/sam/include/same70b/component/gmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for GMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_GMAC_COMPONENT_H_
 #define _SAME70_GMAC_COMPONENT_H_
 #define _SAME70_GMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,12 +47,14 @@
 
 /* -------- GMAC_SAB : (GMAC Offset: 0x00) (R/W 32) Specific Address 1 Bottom Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAB_OFFSET                     (0x00)                                        /**<  (GMAC_SAB) Specific Address 1 Bottom Register  Offset */
@@ -64,6 +68,7 @@ typedef union {
 
 /* -------- GMAC_SAT : (GMAC Offset: 0x04) (R/W 32) Specific Address 1 Top Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1                       */
@@ -71,6 +76,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAT_OFFSET                     (0x04)                                        /**<  (GMAC_SAT) Specific Address 1 Top Register  Offset */
@@ -82,8 +88,67 @@ typedef union {
 #define GMAC_SAT_Msk                        _U_(0xFFFF)                                    /**< (GMAC_SAT) Register Mask  */
 
 
+/* -------- GMAC_ST2CW0 : (GMAC Offset: 0x00) (R/W 32) Screening Type 2 Compare Word 0 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
+    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW0_OFFSET                  (0x00)                                        /**<  (GMAC_ST2CW0) Screening Type 2 Compare Word 0 Register  Offset */
+
+#define GMAC_ST2CW0_MASKVAL_Pos             0                                              /**< (GMAC_ST2CW0) Mask Value Position */
+#define GMAC_ST2CW0_MASKVAL_Msk             (_U_(0xFFFF) << GMAC_ST2CW0_MASKVAL_Pos)       /**< (GMAC_ST2CW0) Mask Value Mask */
+#define GMAC_ST2CW0_MASKVAL(value)          (GMAC_ST2CW0_MASKVAL_Msk & ((value) << GMAC_ST2CW0_MASKVAL_Pos))
+#define GMAC_ST2CW0_COMPVAL_Pos             16                                             /**< (GMAC_ST2CW0) Compare Value Position */
+#define GMAC_ST2CW0_COMPVAL_Msk             (_U_(0xFFFF) << GMAC_ST2CW0_COMPVAL_Pos)       /**< (GMAC_ST2CW0) Compare Value Mask */
+#define GMAC_ST2CW0_COMPVAL(value)          (GMAC_ST2CW0_COMPVAL_Msk & ((value) << GMAC_ST2CW0_COMPVAL_Pos))
+#define GMAC_ST2CW0_Msk                     _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW0) Register Mask  */
+
+
+/* -------- GMAC_ST2CW1 : (GMAC Offset: 0x04) (R/W 32) Screening Type 2 Compare Word 1 Register -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
+    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} GMAC_ST2CW1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GMAC_ST2CW1_OFFSET                  (0x04)                                        /**<  (GMAC_ST2CW1) Screening Type 2 Compare Word 1 Register  Offset */
+
+#define GMAC_ST2CW1_OFFSVAL_Pos             0                                              /**< (GMAC_ST2CW1) Offset Value in Bytes Position */
+#define GMAC_ST2CW1_OFFSVAL_Msk             (_U_(0x7F) << GMAC_ST2CW1_OFFSVAL_Pos)         /**< (GMAC_ST2CW1) Offset Value in Bytes Mask */
+#define GMAC_ST2CW1_OFFSVAL(value)          (GMAC_ST2CW1_OFFSVAL_Msk & ((value) << GMAC_ST2CW1_OFFSVAL_Pos))
+#define GMAC_ST2CW1_OFFSSTRT_Pos            7                                              /**< (GMAC_ST2CW1) Ethernet Frame Offset Start Position */
+#define GMAC_ST2CW1_OFFSSTRT_Msk            (_U_(0x3) << GMAC_ST2CW1_OFFSSTRT_Pos)         /**< (GMAC_ST2CW1) Ethernet Frame Offset Start Mask */
+#define GMAC_ST2CW1_OFFSSTRT(value)         (GMAC_ST2CW1_OFFSSTRT_Msk & ((value) << GMAC_ST2CW1_OFFSSTRT_Pos))
+#define   GMAC_ST2CW1_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW1) Offset from the start of the frame  */
+#define   GMAC_ST2CW1_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW1) Offset from the byte after the EtherType field  */
+#define   GMAC_ST2CW1_OFFSSTRT_IP_Val       _U_(0x2)                                       /**< (GMAC_ST2CW1) Offset from the byte after the IP header field  */
+#define   GMAC_ST2CW1_OFFSSTRT_TCP_UDP_Val  _U_(0x3)                                       /**< (GMAC_ST2CW1) Offset from the byte after the TCP/UDP header field  */
+#define GMAC_ST2CW1_OFFSSTRT_FRAMESTART     (GMAC_ST2CW1_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the start of the frame Position  */
+#define GMAC_ST2CW1_OFFSSTRT_ETHERTYPE      (GMAC_ST2CW1_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the EtherType field Position  */
+#define GMAC_ST2CW1_OFFSSTRT_IP             (GMAC_ST2CW1_OFFSSTRT_IP_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the IP header field Position  */
+#define GMAC_ST2CW1_OFFSSTRT_TCP_UDP        (GMAC_ST2CW1_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW1_OFFSSTRT_Pos)  /**< (GMAC_ST2CW1) Offset from the byte after the TCP/UDP header field Position  */
+#define GMAC_ST2CW1_MASK                    _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW1) Register MASK  (Use GMAC_ST2CW1_Msk instead)  */
+#define GMAC_ST2CW1_Msk                     _U_(0x1FF)                                     /**< (GMAC_ST2CW1) Register Mask  */
+
+
 /* -------- GMAC_NCR : (GMAC Offset: 0x00) (R/W 32) Network Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -104,10 +169,12 @@ typedef union {
     uint32_t ENPBPR:1;                  /**< bit:     16  Enable PFC Priority-based Pause Reception */
     uint32_t TXPBPF:1;                  /**< bit:     17  Transmit PFC Priority-based Pause Frame  */
     uint32_t FNP:1;                     /**< bit:     18  Flush Next Packet                        */
-    uint32_t :13;                       /**< bit: 19..31  Reserved */
+    uint32_t TXLPIEN:1;                 /**< bit:     19  Enable LPI Transmission                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NCR_OFFSET                     (0x00)                                        /**<  (GMAC_NCR) Network Control Register  Offset */
@@ -160,12 +227,16 @@ typedef union {
 #define GMAC_NCR_FNP_Pos                    18                                             /**< (GMAC_NCR) Flush Next Packet Position */
 #define GMAC_NCR_FNP_Msk                    (_U_(0x1) << GMAC_NCR_FNP_Pos)                 /**< (GMAC_NCR) Flush Next Packet Mask */
 #define GMAC_NCR_FNP                        GMAC_NCR_FNP_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_FNP_Msk instead */
-#define GMAC_NCR_MASK                       _U_(0x79FFE)                                   /**< \deprecated (GMAC_NCR) Register MASK  (Use GMAC_NCR_Msk instead)  */
-#define GMAC_NCR_Msk                        _U_(0x79FFE)                                   /**< (GMAC_NCR) Register Mask  */
+#define GMAC_NCR_TXLPIEN_Pos                19                                             /**< (GMAC_NCR) Enable LPI Transmission Position */
+#define GMAC_NCR_TXLPIEN_Msk                (_U_(0x1) << GMAC_NCR_TXLPIEN_Pos)             /**< (GMAC_NCR) Enable LPI Transmission Mask */
+#define GMAC_NCR_TXLPIEN                    GMAC_NCR_TXLPIEN_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NCR_TXLPIEN_Msk instead */
+#define GMAC_NCR_MASK                       _U_(0xF9FFE)                                   /**< \deprecated (GMAC_NCR) Register MASK  (Use GMAC_NCR_Msk instead)  */
+#define GMAC_NCR_Msk                        _U_(0xF9FFE)                                   /**< (GMAC_NCR) Register Mask  */
 
 
 /* -------- GMAC_NCFGR : (GMAC Offset: 0x04) (R/W 32) Network Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPD:1;                     /**< bit:      0  Speed                                    */
@@ -197,6 +268,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NCFGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NCFGR_OFFSET                   (0x04)                                        /**<  (GMAC_NCFGR) Network Configuration Register  Offset */
@@ -288,15 +360,19 @@ typedef union {
 
 /* -------- GMAC_NSR : (GMAC Offset: 0x08) (R/ 32) Network Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
     uint32_t MDIO:1;                    /**< bit:      1  MDIO Input Status                        */
     uint32_t IDLE:1;                    /**< bit:      2  PHY Management Logic Idle                */
-    uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t :4;                        /**< bit:   3..6  Reserved */
+    uint32_t RXLPIS:1;                  /**< bit:      7  LPI Indication                           */
+    uint32_t :24;                       /**< bit:  8..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NSR_OFFSET                     (0x08)                                        /**<  (GMAC_NSR) Network Status Register  Offset */
@@ -307,12 +383,16 @@ typedef union {
 #define GMAC_NSR_IDLE_Pos                   2                                              /**< (GMAC_NSR) PHY Management Logic Idle Position */
 #define GMAC_NSR_IDLE_Msk                   (_U_(0x1) << GMAC_NSR_IDLE_Pos)                /**< (GMAC_NSR) PHY Management Logic Idle Mask */
 #define GMAC_NSR_IDLE                       GMAC_NSR_IDLE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_IDLE_Msk instead */
-#define GMAC_NSR_MASK                       _U_(0x06)                                      /**< \deprecated (GMAC_NSR) Register MASK  (Use GMAC_NSR_Msk instead)  */
-#define GMAC_NSR_Msk                        _U_(0x06)                                      /**< (GMAC_NSR) Register Mask  */
+#define GMAC_NSR_RXLPIS_Pos                 7                                              /**< (GMAC_NSR) LPI Indication Position */
+#define GMAC_NSR_RXLPIS_Msk                 (_U_(0x1) << GMAC_NSR_RXLPIS_Pos)              /**< (GMAC_NSR) LPI Indication Mask */
+#define GMAC_NSR_RXLPIS                     GMAC_NSR_RXLPIS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_NSR_RXLPIS_Msk instead */
+#define GMAC_NSR_MASK                       _U_(0x86)                                      /**< \deprecated (GMAC_NSR) Register MASK  (Use GMAC_NSR_Msk instead)  */
+#define GMAC_NSR_Msk                        _U_(0x86)                                      /**< (GMAC_NSR) Register Mask  */
 
 
 /* -------- GMAC_UR : (GMAC Offset: 0x0c) (R/W 32) User Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RMII:1;                    /**< bit:      0  Reduced MII Mode                         */
@@ -320,6 +400,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UR_OFFSET                      (0x0C)                                        /**<  (GMAC_UR) User Register  Offset */
@@ -333,6 +414,7 @@ typedef union {
 
 /* -------- GMAC_DCFGR : (GMAC Offset: 0x10) (R/W 32) DMA Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FBLDO:5;                   /**< bit:   0..4  Fixed Burst Length for DMA Data Operations: */
@@ -349,6 +431,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_DCFGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_DCFGR_OFFSET                   (0x10)                                        /**<  (GMAC_DCFGR) DMA Configuration Register  Offset */
@@ -399,6 +482,7 @@ typedef union {
 
 /* -------- GMAC_TSR : (GMAC Offset: 0x14) (R/W 32) Transmit Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UBR:1;                     /**< bit:      0  Used Bit Read                            */
@@ -413,6 +497,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSR_OFFSET                     (0x14)                                        /**<  (GMAC_TSR) Transmit Status Register  Offset */
@@ -444,6 +529,7 @@ typedef union {
 
 /* -------- GMAC_RBQB : (GMAC Offset: 0x18) (R/W 32) Receive Buffer Queue Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -451,6 +537,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RBQB_OFFSET                    (0x18)                                        /**<  (GMAC_RBQB) Receive Buffer Queue Base Address Register  Offset */
@@ -464,6 +551,7 @@ typedef union {
 
 /* -------- GMAC_TBQB : (GMAC Offset: 0x1c) (R/W 32) Transmit Buffer Queue Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -471,6 +559,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBQB_OFFSET                    (0x1C)                                        /**<  (GMAC_TBQB) Transmit Buffer Queue Base Address Register  Offset */
@@ -484,6 +573,7 @@ typedef union {
 
 /* -------- GMAC_RSR : (GMAC Offset: 0x20) (R/W 32) Receive Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BNA:1;                     /**< bit:      0  Buffer Not Available                     */
@@ -494,6 +584,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RSR_OFFSET                     (0x20)                                        /**<  (GMAC_RSR) Receive Status Register  Offset */
@@ -516,6 +607,7 @@ typedef union {
 
 /* -------- GMAC_ISR : (GMAC Offset: 0x24) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -542,12 +634,14 @@ typedef union {
     uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
     uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
     uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
-    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Receive LPI indication Status Bit Change */
     uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
-    uint32_t :3;                        /**< bit: 29..31  Reserved */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ISR_OFFSET                     (0x24)                                        /**<  (GMAC_ISR) Interrupt Status Register  Offset */
@@ -618,15 +712,22 @@ typedef union {
 #define GMAC_ISR_SRI_Pos                    26                                             /**< (GMAC_ISR) TSU Seconds Register Increment Position */
 #define GMAC_ISR_SRI_Msk                    (_U_(0x1) << GMAC_ISR_SRI_Pos)                 /**< (GMAC_ISR) TSU Seconds Register Increment Mask */
 #define GMAC_ISR_SRI                        GMAC_ISR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_SRI_Msk instead */
+#define GMAC_ISR_RXLPISBC_Pos               27                                             /**< (GMAC_ISR) Receive LPI indication Status Bit Change Position */
+#define GMAC_ISR_RXLPISBC_Msk               (_U_(0x1) << GMAC_ISR_RXLPISBC_Pos)            /**< (GMAC_ISR) Receive LPI indication Status Bit Change Mask */
+#define GMAC_ISR_RXLPISBC                   GMAC_ISR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_RXLPISBC_Msk instead */
 #define GMAC_ISR_WOL_Pos                    28                                             /**< (GMAC_ISR) Wake On LAN Position */
 #define GMAC_ISR_WOL_Msk                    (_U_(0x1) << GMAC_ISR_WOL_Pos)                 /**< (GMAC_ISR) Wake On LAN Mask */
 #define GMAC_ISR_WOL                        GMAC_ISR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_WOL_Msk instead */
-#define GMAC_ISR_MASK                       _U_(0x17FC7CFF)                                /**< \deprecated (GMAC_ISR) Register MASK  (Use GMAC_ISR_Msk instead)  */
-#define GMAC_ISR_Msk                        _U_(0x17FC7CFF)                                /**< (GMAC_ISR) Register Mask  */
+#define GMAC_ISR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_ISR) TSU Timer Comparison Position */
+#define GMAC_ISR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_ISR_TSUTIMCOMP_Pos)          /**< (GMAC_ISR) TSU Timer Comparison Mask */
+#define GMAC_ISR_TSUTIMCOMP                 GMAC_ISR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_ISR_TSUTIMCOMP_Msk instead */
+#define GMAC_ISR_MASK                       _U_(0x3FFC7CFF)                                /**< \deprecated (GMAC_ISR) Register MASK  (Use GMAC_ISR_Msk instead)  */
+#define GMAC_ISR_Msk                        _U_(0x3FFC7CFF)                                /**< (GMAC_ISR) Register Mask  */
 
 
 /* -------- GMAC_IER : (GMAC Offset: 0x28) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -654,12 +755,14 @@ typedef union {
     uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
     uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
     uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
-    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
     uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
-    uint32_t :3;                        /**< bit: 29..31  Reserved */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IER_OFFSET                     (0x28)                                        /**<  (GMAC_IER) Interrupt Enable Register  Offset */
@@ -733,15 +836,22 @@ typedef union {
 #define GMAC_IER_SRI_Pos                    26                                             /**< (GMAC_IER) TSU Seconds Register Increment Position */
 #define GMAC_IER_SRI_Msk                    (_U_(0x1) << GMAC_IER_SRI_Pos)                 /**< (GMAC_IER) TSU Seconds Register Increment Mask */
 #define GMAC_IER_SRI                        GMAC_IER_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_SRI_Msk instead */
+#define GMAC_IER_RXLPISBC_Pos               27                                             /**< (GMAC_IER) Enable RX LPI Indication Position */
+#define GMAC_IER_RXLPISBC_Msk               (_U_(0x1) << GMAC_IER_RXLPISBC_Pos)            /**< (GMAC_IER) Enable RX LPI Indication Mask */
+#define GMAC_IER_RXLPISBC                   GMAC_IER_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_RXLPISBC_Msk instead */
 #define GMAC_IER_WOL_Pos                    28                                             /**< (GMAC_IER) Wake On LAN Position */
 #define GMAC_IER_WOL_Msk                    (_U_(0x1) << GMAC_IER_WOL_Pos)                 /**< (GMAC_IER) Wake On LAN Mask */
 #define GMAC_IER_WOL                        GMAC_IER_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_WOL_Msk instead */
-#define GMAC_IER_MASK                       _U_(0x17FCFCFF)                                /**< \deprecated (GMAC_IER) Register MASK  (Use GMAC_IER_Msk instead)  */
-#define GMAC_IER_Msk                        _U_(0x17FCFCFF)                                /**< (GMAC_IER) Register Mask  */
+#define GMAC_IER_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IER) TSU Timer Comparison Position */
+#define GMAC_IER_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IER_TSUTIMCOMP_Pos)          /**< (GMAC_IER) TSU Timer Comparison Mask */
+#define GMAC_IER_TSUTIMCOMP                 GMAC_IER_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IER_TSUTIMCOMP_Msk instead */
+#define GMAC_IER_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IER) Register MASK  (Use GMAC_IER_Msk instead)  */
+#define GMAC_IER_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IER) Register Mask  */
 
 
 /* -------- GMAC_IDR : (GMAC Offset: 0x2c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -769,12 +879,14 @@ typedef union {
     uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
     uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
     uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
-    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
     uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
-    uint32_t :3;                        /**< bit: 29..31  Reserved */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IDR_OFFSET                     (0x2C)                                        /**<  (GMAC_IDR) Interrupt Disable Register  Offset */
@@ -848,15 +960,22 @@ typedef union {
 #define GMAC_IDR_SRI_Pos                    26                                             /**< (GMAC_IDR) TSU Seconds Register Increment Position */
 #define GMAC_IDR_SRI_Msk                    (_U_(0x1) << GMAC_IDR_SRI_Pos)                 /**< (GMAC_IDR) TSU Seconds Register Increment Mask */
 #define GMAC_IDR_SRI                        GMAC_IDR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_SRI_Msk instead */
+#define GMAC_IDR_RXLPISBC_Pos               27                                             /**< (GMAC_IDR) Enable RX LPI Indication Position */
+#define GMAC_IDR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IDR_RXLPISBC_Pos)            /**< (GMAC_IDR) Enable RX LPI Indication Mask */
+#define GMAC_IDR_RXLPISBC                   GMAC_IDR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_RXLPISBC_Msk instead */
 #define GMAC_IDR_WOL_Pos                    28                                             /**< (GMAC_IDR) Wake On LAN Position */
 #define GMAC_IDR_WOL_Msk                    (_U_(0x1) << GMAC_IDR_WOL_Pos)                 /**< (GMAC_IDR) Wake On LAN Mask */
 #define GMAC_IDR_WOL                        GMAC_IDR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_WOL_Msk instead */
-#define GMAC_IDR_MASK                       _U_(0x17FCFCFF)                                /**< \deprecated (GMAC_IDR) Register MASK  (Use GMAC_IDR_Msk instead)  */
-#define GMAC_IDR_Msk                        _U_(0x17FCFCFF)                                /**< (GMAC_IDR) Register Mask  */
+#define GMAC_IDR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IDR) TSU Timer Comparison Position */
+#define GMAC_IDR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IDR_TSUTIMCOMP_Pos)          /**< (GMAC_IDR) TSU Timer Comparison Mask */
+#define GMAC_IDR_TSUTIMCOMP                 GMAC_IDR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IDR_TSUTIMCOMP_Msk instead */
+#define GMAC_IDR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IDR) Register MASK  (Use GMAC_IDR_Msk instead)  */
+#define GMAC_IDR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IDR) Register Mask  */
 
 
 /* -------- GMAC_IMR : (GMAC Offset: 0x30) (R/W 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFS:1;                     /**< bit:      0  Management Frame Sent                    */
@@ -884,12 +1003,14 @@ typedef union {
     uint32_t PDRQFT:1;                  /**< bit:     24  PDelay Request Frame Transmitted         */
     uint32_t PDRSFT:1;                  /**< bit:     25  PDelay Response Frame Transmitted        */
     uint32_t SRI:1;                     /**< bit:     26  TSU Seconds Register Increment           */
-    uint32_t :1;                        /**< bit:     27  Reserved */
+    uint32_t RXLPISBC:1;                /**< bit:     27  Enable RX LPI Indication                 */
     uint32_t WOL:1;                     /**< bit:     28  Wake On LAN                              */
-    uint32_t :3;                        /**< bit: 29..31  Reserved */
+    uint32_t TSUTIMCOMP:1;              /**< bit:     29  TSU Timer Comparison                     */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IMR_OFFSET                     (0x30)                                        /**<  (GMAC_IMR) Interrupt Mask Register  Offset */
@@ -963,15 +1084,22 @@ typedef union {
 #define GMAC_IMR_SRI_Pos                    26                                             /**< (GMAC_IMR) TSU Seconds Register Increment Position */
 #define GMAC_IMR_SRI_Msk                    (_U_(0x1) << GMAC_IMR_SRI_Pos)                 /**< (GMAC_IMR) TSU Seconds Register Increment Mask */
 #define GMAC_IMR_SRI                        GMAC_IMR_SRI_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_SRI_Msk instead */
+#define GMAC_IMR_RXLPISBC_Pos               27                                             /**< (GMAC_IMR) Enable RX LPI Indication Position */
+#define GMAC_IMR_RXLPISBC_Msk               (_U_(0x1) << GMAC_IMR_RXLPISBC_Pos)            /**< (GMAC_IMR) Enable RX LPI Indication Mask */
+#define GMAC_IMR_RXLPISBC                   GMAC_IMR_RXLPISBC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_RXLPISBC_Msk instead */
 #define GMAC_IMR_WOL_Pos                    28                                             /**< (GMAC_IMR) Wake On LAN Position */
 #define GMAC_IMR_WOL_Msk                    (_U_(0x1) << GMAC_IMR_WOL_Pos)                 /**< (GMAC_IMR) Wake On LAN Mask */
 #define GMAC_IMR_WOL                        GMAC_IMR_WOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_WOL_Msk instead */
-#define GMAC_IMR_MASK                       _U_(0x17FCFCFF)                                /**< \deprecated (GMAC_IMR) Register MASK  (Use GMAC_IMR_Msk instead)  */
-#define GMAC_IMR_Msk                        _U_(0x17FCFCFF)                                /**< (GMAC_IMR) Register Mask  */
+#define GMAC_IMR_TSUTIMCOMP_Pos             29                                             /**< (GMAC_IMR) TSU Timer Comparison Position */
+#define GMAC_IMR_TSUTIMCOMP_Msk             (_U_(0x1) << GMAC_IMR_TSUTIMCOMP_Pos)          /**< (GMAC_IMR) TSU Timer Comparison Mask */
+#define GMAC_IMR_TSUTIMCOMP                 GMAC_IMR_TSUTIMCOMP_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use GMAC_IMR_TSUTIMCOMP_Msk instead */
+#define GMAC_IMR_MASK                       _U_(0x3FFCFCFF)                                /**< \deprecated (GMAC_IMR) Register MASK  (Use GMAC_IMR_Msk instead)  */
+#define GMAC_IMR_Msk                        _U_(0x3FFCFCFF)                                /**< (GMAC_IMR) Register Mask  */
 
 
 /* -------- GMAC_MAN : (GMAC Offset: 0x34) (R/W 32) PHY Maintenance Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:16;                   /**< bit:  0..15  PHY Data                                 */
@@ -984,6 +1112,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MAN_OFFSET                     (0x34)                                        /**<  (GMAC_MAN) PHY Maintenance Register  Offset */
@@ -1015,6 +1144,7 @@ typedef union {
 
 /* -------- GMAC_RPQ : (GMAC Offset: 0x38) (R/ 32) Received Pause Quantum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RPQ:16;                    /**< bit:  0..15  Received Pause Quantum                   */
@@ -1022,6 +1152,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RPQ_OFFSET                     (0x38)                                        /**<  (GMAC_RPQ) Received Pause Quantum Register  Offset */
@@ -1035,6 +1166,7 @@ typedef union {
 
 /* -------- GMAC_TPQ : (GMAC Offset: 0x3c) (R/W 32) Transmit Pause Quantum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TPQ:16;                    /**< bit:  0..15  Transmit Pause Quantum                   */
@@ -1042,6 +1174,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPQ_OFFSET                     (0x3C)                                        /**<  (GMAC_TPQ) Transmit Pause Quantum Register  Offset */
@@ -1055,6 +1188,7 @@ typedef union {
 
 /* -------- GMAC_TPSF : (GMAC Offset: 0x40) (R/W 32) TX Partial Store and Forward Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TPB1ADR:12;                /**< bit:  0..11  Transmit Partial Store and Forward Address */
@@ -1063,6 +1197,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPSF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPSF_OFFSET                    (0x40)                                        /**<  (GMAC_TPSF) TX Partial Store and Forward Register  Offset */
@@ -1079,6 +1214,7 @@ typedef union {
 
 /* -------- GMAC_RPSF : (GMAC Offset: 0x44) (R/W 32) RX Partial Store and Forward Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RPB1ADR:12;                /**< bit:  0..11  Receive Partial Store and Forward Address */
@@ -1087,6 +1223,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RPSF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RPSF_OFFSET                    (0x44)                                        /**<  (GMAC_RPSF) RX Partial Store and Forward Register  Offset */
@@ -1103,6 +1240,7 @@ typedef union {
 
 /* -------- GMAC_RJFML : (GMAC Offset: 0x48) (R/W 32) RX Jumbo Frame Max Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FML:14;                    /**< bit:  0..13  Frame Max Length                         */
@@ -1110,6 +1248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RJFML_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RJFML_OFFSET                   (0x48)                                        /**<  (GMAC_RJFML) RX Jumbo Frame Max Length Register  Offset */
@@ -1123,12 +1262,14 @@ typedef union {
 
 /* -------- GMAC_HRB : (GMAC Offset: 0x80) (R/W 32) Hash Register Bottom -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_HRB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_HRB_OFFSET                     (0x80)                                        /**<  (GMAC_HRB) Hash Register Bottom  Offset */
@@ -1142,12 +1283,14 @@ typedef union {
 
 /* -------- GMAC_HRT : (GMAC Offset: 0x84) (R/W 32) Hash Register Top -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Hash Address                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_HRT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_HRT_OFFSET                     (0x84)                                        /**<  (GMAC_HRT) Hash Register Top  Offset */
@@ -1161,14 +1304,20 @@ typedef union {
 
 /* -------- GMAC_TIDM1 : (GMAC Offset: 0xa8) (R/W 32) Type ID Match 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 1                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID1:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM1_OFFSET                   (0xA8)                                        /**<  (GMAC_TIDM1) Type ID Match 1 Register  Offset */
@@ -1182,17 +1331,26 @@ typedef union {
 #define GMAC_TIDM1_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM1) Register MASK  (Use GMAC_TIDM1_Msk instead)  */
 #define GMAC_TIDM1_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM1) Register Mask  */
 
+#define GMAC_TIDM1_ENID_Pos                 31                                             /**< (GMAC_TIDM1 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM1_ENID_Msk                 (_U_(0x1) << GMAC_TIDM1_ENID_Pos)              /**< (GMAC_TIDM1 Mask) ENID */
+#define GMAC_TIDM1_ENID(value)              (GMAC_TIDM1_ENID_Msk & ((value) << GMAC_TIDM1_ENID_Pos))  
 
 /* -------- GMAC_TIDM2 : (GMAC Offset: 0xac) (R/W 32) Type ID Match 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 2                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID2:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM2_OFFSET                   (0xAC)                                        /**<  (GMAC_TIDM2) Type ID Match 2 Register  Offset */
@@ -1206,17 +1364,26 @@ typedef union {
 #define GMAC_TIDM2_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM2) Register MASK  (Use GMAC_TIDM2_Msk instead)  */
 #define GMAC_TIDM2_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM2) Register Mask  */
 
+#define GMAC_TIDM2_ENID_Pos                 31                                             /**< (GMAC_TIDM2 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM2_ENID_Msk                 (_U_(0x1) << GMAC_TIDM2_ENID_Pos)              /**< (GMAC_TIDM2 Mask) ENID */
+#define GMAC_TIDM2_ENID(value)              (GMAC_TIDM2_ENID_Msk & ((value) << GMAC_TIDM2_ENID_Pos))  
 
 /* -------- GMAC_TIDM3 : (GMAC Offset: 0xb0) (R/W 32) Type ID Match 3 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 3                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID3:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM3_OFFSET                   (0xB0)                                        /**<  (GMAC_TIDM3) Type ID Match 3 Register  Offset */
@@ -1230,17 +1397,26 @@ typedef union {
 #define GMAC_TIDM3_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM3) Register MASK  (Use GMAC_TIDM3_Msk instead)  */
 #define GMAC_TIDM3_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM3) Register Mask  */
 
+#define GMAC_TIDM3_ENID_Pos                 31                                             /**< (GMAC_TIDM3 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM3_ENID_Msk                 (_U_(0x1) << GMAC_TIDM3_ENID_Pos)              /**< (GMAC_TIDM3 Mask) ENID */
+#define GMAC_TIDM3_ENID(value)              (GMAC_TIDM3_ENID_Msk & ((value) << GMAC_TIDM3_ENID_Pos))  
 
 /* -------- GMAC_TIDM4 : (GMAC Offset: 0xb4) (R/W 32) Type ID Match 4 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TID:16;                    /**< bit:  0..15  Type ID Match 4                          */
     uint32_t :15;                       /**< bit: 16..30  Reserved */
     uint32_t ENID4:1;                   /**< bit:     31  Enable Copying of TID Matched Frames     */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :31;                       /**< bit:  0..30  Reserved */
+    uint32_t ENID:1;                    /**< bit:     31  Enable Copying of TID Matched Frames     */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TIDM4_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TIDM4_OFFSET                   (0xB4)                                        /**<  (GMAC_TIDM4) Type ID Match 4 Register  Offset */
@@ -1254,9 +1430,13 @@ typedef union {
 #define GMAC_TIDM4_MASK                     _U_(0x8000FFFF)                                /**< \deprecated (GMAC_TIDM4) Register MASK  (Use GMAC_TIDM4_Msk instead)  */
 #define GMAC_TIDM4_Msk                      _U_(0x8000FFFF)                                /**< (GMAC_TIDM4) Register Mask  */
 
+#define GMAC_TIDM4_ENID_Pos                 31                                             /**< (GMAC_TIDM4 Position) Enable Copying of TID Matched Frames */
+#define GMAC_TIDM4_ENID_Msk                 (_U_(0x1) << GMAC_TIDM4_ENID_Pos)              /**< (GMAC_TIDM4 Mask) ENID */
+#define GMAC_TIDM4_ENID(value)              (GMAC_TIDM4_ENID_Msk & ((value) << GMAC_TIDM4_ENID_Pos))  
 
 /* -------- GMAC_WOL : (GMAC Offset: 0xb8) (R/W 32) Wake on LAN Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IP:16;                     /**< bit:  0..15  ARP Request IP Address                   */
@@ -1266,8 +1446,14 @@ typedef union {
     uint32_t MTI:1;                     /**< bit:     19  Multicast Hash Event Enable              */
     uint32_t :12;                       /**< bit: 20..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t SA:1;                      /**< bit:     18  Specific Address Register x Event Enable */
+    uint32_t :13;                       /**< bit: 19..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_WOL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_WOL_OFFSET                     (0xB8)                                        /**<  (GMAC_WOL) Wake on LAN Register  Offset */
@@ -1290,9 +1476,13 @@ typedef union {
 #define GMAC_WOL_MASK                       _U_(0xFFFFF)                                   /**< \deprecated (GMAC_WOL) Register MASK  (Use GMAC_WOL_Msk instead)  */
 #define GMAC_WOL_Msk                        _U_(0xFFFFF)                                   /**< (GMAC_WOL) Register Mask  */
 
+#define GMAC_WOL_SA_Pos                     18                                             /**< (GMAC_WOL Position) Specific Address Register x Event Enable */
+#define GMAC_WOL_SA_Msk                     (_U_(0x1) << GMAC_WOL_SA_Pos)                  /**< (GMAC_WOL Mask) SA */
+#define GMAC_WOL_SA(value)                  (GMAC_WOL_SA_Msk & ((value) << GMAC_WOL_SA_Pos))  
 
 /* -------- GMAC_IPGS : (GMAC Offset: 0xbc) (R/W 32) IPG Stretch Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FL:16;                     /**< bit:  0..15  Frame Length                             */
@@ -1300,6 +1490,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IPGS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IPGS_OFFSET                    (0xBC)                                        /**<  (GMAC_IPGS) IPG Stretch Register  Offset */
@@ -1313,6 +1504,7 @@ typedef union {
 
 /* -------- GMAC_SVLAN : (GMAC Offset: 0xc0) (R/W 32) Stacked VLAN Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VLAN_TYPE:16;              /**< bit:  0..15  User Defined VLAN_TYPE Field             */
@@ -1321,6 +1513,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SVLAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SVLAN_OFFSET                   (0xC0)                                        /**<  (GMAC_SVLAN) Stacked VLAN Register  Offset */
@@ -1337,6 +1530,7 @@ typedef union {
 
 /* -------- GMAC_TPFCP : (GMAC Offset: 0xc4) (R/W 32) Transmit PFC Pause Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PEV:8;                     /**< bit:   0..7  Priority Enable Vector                   */
@@ -1345,6 +1539,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TPFCP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TPFCP_OFFSET                   (0xC4)                                        /**<  (GMAC_TPFCP) Transmit PFC Pause Register  Offset */
@@ -1361,12 +1556,14 @@ typedef union {
 
 /* -------- GMAC_SAMB1 : (GMAC Offset: 0xc8) (R/W 32) Specific Address 1 Mask Bottom Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Specific Address 1 Mask                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAMB1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAMB1_OFFSET                   (0xC8)                                        /**<  (GMAC_SAMB1) Specific Address 1 Mask Bottom Register  Offset */
@@ -1380,6 +1577,7 @@ typedef union {
 
 /* -------- GMAC_SAMT1 : (GMAC Offset: 0xcc) (R/W 32) Specific Address 1 Mask Top Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:16;                   /**< bit:  0..15  Specific Address 1 Mask                  */
@@ -1387,6 +1585,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SAMT1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SAMT1_OFFSET                   (0xCC)                                        /**<  (GMAC_SAMT1) Specific Address 1 Mask Top Register  Offset */
@@ -1400,6 +1599,7 @@ typedef union {
 
 /* -------- GMAC_NSC : (GMAC Offset: 0xdc) (R/W 32) 1588 Timer Nanosecond Comparison Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NANOSEC:22;                /**< bit:  0..21  1588 Timer Nanosecond Comparison Value   */
@@ -1407,6 +1607,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_NSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_NSC_OFFSET                     (0xDC)                                        /**<  (GMAC_NSC) 1588 Timer Nanosecond Comparison Register  Offset */
@@ -1420,12 +1621,14 @@ typedef union {
 
 /* -------- GMAC_SCL : (GMAC Offset: 0xe0) (R/W 32) 1588 Timer Second Comparison Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:32;                    /**< bit:  0..31  1588 Timer Second Comparison Value       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCL_OFFSET                     (0xE0)                                        /**<  (GMAC_SCL) 1588 Timer Second Comparison Low Register  Offset */
@@ -1439,6 +1642,7 @@ typedef union {
 
 /* -------- GMAC_SCH : (GMAC Offset: 0xe4) (R/W 32) 1588 Timer Second Comparison High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:16;                    /**< bit:  0..15  1588 Timer Second Comparison Value       */
@@ -1446,6 +1650,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCH_OFFSET                     (0xE4)                                        /**<  (GMAC_SCH) 1588 Timer Second Comparison High Register  Offset */
@@ -1459,6 +1664,7 @@ typedef union {
 
 /* -------- GMAC_EFTSH : (GMAC Offset: 0xe8) (R/ 32) PTP Event Frame Transmitted Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1466,6 +1672,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTSH_OFFSET                   (0xE8)                                        /**<  (GMAC_EFTSH) PTP Event Frame Transmitted Seconds High Register  Offset */
@@ -1479,6 +1686,7 @@ typedef union {
 
 /* -------- GMAC_EFRSH : (GMAC Offset: 0xec) (R/ 32) PTP Event Frame Received Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1486,6 +1694,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRSH_OFFSET                   (0xEC)                                        /**<  (GMAC_EFRSH) PTP Event Frame Received Seconds High Register  Offset */
@@ -1499,6 +1708,7 @@ typedef union {
 
 /* -------- GMAC_PEFTSH : (GMAC Offset: 0xf0) (R/ 32) PTP Peer Event Frame Transmitted Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1506,6 +1716,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTSH_OFFSET                  (0xF0)                                        /**<  (GMAC_PEFTSH) PTP Peer Event Frame Transmitted Seconds High Register  Offset */
@@ -1519,6 +1730,7 @@ typedef union {
 
 /* -------- GMAC_PEFRSH : (GMAC Offset: 0xf4) (R/ 32) PTP Peer Event Frame Received Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:16;                    /**< bit:  0..15  Register Update                          */
@@ -1526,6 +1738,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRSH_OFFSET                  (0xF4)                                        /**<  (GMAC_PEFRSH) PTP Peer Event Frame Received Seconds High Register  Offset */
@@ -1539,12 +1752,14 @@ typedef union {
 
 /* -------- GMAC_OTLO : (GMAC Offset: 0x100) (R/ 32) Octets Transmitted Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXO:32;                    /**< bit:  0..31  Transmitted Octets                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OTLO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OTLO_OFFSET                    (0x100)                                       /**<  (GMAC_OTLO) Octets Transmitted Low Register  Offset */
@@ -1558,6 +1773,7 @@ typedef union {
 
 /* -------- GMAC_OTHI : (GMAC Offset: 0x104) (R/ 32) Octets Transmitted High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXO:16;                    /**< bit:  0..15  Transmitted Octets                       */
@@ -1565,6 +1781,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OTHI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OTHI_OFFSET                    (0x104)                                       /**<  (GMAC_OTHI) Octets Transmitted High Register  Offset */
@@ -1578,12 +1795,14 @@ typedef union {
 
 /* -------- GMAC_FT : (GMAC Offset: 0x108) (R/ 32) Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FTX:32;                    /**< bit:  0..31  Frames Transmitted without Error         */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FT_OFFSET                      (0x108)                                       /**<  (GMAC_FT) Frames Transmitted Register  Offset */
@@ -1597,12 +1816,14 @@ typedef union {
 
 /* -------- GMAC_BCFT : (GMAC Offset: 0x10c) (R/ 32) Broadcast Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BFTX:32;                   /**< bit:  0..31  Broadcast Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BCFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BCFT_OFFSET                    (0x10C)                                       /**<  (GMAC_BCFT) Broadcast Frames Transmitted Register  Offset */
@@ -1616,12 +1837,14 @@ typedef union {
 
 /* -------- GMAC_MFT : (GMAC Offset: 0x110) (R/ 32) Multicast Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFTX:32;                   /**< bit:  0..31  Multicast Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MFT_OFFSET                     (0x110)                                       /**<  (GMAC_MFT) Multicast Frames Transmitted Register  Offset */
@@ -1635,6 +1858,7 @@ typedef union {
 
 /* -------- GMAC_PFT : (GMAC Offset: 0x114) (R/ 32) Pause Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PFTX:16;                   /**< bit:  0..15  Pause Frames Transmitted Register        */
@@ -1642,6 +1866,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PFT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PFT_OFFSET                     (0x114)                                       /**<  (GMAC_PFT) Pause Frames Transmitted Register  Offset */
@@ -1655,12 +1880,14 @@ typedef union {
 
 /* -------- GMAC_BFT64 : (GMAC Offset: 0x118) (R/ 32) 64 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  64 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BFT64_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BFT64_OFFSET                   (0x118)                                       /**<  (GMAC_BFT64) 64 Byte Frames Transmitted Register  Offset */
@@ -1674,12 +1901,14 @@ typedef union {
 
 /* -------- GMAC_TBFT127 : (GMAC Offset: 0x11c) (R/ 32) 65 to 127 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT127_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT127_OFFSET                 (0x11C)                                       /**<  (GMAC_TBFT127) 65 to 127 Byte Frames Transmitted Register  Offset */
@@ -1693,12 +1922,14 @@ typedef union {
 
 /* -------- GMAC_TBFT255 : (GMAC Offset: 0x120) (R/ 32) 128 to 255 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT255_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT255_OFFSET                 (0x120)                                       /**<  (GMAC_TBFT255) 128 to 255 Byte Frames Transmitted Register  Offset */
@@ -1712,12 +1943,14 @@ typedef union {
 
 /* -------- GMAC_TBFT511 : (GMAC Offset: 0x124) (R/ 32) 256 to 511 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT511_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT511_OFFSET                 (0x124)                                       /**<  (GMAC_TBFT511) 256 to 511 Byte Frames Transmitted Register  Offset */
@@ -1731,12 +1964,14 @@ typedef union {
 
 /* -------- GMAC_TBFT1023 : (GMAC Offset: 0x128) (R/ 32) 512 to 1023 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT1023_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT1023_OFFSET                (0x128)                                       /**<  (GMAC_TBFT1023) 512 to 1023 Byte Frames Transmitted Register  Offset */
@@ -1750,12 +1985,14 @@ typedef union {
 
 /* -------- GMAC_TBFT1518 : (GMAC Offset: 0x12c) (R/ 32) 1024 to 1518 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFT1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFT1518_OFFSET                (0x12C)                                       /**<  (GMAC_TBFT1518) 1024 to 1518 Byte Frames Transmitted Register  Offset */
@@ -1769,12 +2006,14 @@ typedef union {
 
 /* -------- GMAC_GTBFT1518 : (GMAC Offset: 0x130) (R/ 32) Greater Than 1518 Byte Frames Transmitted Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFTX:32;                   /**< bit:  0..31  Greater than 1518 Byte Frames Transmitted without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_GTBFT1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_GTBFT1518_OFFSET               (0x130)                                       /**<  (GMAC_GTBFT1518) Greater Than 1518 Byte Frames Transmitted Register  Offset */
@@ -1788,6 +2027,7 @@ typedef union {
 
 /* -------- GMAC_TUR : (GMAC Offset: 0x134) (R/ 32) Transmit Underruns Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXUNR:10;                  /**< bit:   0..9  Transmit Underruns                       */
@@ -1795,6 +2035,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TUR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TUR_OFFSET                     (0x134)                                       /**<  (GMAC_TUR) Transmit Underruns Register  Offset */
@@ -1808,6 +2049,7 @@ typedef union {
 
 /* -------- GMAC_SCF : (GMAC Offset: 0x138) (R/ 32) Single Collision Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCOL:18;                   /**< bit:  0..17  Single Collision                         */
@@ -1815,6 +2057,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_SCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_SCF_OFFSET                     (0x138)                                       /**<  (GMAC_SCF) Single Collision Frames Register  Offset */
@@ -1828,6 +2071,7 @@ typedef union {
 
 /* -------- GMAC_MCF : (GMAC Offset: 0x13c) (R/ 32) Multiple Collision Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MCOL:18;                   /**< bit:  0..17  Multiple Collision                       */
@@ -1835,6 +2079,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MCF_OFFSET                     (0x13C)                                       /**<  (GMAC_MCF) Multiple Collision Frames Register  Offset */
@@ -1848,6 +2093,7 @@ typedef union {
 
 /* -------- GMAC_EC : (GMAC Offset: 0x140) (R/ 32) Excessive Collisions Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t XCOL:10;                   /**< bit:   0..9  Excessive Collisions                     */
@@ -1855,6 +2101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EC_OFFSET                      (0x140)                                       /**<  (GMAC_EC) Excessive Collisions Register  Offset */
@@ -1868,6 +2115,7 @@ typedef union {
 
 /* -------- GMAC_LC : (GMAC Offset: 0x144) (R/ 32) Late Collisions Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LCOL:10;                   /**< bit:   0..9  Late Collisions                          */
@@ -1875,6 +2123,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_LC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_LC_OFFSET                      (0x144)                                       /**<  (GMAC_LC) Late Collisions Register  Offset */
@@ -1888,6 +2137,7 @@ typedef union {
 
 /* -------- GMAC_DTF : (GMAC Offset: 0x148) (R/ 32) Deferred Transmission Frames Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DEFT:18;                   /**< bit:  0..17  Deferred Transmission                    */
@@ -1895,6 +2145,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_DTF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_DTF_OFFSET                     (0x148)                                       /**<  (GMAC_DTF) Deferred Transmission Frames Register  Offset */
@@ -1908,6 +2159,7 @@ typedef union {
 
 /* -------- GMAC_CSE : (GMAC Offset: 0x14c) (R/ 32) Carrier Sense Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSR:10;                    /**< bit:   0..9  Carrier Sense Error                      */
@@ -1915,6 +2167,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CSE_OFFSET                     (0x14C)                                       /**<  (GMAC_CSE) Carrier Sense Errors Register  Offset */
@@ -1928,12 +2181,14 @@ typedef union {
 
 /* -------- GMAC_ORLO : (GMAC Offset: 0x150) (R/ 32) Octets Received Low Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXO:32;                    /**< bit:  0..31  Received Octets                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ORLO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ORLO_OFFSET                    (0x150)                                       /**<  (GMAC_ORLO) Octets Received Low Received Register  Offset */
@@ -1947,6 +2202,7 @@ typedef union {
 
 /* -------- GMAC_ORHI : (GMAC Offset: 0x154) (R/ 32) Octets Received High Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXO:16;                    /**< bit:  0..15  Received Octets                          */
@@ -1954,6 +2210,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ORHI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ORHI_OFFSET                    (0x154)                                       /**<  (GMAC_ORHI) Octets Received High Received Register  Offset */
@@ -1967,12 +2224,14 @@ typedef union {
 
 /* -------- GMAC_FR : (GMAC Offset: 0x158) (R/ 32) Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FRX:32;                    /**< bit:  0..31  Frames Received without Error            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FR_OFFSET                      (0x158)                                       /**<  (GMAC_FR) Frames Received Register  Offset */
@@ -1986,12 +2245,14 @@ typedef union {
 
 /* -------- GMAC_BCFR : (GMAC Offset: 0x15c) (R/ 32) Broadcast Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BFRX:32;                   /**< bit:  0..31  Broadcast Frames Received without Error  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BCFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BCFR_OFFSET                    (0x15C)                                       /**<  (GMAC_BCFR) Broadcast Frames Received Register  Offset */
@@ -2005,12 +2266,14 @@ typedef union {
 
 /* -------- GMAC_MFR : (GMAC Offset: 0x160) (R/ 32) Multicast Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFRX:32;                   /**< bit:  0..31  Multicast Frames Received without Error  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_MFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_MFR_OFFSET                     (0x160)                                       /**<  (GMAC_MFR) Multicast Frames Received Register  Offset */
@@ -2024,6 +2287,7 @@ typedef union {
 
 /* -------- GMAC_PFR : (GMAC Offset: 0x164) (R/ 32) Pause Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PFRX:16;                   /**< bit:  0..15  Pause Frames Received Register           */
@@ -2031,6 +2295,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PFR_OFFSET                     (0x164)                                       /**<  (GMAC_PFR) Pause Frames Received Register  Offset */
@@ -2044,12 +2309,14 @@ typedef union {
 
 /* -------- GMAC_BFR64 : (GMAC Offset: 0x168) (R/ 32) 64 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  64 Byte Frames Received without Error    */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_BFR64_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_BFR64_OFFSET                   (0x168)                                       /**<  (GMAC_BFR64) 64 Byte Frames Received Register  Offset */
@@ -2063,12 +2330,14 @@ typedef union {
 
 /* -------- GMAC_TBFR127 : (GMAC Offset: 0x16c) (R/ 32) 65 to 127 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  65 to 127 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR127_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR127_OFFSET                 (0x16C)                                       /**<  (GMAC_TBFR127) 65 to 127 Byte Frames Received Register  Offset */
@@ -2082,12 +2351,14 @@ typedef union {
 
 /* -------- GMAC_TBFR255 : (GMAC Offset: 0x170) (R/ 32) 128 to 255 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  128 to 255 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR255_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR255_OFFSET                 (0x170)                                       /**<  (GMAC_TBFR255) 128 to 255 Byte Frames Received Register  Offset */
@@ -2101,12 +2372,14 @@ typedef union {
 
 /* -------- GMAC_TBFR511 : (GMAC Offset: 0x174) (R/ 32) 256 to 511 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  256 to 511 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR511_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR511_OFFSET                 (0x174)                                       /**<  (GMAC_TBFR511) 256 to 511 Byte Frames Received Register  Offset */
@@ -2120,12 +2393,14 @@ typedef union {
 
 /* -------- GMAC_TBFR1023 : (GMAC Offset: 0x178) (R/ 32) 512 to 1023 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  512 to 1023 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR1023_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR1023_OFFSET                (0x178)                                       /**<  (GMAC_TBFR1023) 512 to 1023 Byte Frames Received Register  Offset */
@@ -2139,12 +2414,14 @@ typedef union {
 
 /* -------- GMAC_TBFR1518 : (GMAC Offset: 0x17c) (R/ 32) 1024 to 1518 Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  1024 to 1518 Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBFR1518_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TBFR1518_OFFSET                (0x17C)                                       /**<  (GMAC_TBFR1518) 1024 to 1518 Byte Frames Received Register  Offset */
@@ -2158,12 +2435,14 @@ typedef union {
 
 /* -------- GMAC_TMXBFR : (GMAC Offset: 0x180) (R/ 32) 1519 to Maximum Byte Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NFRX:32;                   /**< bit:  0..31  1519 to Maximum Byte Frames Received without Error */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TMXBFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TMXBFR_OFFSET                  (0x180)                                       /**<  (GMAC_TMXBFR) 1519 to Maximum Byte Frames Received Register  Offset */
@@ -2177,6 +2456,7 @@ typedef union {
 
 /* -------- GMAC_UFR : (GMAC Offset: 0x184) (R/ 32) Undersize Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UFRX:10;                   /**< bit:   0..9  Undersize Frames Received                */
@@ -2184,6 +2464,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UFR_OFFSET                     (0x184)                                       /**<  (GMAC_UFR) Undersize Frames Received Register  Offset */
@@ -2197,6 +2478,7 @@ typedef union {
 
 /* -------- GMAC_OFR : (GMAC Offset: 0x188) (R/ 32) Oversize Frames Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OFRX:10;                   /**< bit:   0..9  Oversized Frames Received                */
@@ -2204,6 +2486,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_OFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_OFR_OFFSET                     (0x188)                                       /**<  (GMAC_OFR) Oversize Frames Received Register  Offset */
@@ -2217,6 +2500,7 @@ typedef union {
 
 /* -------- GMAC_JR : (GMAC Offset: 0x18c) (R/ 32) Jabbers Received Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t JRX:10;                    /**< bit:   0..9  Jabbers Received                         */
@@ -2224,6 +2508,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_JR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_JR_OFFSET                      (0x18C)                                       /**<  (GMAC_JR) Jabbers Received Register  Offset */
@@ -2237,6 +2522,7 @@ typedef union {
 
 /* -------- GMAC_FCSE : (GMAC Offset: 0x190) (R/ 32) Frame Check Sequence Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCKR:10;                   /**< bit:   0..9  Frame Check Sequence Errors              */
@@ -2244,6 +2530,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_FCSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_FCSE_OFFSET                    (0x190)                                       /**<  (GMAC_FCSE) Frame Check Sequence Errors Register  Offset */
@@ -2257,6 +2544,7 @@ typedef union {
 
 /* -------- GMAC_LFFE : (GMAC Offset: 0x194) (R/ 32) Length Field Frame Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LFER:10;                   /**< bit:   0..9  Length Field Frame Errors                */
@@ -2264,6 +2552,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_LFFE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_LFFE_OFFSET                    (0x194)                                       /**<  (GMAC_LFFE) Length Field Frame Errors Register  Offset */
@@ -2277,6 +2566,7 @@ typedef union {
 
 /* -------- GMAC_RSE : (GMAC Offset: 0x198) (R/ 32) Receive Symbol Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXSE:10;                   /**< bit:   0..9  Receive Symbol Errors                    */
@@ -2284,6 +2574,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RSE_OFFSET                     (0x198)                                       /**<  (GMAC_RSE) Receive Symbol Errors Register  Offset */
@@ -2297,6 +2588,7 @@ typedef union {
 
 /* -------- GMAC_AE : (GMAC Offset: 0x19c) (R/ 32) Alignment Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AER:10;                    /**< bit:   0..9  Alignment Errors                         */
@@ -2304,6 +2596,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_AE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_AE_OFFSET                      (0x19C)                                       /**<  (GMAC_AE) Alignment Errors Register  Offset */
@@ -2317,6 +2610,7 @@ typedef union {
 
 /* -------- GMAC_RRE : (GMAC Offset: 0x1a0) (R/ 32) Receive Resource Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRER:18;                  /**< bit:  0..17  Receive Resource Errors                  */
@@ -2324,6 +2618,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RRE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RRE_OFFSET                     (0x1A0)                                       /**<  (GMAC_RRE) Receive Resource Errors Register  Offset */
@@ -2337,6 +2632,7 @@ typedef union {
 
 /* -------- GMAC_ROE : (GMAC Offset: 0x1a4) (R/ 32) Receive Overrun Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXOVR:10;                  /**< bit:   0..9  Receive Overruns                         */
@@ -2344,6 +2640,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ROE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_ROE_OFFSET                     (0x1A4)                                       /**<  (GMAC_ROE) Receive Overrun Register  Offset */
@@ -2357,6 +2654,7 @@ typedef union {
 
 /* -------- GMAC_IHCE : (GMAC Offset: 0x1a8) (R/ 32) IP Header Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HCKER:8;                   /**< bit:   0..7  IP Header Checksum Errors                */
@@ -2364,6 +2662,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IHCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_IHCE_OFFSET                    (0x1A8)                                       /**<  (GMAC_IHCE) IP Header Checksum Errors Register  Offset */
@@ -2377,6 +2676,7 @@ typedef union {
 
 /* -------- GMAC_TCE : (GMAC Offset: 0x1ac) (R/ 32) TCP Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCKER:8;                   /**< bit:   0..7  TCP Checksum Errors                      */
@@ -2384,6 +2684,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TCE_OFFSET                     (0x1AC)                                       /**<  (GMAC_TCE) TCP Checksum Errors Register  Offset */
@@ -2397,6 +2698,7 @@ typedef union {
 
 /* -------- GMAC_UCE : (GMAC Offset: 0x1b0) (R/ 32) UDP Checksum Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UCKER:8;                   /**< bit:   0..7  UDP Checksum Errors                      */
@@ -2404,6 +2706,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_UCE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_UCE_OFFSET                     (0x1B0)                                       /**<  (GMAC_UCE) UDP Checksum Errors Register  Offset */
@@ -2417,6 +2720,7 @@ typedef union {
 
 /* -------- GMAC_TISUBN : (GMAC Offset: 0x1bc) (R/W 32) 1588 Timer Increment Sub-nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LSBTIR:16;                 /**< bit:  0..15  Lower Significant Bits of Timer Increment Register */
@@ -2424,6 +2728,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TISUBN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TISUBN_OFFSET                  (0x1BC)                                       /**<  (GMAC_TISUBN) 1588 Timer Increment Sub-nanoseconds Register  Offset */
@@ -2437,6 +2742,7 @@ typedef union {
 
 /* -------- GMAC_TSH : (GMAC Offset: 0x1c0) (R/W 32) 1588 Timer Seconds High Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCS:16;                    /**< bit:  0..15  Timer Count in Seconds                   */
@@ -2444,6 +2750,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSH_OFFSET                     (0x1C0)                                       /**<  (GMAC_TSH) 1588 Timer Seconds High Register  Offset */
@@ -2457,12 +2764,14 @@ typedef union {
 
 /* -------- GMAC_TSL : (GMAC Offset: 0x1d0) (R/W 32) 1588 Timer Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCS:32;                    /**< bit:  0..31  Timer Count in Seconds                   */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TSL_OFFSET                     (0x1D0)                                       /**<  (GMAC_TSL) 1588 Timer Seconds Low Register  Offset */
@@ -2476,6 +2785,7 @@ typedef union {
 
 /* -------- GMAC_TN : (GMAC Offset: 0x1d4) (R/W 32) 1588 Timer Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TNS:30;                    /**< bit:  0..29  Timer Count in Nanoseconds               */
@@ -2483,6 +2793,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TN_OFFSET                      (0x1D4)                                       /**<  (GMAC_TN) 1588 Timer Nanoseconds Register  Offset */
@@ -2496,6 +2807,7 @@ typedef union {
 
 /* -------- GMAC_TA : (GMAC Offset: 0x1d8) (/W 32) 1588 Timer Adjust Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ITDT:30;                   /**< bit:  0..29  Increment/Decrement                      */
@@ -2504,6 +2816,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TA_OFFSET                      (0x1D8)                                       /**<  (GMAC_TA) 1588 Timer Adjust Register  Offset */
@@ -2520,6 +2833,7 @@ typedef union {
 
 /* -------- GMAC_TI : (GMAC Offset: 0x1dc) (R/W 32) 1588 Timer Increment Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CNS:8;                     /**< bit:   0..7  Count Nanoseconds                        */
@@ -2529,6 +2843,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TI_OFFSET                      (0x1DC)                                       /**<  (GMAC_TI) 1588 Timer Increment Register  Offset */
@@ -2548,12 +2863,14 @@ typedef union {
 
 /* -------- GMAC_EFTSL : (GMAC Offset: 0x1e0) (R/ 32) PTP Event Frame Transmitted Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTSL_OFFSET                   (0x1E0)                                       /**<  (GMAC_EFTSL) PTP Event Frame Transmitted Seconds Low Register  Offset */
@@ -2567,6 +2884,7 @@ typedef union {
 
 /* -------- GMAC_EFTN : (GMAC Offset: 0x1e4) (R/ 32) PTP Event Frame Transmitted Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2574,6 +2892,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFTN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFTN_OFFSET                    (0x1E4)                                       /**<  (GMAC_EFTN) PTP Event Frame Transmitted Nanoseconds Register  Offset */
@@ -2587,12 +2906,14 @@ typedef union {
 
 /* -------- GMAC_EFRSL : (GMAC Offset: 0x1e8) (R/ 32) PTP Event Frame Received Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRSL_OFFSET                   (0x1E8)                                       /**<  (GMAC_EFRSL) PTP Event Frame Received Seconds Low Register  Offset */
@@ -2606,6 +2927,7 @@ typedef union {
 
 /* -------- GMAC_EFRN : (GMAC Offset: 0x1ec) (R/ 32) PTP Event Frame Received Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2613,6 +2935,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_EFRN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_EFRN_OFFSET                    (0x1EC)                                       /**<  (GMAC_EFRN) PTP Event Frame Received Nanoseconds Register  Offset */
@@ -2626,12 +2949,14 @@ typedef union {
 
 /* -------- GMAC_PEFTSL : (GMAC Offset: 0x1f0) (R/ 32) PTP Peer Event Frame Transmitted Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTSL_OFFSET                  (0x1F0)                                       /**<  (GMAC_PEFTSL) PTP Peer Event Frame Transmitted Seconds Low Register  Offset */
@@ -2645,6 +2970,7 @@ typedef union {
 
 /* -------- GMAC_PEFTN : (GMAC Offset: 0x1f4) (R/ 32) PTP Peer Event Frame Transmitted Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2652,6 +2978,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFTN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFTN_OFFSET                   (0x1F4)                                       /**<  (GMAC_PEFTN) PTP Peer Event Frame Transmitted Nanoseconds Register  Offset */
@@ -2665,12 +2992,14 @@ typedef union {
 
 /* -------- GMAC_PEFRSL : (GMAC Offset: 0x1f8) (R/ 32) PTP Peer Event Frame Received Seconds Low Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:32;                    /**< bit:  0..31  Register Update                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRSL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRSL_OFFSET                  (0x1F8)                                       /**<  (GMAC_PEFRSL) PTP Peer Event Frame Received Seconds Low Register  Offset */
@@ -2684,6 +3013,7 @@ typedef union {
 
 /* -------- GMAC_PEFRN : (GMAC Offset: 0x1fc) (R/ 32) PTP Peer Event Frame Received Nanoseconds Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RUD:30;                    /**< bit:  0..29  Register Update                          */
@@ -2691,6 +3021,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_PEFRN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_PEFRN_OFFSET                   (0x1FC)                                       /**<  (GMAC_PEFRN) PTP Peer Event Frame Received Nanoseconds Register  Offset */
@@ -2704,6 +3035,7 @@ typedef union {
 
 /* -------- GMAC_RXLPI : (GMAC Offset: 0x270) (R/ 32) Received LPI Transitions -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COUNT:16;                  /**< bit:  0..15  Count of RX LPI transitions (cleared on read) */
@@ -2711,6 +3043,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RXLPI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RXLPI_OFFSET                   (0x270)                                       /**<  (GMAC_RXLPI) Received LPI Transitions  Offset */
@@ -2724,6 +3057,7 @@ typedef union {
 
 /* -------- GMAC_RXLPITIME : (GMAC Offset: 0x274) (R/ 32) Received LPI Time -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LPITIME:24;                /**< bit:  0..23  Time in LPI (cleared on read)            */
@@ -2731,6 +3065,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RXLPITIME_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_RXLPITIME_OFFSET               (0x274)                                       /**<  (GMAC_RXLPITIME) Received LPI Time  Offset */
@@ -2744,6 +3079,7 @@ typedef union {
 
 /* -------- GMAC_TXLPI : (GMAC Offset: 0x278) (R/ 32) Transmit LPI Transitions -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COUNT:16;                  /**< bit:  0..15  Count of LPI transitions (cleared on read) */
@@ -2751,6 +3087,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TXLPI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TXLPI_OFFSET                   (0x278)                                       /**<  (GMAC_TXLPI) Transmit LPI Transitions  Offset */
@@ -2764,6 +3101,7 @@ typedef union {
 
 /* -------- GMAC_TXLPITIME : (GMAC Offset: 0x27c) (R/ 32) Transmit LPI Time -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LPITIME:24;                /**< bit:  0..23  Time in LPI (cleared on read)            */
@@ -2771,6 +3109,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TXLPITIME_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_TXLPITIME_OFFSET               (0x27C)                                       /**<  (GMAC_TXLPITIME) Transmit LPI Time  Offset */
@@ -2782,8 +3121,9 @@ typedef union {
 #define GMAC_TXLPITIME_Msk                  _U_(0xFFFFFF)                                  /**< (GMAC_TXLPITIME) Register Mask  */
 
 
-/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_ISRPQ : (GMAC Offset: 0x400) (R/ 32) Interrupt Status Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -2800,9 +3140,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ISRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_ISRPQ_OFFSET                   (0x400)                                       /**<  (GMAC_ISRPQ) Interrupt Status Register Priority Queue (1..5)  Offset */
 
 #define GMAC_ISRPQ_RCOMP_Pos                1                                              /**< (GMAC_ISRPQ) Receive Complete Position */
 #define GMAC_ISRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_ISRPQ_RCOMP_Pos)             /**< (GMAC_ISRPQ) Receive Complete Mask */
@@ -2829,8 +3170,9 @@ typedef union {
 #define GMAC_ISRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_ISRPQ) Register Mask  */
 
 
-/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_TBQBAPQ : (GMAC Offset: 0x440) (R/W 32) Transmit Buffer Queue Base Address Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2838,9 +3180,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_TBQBAPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_TBQBAPQ_OFFSET                 (0x440)                                       /**<  (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Register Priority Queue (1..5)  Offset */
 
 #define GMAC_TBQBAPQ_TXBQBA_Pos             2                                              /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Position */
 #define GMAC_TBQBAPQ_TXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_TBQBAPQ_TXBQBA_Pos)   /**< (GMAC_TBQBAPQ) Transmit Buffer Queue Base Address Mask */
@@ -2849,8 +3192,9 @@ typedef union {
 #define GMAC_TBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_TBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBQBAPQ : (GMAC Offset: 0x480) (R/W 32) Receive Buffer Queue Base Address Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2858,9 +3202,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBQBAPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBQBAPQ_OFFSET                 (0x480)                                       /**<  (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Register Priority Queue (1..5)  Offset */
 
 #define GMAC_RBQBAPQ_RXBQBA_Pos             2                                              /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Position */
 #define GMAC_RBQBAPQ_RXBQBA_Msk             (_U_(0x3FFFFFFF) << GMAC_RBQBAPQ_RXBQBA_Pos)   /**< (GMAC_RBQBAPQ) Receive Buffer Queue Base Address Mask */
@@ -2869,8 +3214,9 @@ typedef union {
 #define GMAC_RBQBAPQ_Msk                    _U_(0xFFFFFFFC)                                /**< (GMAC_RBQBAPQ) Register Mask  */
 
 
-/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_RBSRPQ : (GMAC Offset: 0x4a0) (R/W 32) Receive Buffer Size Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RBS:16;                    /**< bit:  0..15  Receive Buffer Size                      */
@@ -2878,9 +3224,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_RBSRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_RBSRPQ_OFFSET                  (0x4A0)                                       /**<  (GMAC_RBSRPQ) Receive Buffer Size Register Priority Queue (1..5)  Offset */
 
 #define GMAC_RBSRPQ_RBS_Pos                 0                                              /**< (GMAC_RBSRPQ) Receive Buffer Size Position */
 #define GMAC_RBSRPQ_RBS_Msk                 (_U_(0xFFFF) << GMAC_RBSRPQ_RBS_Pos)           /**< (GMAC_RBSRPQ) Receive Buffer Size Mask */
@@ -2891,6 +3238,7 @@ typedef union {
 
 /* -------- GMAC_CBSCR : (GMAC Offset: 0x4bc) (R/W 32) Credit-Based Shaping Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QBE:1;                     /**< bit:      0  Queue B CBS Enable                       */
@@ -2899,6 +3247,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSCR_OFFSET                   (0x4BC)                                       /**<  (GMAC_CBSCR) Credit-Based Shaping Control Register  Offset */
@@ -2915,12 +3264,14 @@ typedef union {
 
 /* -------- GMAC_CBSISQA : (GMAC Offset: 0x4c0) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue A -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSISQA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSISQA_OFFSET                 (0x4C0)                                       /**<  (GMAC_CBSISQA) Credit-Based Shaping IdleSlope Register for Queue A  Offset */
@@ -2934,12 +3285,14 @@ typedef union {
 
 /* -------- GMAC_CBSISQB : (GMAC Offset: 0x4c4) (R/W 32) Credit-Based Shaping IdleSlope Register for Queue B -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS:32;                     /**< bit:  0..31  IdleSlope                                */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_CBSISQB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GMAC_CBSISQB_OFFSET                 (0x4C4)                                       /**<  (GMAC_CBSISQB) Credit-Based Shaping IdleSlope Register for Queue B  Offset */
@@ -2951,11 +3304,12 @@ typedef union {
 #define GMAC_CBSISQB_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_CBSISQB) Register Mask  */
 
 
-/* -------- GMAC_ST1RPQ : (GMAC Offset: 0x500) (R/W 32) Screening Type 1 Register Priority Queue (index = 0) 0 -------- */
+/* -------- GMAC_ST1RPQ : (GMAC Offset: 0x500) (R/W 32) Screening Type 1 Register Priority Queue -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-5)                       */
     uint32_t :1;                        /**< bit:      3  Reserved */
     uint32_t DSTCM:8;                   /**< bit:  4..11  Differentiated Services or Traffic Class Match */
     uint32_t UDPM:16;                   /**< bit: 12..27  UDP Port Match                           */
@@ -2965,12 +3319,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST1RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ST1RPQ_OFFSET                  (0x500)                                       /**<  (GMAC_ST1RPQ) Screening Type 1 Register Priority Queue (index = 0) 0  Offset */
+#define GMAC_ST1RPQ_OFFSET                  (0x500)                                       /**<  (GMAC_ST1RPQ) Screening Type 1 Register Priority Queue  Offset */
 
-#define GMAC_ST1RPQ_QNB_Pos                 0                                              /**< (GMAC_ST1RPQ) Queue Number (0-2) Position */
-#define GMAC_ST1RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST1RPQ_QNB_Pos)              /**< (GMAC_ST1RPQ) Queue Number (0-2) Mask */
+#define GMAC_ST1RPQ_QNB_Pos                 0                                              /**< (GMAC_ST1RPQ) Queue Number (0-5) Position */
+#define GMAC_ST1RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST1RPQ_QNB_Pos)              /**< (GMAC_ST1RPQ) Queue Number (0-5) Mask */
 #define GMAC_ST1RPQ_QNB(value)              (GMAC_ST1RPQ_QNB_Msk & ((value) << GMAC_ST1RPQ_QNB_Pos))
 #define GMAC_ST1RPQ_DSTCM_Pos               4                                              /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Position */
 #define GMAC_ST1RPQ_DSTCM_Msk               (_U_(0xFF) << GMAC_ST1RPQ_DSTCM_Pos)           /**< (GMAC_ST1RPQ) Differentiated Services or Traffic Class Match Mask */
@@ -2988,11 +3343,12 @@ typedef union {
 #define GMAC_ST1RPQ_Msk                     _U_(0x3FFFFFF7)                                /**< (GMAC_ST1RPQ) Register Mask  */
 
 
-/* -------- GMAC_ST2RPQ : (GMAC Offset: 0x540) (R/W 32) Screening Type 2 Register Priority Queue (index = 0) 0 -------- */
+/* -------- GMAC_ST2RPQ : (GMAC Offset: 0x540) (R/W 32) Screening Type 2 Register Priority Queue -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-2)                       */
+    uint32_t QNB:3;                     /**< bit:   0..2  Queue Number (0-5)                       */
     uint32_t :1;                        /**< bit:      3  Reserved */
     uint32_t VLANP:3;                   /**< bit:   4..6  VLAN Priority                            */
     uint32_t :1;                        /**< bit:      7  Reserved */
@@ -3009,12 +3365,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2RPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ST2RPQ_OFFSET                  (0x540)                                       /**<  (GMAC_ST2RPQ) Screening Type 2 Register Priority Queue (index = 0) 0  Offset */
+#define GMAC_ST2RPQ_OFFSET                  (0x540)                                       /**<  (GMAC_ST2RPQ) Screening Type 2 Register Priority Queue  Offset */
 
-#define GMAC_ST2RPQ_QNB_Pos                 0                                              /**< (GMAC_ST2RPQ) Queue Number (0-2) Position */
-#define GMAC_ST2RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST2RPQ_QNB_Pos)              /**< (GMAC_ST2RPQ) Queue Number (0-2) Mask */
+#define GMAC_ST2RPQ_QNB_Pos                 0                                              /**< (GMAC_ST2RPQ) Queue Number (0-5) Position */
+#define GMAC_ST2RPQ_QNB_Msk                 (_U_(0x7) << GMAC_ST2RPQ_QNB_Pos)              /**< (GMAC_ST2RPQ) Queue Number (0-5) Mask */
 #define GMAC_ST2RPQ_QNB(value)              (GMAC_ST2RPQ_QNB_Msk & ((value) << GMAC_ST2RPQ_QNB_Pos))
 #define GMAC_ST2RPQ_VLANP_Pos               4                                              /**< (GMAC_ST2RPQ) VLAN Priority Position */
 #define GMAC_ST2RPQ_VLANP_Msk               (_U_(0x7) << GMAC_ST2RPQ_VLANP_Pos)            /**< (GMAC_ST2RPQ) VLAN Priority Mask */
@@ -3050,8 +3407,9 @@ typedef union {
 #define GMAC_ST2RPQ_Msk                     _U_(0x7FFFFF77)                                /**< (GMAC_ST2RPQ) Register Mask  */
 
 
-/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IERPQ : (GMAC Offset: 0x600) (/W 32) Interrupt Enable Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -3068,9 +3426,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IERPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IERPQ_OFFSET                   (0x600)                                       /**<  (GMAC_IERPQ) Interrupt Enable Register Priority Queue (1..5)  Offset */
 
 #define GMAC_IERPQ_RCOMP_Pos                1                                              /**< (GMAC_IERPQ) Receive Complete Position */
 #define GMAC_IERPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IERPQ_RCOMP_Pos)             /**< (GMAC_IERPQ) Receive Complete Mask */
@@ -3097,8 +3456,9 @@ typedef union {
 #define GMAC_IERPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IERPQ) Register Mask  */
 
 
-/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IDRPQ : (GMAC Offset: 0x620) (/W 32) Interrupt Disable Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -3115,9 +3475,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IDRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IDRPQ_OFFSET                   (0x620)                                       /**<  (GMAC_IDRPQ) Interrupt Disable Register Priority Queue (1..5)  Offset */
 
 #define GMAC_IDRPQ_RCOMP_Pos                1                                              /**< (GMAC_IDRPQ) Receive Complete Position */
 #define GMAC_IDRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IDRPQ_RCOMP_Pos)             /**< (GMAC_IDRPQ) Receive Complete Mask */
@@ -3144,8 +3505,9 @@ typedef union {
 #define GMAC_IDRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IDRPQ) Register Mask  */
 
 
-/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (index = 1) 0 -------- */
+/* -------- GMAC_IMRPQ : (GMAC Offset: 0x640) (R/W 32) Interrupt Mask Register Priority Queue (1..5) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -3162,9 +3524,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_IMRPQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (index = 1) 0  Offset */
+#define GMAC_IMRPQ_OFFSET                   (0x640)                                       /**<  (GMAC_IMRPQ) Interrupt Mask Register Priority Queue (1..5)  Offset */
 
 #define GMAC_IMRPQ_RCOMP_Pos                1                                              /**< (GMAC_IMRPQ) Receive Complete Position */
 #define GMAC_IMRPQ_RCOMP_Msk                (_U_(0x1) << GMAC_IMRPQ_RCOMP_Pos)             /**< (GMAC_IMRPQ) Receive Complete Mask */
@@ -3191,8 +3554,9 @@ typedef union {
 #define GMAC_IMRPQ_Msk                      _U_(0xCE6)                                     /**< (GMAC_IMRPQ) Register Mask  */
 
 
-/* -------- GMAC_ST2ER : (GMAC Offset: 0x6e0) (R/W 32) Screening Type 2 Ethertype Register (index = 0) 0 -------- */
+/* -------- GMAC_ST2ER : (GMAC Offset: 0x6e0) (R/W 32) Screening Type 2 Ethertype Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COMPVAL:16;                /**< bit:  0..15  Ethertype Compare Value                  */
@@ -3200,1311 +3564,16 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GMAC_ST2ER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define GMAC_ST2ER_OFFSET                   (0x6E0)                                       /**<  (GMAC_ST2ER) Screening Type 2 Ethertype Register (index = 0) 0  Offset */
+#define GMAC_ST2ER_OFFSET                   (0x6E0)                                       /**<  (GMAC_ST2ER) Screening Type 2 Ethertype Register  Offset */
 
 #define GMAC_ST2ER_COMPVAL_Pos              0                                              /**< (GMAC_ST2ER) Ethertype Compare Value Position */
 #define GMAC_ST2ER_COMPVAL_Msk              (_U_(0xFFFF) << GMAC_ST2ER_COMPVAL_Pos)        /**< (GMAC_ST2ER) Ethertype Compare Value Mask */
 #define GMAC_ST2ER_COMPVAL(value)           (GMAC_ST2ER_COMPVAL_Msk & ((value) << GMAC_ST2ER_COMPVAL_Pos))
 #define GMAC_ST2ER_MASK                     _U_(0xFFFF)                                    /**< \deprecated (GMAC_ST2ER) Register MASK  (Use GMAC_ST2ER_Msk instead)  */
 #define GMAC_ST2ER_Msk                      _U_(0xFFFF)                                    /**< (GMAC_ST2ER) Register Mask  */
-
-
-/* -------- GMAC_ST2CW00 : (GMAC Offset: 0x700) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 0) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW00_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW00_OFFSET                 (0x700)                                       /**<  (GMAC_ST2CW00) Screening Type 2 Compare Word 0 Register (index = 0)  Offset */
-
-#define GMAC_ST2CW00_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW00) Mask Value Position */
-#define GMAC_ST2CW00_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW00_MASKVAL_Pos)      /**< (GMAC_ST2CW00) Mask Value Mask */
-#define GMAC_ST2CW00_MASKVAL(value)         (GMAC_ST2CW00_MASKVAL_Msk & ((value) << GMAC_ST2CW00_MASKVAL_Pos))
-#define GMAC_ST2CW00_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW00) Compare Value Position */
-#define GMAC_ST2CW00_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW00_COMPVAL_Pos)      /**< (GMAC_ST2CW00) Compare Value Mask */
-#define GMAC_ST2CW00_COMPVAL(value)         (GMAC_ST2CW00_COMPVAL_Msk & ((value) << GMAC_ST2CW00_COMPVAL_Pos))
-#define GMAC_ST2CW00_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW00) Register Mask  */
-
-
-/* -------- GMAC_ST2CW10 : (GMAC Offset: 0x704) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 0) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW10_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW10_OFFSET                 (0x704)                                       /**<  (GMAC_ST2CW10) Screening Type 2 Compare Word 1 Register (index = 0)  Offset */
-
-#define GMAC_ST2CW10_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW10) Offset Value in Bytes Position */
-#define GMAC_ST2CW10_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW10_OFFSVAL_Pos)        /**< (GMAC_ST2CW10) Offset Value in Bytes Mask */
-#define GMAC_ST2CW10_OFFSVAL(value)         (GMAC_ST2CW10_OFFSVAL_Msk & ((value) << GMAC_ST2CW10_OFFSVAL_Pos))
-#define GMAC_ST2CW10_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW10) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW10_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW10_OFFSSTRT_Pos)        /**< (GMAC_ST2CW10) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW10_OFFSSTRT(value)        (GMAC_ST2CW10_OFFSSTRT_Msk & ((value) << GMAC_ST2CW10_OFFSSTRT_Pos))
-#define   GMAC_ST2CW10_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW10) Offset from the start of the frame  */
-#define   GMAC_ST2CW10_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW10) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW10_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW10) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW10_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW10) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW10_OFFSSTRT_FRAMESTART    (GMAC_ST2CW10_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the start of the frame Position  */
-#define GMAC_ST2CW10_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW10_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW10_OFFSSTRT_IP            (GMAC_ST2CW10_OFFSSTRT_IP_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW10_OFFSSTRT_TCP_UDP       (GMAC_ST2CW10_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW10_OFFSSTRT_Pos)  /**< (GMAC_ST2CW10) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW10_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW10) Register MASK  (Use GMAC_ST2CW10_Msk instead)  */
-#define GMAC_ST2CW10_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW10) Register Mask  */
-
-
-/* -------- GMAC_ST2CW01 : (GMAC Offset: 0x708) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 1) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW01_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW01_OFFSET                 (0x708)                                       /**<  (GMAC_ST2CW01) Screening Type 2 Compare Word 0 Register (index = 1)  Offset */
-
-#define GMAC_ST2CW01_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW01) Mask Value Position */
-#define GMAC_ST2CW01_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW01_MASKVAL_Pos)      /**< (GMAC_ST2CW01) Mask Value Mask */
-#define GMAC_ST2CW01_MASKVAL(value)         (GMAC_ST2CW01_MASKVAL_Msk & ((value) << GMAC_ST2CW01_MASKVAL_Pos))
-#define GMAC_ST2CW01_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW01) Compare Value Position */
-#define GMAC_ST2CW01_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW01_COMPVAL_Pos)      /**< (GMAC_ST2CW01) Compare Value Mask */
-#define GMAC_ST2CW01_COMPVAL(value)         (GMAC_ST2CW01_COMPVAL_Msk & ((value) << GMAC_ST2CW01_COMPVAL_Pos))
-#define GMAC_ST2CW01_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW01) Register Mask  */
-
-
-/* -------- GMAC_ST2CW11 : (GMAC Offset: 0x70c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 1) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW11_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW11_OFFSET                 (0x70C)                                       /**<  (GMAC_ST2CW11) Screening Type 2 Compare Word 1 Register (index = 1)  Offset */
-
-#define GMAC_ST2CW11_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW11) Offset Value in Bytes Position */
-#define GMAC_ST2CW11_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW11_OFFSVAL_Pos)        /**< (GMAC_ST2CW11) Offset Value in Bytes Mask */
-#define GMAC_ST2CW11_OFFSVAL(value)         (GMAC_ST2CW11_OFFSVAL_Msk & ((value) << GMAC_ST2CW11_OFFSVAL_Pos))
-#define GMAC_ST2CW11_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW11) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW11_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW11_OFFSSTRT_Pos)        /**< (GMAC_ST2CW11) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW11_OFFSSTRT(value)        (GMAC_ST2CW11_OFFSSTRT_Msk & ((value) << GMAC_ST2CW11_OFFSSTRT_Pos))
-#define   GMAC_ST2CW11_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW11) Offset from the start of the frame  */
-#define   GMAC_ST2CW11_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW11) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW11_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW11) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW11_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW11) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW11_OFFSSTRT_FRAMESTART    (GMAC_ST2CW11_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the start of the frame Position  */
-#define GMAC_ST2CW11_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW11_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW11_OFFSSTRT_IP            (GMAC_ST2CW11_OFFSSTRT_IP_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW11_OFFSSTRT_TCP_UDP       (GMAC_ST2CW11_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW11_OFFSSTRT_Pos)  /**< (GMAC_ST2CW11) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW11_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW11) Register MASK  (Use GMAC_ST2CW11_Msk instead)  */
-#define GMAC_ST2CW11_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW11) Register Mask  */
-
-
-/* -------- GMAC_ST2CW02 : (GMAC Offset: 0x710) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 2) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW02_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW02_OFFSET                 (0x710)                                       /**<  (GMAC_ST2CW02) Screening Type 2 Compare Word 0 Register (index = 2)  Offset */
-
-#define GMAC_ST2CW02_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW02) Mask Value Position */
-#define GMAC_ST2CW02_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW02_MASKVAL_Pos)      /**< (GMAC_ST2CW02) Mask Value Mask */
-#define GMAC_ST2CW02_MASKVAL(value)         (GMAC_ST2CW02_MASKVAL_Msk & ((value) << GMAC_ST2CW02_MASKVAL_Pos))
-#define GMAC_ST2CW02_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW02) Compare Value Position */
-#define GMAC_ST2CW02_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW02_COMPVAL_Pos)      /**< (GMAC_ST2CW02) Compare Value Mask */
-#define GMAC_ST2CW02_COMPVAL(value)         (GMAC_ST2CW02_COMPVAL_Msk & ((value) << GMAC_ST2CW02_COMPVAL_Pos))
-#define GMAC_ST2CW02_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW02) Register Mask  */
-
-
-/* -------- GMAC_ST2CW12 : (GMAC Offset: 0x714) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 2) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW12_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW12_OFFSET                 (0x714)                                       /**<  (GMAC_ST2CW12) Screening Type 2 Compare Word 1 Register (index = 2)  Offset */
-
-#define GMAC_ST2CW12_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW12) Offset Value in Bytes Position */
-#define GMAC_ST2CW12_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW12_OFFSVAL_Pos)        /**< (GMAC_ST2CW12) Offset Value in Bytes Mask */
-#define GMAC_ST2CW12_OFFSVAL(value)         (GMAC_ST2CW12_OFFSVAL_Msk & ((value) << GMAC_ST2CW12_OFFSVAL_Pos))
-#define GMAC_ST2CW12_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW12) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW12_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW12_OFFSSTRT_Pos)        /**< (GMAC_ST2CW12) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW12_OFFSSTRT(value)        (GMAC_ST2CW12_OFFSSTRT_Msk & ((value) << GMAC_ST2CW12_OFFSSTRT_Pos))
-#define   GMAC_ST2CW12_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW12) Offset from the start of the frame  */
-#define   GMAC_ST2CW12_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW12) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW12_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW12) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW12_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW12) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW12_OFFSSTRT_FRAMESTART    (GMAC_ST2CW12_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the start of the frame Position  */
-#define GMAC_ST2CW12_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW12_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW12_OFFSSTRT_IP            (GMAC_ST2CW12_OFFSSTRT_IP_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW12_OFFSSTRT_TCP_UDP       (GMAC_ST2CW12_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW12_OFFSSTRT_Pos)  /**< (GMAC_ST2CW12) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW12_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW12) Register MASK  (Use GMAC_ST2CW12_Msk instead)  */
-#define GMAC_ST2CW12_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW12) Register Mask  */
-
-
-/* -------- GMAC_ST2CW03 : (GMAC Offset: 0x718) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 3) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW03_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW03_OFFSET                 (0x718)                                       /**<  (GMAC_ST2CW03) Screening Type 2 Compare Word 0 Register (index = 3)  Offset */
-
-#define GMAC_ST2CW03_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW03) Mask Value Position */
-#define GMAC_ST2CW03_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW03_MASKVAL_Pos)      /**< (GMAC_ST2CW03) Mask Value Mask */
-#define GMAC_ST2CW03_MASKVAL(value)         (GMAC_ST2CW03_MASKVAL_Msk & ((value) << GMAC_ST2CW03_MASKVAL_Pos))
-#define GMAC_ST2CW03_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW03) Compare Value Position */
-#define GMAC_ST2CW03_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW03_COMPVAL_Pos)      /**< (GMAC_ST2CW03) Compare Value Mask */
-#define GMAC_ST2CW03_COMPVAL(value)         (GMAC_ST2CW03_COMPVAL_Msk & ((value) << GMAC_ST2CW03_COMPVAL_Pos))
-#define GMAC_ST2CW03_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW03) Register Mask  */
-
-
-/* -------- GMAC_ST2CW13 : (GMAC Offset: 0x71c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 3) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW13_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW13_OFFSET                 (0x71C)                                       /**<  (GMAC_ST2CW13) Screening Type 2 Compare Word 1 Register (index = 3)  Offset */
-
-#define GMAC_ST2CW13_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW13) Offset Value in Bytes Position */
-#define GMAC_ST2CW13_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW13_OFFSVAL_Pos)        /**< (GMAC_ST2CW13) Offset Value in Bytes Mask */
-#define GMAC_ST2CW13_OFFSVAL(value)         (GMAC_ST2CW13_OFFSVAL_Msk & ((value) << GMAC_ST2CW13_OFFSVAL_Pos))
-#define GMAC_ST2CW13_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW13) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW13_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW13_OFFSSTRT_Pos)        /**< (GMAC_ST2CW13) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW13_OFFSSTRT(value)        (GMAC_ST2CW13_OFFSSTRT_Msk & ((value) << GMAC_ST2CW13_OFFSSTRT_Pos))
-#define   GMAC_ST2CW13_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW13) Offset from the start of the frame  */
-#define   GMAC_ST2CW13_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW13) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW13_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW13) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW13_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW13) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW13_OFFSSTRT_FRAMESTART    (GMAC_ST2CW13_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the start of the frame Position  */
-#define GMAC_ST2CW13_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW13_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW13_OFFSSTRT_IP            (GMAC_ST2CW13_OFFSSTRT_IP_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW13_OFFSSTRT_TCP_UDP       (GMAC_ST2CW13_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW13_OFFSSTRT_Pos)  /**< (GMAC_ST2CW13) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW13_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW13) Register MASK  (Use GMAC_ST2CW13_Msk instead)  */
-#define GMAC_ST2CW13_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW13) Register Mask  */
-
-
-/* -------- GMAC_ST2CW04 : (GMAC Offset: 0x720) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 4) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW04_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW04_OFFSET                 (0x720)                                       /**<  (GMAC_ST2CW04) Screening Type 2 Compare Word 0 Register (index = 4)  Offset */
-
-#define GMAC_ST2CW04_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW04) Mask Value Position */
-#define GMAC_ST2CW04_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW04_MASKVAL_Pos)      /**< (GMAC_ST2CW04) Mask Value Mask */
-#define GMAC_ST2CW04_MASKVAL(value)         (GMAC_ST2CW04_MASKVAL_Msk & ((value) << GMAC_ST2CW04_MASKVAL_Pos))
-#define GMAC_ST2CW04_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW04) Compare Value Position */
-#define GMAC_ST2CW04_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW04_COMPVAL_Pos)      /**< (GMAC_ST2CW04) Compare Value Mask */
-#define GMAC_ST2CW04_COMPVAL(value)         (GMAC_ST2CW04_COMPVAL_Msk & ((value) << GMAC_ST2CW04_COMPVAL_Pos))
-#define GMAC_ST2CW04_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW04) Register Mask  */
-
-
-/* -------- GMAC_ST2CW14 : (GMAC Offset: 0x724) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 4) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW14_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW14_OFFSET                 (0x724)                                       /**<  (GMAC_ST2CW14) Screening Type 2 Compare Word 1 Register (index = 4)  Offset */
-
-#define GMAC_ST2CW14_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW14) Offset Value in Bytes Position */
-#define GMAC_ST2CW14_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW14_OFFSVAL_Pos)        /**< (GMAC_ST2CW14) Offset Value in Bytes Mask */
-#define GMAC_ST2CW14_OFFSVAL(value)         (GMAC_ST2CW14_OFFSVAL_Msk & ((value) << GMAC_ST2CW14_OFFSVAL_Pos))
-#define GMAC_ST2CW14_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW14) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW14_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW14_OFFSSTRT_Pos)        /**< (GMAC_ST2CW14) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW14_OFFSSTRT(value)        (GMAC_ST2CW14_OFFSSTRT_Msk & ((value) << GMAC_ST2CW14_OFFSSTRT_Pos))
-#define   GMAC_ST2CW14_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW14) Offset from the start of the frame  */
-#define   GMAC_ST2CW14_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW14) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW14_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW14) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW14_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW14) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW14_OFFSSTRT_FRAMESTART    (GMAC_ST2CW14_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the start of the frame Position  */
-#define GMAC_ST2CW14_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW14_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW14_OFFSSTRT_IP            (GMAC_ST2CW14_OFFSSTRT_IP_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW14_OFFSSTRT_TCP_UDP       (GMAC_ST2CW14_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW14_OFFSSTRT_Pos)  /**< (GMAC_ST2CW14) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW14_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW14) Register MASK  (Use GMAC_ST2CW14_Msk instead)  */
-#define GMAC_ST2CW14_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW14) Register Mask  */
-
-
-/* -------- GMAC_ST2CW05 : (GMAC Offset: 0x728) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 5) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW05_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW05_OFFSET                 (0x728)                                       /**<  (GMAC_ST2CW05) Screening Type 2 Compare Word 0 Register (index = 5)  Offset */
-
-#define GMAC_ST2CW05_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW05) Mask Value Position */
-#define GMAC_ST2CW05_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW05_MASKVAL_Pos)      /**< (GMAC_ST2CW05) Mask Value Mask */
-#define GMAC_ST2CW05_MASKVAL(value)         (GMAC_ST2CW05_MASKVAL_Msk & ((value) << GMAC_ST2CW05_MASKVAL_Pos))
-#define GMAC_ST2CW05_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW05) Compare Value Position */
-#define GMAC_ST2CW05_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW05_COMPVAL_Pos)      /**< (GMAC_ST2CW05) Compare Value Mask */
-#define GMAC_ST2CW05_COMPVAL(value)         (GMAC_ST2CW05_COMPVAL_Msk & ((value) << GMAC_ST2CW05_COMPVAL_Pos))
-#define GMAC_ST2CW05_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW05) Register Mask  */
-
-
-/* -------- GMAC_ST2CW15 : (GMAC Offset: 0x72c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 5) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW15_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW15_OFFSET                 (0x72C)                                       /**<  (GMAC_ST2CW15) Screening Type 2 Compare Word 1 Register (index = 5)  Offset */
-
-#define GMAC_ST2CW15_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW15) Offset Value in Bytes Position */
-#define GMAC_ST2CW15_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW15_OFFSVAL_Pos)        /**< (GMAC_ST2CW15) Offset Value in Bytes Mask */
-#define GMAC_ST2CW15_OFFSVAL(value)         (GMAC_ST2CW15_OFFSVAL_Msk & ((value) << GMAC_ST2CW15_OFFSVAL_Pos))
-#define GMAC_ST2CW15_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW15) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW15_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW15_OFFSSTRT_Pos)        /**< (GMAC_ST2CW15) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW15_OFFSSTRT(value)        (GMAC_ST2CW15_OFFSSTRT_Msk & ((value) << GMAC_ST2CW15_OFFSSTRT_Pos))
-#define   GMAC_ST2CW15_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW15) Offset from the start of the frame  */
-#define   GMAC_ST2CW15_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW15) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW15_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW15) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW15_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW15) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW15_OFFSSTRT_FRAMESTART    (GMAC_ST2CW15_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the start of the frame Position  */
-#define GMAC_ST2CW15_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW15_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW15_OFFSSTRT_IP            (GMAC_ST2CW15_OFFSSTRT_IP_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW15_OFFSSTRT_TCP_UDP       (GMAC_ST2CW15_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW15_OFFSSTRT_Pos)  /**< (GMAC_ST2CW15) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW15_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW15) Register MASK  (Use GMAC_ST2CW15_Msk instead)  */
-#define GMAC_ST2CW15_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW15) Register Mask  */
-
-
-/* -------- GMAC_ST2CW06 : (GMAC Offset: 0x730) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 6) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW06_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW06_OFFSET                 (0x730)                                       /**<  (GMAC_ST2CW06) Screening Type 2 Compare Word 0 Register (index = 6)  Offset */
-
-#define GMAC_ST2CW06_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW06) Mask Value Position */
-#define GMAC_ST2CW06_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW06_MASKVAL_Pos)      /**< (GMAC_ST2CW06) Mask Value Mask */
-#define GMAC_ST2CW06_MASKVAL(value)         (GMAC_ST2CW06_MASKVAL_Msk & ((value) << GMAC_ST2CW06_MASKVAL_Pos))
-#define GMAC_ST2CW06_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW06) Compare Value Position */
-#define GMAC_ST2CW06_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW06_COMPVAL_Pos)      /**< (GMAC_ST2CW06) Compare Value Mask */
-#define GMAC_ST2CW06_COMPVAL(value)         (GMAC_ST2CW06_COMPVAL_Msk & ((value) << GMAC_ST2CW06_COMPVAL_Pos))
-#define GMAC_ST2CW06_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW06) Register Mask  */
-
-
-/* -------- GMAC_ST2CW16 : (GMAC Offset: 0x734) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 6) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW16_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW16_OFFSET                 (0x734)                                       /**<  (GMAC_ST2CW16) Screening Type 2 Compare Word 1 Register (index = 6)  Offset */
-
-#define GMAC_ST2CW16_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW16) Offset Value in Bytes Position */
-#define GMAC_ST2CW16_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW16_OFFSVAL_Pos)        /**< (GMAC_ST2CW16) Offset Value in Bytes Mask */
-#define GMAC_ST2CW16_OFFSVAL(value)         (GMAC_ST2CW16_OFFSVAL_Msk & ((value) << GMAC_ST2CW16_OFFSVAL_Pos))
-#define GMAC_ST2CW16_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW16) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW16_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW16_OFFSSTRT_Pos)        /**< (GMAC_ST2CW16) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW16_OFFSSTRT(value)        (GMAC_ST2CW16_OFFSSTRT_Msk & ((value) << GMAC_ST2CW16_OFFSSTRT_Pos))
-#define   GMAC_ST2CW16_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW16) Offset from the start of the frame  */
-#define   GMAC_ST2CW16_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW16) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW16_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW16) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW16_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW16) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW16_OFFSSTRT_FRAMESTART    (GMAC_ST2CW16_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the start of the frame Position  */
-#define GMAC_ST2CW16_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW16_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW16_OFFSSTRT_IP            (GMAC_ST2CW16_OFFSSTRT_IP_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW16_OFFSSTRT_TCP_UDP       (GMAC_ST2CW16_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW16_OFFSSTRT_Pos)  /**< (GMAC_ST2CW16) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW16_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW16) Register MASK  (Use GMAC_ST2CW16_Msk instead)  */
-#define GMAC_ST2CW16_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW16) Register Mask  */
-
-
-/* -------- GMAC_ST2CW07 : (GMAC Offset: 0x738) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 7) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW07_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW07_OFFSET                 (0x738)                                       /**<  (GMAC_ST2CW07) Screening Type 2 Compare Word 0 Register (index = 7)  Offset */
-
-#define GMAC_ST2CW07_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW07) Mask Value Position */
-#define GMAC_ST2CW07_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW07_MASKVAL_Pos)      /**< (GMAC_ST2CW07) Mask Value Mask */
-#define GMAC_ST2CW07_MASKVAL(value)         (GMAC_ST2CW07_MASKVAL_Msk & ((value) << GMAC_ST2CW07_MASKVAL_Pos))
-#define GMAC_ST2CW07_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW07) Compare Value Position */
-#define GMAC_ST2CW07_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW07_COMPVAL_Pos)      /**< (GMAC_ST2CW07) Compare Value Mask */
-#define GMAC_ST2CW07_COMPVAL(value)         (GMAC_ST2CW07_COMPVAL_Msk & ((value) << GMAC_ST2CW07_COMPVAL_Pos))
-#define GMAC_ST2CW07_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW07) Register Mask  */
-
-
-/* -------- GMAC_ST2CW17 : (GMAC Offset: 0x73c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 7) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW17_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW17_OFFSET                 (0x73C)                                       /**<  (GMAC_ST2CW17) Screening Type 2 Compare Word 1 Register (index = 7)  Offset */
-
-#define GMAC_ST2CW17_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW17) Offset Value in Bytes Position */
-#define GMAC_ST2CW17_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW17_OFFSVAL_Pos)        /**< (GMAC_ST2CW17) Offset Value in Bytes Mask */
-#define GMAC_ST2CW17_OFFSVAL(value)         (GMAC_ST2CW17_OFFSVAL_Msk & ((value) << GMAC_ST2CW17_OFFSVAL_Pos))
-#define GMAC_ST2CW17_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW17) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW17_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW17_OFFSSTRT_Pos)        /**< (GMAC_ST2CW17) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW17_OFFSSTRT(value)        (GMAC_ST2CW17_OFFSSTRT_Msk & ((value) << GMAC_ST2CW17_OFFSSTRT_Pos))
-#define   GMAC_ST2CW17_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW17) Offset from the start of the frame  */
-#define   GMAC_ST2CW17_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW17) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW17_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW17) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW17_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW17) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW17_OFFSSTRT_FRAMESTART    (GMAC_ST2CW17_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the start of the frame Position  */
-#define GMAC_ST2CW17_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW17_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW17_OFFSSTRT_IP            (GMAC_ST2CW17_OFFSSTRT_IP_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW17_OFFSSTRT_TCP_UDP       (GMAC_ST2CW17_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW17_OFFSSTRT_Pos)  /**< (GMAC_ST2CW17) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW17_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW17) Register MASK  (Use GMAC_ST2CW17_Msk instead)  */
-#define GMAC_ST2CW17_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW17) Register Mask  */
-
-
-/* -------- GMAC_ST2CW08 : (GMAC Offset: 0x740) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 8) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW08_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW08_OFFSET                 (0x740)                                       /**<  (GMAC_ST2CW08) Screening Type 2 Compare Word 0 Register (index = 8)  Offset */
-
-#define GMAC_ST2CW08_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW08) Mask Value Position */
-#define GMAC_ST2CW08_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW08_MASKVAL_Pos)      /**< (GMAC_ST2CW08) Mask Value Mask */
-#define GMAC_ST2CW08_MASKVAL(value)         (GMAC_ST2CW08_MASKVAL_Msk & ((value) << GMAC_ST2CW08_MASKVAL_Pos))
-#define GMAC_ST2CW08_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW08) Compare Value Position */
-#define GMAC_ST2CW08_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW08_COMPVAL_Pos)      /**< (GMAC_ST2CW08) Compare Value Mask */
-#define GMAC_ST2CW08_COMPVAL(value)         (GMAC_ST2CW08_COMPVAL_Msk & ((value) << GMAC_ST2CW08_COMPVAL_Pos))
-#define GMAC_ST2CW08_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW08) Register Mask  */
-
-
-/* -------- GMAC_ST2CW18 : (GMAC Offset: 0x744) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 8) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW18_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW18_OFFSET                 (0x744)                                       /**<  (GMAC_ST2CW18) Screening Type 2 Compare Word 1 Register (index = 8)  Offset */
-
-#define GMAC_ST2CW18_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW18) Offset Value in Bytes Position */
-#define GMAC_ST2CW18_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW18_OFFSVAL_Pos)        /**< (GMAC_ST2CW18) Offset Value in Bytes Mask */
-#define GMAC_ST2CW18_OFFSVAL(value)         (GMAC_ST2CW18_OFFSVAL_Msk & ((value) << GMAC_ST2CW18_OFFSVAL_Pos))
-#define GMAC_ST2CW18_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW18) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW18_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW18_OFFSSTRT_Pos)        /**< (GMAC_ST2CW18) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW18_OFFSSTRT(value)        (GMAC_ST2CW18_OFFSSTRT_Msk & ((value) << GMAC_ST2CW18_OFFSSTRT_Pos))
-#define   GMAC_ST2CW18_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW18) Offset from the start of the frame  */
-#define   GMAC_ST2CW18_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW18) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW18_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW18) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW18_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW18) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW18_OFFSSTRT_FRAMESTART    (GMAC_ST2CW18_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the start of the frame Position  */
-#define GMAC_ST2CW18_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW18_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW18_OFFSSTRT_IP            (GMAC_ST2CW18_OFFSSTRT_IP_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW18_OFFSSTRT_TCP_UDP       (GMAC_ST2CW18_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW18_OFFSSTRT_Pos)  /**< (GMAC_ST2CW18) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW18_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW18) Register MASK  (Use GMAC_ST2CW18_Msk instead)  */
-#define GMAC_ST2CW18_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW18) Register Mask  */
-
-
-/* -------- GMAC_ST2CW09 : (GMAC Offset: 0x748) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 9) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW09_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW09_OFFSET                 (0x748)                                       /**<  (GMAC_ST2CW09) Screening Type 2 Compare Word 0 Register (index = 9)  Offset */
-
-#define GMAC_ST2CW09_MASKVAL_Pos            0                                              /**< (GMAC_ST2CW09) Mask Value Position */
-#define GMAC_ST2CW09_MASKVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW09_MASKVAL_Pos)      /**< (GMAC_ST2CW09) Mask Value Mask */
-#define GMAC_ST2CW09_MASKVAL(value)         (GMAC_ST2CW09_MASKVAL_Msk & ((value) << GMAC_ST2CW09_MASKVAL_Pos))
-#define GMAC_ST2CW09_COMPVAL_Pos            16                                             /**< (GMAC_ST2CW09) Compare Value Position */
-#define GMAC_ST2CW09_COMPVAL_Msk            (_U_(0xFFFF) << GMAC_ST2CW09_COMPVAL_Pos)      /**< (GMAC_ST2CW09) Compare Value Mask */
-#define GMAC_ST2CW09_COMPVAL(value)         (GMAC_ST2CW09_COMPVAL_Msk & ((value) << GMAC_ST2CW09_COMPVAL_Pos))
-#define GMAC_ST2CW09_Msk                    _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW09) Register Mask  */
-
-
-/* -------- GMAC_ST2CW19 : (GMAC Offset: 0x74c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 9) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW19_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW19_OFFSET                 (0x74C)                                       /**<  (GMAC_ST2CW19) Screening Type 2 Compare Word 1 Register (index = 9)  Offset */
-
-#define GMAC_ST2CW19_OFFSVAL_Pos            0                                              /**< (GMAC_ST2CW19) Offset Value in Bytes Position */
-#define GMAC_ST2CW19_OFFSVAL_Msk            (_U_(0x7F) << GMAC_ST2CW19_OFFSVAL_Pos)        /**< (GMAC_ST2CW19) Offset Value in Bytes Mask */
-#define GMAC_ST2CW19_OFFSVAL(value)         (GMAC_ST2CW19_OFFSVAL_Msk & ((value) << GMAC_ST2CW19_OFFSVAL_Pos))
-#define GMAC_ST2CW19_OFFSSTRT_Pos           7                                              /**< (GMAC_ST2CW19) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW19_OFFSSTRT_Msk           (_U_(0x3) << GMAC_ST2CW19_OFFSSTRT_Pos)        /**< (GMAC_ST2CW19) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW19_OFFSSTRT(value)        (GMAC_ST2CW19_OFFSSTRT_Msk & ((value) << GMAC_ST2CW19_OFFSSTRT_Pos))
-#define   GMAC_ST2CW19_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW19) Offset from the start of the frame  */
-#define   GMAC_ST2CW19_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW19) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW19_OFFSSTRT_IP_Val      _U_(0x2)                                       /**< (GMAC_ST2CW19) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW19_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW19) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW19_OFFSSTRT_FRAMESTART    (GMAC_ST2CW19_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the start of the frame Position  */
-#define GMAC_ST2CW19_OFFSSTRT_ETHERTYPE     (GMAC_ST2CW19_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW19_OFFSSTRT_IP            (GMAC_ST2CW19_OFFSSTRT_IP_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW19_OFFSSTRT_TCP_UDP       (GMAC_ST2CW19_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW19_OFFSSTRT_Pos)  /**< (GMAC_ST2CW19) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW19_MASK                   _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW19) Register MASK  (Use GMAC_ST2CW19_Msk instead)  */
-#define GMAC_ST2CW19_Msk                    _U_(0x1FF)                                     /**< (GMAC_ST2CW19) Register Mask  */
-
-
-/* -------- GMAC_ST2CW010 : (GMAC Offset: 0x750) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 10) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW010_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW010_OFFSET                (0x750)                                       /**<  (GMAC_ST2CW010) Screening Type 2 Compare Word 0 Register (index = 10)  Offset */
-
-#define GMAC_ST2CW010_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW010) Mask Value Position */
-#define GMAC_ST2CW010_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW010_MASKVAL_Pos)     /**< (GMAC_ST2CW010) Mask Value Mask */
-#define GMAC_ST2CW010_MASKVAL(value)        (GMAC_ST2CW010_MASKVAL_Msk & ((value) << GMAC_ST2CW010_MASKVAL_Pos))
-#define GMAC_ST2CW010_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW010) Compare Value Position */
-#define GMAC_ST2CW010_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW010_COMPVAL_Pos)     /**< (GMAC_ST2CW010) Compare Value Mask */
-#define GMAC_ST2CW010_COMPVAL(value)        (GMAC_ST2CW010_COMPVAL_Msk & ((value) << GMAC_ST2CW010_COMPVAL_Pos))
-#define GMAC_ST2CW010_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW010) Register Mask  */
-
-
-/* -------- GMAC_ST2CW110 : (GMAC Offset: 0x754) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 10) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW110_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW110_OFFSET                (0x754)                                       /**<  (GMAC_ST2CW110) Screening Type 2 Compare Word 1 Register (index = 10)  Offset */
-
-#define GMAC_ST2CW110_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW110) Offset Value in Bytes Position */
-#define GMAC_ST2CW110_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW110_OFFSVAL_Pos)       /**< (GMAC_ST2CW110) Offset Value in Bytes Mask */
-#define GMAC_ST2CW110_OFFSVAL(value)        (GMAC_ST2CW110_OFFSVAL_Msk & ((value) << GMAC_ST2CW110_OFFSVAL_Pos))
-#define GMAC_ST2CW110_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW110) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW110_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW110_OFFSSTRT_Pos)       /**< (GMAC_ST2CW110) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW110_OFFSSTRT(value)       (GMAC_ST2CW110_OFFSSTRT_Msk & ((value) << GMAC_ST2CW110_OFFSSTRT_Pos))
-#define   GMAC_ST2CW110_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW110) Offset from the start of the frame  */
-#define   GMAC_ST2CW110_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW110) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW110_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW110) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW110_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW110) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW110_OFFSSTRT_FRAMESTART   (GMAC_ST2CW110_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the start of the frame Position  */
-#define GMAC_ST2CW110_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW110_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW110_OFFSSTRT_IP           (GMAC_ST2CW110_OFFSSTRT_IP_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW110_OFFSSTRT_TCP_UDP      (GMAC_ST2CW110_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW110_OFFSSTRT_Pos)  /**< (GMAC_ST2CW110) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW110_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW110) Register MASK  (Use GMAC_ST2CW110_Msk instead)  */
-#define GMAC_ST2CW110_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW110) Register Mask  */
-
-
-/* -------- GMAC_ST2CW011 : (GMAC Offset: 0x758) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 11) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW011_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW011_OFFSET                (0x758)                                       /**<  (GMAC_ST2CW011) Screening Type 2 Compare Word 0 Register (index = 11)  Offset */
-
-#define GMAC_ST2CW011_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW011) Mask Value Position */
-#define GMAC_ST2CW011_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW011_MASKVAL_Pos)     /**< (GMAC_ST2CW011) Mask Value Mask */
-#define GMAC_ST2CW011_MASKVAL(value)        (GMAC_ST2CW011_MASKVAL_Msk & ((value) << GMAC_ST2CW011_MASKVAL_Pos))
-#define GMAC_ST2CW011_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW011) Compare Value Position */
-#define GMAC_ST2CW011_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW011_COMPVAL_Pos)     /**< (GMAC_ST2CW011) Compare Value Mask */
-#define GMAC_ST2CW011_COMPVAL(value)        (GMAC_ST2CW011_COMPVAL_Msk & ((value) << GMAC_ST2CW011_COMPVAL_Pos))
-#define GMAC_ST2CW011_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW011) Register Mask  */
-
-
-/* -------- GMAC_ST2CW111 : (GMAC Offset: 0x75c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 11) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW111_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW111_OFFSET                (0x75C)                                       /**<  (GMAC_ST2CW111) Screening Type 2 Compare Word 1 Register (index = 11)  Offset */
-
-#define GMAC_ST2CW111_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW111) Offset Value in Bytes Position */
-#define GMAC_ST2CW111_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW111_OFFSVAL_Pos)       /**< (GMAC_ST2CW111) Offset Value in Bytes Mask */
-#define GMAC_ST2CW111_OFFSVAL(value)        (GMAC_ST2CW111_OFFSVAL_Msk & ((value) << GMAC_ST2CW111_OFFSVAL_Pos))
-#define GMAC_ST2CW111_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW111) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW111_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW111_OFFSSTRT_Pos)       /**< (GMAC_ST2CW111) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW111_OFFSSTRT(value)       (GMAC_ST2CW111_OFFSSTRT_Msk & ((value) << GMAC_ST2CW111_OFFSSTRT_Pos))
-#define   GMAC_ST2CW111_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW111) Offset from the start of the frame  */
-#define   GMAC_ST2CW111_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW111) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW111_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW111) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW111_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW111) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW111_OFFSSTRT_FRAMESTART   (GMAC_ST2CW111_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the start of the frame Position  */
-#define GMAC_ST2CW111_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW111_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW111_OFFSSTRT_IP           (GMAC_ST2CW111_OFFSSTRT_IP_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW111_OFFSSTRT_TCP_UDP      (GMAC_ST2CW111_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW111_OFFSSTRT_Pos)  /**< (GMAC_ST2CW111) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW111_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW111) Register MASK  (Use GMAC_ST2CW111_Msk instead)  */
-#define GMAC_ST2CW111_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW111) Register Mask  */
-
-
-/* -------- GMAC_ST2CW012 : (GMAC Offset: 0x760) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 12) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW012_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW012_OFFSET                (0x760)                                       /**<  (GMAC_ST2CW012) Screening Type 2 Compare Word 0 Register (index = 12)  Offset */
-
-#define GMAC_ST2CW012_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW012) Mask Value Position */
-#define GMAC_ST2CW012_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW012_MASKVAL_Pos)     /**< (GMAC_ST2CW012) Mask Value Mask */
-#define GMAC_ST2CW012_MASKVAL(value)        (GMAC_ST2CW012_MASKVAL_Msk & ((value) << GMAC_ST2CW012_MASKVAL_Pos))
-#define GMAC_ST2CW012_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW012) Compare Value Position */
-#define GMAC_ST2CW012_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW012_COMPVAL_Pos)     /**< (GMAC_ST2CW012) Compare Value Mask */
-#define GMAC_ST2CW012_COMPVAL(value)        (GMAC_ST2CW012_COMPVAL_Msk & ((value) << GMAC_ST2CW012_COMPVAL_Pos))
-#define GMAC_ST2CW012_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW012) Register Mask  */
-
-
-/* -------- GMAC_ST2CW112 : (GMAC Offset: 0x764) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 12) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW112_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW112_OFFSET                (0x764)                                       /**<  (GMAC_ST2CW112) Screening Type 2 Compare Word 1 Register (index = 12)  Offset */
-
-#define GMAC_ST2CW112_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW112) Offset Value in Bytes Position */
-#define GMAC_ST2CW112_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW112_OFFSVAL_Pos)       /**< (GMAC_ST2CW112) Offset Value in Bytes Mask */
-#define GMAC_ST2CW112_OFFSVAL(value)        (GMAC_ST2CW112_OFFSVAL_Msk & ((value) << GMAC_ST2CW112_OFFSVAL_Pos))
-#define GMAC_ST2CW112_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW112) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW112_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW112_OFFSSTRT_Pos)       /**< (GMAC_ST2CW112) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW112_OFFSSTRT(value)       (GMAC_ST2CW112_OFFSSTRT_Msk & ((value) << GMAC_ST2CW112_OFFSSTRT_Pos))
-#define   GMAC_ST2CW112_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW112) Offset from the start of the frame  */
-#define   GMAC_ST2CW112_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW112) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW112_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW112) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW112_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW112) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW112_OFFSSTRT_FRAMESTART   (GMAC_ST2CW112_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the start of the frame Position  */
-#define GMAC_ST2CW112_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW112_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW112_OFFSSTRT_IP           (GMAC_ST2CW112_OFFSSTRT_IP_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW112_OFFSSTRT_TCP_UDP      (GMAC_ST2CW112_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW112_OFFSSTRT_Pos)  /**< (GMAC_ST2CW112) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW112_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW112) Register MASK  (Use GMAC_ST2CW112_Msk instead)  */
-#define GMAC_ST2CW112_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW112) Register Mask  */
-
-
-/* -------- GMAC_ST2CW013 : (GMAC Offset: 0x768) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 13) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW013_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW013_OFFSET                (0x768)                                       /**<  (GMAC_ST2CW013) Screening Type 2 Compare Word 0 Register (index = 13)  Offset */
-
-#define GMAC_ST2CW013_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW013) Mask Value Position */
-#define GMAC_ST2CW013_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW013_MASKVAL_Pos)     /**< (GMAC_ST2CW013) Mask Value Mask */
-#define GMAC_ST2CW013_MASKVAL(value)        (GMAC_ST2CW013_MASKVAL_Msk & ((value) << GMAC_ST2CW013_MASKVAL_Pos))
-#define GMAC_ST2CW013_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW013) Compare Value Position */
-#define GMAC_ST2CW013_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW013_COMPVAL_Pos)     /**< (GMAC_ST2CW013) Compare Value Mask */
-#define GMAC_ST2CW013_COMPVAL(value)        (GMAC_ST2CW013_COMPVAL_Msk & ((value) << GMAC_ST2CW013_COMPVAL_Pos))
-#define GMAC_ST2CW013_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW013) Register Mask  */
-
-
-/* -------- GMAC_ST2CW113 : (GMAC Offset: 0x76c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 13) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW113_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW113_OFFSET                (0x76C)                                       /**<  (GMAC_ST2CW113) Screening Type 2 Compare Word 1 Register (index = 13)  Offset */
-
-#define GMAC_ST2CW113_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW113) Offset Value in Bytes Position */
-#define GMAC_ST2CW113_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW113_OFFSVAL_Pos)       /**< (GMAC_ST2CW113) Offset Value in Bytes Mask */
-#define GMAC_ST2CW113_OFFSVAL(value)        (GMAC_ST2CW113_OFFSVAL_Msk & ((value) << GMAC_ST2CW113_OFFSVAL_Pos))
-#define GMAC_ST2CW113_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW113) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW113_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW113_OFFSSTRT_Pos)       /**< (GMAC_ST2CW113) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW113_OFFSSTRT(value)       (GMAC_ST2CW113_OFFSSTRT_Msk & ((value) << GMAC_ST2CW113_OFFSSTRT_Pos))
-#define   GMAC_ST2CW113_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW113) Offset from the start of the frame  */
-#define   GMAC_ST2CW113_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW113) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW113_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW113) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW113_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW113) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW113_OFFSSTRT_FRAMESTART   (GMAC_ST2CW113_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the start of the frame Position  */
-#define GMAC_ST2CW113_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW113_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW113_OFFSSTRT_IP           (GMAC_ST2CW113_OFFSSTRT_IP_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW113_OFFSSTRT_TCP_UDP      (GMAC_ST2CW113_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW113_OFFSSTRT_Pos)  /**< (GMAC_ST2CW113) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW113_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW113) Register MASK  (Use GMAC_ST2CW113_Msk instead)  */
-#define GMAC_ST2CW113_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW113) Register Mask  */
-
-
-/* -------- GMAC_ST2CW014 : (GMAC Offset: 0x770) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 14) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW014_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW014_OFFSET                (0x770)                                       /**<  (GMAC_ST2CW014) Screening Type 2 Compare Word 0 Register (index = 14)  Offset */
-
-#define GMAC_ST2CW014_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW014) Mask Value Position */
-#define GMAC_ST2CW014_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW014_MASKVAL_Pos)     /**< (GMAC_ST2CW014) Mask Value Mask */
-#define GMAC_ST2CW014_MASKVAL(value)        (GMAC_ST2CW014_MASKVAL_Msk & ((value) << GMAC_ST2CW014_MASKVAL_Pos))
-#define GMAC_ST2CW014_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW014) Compare Value Position */
-#define GMAC_ST2CW014_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW014_COMPVAL_Pos)     /**< (GMAC_ST2CW014) Compare Value Mask */
-#define GMAC_ST2CW014_COMPVAL(value)        (GMAC_ST2CW014_COMPVAL_Msk & ((value) << GMAC_ST2CW014_COMPVAL_Pos))
-#define GMAC_ST2CW014_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW014) Register Mask  */
-
-
-/* -------- GMAC_ST2CW114 : (GMAC Offset: 0x774) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 14) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW114_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW114_OFFSET                (0x774)                                       /**<  (GMAC_ST2CW114) Screening Type 2 Compare Word 1 Register (index = 14)  Offset */
-
-#define GMAC_ST2CW114_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW114) Offset Value in Bytes Position */
-#define GMAC_ST2CW114_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW114_OFFSVAL_Pos)       /**< (GMAC_ST2CW114) Offset Value in Bytes Mask */
-#define GMAC_ST2CW114_OFFSVAL(value)        (GMAC_ST2CW114_OFFSVAL_Msk & ((value) << GMAC_ST2CW114_OFFSVAL_Pos))
-#define GMAC_ST2CW114_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW114) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW114_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW114_OFFSSTRT_Pos)       /**< (GMAC_ST2CW114) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW114_OFFSSTRT(value)       (GMAC_ST2CW114_OFFSSTRT_Msk & ((value) << GMAC_ST2CW114_OFFSSTRT_Pos))
-#define   GMAC_ST2CW114_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW114) Offset from the start of the frame  */
-#define   GMAC_ST2CW114_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW114) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW114_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW114) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW114_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW114) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW114_OFFSSTRT_FRAMESTART   (GMAC_ST2CW114_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the start of the frame Position  */
-#define GMAC_ST2CW114_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW114_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW114_OFFSSTRT_IP           (GMAC_ST2CW114_OFFSSTRT_IP_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW114_OFFSSTRT_TCP_UDP      (GMAC_ST2CW114_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW114_OFFSSTRT_Pos)  /**< (GMAC_ST2CW114) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW114_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW114) Register MASK  (Use GMAC_ST2CW114_Msk instead)  */
-#define GMAC_ST2CW114_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW114) Register Mask  */
-
-
-/* -------- GMAC_ST2CW015 : (GMAC Offset: 0x778) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 15) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW015_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW015_OFFSET                (0x778)                                       /**<  (GMAC_ST2CW015) Screening Type 2 Compare Word 0 Register (index = 15)  Offset */
-
-#define GMAC_ST2CW015_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW015) Mask Value Position */
-#define GMAC_ST2CW015_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW015_MASKVAL_Pos)     /**< (GMAC_ST2CW015) Mask Value Mask */
-#define GMAC_ST2CW015_MASKVAL(value)        (GMAC_ST2CW015_MASKVAL_Msk & ((value) << GMAC_ST2CW015_MASKVAL_Pos))
-#define GMAC_ST2CW015_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW015) Compare Value Position */
-#define GMAC_ST2CW015_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW015_COMPVAL_Pos)     /**< (GMAC_ST2CW015) Compare Value Mask */
-#define GMAC_ST2CW015_COMPVAL(value)        (GMAC_ST2CW015_COMPVAL_Msk & ((value) << GMAC_ST2CW015_COMPVAL_Pos))
-#define GMAC_ST2CW015_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW015) Register Mask  */
-
-
-/* -------- GMAC_ST2CW115 : (GMAC Offset: 0x77c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 15) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW115_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW115_OFFSET                (0x77C)                                       /**<  (GMAC_ST2CW115) Screening Type 2 Compare Word 1 Register (index = 15)  Offset */
-
-#define GMAC_ST2CW115_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW115) Offset Value in Bytes Position */
-#define GMAC_ST2CW115_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW115_OFFSVAL_Pos)       /**< (GMAC_ST2CW115) Offset Value in Bytes Mask */
-#define GMAC_ST2CW115_OFFSVAL(value)        (GMAC_ST2CW115_OFFSVAL_Msk & ((value) << GMAC_ST2CW115_OFFSVAL_Pos))
-#define GMAC_ST2CW115_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW115) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW115_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW115_OFFSSTRT_Pos)       /**< (GMAC_ST2CW115) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW115_OFFSSTRT(value)       (GMAC_ST2CW115_OFFSSTRT_Msk & ((value) << GMAC_ST2CW115_OFFSSTRT_Pos))
-#define   GMAC_ST2CW115_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW115) Offset from the start of the frame  */
-#define   GMAC_ST2CW115_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW115) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW115_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW115) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW115_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW115) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW115_OFFSSTRT_FRAMESTART   (GMAC_ST2CW115_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the start of the frame Position  */
-#define GMAC_ST2CW115_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW115_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW115_OFFSSTRT_IP           (GMAC_ST2CW115_OFFSSTRT_IP_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW115_OFFSSTRT_TCP_UDP      (GMAC_ST2CW115_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW115_OFFSSTRT_Pos)  /**< (GMAC_ST2CW115) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW115_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW115) Register MASK  (Use GMAC_ST2CW115_Msk instead)  */
-#define GMAC_ST2CW115_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW115) Register Mask  */
-
-
-/* -------- GMAC_ST2CW016 : (GMAC Offset: 0x780) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 16) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW016_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW016_OFFSET                (0x780)                                       /**<  (GMAC_ST2CW016) Screening Type 2 Compare Word 0 Register (index = 16)  Offset */
-
-#define GMAC_ST2CW016_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW016) Mask Value Position */
-#define GMAC_ST2CW016_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW016_MASKVAL_Pos)     /**< (GMAC_ST2CW016) Mask Value Mask */
-#define GMAC_ST2CW016_MASKVAL(value)        (GMAC_ST2CW016_MASKVAL_Msk & ((value) << GMAC_ST2CW016_MASKVAL_Pos))
-#define GMAC_ST2CW016_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW016) Compare Value Position */
-#define GMAC_ST2CW016_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW016_COMPVAL_Pos)     /**< (GMAC_ST2CW016) Compare Value Mask */
-#define GMAC_ST2CW016_COMPVAL(value)        (GMAC_ST2CW016_COMPVAL_Msk & ((value) << GMAC_ST2CW016_COMPVAL_Pos))
-#define GMAC_ST2CW016_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW016) Register Mask  */
-
-
-/* -------- GMAC_ST2CW116 : (GMAC Offset: 0x784) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 16) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW116_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW116_OFFSET                (0x784)                                       /**<  (GMAC_ST2CW116) Screening Type 2 Compare Word 1 Register (index = 16)  Offset */
-
-#define GMAC_ST2CW116_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW116) Offset Value in Bytes Position */
-#define GMAC_ST2CW116_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW116_OFFSVAL_Pos)       /**< (GMAC_ST2CW116) Offset Value in Bytes Mask */
-#define GMAC_ST2CW116_OFFSVAL(value)        (GMAC_ST2CW116_OFFSVAL_Msk & ((value) << GMAC_ST2CW116_OFFSVAL_Pos))
-#define GMAC_ST2CW116_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW116) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW116_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW116_OFFSSTRT_Pos)       /**< (GMAC_ST2CW116) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW116_OFFSSTRT(value)       (GMAC_ST2CW116_OFFSSTRT_Msk & ((value) << GMAC_ST2CW116_OFFSSTRT_Pos))
-#define   GMAC_ST2CW116_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW116) Offset from the start of the frame  */
-#define   GMAC_ST2CW116_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW116) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW116_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW116) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW116_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW116) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW116_OFFSSTRT_FRAMESTART   (GMAC_ST2CW116_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the start of the frame Position  */
-#define GMAC_ST2CW116_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW116_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW116_OFFSSTRT_IP           (GMAC_ST2CW116_OFFSSTRT_IP_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW116_OFFSSTRT_TCP_UDP      (GMAC_ST2CW116_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW116_OFFSSTRT_Pos)  /**< (GMAC_ST2CW116) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW116_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW116) Register MASK  (Use GMAC_ST2CW116_Msk instead)  */
-#define GMAC_ST2CW116_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW116) Register Mask  */
-
-
-/* -------- GMAC_ST2CW017 : (GMAC Offset: 0x788) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 17) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW017_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW017_OFFSET                (0x788)                                       /**<  (GMAC_ST2CW017) Screening Type 2 Compare Word 0 Register (index = 17)  Offset */
-
-#define GMAC_ST2CW017_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW017) Mask Value Position */
-#define GMAC_ST2CW017_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW017_MASKVAL_Pos)     /**< (GMAC_ST2CW017) Mask Value Mask */
-#define GMAC_ST2CW017_MASKVAL(value)        (GMAC_ST2CW017_MASKVAL_Msk & ((value) << GMAC_ST2CW017_MASKVAL_Pos))
-#define GMAC_ST2CW017_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW017) Compare Value Position */
-#define GMAC_ST2CW017_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW017_COMPVAL_Pos)     /**< (GMAC_ST2CW017) Compare Value Mask */
-#define GMAC_ST2CW017_COMPVAL(value)        (GMAC_ST2CW017_COMPVAL_Msk & ((value) << GMAC_ST2CW017_COMPVAL_Pos))
-#define GMAC_ST2CW017_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW017) Register Mask  */
-
-
-/* -------- GMAC_ST2CW117 : (GMAC Offset: 0x78c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 17) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW117_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW117_OFFSET                (0x78C)                                       /**<  (GMAC_ST2CW117) Screening Type 2 Compare Word 1 Register (index = 17)  Offset */
-
-#define GMAC_ST2CW117_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW117) Offset Value in Bytes Position */
-#define GMAC_ST2CW117_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW117_OFFSVAL_Pos)       /**< (GMAC_ST2CW117) Offset Value in Bytes Mask */
-#define GMAC_ST2CW117_OFFSVAL(value)        (GMAC_ST2CW117_OFFSVAL_Msk & ((value) << GMAC_ST2CW117_OFFSVAL_Pos))
-#define GMAC_ST2CW117_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW117) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW117_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW117_OFFSSTRT_Pos)       /**< (GMAC_ST2CW117) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW117_OFFSSTRT(value)       (GMAC_ST2CW117_OFFSSTRT_Msk & ((value) << GMAC_ST2CW117_OFFSSTRT_Pos))
-#define   GMAC_ST2CW117_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW117) Offset from the start of the frame  */
-#define   GMAC_ST2CW117_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW117) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW117_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW117) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW117_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW117) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW117_OFFSSTRT_FRAMESTART   (GMAC_ST2CW117_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the start of the frame Position  */
-#define GMAC_ST2CW117_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW117_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW117_OFFSSTRT_IP           (GMAC_ST2CW117_OFFSSTRT_IP_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW117_OFFSSTRT_TCP_UDP      (GMAC_ST2CW117_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW117_OFFSSTRT_Pos)  /**< (GMAC_ST2CW117) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW117_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW117) Register MASK  (Use GMAC_ST2CW117_Msk instead)  */
-#define GMAC_ST2CW117_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW117) Register Mask  */
-
-
-/* -------- GMAC_ST2CW018 : (GMAC Offset: 0x790) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 18) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW018_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW018_OFFSET                (0x790)                                       /**<  (GMAC_ST2CW018) Screening Type 2 Compare Word 0 Register (index = 18)  Offset */
-
-#define GMAC_ST2CW018_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW018) Mask Value Position */
-#define GMAC_ST2CW018_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW018_MASKVAL_Pos)     /**< (GMAC_ST2CW018) Mask Value Mask */
-#define GMAC_ST2CW018_MASKVAL(value)        (GMAC_ST2CW018_MASKVAL_Msk & ((value) << GMAC_ST2CW018_MASKVAL_Pos))
-#define GMAC_ST2CW018_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW018) Compare Value Position */
-#define GMAC_ST2CW018_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW018_COMPVAL_Pos)     /**< (GMAC_ST2CW018) Compare Value Mask */
-#define GMAC_ST2CW018_COMPVAL(value)        (GMAC_ST2CW018_COMPVAL_Msk & ((value) << GMAC_ST2CW018_COMPVAL_Pos))
-#define GMAC_ST2CW018_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW018) Register Mask  */
-
-
-/* -------- GMAC_ST2CW118 : (GMAC Offset: 0x794) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 18) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW118_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW118_OFFSET                (0x794)                                       /**<  (GMAC_ST2CW118) Screening Type 2 Compare Word 1 Register (index = 18)  Offset */
-
-#define GMAC_ST2CW118_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW118) Offset Value in Bytes Position */
-#define GMAC_ST2CW118_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW118_OFFSVAL_Pos)       /**< (GMAC_ST2CW118) Offset Value in Bytes Mask */
-#define GMAC_ST2CW118_OFFSVAL(value)        (GMAC_ST2CW118_OFFSVAL_Msk & ((value) << GMAC_ST2CW118_OFFSVAL_Pos))
-#define GMAC_ST2CW118_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW118) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW118_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW118_OFFSSTRT_Pos)       /**< (GMAC_ST2CW118) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW118_OFFSSTRT(value)       (GMAC_ST2CW118_OFFSSTRT_Msk & ((value) << GMAC_ST2CW118_OFFSSTRT_Pos))
-#define   GMAC_ST2CW118_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW118) Offset from the start of the frame  */
-#define   GMAC_ST2CW118_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW118) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW118_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW118) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW118_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW118) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW118_OFFSSTRT_FRAMESTART   (GMAC_ST2CW118_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the start of the frame Position  */
-#define GMAC_ST2CW118_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW118_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW118_OFFSSTRT_IP           (GMAC_ST2CW118_OFFSSTRT_IP_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW118_OFFSSTRT_TCP_UDP      (GMAC_ST2CW118_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW118_OFFSSTRT_Pos)  /**< (GMAC_ST2CW118) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW118_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW118) Register MASK  (Use GMAC_ST2CW118_Msk instead)  */
-#define GMAC_ST2CW118_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW118) Register Mask  */
-
-
-/* -------- GMAC_ST2CW019 : (GMAC Offset: 0x798) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 19) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW019_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW019_OFFSET                (0x798)                                       /**<  (GMAC_ST2CW019) Screening Type 2 Compare Word 0 Register (index = 19)  Offset */
-
-#define GMAC_ST2CW019_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW019) Mask Value Position */
-#define GMAC_ST2CW019_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW019_MASKVAL_Pos)     /**< (GMAC_ST2CW019) Mask Value Mask */
-#define GMAC_ST2CW019_MASKVAL(value)        (GMAC_ST2CW019_MASKVAL_Msk & ((value) << GMAC_ST2CW019_MASKVAL_Pos))
-#define GMAC_ST2CW019_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW019) Compare Value Position */
-#define GMAC_ST2CW019_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW019_COMPVAL_Pos)     /**< (GMAC_ST2CW019) Compare Value Mask */
-#define GMAC_ST2CW019_COMPVAL(value)        (GMAC_ST2CW019_COMPVAL_Msk & ((value) << GMAC_ST2CW019_COMPVAL_Pos))
-#define GMAC_ST2CW019_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW019) Register Mask  */
-
-
-/* -------- GMAC_ST2CW119 : (GMAC Offset: 0x79c) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 19) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW119_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW119_OFFSET                (0x79C)                                       /**<  (GMAC_ST2CW119) Screening Type 2 Compare Word 1 Register (index = 19)  Offset */
-
-#define GMAC_ST2CW119_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW119) Offset Value in Bytes Position */
-#define GMAC_ST2CW119_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW119_OFFSVAL_Pos)       /**< (GMAC_ST2CW119) Offset Value in Bytes Mask */
-#define GMAC_ST2CW119_OFFSVAL(value)        (GMAC_ST2CW119_OFFSVAL_Msk & ((value) << GMAC_ST2CW119_OFFSVAL_Pos))
-#define GMAC_ST2CW119_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW119) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW119_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW119_OFFSSTRT_Pos)       /**< (GMAC_ST2CW119) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW119_OFFSSTRT(value)       (GMAC_ST2CW119_OFFSSTRT_Msk & ((value) << GMAC_ST2CW119_OFFSSTRT_Pos))
-#define   GMAC_ST2CW119_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW119) Offset from the start of the frame  */
-#define   GMAC_ST2CW119_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW119) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW119_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW119) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW119_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW119) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW119_OFFSSTRT_FRAMESTART   (GMAC_ST2CW119_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the start of the frame Position  */
-#define GMAC_ST2CW119_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW119_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW119_OFFSSTRT_IP           (GMAC_ST2CW119_OFFSSTRT_IP_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW119_OFFSSTRT_TCP_UDP      (GMAC_ST2CW119_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW119_OFFSSTRT_Pos)  /**< (GMAC_ST2CW119) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW119_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW119) Register MASK  (Use GMAC_ST2CW119_Msk instead)  */
-#define GMAC_ST2CW119_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW119) Register Mask  */
-
-
-/* -------- GMAC_ST2CW020 : (GMAC Offset: 0x7a0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 20) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW020_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW020_OFFSET                (0x7A0)                                       /**<  (GMAC_ST2CW020) Screening Type 2 Compare Word 0 Register (index = 20)  Offset */
-
-#define GMAC_ST2CW020_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW020) Mask Value Position */
-#define GMAC_ST2CW020_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW020_MASKVAL_Pos)     /**< (GMAC_ST2CW020) Mask Value Mask */
-#define GMAC_ST2CW020_MASKVAL(value)        (GMAC_ST2CW020_MASKVAL_Msk & ((value) << GMAC_ST2CW020_MASKVAL_Pos))
-#define GMAC_ST2CW020_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW020) Compare Value Position */
-#define GMAC_ST2CW020_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW020_COMPVAL_Pos)     /**< (GMAC_ST2CW020) Compare Value Mask */
-#define GMAC_ST2CW020_COMPVAL(value)        (GMAC_ST2CW020_COMPVAL_Msk & ((value) << GMAC_ST2CW020_COMPVAL_Pos))
-#define GMAC_ST2CW020_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW020) Register Mask  */
-
-
-/* -------- GMAC_ST2CW120 : (GMAC Offset: 0x7a4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 20) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW120_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW120_OFFSET                (0x7A4)                                       /**<  (GMAC_ST2CW120) Screening Type 2 Compare Word 1 Register (index = 20)  Offset */
-
-#define GMAC_ST2CW120_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW120) Offset Value in Bytes Position */
-#define GMAC_ST2CW120_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW120_OFFSVAL_Pos)       /**< (GMAC_ST2CW120) Offset Value in Bytes Mask */
-#define GMAC_ST2CW120_OFFSVAL(value)        (GMAC_ST2CW120_OFFSVAL_Msk & ((value) << GMAC_ST2CW120_OFFSVAL_Pos))
-#define GMAC_ST2CW120_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW120) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW120_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW120_OFFSSTRT_Pos)       /**< (GMAC_ST2CW120) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW120_OFFSSTRT(value)       (GMAC_ST2CW120_OFFSSTRT_Msk & ((value) << GMAC_ST2CW120_OFFSSTRT_Pos))
-#define   GMAC_ST2CW120_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW120) Offset from the start of the frame  */
-#define   GMAC_ST2CW120_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW120) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW120_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW120) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW120_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW120) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW120_OFFSSTRT_FRAMESTART   (GMAC_ST2CW120_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the start of the frame Position  */
-#define GMAC_ST2CW120_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW120_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW120_OFFSSTRT_IP           (GMAC_ST2CW120_OFFSSTRT_IP_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW120_OFFSSTRT_TCP_UDP      (GMAC_ST2CW120_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW120_OFFSSTRT_Pos)  /**< (GMAC_ST2CW120) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW120_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW120) Register MASK  (Use GMAC_ST2CW120_Msk instead)  */
-#define GMAC_ST2CW120_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW120) Register Mask  */
-
-
-/* -------- GMAC_ST2CW021 : (GMAC Offset: 0x7a8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 21) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW021_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW021_OFFSET                (0x7A8)                                       /**<  (GMAC_ST2CW021) Screening Type 2 Compare Word 0 Register (index = 21)  Offset */
-
-#define GMAC_ST2CW021_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW021) Mask Value Position */
-#define GMAC_ST2CW021_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW021_MASKVAL_Pos)     /**< (GMAC_ST2CW021) Mask Value Mask */
-#define GMAC_ST2CW021_MASKVAL(value)        (GMAC_ST2CW021_MASKVAL_Msk & ((value) << GMAC_ST2CW021_MASKVAL_Pos))
-#define GMAC_ST2CW021_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW021) Compare Value Position */
-#define GMAC_ST2CW021_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW021_COMPVAL_Pos)     /**< (GMAC_ST2CW021) Compare Value Mask */
-#define GMAC_ST2CW021_COMPVAL(value)        (GMAC_ST2CW021_COMPVAL_Msk & ((value) << GMAC_ST2CW021_COMPVAL_Pos))
-#define GMAC_ST2CW021_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW021) Register Mask  */
-
-
-/* -------- GMAC_ST2CW121 : (GMAC Offset: 0x7ac) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 21) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW121_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW121_OFFSET                (0x7AC)                                       /**<  (GMAC_ST2CW121) Screening Type 2 Compare Word 1 Register (index = 21)  Offset */
-
-#define GMAC_ST2CW121_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW121) Offset Value in Bytes Position */
-#define GMAC_ST2CW121_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW121_OFFSVAL_Pos)       /**< (GMAC_ST2CW121) Offset Value in Bytes Mask */
-#define GMAC_ST2CW121_OFFSVAL(value)        (GMAC_ST2CW121_OFFSVAL_Msk & ((value) << GMAC_ST2CW121_OFFSVAL_Pos))
-#define GMAC_ST2CW121_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW121) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW121_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW121_OFFSSTRT_Pos)       /**< (GMAC_ST2CW121) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW121_OFFSSTRT(value)       (GMAC_ST2CW121_OFFSSTRT_Msk & ((value) << GMAC_ST2CW121_OFFSSTRT_Pos))
-#define   GMAC_ST2CW121_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW121) Offset from the start of the frame  */
-#define   GMAC_ST2CW121_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW121) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW121_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW121) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW121_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW121) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW121_OFFSSTRT_FRAMESTART   (GMAC_ST2CW121_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the start of the frame Position  */
-#define GMAC_ST2CW121_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW121_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW121_OFFSSTRT_IP           (GMAC_ST2CW121_OFFSSTRT_IP_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW121_OFFSSTRT_TCP_UDP      (GMAC_ST2CW121_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW121_OFFSSTRT_Pos)  /**< (GMAC_ST2CW121) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW121_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW121) Register MASK  (Use GMAC_ST2CW121_Msk instead)  */
-#define GMAC_ST2CW121_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW121) Register Mask  */
-
-
-/* -------- GMAC_ST2CW022 : (GMAC Offset: 0x7b0) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 22) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW022_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW022_OFFSET                (0x7B0)                                       /**<  (GMAC_ST2CW022) Screening Type 2 Compare Word 0 Register (index = 22)  Offset */
-
-#define GMAC_ST2CW022_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW022) Mask Value Position */
-#define GMAC_ST2CW022_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW022_MASKVAL_Pos)     /**< (GMAC_ST2CW022) Mask Value Mask */
-#define GMAC_ST2CW022_MASKVAL(value)        (GMAC_ST2CW022_MASKVAL_Msk & ((value) << GMAC_ST2CW022_MASKVAL_Pos))
-#define GMAC_ST2CW022_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW022) Compare Value Position */
-#define GMAC_ST2CW022_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW022_COMPVAL_Pos)     /**< (GMAC_ST2CW022) Compare Value Mask */
-#define GMAC_ST2CW022_COMPVAL(value)        (GMAC_ST2CW022_COMPVAL_Msk & ((value) << GMAC_ST2CW022_COMPVAL_Pos))
-#define GMAC_ST2CW022_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW022) Register Mask  */
-
-
-/* -------- GMAC_ST2CW122 : (GMAC Offset: 0x7b4) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 22) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW122_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW122_OFFSET                (0x7B4)                                       /**<  (GMAC_ST2CW122) Screening Type 2 Compare Word 1 Register (index = 22)  Offset */
-
-#define GMAC_ST2CW122_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW122) Offset Value in Bytes Position */
-#define GMAC_ST2CW122_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW122_OFFSVAL_Pos)       /**< (GMAC_ST2CW122) Offset Value in Bytes Mask */
-#define GMAC_ST2CW122_OFFSVAL(value)        (GMAC_ST2CW122_OFFSVAL_Msk & ((value) << GMAC_ST2CW122_OFFSVAL_Pos))
-#define GMAC_ST2CW122_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW122) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW122_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW122_OFFSSTRT_Pos)       /**< (GMAC_ST2CW122) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW122_OFFSSTRT(value)       (GMAC_ST2CW122_OFFSSTRT_Msk & ((value) << GMAC_ST2CW122_OFFSSTRT_Pos))
-#define   GMAC_ST2CW122_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW122) Offset from the start of the frame  */
-#define   GMAC_ST2CW122_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW122) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW122_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW122) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW122_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW122) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW122_OFFSSTRT_FRAMESTART   (GMAC_ST2CW122_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the start of the frame Position  */
-#define GMAC_ST2CW122_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW122_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW122_OFFSSTRT_IP           (GMAC_ST2CW122_OFFSSTRT_IP_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW122_OFFSSTRT_TCP_UDP      (GMAC_ST2CW122_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW122_OFFSSTRT_Pos)  /**< (GMAC_ST2CW122) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW122_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW122) Register MASK  (Use GMAC_ST2CW122_Msk instead)  */
-#define GMAC_ST2CW122_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW122) Register Mask  */
-
-
-/* -------- GMAC_ST2CW023 : (GMAC Offset: 0x7b8) (R/W 32) Screening Type 2 Compare Word 0 Register (index = 23) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t MASKVAL:16;                /**< bit:  0..15  Mask Value                               */
-    uint32_t COMPVAL:16;                /**< bit: 16..31  Compare Value                            */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW023_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW023_OFFSET                (0x7B8)                                       /**<  (GMAC_ST2CW023) Screening Type 2 Compare Word 0 Register (index = 23)  Offset */
-
-#define GMAC_ST2CW023_MASKVAL_Pos           0                                              /**< (GMAC_ST2CW023) Mask Value Position */
-#define GMAC_ST2CW023_MASKVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW023_MASKVAL_Pos)     /**< (GMAC_ST2CW023) Mask Value Mask */
-#define GMAC_ST2CW023_MASKVAL(value)        (GMAC_ST2CW023_MASKVAL_Msk & ((value) << GMAC_ST2CW023_MASKVAL_Pos))
-#define GMAC_ST2CW023_COMPVAL_Pos           16                                             /**< (GMAC_ST2CW023) Compare Value Position */
-#define GMAC_ST2CW023_COMPVAL_Msk           (_U_(0xFFFF) << GMAC_ST2CW023_COMPVAL_Pos)     /**< (GMAC_ST2CW023) Compare Value Mask */
-#define GMAC_ST2CW023_COMPVAL(value)        (GMAC_ST2CW023_COMPVAL_Msk & ((value) << GMAC_ST2CW023_COMPVAL_Pos))
-#define GMAC_ST2CW023_Msk                   _U_(0xFFFFFFFF)                                /**< (GMAC_ST2CW023) Register Mask  */
-
-
-/* -------- GMAC_ST2CW123 : (GMAC Offset: 0x7bc) (R/W 32) Screening Type 2 Compare Word 1 Register (index = 23) -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t OFFSVAL:7;                 /**< bit:   0..6  Offset Value in Bytes                    */
-    uint32_t OFFSSTRT:2;                /**< bit:   7..8  Ethernet Frame Offset Start              */
-    uint32_t :23;                       /**< bit:  9..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} GMAC_ST2CW123_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define GMAC_ST2CW123_OFFSET                (0x7BC)                                       /**<  (GMAC_ST2CW123) Screening Type 2 Compare Word 1 Register (index = 23)  Offset */
-
-#define GMAC_ST2CW123_OFFSVAL_Pos           0                                              /**< (GMAC_ST2CW123) Offset Value in Bytes Position */
-#define GMAC_ST2CW123_OFFSVAL_Msk           (_U_(0x7F) << GMAC_ST2CW123_OFFSVAL_Pos)       /**< (GMAC_ST2CW123) Offset Value in Bytes Mask */
-#define GMAC_ST2CW123_OFFSVAL(value)        (GMAC_ST2CW123_OFFSVAL_Msk & ((value) << GMAC_ST2CW123_OFFSVAL_Pos))
-#define GMAC_ST2CW123_OFFSSTRT_Pos          7                                              /**< (GMAC_ST2CW123) Ethernet Frame Offset Start Position */
-#define GMAC_ST2CW123_OFFSSTRT_Msk          (_U_(0x3) << GMAC_ST2CW123_OFFSSTRT_Pos)       /**< (GMAC_ST2CW123) Ethernet Frame Offset Start Mask */
-#define GMAC_ST2CW123_OFFSSTRT(value)       (GMAC_ST2CW123_OFFSSTRT_Msk & ((value) << GMAC_ST2CW123_OFFSSTRT_Pos))
-#define   GMAC_ST2CW123_OFFSSTRT_FRAMESTART_Val _U_(0x0)                                       /**< (GMAC_ST2CW123) Offset from the start of the frame  */
-#define   GMAC_ST2CW123_OFFSSTRT_ETHERTYPE_Val _U_(0x1)                                       /**< (GMAC_ST2CW123) Offset from the byte after the EtherType field  */
-#define   GMAC_ST2CW123_OFFSSTRT_IP_Val     _U_(0x2)                                       /**< (GMAC_ST2CW123) Offset from the byte after the IP header field  */
-#define   GMAC_ST2CW123_OFFSSTRT_TCP_UDP_Val _U_(0x3)                                       /**< (GMAC_ST2CW123) Offset from the byte after the TCP/UDP header field  */
-#define GMAC_ST2CW123_OFFSSTRT_FRAMESTART   (GMAC_ST2CW123_OFFSSTRT_FRAMESTART_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the start of the frame Position  */
-#define GMAC_ST2CW123_OFFSSTRT_ETHERTYPE    (GMAC_ST2CW123_OFFSSTRT_ETHERTYPE_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the EtherType field Position  */
-#define GMAC_ST2CW123_OFFSSTRT_IP           (GMAC_ST2CW123_OFFSSTRT_IP_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the IP header field Position  */
-#define GMAC_ST2CW123_OFFSSTRT_TCP_UDP      (GMAC_ST2CW123_OFFSSTRT_TCP_UDP_Val << GMAC_ST2CW123_OFFSSTRT_Pos)  /**< (GMAC_ST2CW123) Offset from the byte after the TCP/UDP header field Position  */
-#define GMAC_ST2CW123_MASK                  _U_(0x1FF)                                     /**< \deprecated (GMAC_ST2CW123) Register MASK  (Use GMAC_ST2CW123_Msk instead)  */
-#define GMAC_ST2CW123_Msk                   _U_(0x1FF)                                     /**< (GMAC_ST2CW123) Register Mask  */
 
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -4515,7 +3584,14 @@ typedef struct {
   __IO uint32_t GMAC_SAT;       /**< (GMAC_SA Offset: 0x04) Specific Address 1 Top Register */
 } GmacSa;
 
+/** \brief GMAC_ST2CW hardware registers */
+typedef struct {  
+  __IO uint32_t GMAC_ST2CW0;    /**< (GMAC_ST2CW Offset: 0x00) Screening Type 2 Compare Word 0 Register */
+  __IO uint32_t GMAC_ST2CW1;    /**< (GMAC_ST2CW Offset: 0x04) Screening Type 2 Compare Word 1 Register */
+} GmacSt2cw;
+
 #define GMACSA_NUMBER 4
+#define GMACST2CW_NUMBER 24
 /** \brief GMAC hardware registers */
 typedef struct {  
   __IO uint32_t GMAC_NCR;       /**< (GMAC Offset: 0x00) Network Control Register */
@@ -4537,10 +3613,10 @@ typedef struct {
   __IO uint32_t GMAC_TPSF;      /**< (GMAC Offset: 0x40) TX Partial Store and Forward Register */
   __IO uint32_t GMAC_RPSF;      /**< (GMAC Offset: 0x44) RX Partial Store and Forward Register */
   __IO uint32_t GMAC_RJFML;     /**< (GMAC Offset: 0x48) RX Jumbo Frame Max Length Register */
-  RoReg8  Reserved1[0x34];
+  __I  uint8_t                        Reserved1[52];
   __IO uint32_t GMAC_HRB;       /**< (GMAC Offset: 0x80) Hash Register Bottom */
   __IO uint32_t GMAC_HRT;       /**< (GMAC Offset: 0x84) Hash Register Top */
-       GmacSa   GMAC_SA[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa   GmacSa[GMACSA_NUMBER]; /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO uint32_t GMAC_TIDM1;     /**< (GMAC Offset: 0xA8) Type ID Match 1 Register */
   __IO uint32_t GMAC_TIDM2;     /**< (GMAC Offset: 0xAC) Type ID Match 2 Register */
   __IO uint32_t GMAC_TIDM3;     /**< (GMAC Offset: 0xB0) Type ID Match 3 Register */
@@ -4551,7 +3627,7 @@ typedef struct {
   __IO uint32_t GMAC_TPFCP;     /**< (GMAC Offset: 0xC4) Transmit PFC Pause Register */
   __IO uint32_t GMAC_SAMB1;     /**< (GMAC Offset: 0xC8) Specific Address 1 Mask Bottom Register */
   __IO uint32_t GMAC_SAMT1;     /**< (GMAC Offset: 0xCC) Specific Address 1 Mask Top Register */
-  RoReg8  Reserved2[0xC];
+  __I  uint8_t                        Reserved2[12];
   __IO uint32_t GMAC_NSC;       /**< (GMAC Offset: 0xDC) 1588 Timer Nanosecond Comparison Register */
   __IO uint32_t GMAC_SCL;       /**< (GMAC Offset: 0xE0) 1588 Timer Second Comparison Low Register */
   __IO uint32_t GMAC_SCH;       /**< (GMAC Offset: 0xE4) 1588 Timer Second Comparison High Register */
@@ -4559,7 +3635,7 @@ typedef struct {
   __I  uint32_t GMAC_EFRSH;     /**< (GMAC Offset: 0xEC) PTP Event Frame Received Seconds High Register */
   __I  uint32_t GMAC_PEFTSH;    /**< (GMAC Offset: 0xF0) PTP Peer Event Frame Transmitted Seconds High Register */
   __I  uint32_t GMAC_PEFRSH;    /**< (GMAC Offset: 0xF4) PTP Peer Event Frame Received Seconds High Register */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __I  uint32_t GMAC_OTLO;      /**< (GMAC Offset: 0x100) Octets Transmitted Low Register */
   __I  uint32_t GMAC_OTHI;      /**< (GMAC Offset: 0x104) Octets Transmitted High Register */
   __I  uint32_t GMAC_FT;        /**< (GMAC Offset: 0x108) Frames Transmitted Register */
@@ -4605,10 +3681,10 @@ typedef struct {
   __I  uint32_t GMAC_IHCE;      /**< (GMAC Offset: 0x1A8) IP Header Checksum Errors Register */
   __I  uint32_t GMAC_TCE;       /**< (GMAC Offset: 0x1AC) TCP Checksum Errors Register */
   __I  uint32_t GMAC_UCE;       /**< (GMAC Offset: 0x1B0) UDP Checksum Errors Register */
-  RoReg8  Reserved4[0x8];
+  __I  uint8_t                        Reserved4[8];
   __IO uint32_t GMAC_TISUBN;    /**< (GMAC Offset: 0x1BC) 1588 Timer Increment Sub-nanoseconds Register */
   __IO uint32_t GMAC_TSH;       /**< (GMAC Offset: 0x1C0) 1588 Timer Seconds High Register */
-  RoReg8  Reserved5[0xC];
+  __I  uint8_t                        Reserved5[12];
   __IO uint32_t GMAC_TSL;       /**< (GMAC Offset: 0x1D0) 1588 Timer Seconds Low Register */
   __IO uint32_t GMAC_TN;        /**< (GMAC Offset: 0x1D4) 1588 Timer Nanoseconds Register */
   __O  uint32_t GMAC_TA;        /**< (GMAC Offset: 0x1D8) 1588 Timer Adjust Register */
@@ -4621,84 +3697,37 @@ typedef struct {
   __I  uint32_t GMAC_PEFTN;     /**< (GMAC Offset: 0x1F4) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  uint32_t GMAC_PEFRSL;    /**< (GMAC Offset: 0x1F8) PTP Peer Event Frame Received Seconds Low Register */
   __I  uint32_t GMAC_PEFRN;     /**< (GMAC Offset: 0x1FC) PTP Peer Event Frame Received Nanoseconds Register */
-  RoReg8  Reserved6[0x70];
+  __I  uint8_t                        Reserved6[112];
   __I  uint32_t GMAC_RXLPI;     /**< (GMAC Offset: 0x270) Received LPI Transitions */
   __I  uint32_t GMAC_RXLPITIME; /**< (GMAC Offset: 0x274) Received LPI Time */
   __I  uint32_t GMAC_TXLPI;     /**< (GMAC Offset: 0x278) Transmit LPI Transitions */
   __I  uint32_t GMAC_TXLPITIME; /**< (GMAC Offset: 0x27C) Transmit LPI Time */
-  RoReg8  Reserved7[0x180];
-  __I  uint32_t GMAC_ISRPQ[5];  /**< (GMAC Offset: 0x400) Interrupt Status Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved8[0x2C];
-  __IO uint32_t GMAC_TBQBAPQ[5]; /**< (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved9[0x2C];
-  __IO uint32_t GMAC_RBQBAPQ[5]; /**< (GMAC Offset: 0x480) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved10[0xC];
-  __IO uint32_t GMAC_RBSRPQ[5]; /**< (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved11[0x8];
+  __I  uint8_t                        Reserved7[384];
+  __I  uint32_t GMAC_ISRPQ[5];  /**< (GMAC Offset: 0x400) Interrupt Status Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved8[44];
+  __IO uint32_t GMAC_TBQBAPQ[5]; /**< (GMAC Offset: 0x440) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved9[44];
+  __IO uint32_t GMAC_RBQBAPQ[5]; /**< (GMAC Offset: 0x480) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved10[12];
+  __IO uint32_t GMAC_RBSRPQ[5]; /**< (GMAC Offset: 0x4A0) Receive Buffer Size Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved11[8];
   __IO uint32_t GMAC_CBSCR;     /**< (GMAC Offset: 0x4BC) Credit-Based Shaping Control Register */
   __IO uint32_t GMAC_CBSISQA;   /**< (GMAC Offset: 0x4C0) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO uint32_t GMAC_CBSISQB;   /**< (GMAC Offset: 0x4C4) Credit-Based Shaping IdleSlope Register for Queue B */
-  RoReg8  Reserved12[0x38];
-  __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue (index = 0) 0 */
-  RoReg8  Reserved13[0x30];
-  __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  RoReg8  Reserved14[0xA0];
-  __O  uint32_t GMAC_IERPQ[5];  /**< (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved15[0xC];
-  __O  uint32_t GMAC_IDRPQ[5];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved16[0xC];
-  __IO uint32_t GMAC_IMRPQ[5];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  RoReg8  Reserved17[0x90];
-  __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register (index = 0) 0 */
-  RoReg8  Reserved18[0x10];
-  __IO uint32_t GMAC_ST2CW00;   /**< (GMAC Offset: 0x700) Screening Type 2 Compare Word 0 Register (index = 0) */
-  __IO uint32_t GMAC_ST2CW10;   /**< (GMAC Offset: 0x704) Screening Type 2 Compare Word 1 Register (index = 0) */
-  __IO uint32_t GMAC_ST2CW01;   /**< (GMAC Offset: 0x708) Screening Type 2 Compare Word 0 Register (index = 1) */
-  __IO uint32_t GMAC_ST2CW11;   /**< (GMAC Offset: 0x70C) Screening Type 2 Compare Word 1 Register (index = 1) */
-  __IO uint32_t GMAC_ST2CW02;   /**< (GMAC Offset: 0x710) Screening Type 2 Compare Word 0 Register (index = 2) */
-  __IO uint32_t GMAC_ST2CW12;   /**< (GMAC Offset: 0x714) Screening Type 2 Compare Word 1 Register (index = 2) */
-  __IO uint32_t GMAC_ST2CW03;   /**< (GMAC Offset: 0x718) Screening Type 2 Compare Word 0 Register (index = 3) */
-  __IO uint32_t GMAC_ST2CW13;   /**< (GMAC Offset: 0x71C) Screening Type 2 Compare Word 1 Register (index = 3) */
-  __IO uint32_t GMAC_ST2CW04;   /**< (GMAC Offset: 0x720) Screening Type 2 Compare Word 0 Register (index = 4) */
-  __IO uint32_t GMAC_ST2CW14;   /**< (GMAC Offset: 0x724) Screening Type 2 Compare Word 1 Register (index = 4) */
-  __IO uint32_t GMAC_ST2CW05;   /**< (GMAC Offset: 0x728) Screening Type 2 Compare Word 0 Register (index = 5) */
-  __IO uint32_t GMAC_ST2CW15;   /**< (GMAC Offset: 0x72C) Screening Type 2 Compare Word 1 Register (index = 5) */
-  __IO uint32_t GMAC_ST2CW06;   /**< (GMAC Offset: 0x730) Screening Type 2 Compare Word 0 Register (index = 6) */
-  __IO uint32_t GMAC_ST2CW16;   /**< (GMAC Offset: 0x734) Screening Type 2 Compare Word 1 Register (index = 6) */
-  __IO uint32_t GMAC_ST2CW07;   /**< (GMAC Offset: 0x738) Screening Type 2 Compare Word 0 Register (index = 7) */
-  __IO uint32_t GMAC_ST2CW17;   /**< (GMAC Offset: 0x73C) Screening Type 2 Compare Word 1 Register (index = 7) */
-  __IO uint32_t GMAC_ST2CW08;   /**< (GMAC Offset: 0x740) Screening Type 2 Compare Word 0 Register (index = 8) */
-  __IO uint32_t GMAC_ST2CW18;   /**< (GMAC Offset: 0x744) Screening Type 2 Compare Word 1 Register (index = 8) */
-  __IO uint32_t GMAC_ST2CW09;   /**< (GMAC Offset: 0x748) Screening Type 2 Compare Word 0 Register (index = 9) */
-  __IO uint32_t GMAC_ST2CW19;   /**< (GMAC Offset: 0x74C) Screening Type 2 Compare Word 1 Register (index = 9) */
-  __IO uint32_t GMAC_ST2CW010;  /**< (GMAC Offset: 0x750) Screening Type 2 Compare Word 0 Register (index = 10) */
-  __IO uint32_t GMAC_ST2CW110;  /**< (GMAC Offset: 0x754) Screening Type 2 Compare Word 1 Register (index = 10) */
-  __IO uint32_t GMAC_ST2CW011;  /**< (GMAC Offset: 0x758) Screening Type 2 Compare Word 0 Register (index = 11) */
-  __IO uint32_t GMAC_ST2CW111;  /**< (GMAC Offset: 0x75C) Screening Type 2 Compare Word 1 Register (index = 11) */
-  __IO uint32_t GMAC_ST2CW012;  /**< (GMAC Offset: 0x760) Screening Type 2 Compare Word 0 Register (index = 12) */
-  __IO uint32_t GMAC_ST2CW112;  /**< (GMAC Offset: 0x764) Screening Type 2 Compare Word 1 Register (index = 12) */
-  __IO uint32_t GMAC_ST2CW013;  /**< (GMAC Offset: 0x768) Screening Type 2 Compare Word 0 Register (index = 13) */
-  __IO uint32_t GMAC_ST2CW113;  /**< (GMAC Offset: 0x76C) Screening Type 2 Compare Word 1 Register (index = 13) */
-  __IO uint32_t GMAC_ST2CW014;  /**< (GMAC Offset: 0x770) Screening Type 2 Compare Word 0 Register (index = 14) */
-  __IO uint32_t GMAC_ST2CW114;  /**< (GMAC Offset: 0x774) Screening Type 2 Compare Word 1 Register (index = 14) */
-  __IO uint32_t GMAC_ST2CW015;  /**< (GMAC Offset: 0x778) Screening Type 2 Compare Word 0 Register (index = 15) */
-  __IO uint32_t GMAC_ST2CW115;  /**< (GMAC Offset: 0x77C) Screening Type 2 Compare Word 1 Register (index = 15) */
-  __IO uint32_t GMAC_ST2CW016;  /**< (GMAC Offset: 0x780) Screening Type 2 Compare Word 0 Register (index = 16) */
-  __IO uint32_t GMAC_ST2CW116;  /**< (GMAC Offset: 0x784) Screening Type 2 Compare Word 1 Register (index = 16) */
-  __IO uint32_t GMAC_ST2CW017;  /**< (GMAC Offset: 0x788) Screening Type 2 Compare Word 0 Register (index = 17) */
-  __IO uint32_t GMAC_ST2CW117;  /**< (GMAC Offset: 0x78C) Screening Type 2 Compare Word 1 Register (index = 17) */
-  __IO uint32_t GMAC_ST2CW018;  /**< (GMAC Offset: 0x790) Screening Type 2 Compare Word 0 Register (index = 18) */
-  __IO uint32_t GMAC_ST2CW118;  /**< (GMAC Offset: 0x794) Screening Type 2 Compare Word 1 Register (index = 18) */
-  __IO uint32_t GMAC_ST2CW019;  /**< (GMAC Offset: 0x798) Screening Type 2 Compare Word 0 Register (index = 19) */
-  __IO uint32_t GMAC_ST2CW119;  /**< (GMAC Offset: 0x79C) Screening Type 2 Compare Word 1 Register (index = 19) */
-  __IO uint32_t GMAC_ST2CW020;  /**< (GMAC Offset: 0x7A0) Screening Type 2 Compare Word 0 Register (index = 20) */
-  __IO uint32_t GMAC_ST2CW120;  /**< (GMAC Offset: 0x7A4) Screening Type 2 Compare Word 1 Register (index = 20) */
-  __IO uint32_t GMAC_ST2CW021;  /**< (GMAC Offset: 0x7A8) Screening Type 2 Compare Word 0 Register (index = 21) */
-  __IO uint32_t GMAC_ST2CW121;  /**< (GMAC Offset: 0x7AC) Screening Type 2 Compare Word 1 Register (index = 21) */
-  __IO uint32_t GMAC_ST2CW022;  /**< (GMAC Offset: 0x7B0) Screening Type 2 Compare Word 0 Register (index = 22) */
-  __IO uint32_t GMAC_ST2CW122;  /**< (GMAC Offset: 0x7B4) Screening Type 2 Compare Word 1 Register (index = 22) */
-  __IO uint32_t GMAC_ST2CW023;  /**< (GMAC Offset: 0x7B8) Screening Type 2 Compare Word 0 Register (index = 23) */
-  __IO uint32_t GMAC_ST2CW123;  /**< (GMAC Offset: 0x7BC) Screening Type 2 Compare Word 1 Register (index = 23) */
+  __I  uint8_t                        Reserved12[56];
+  __IO uint32_t GMAC_ST1RPQ[4]; /**< (GMAC Offset: 0x500) Screening Type 1 Register Priority Queue */
+  __I  uint8_t                        Reserved13[48];
+  __IO uint32_t GMAC_ST2RPQ[8]; /**< (GMAC Offset: 0x540) Screening Type 2 Register Priority Queue */
+  __I  uint8_t                        Reserved14[160];
+  __O  uint32_t GMAC_IERPQ[5];  /**< (GMAC Offset: 0x600) Interrupt Enable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved15[12];
+  __O  uint32_t GMAC_IDRPQ[5];  /**< (GMAC Offset: 0x620) Interrupt Disable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved16[12];
+  __IO uint32_t GMAC_IMRPQ[5];  /**< (GMAC Offset: 0x640) Interrupt Mask Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved17[140];
+  __IO uint32_t GMAC_ST2ER[4];  /**< (GMAC Offset: 0x6E0) Screening Type 2 Ethertype Register */
+  __I  uint8_t                        Reserved18[16];
+       GmacSt2cw GmacSt2cw[GMACST2CW_NUMBER]; /**< Offset: 0x700 Screening Type 2 Compare Word 0 Register */
 } Gmac;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -4707,6 +3736,12 @@ typedef struct {
   __IO GMAC_SAB_Type                  GMAC_SAB;       /**< Offset: 0x00 (R/W  32) Specific Address 1 Bottom Register */
   __IO GMAC_SAT_Type                  GMAC_SAT;       /**< Offset: 0x04 (R/W  32) Specific Address 1 Top Register */
 } GmacSa;
+
+/** \brief GMAC_ST2CW hardware registers */
+typedef struct {  
+  __IO GMAC_ST2CW0_Type               GMAC_ST2CW0;    /**< Offset: 0x00 (R/W  32) Screening Type 2 Compare Word 0 Register */
+  __IO GMAC_ST2CW1_Type               GMAC_ST2CW1;    /**< Offset: 0x04 (R/W  32) Screening Type 2 Compare Word 1 Register */
+} GmacSt2cw;
 
 /** \brief GMAC hardware registers */
 typedef struct {  
@@ -4729,10 +3764,10 @@ typedef struct {
   __IO GMAC_TPSF_Type                 GMAC_TPSF;      /**< Offset: 0x40 (R/W  32) TX Partial Store and Forward Register */
   __IO GMAC_RPSF_Type                 GMAC_RPSF;      /**< Offset: 0x44 (R/W  32) RX Partial Store and Forward Register */
   __IO GMAC_RJFML_Type                GMAC_RJFML;     /**< Offset: 0x48 (R/W  32) RX Jumbo Frame Max Length Register */
-  __I  uint32_t                       Reserved1[13];
+  __I  uint8_t                        Reserved1[52];
   __IO GMAC_HRB_Type                  GMAC_HRB;       /**< Offset: 0x80 (R/W  32) Hash Register Bottom */
   __IO GMAC_HRT_Type                  GMAC_HRT;       /**< Offset: 0x84 (R/W  32) Hash Register Top */
-       GmacSa                         GMAC_SA[4];     /**< Offset: 0x88 Specific Address 1 Bottom Register */
+       GmacSa                         GmacSa[4];      /**< Offset: 0x88 Specific Address 1 Bottom Register */
   __IO GMAC_TIDM1_Type                GMAC_TIDM1;     /**< Offset: 0xA8 (R/W  32) Type ID Match 1 Register */
   __IO GMAC_TIDM2_Type                GMAC_TIDM2;     /**< Offset: 0xAC (R/W  32) Type ID Match 2 Register */
   __IO GMAC_TIDM3_Type                GMAC_TIDM3;     /**< Offset: 0xB0 (R/W  32) Type ID Match 3 Register */
@@ -4743,7 +3778,7 @@ typedef struct {
   __IO GMAC_TPFCP_Type                GMAC_TPFCP;     /**< Offset: 0xC4 (R/W  32) Transmit PFC Pause Register */
   __IO GMAC_SAMB1_Type                GMAC_SAMB1;     /**< Offset: 0xC8 (R/W  32) Specific Address 1 Mask Bottom Register */
   __IO GMAC_SAMT1_Type                GMAC_SAMT1;     /**< Offset: 0xCC (R/W  32) Specific Address 1 Mask Top Register */
-  __I  uint32_t                       Reserved2[3];
+  __I  uint8_t                        Reserved2[12];
   __IO GMAC_NSC_Type                  GMAC_NSC;       /**< Offset: 0xDC (R/W  32) 1588 Timer Nanosecond Comparison Register */
   __IO GMAC_SCL_Type                  GMAC_SCL;       /**< Offset: 0xE0 (R/W  32) 1588 Timer Second Comparison Low Register */
   __IO GMAC_SCH_Type                  GMAC_SCH;       /**< Offset: 0xE4 (R/W  32) 1588 Timer Second Comparison High Register */
@@ -4751,7 +3786,7 @@ typedef struct {
   __I  GMAC_EFRSH_Type                GMAC_EFRSH;     /**< Offset: 0xEC (R/   32) PTP Event Frame Received Seconds High Register */
   __I  GMAC_PEFTSH_Type               GMAC_PEFTSH;    /**< Offset: 0xF0 (R/   32) PTP Peer Event Frame Transmitted Seconds High Register */
   __I  GMAC_PEFRSH_Type               GMAC_PEFRSH;    /**< Offset: 0xF4 (R/   32) PTP Peer Event Frame Received Seconds High Register */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __I  GMAC_OTLO_Type                 GMAC_OTLO;      /**< Offset: 0x100 (R/   32) Octets Transmitted Low Register */
   __I  GMAC_OTHI_Type                 GMAC_OTHI;      /**< Offset: 0x104 (R/   32) Octets Transmitted High Register */
   __I  GMAC_FT_Type                   GMAC_FT;        /**< Offset: 0x108 (R/   32) Frames Transmitted Register */
@@ -4797,10 +3832,10 @@ typedef struct {
   __I  GMAC_IHCE_Type                 GMAC_IHCE;      /**< Offset: 0x1A8 (R/   32) IP Header Checksum Errors Register */
   __I  GMAC_TCE_Type                  GMAC_TCE;       /**< Offset: 0x1AC (R/   32) TCP Checksum Errors Register */
   __I  GMAC_UCE_Type                  GMAC_UCE;       /**< Offset: 0x1B0 (R/   32) UDP Checksum Errors Register */
-  __I  uint32_t                       Reserved4[2];
+  __I  uint8_t                        Reserved4[8];
   __IO GMAC_TISUBN_Type               GMAC_TISUBN;    /**< Offset: 0x1BC (R/W  32) 1588 Timer Increment Sub-nanoseconds Register */
   __IO GMAC_TSH_Type                  GMAC_TSH;       /**< Offset: 0x1C0 (R/W  32) 1588 Timer Seconds High Register */
-  __I  uint32_t                       Reserved5[3];
+  __I  uint8_t                        Reserved5[12];
   __IO GMAC_TSL_Type                  GMAC_TSL;       /**< Offset: 0x1D0 (R/W  32) 1588 Timer Seconds Low Register */
   __IO GMAC_TN_Type                   GMAC_TN;        /**< Offset: 0x1D4 (R/W  32) 1588 Timer Nanoseconds Register */
   __O  GMAC_TA_Type                   GMAC_TA;        /**< Offset: 0x1D8 ( /W  32) 1588 Timer Adjust Register */
@@ -4813,84 +3848,37 @@ typedef struct {
   __I  GMAC_PEFTN_Type                GMAC_PEFTN;     /**< Offset: 0x1F4 (R/   32) PTP Peer Event Frame Transmitted Nanoseconds Register */
   __I  GMAC_PEFRSL_Type               GMAC_PEFRSL;    /**< Offset: 0x1F8 (R/   32) PTP Peer Event Frame Received Seconds Low Register */
   __I  GMAC_PEFRN_Type                GMAC_PEFRN;     /**< Offset: 0x1FC (R/   32) PTP Peer Event Frame Received Nanoseconds Register */
-  __I  uint32_t                       Reserved6[28];
+  __I  uint8_t                        Reserved6[112];
   __I  GMAC_RXLPI_Type                GMAC_RXLPI;     /**< Offset: 0x270 (R/   32) Received LPI Transitions */
   __I  GMAC_RXLPITIME_Type            GMAC_RXLPITIME; /**< Offset: 0x274 (R/   32) Received LPI Time */
   __I  GMAC_TXLPI_Type                GMAC_TXLPI;     /**< Offset: 0x278 (R/   32) Transmit LPI Transitions */
   __I  GMAC_TXLPITIME_Type            GMAC_TXLPITIME; /**< Offset: 0x27C (R/   32) Transmit LPI Time */
-  __I  uint32_t                       Reserved7[96];
-  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[5];  /**< Offset: 0x400 (R/   32) Interrupt Status Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved8[11];
-  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[5]; /**< Offset: 0x440 (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved9[11];
-  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[5]; /**< Offset: 0x480 (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved10[3];
-  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[5]; /**< Offset: 0x4A0 (R/W  32) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved11[2];
+  __I  uint8_t                        Reserved7[384];
+  __I  GMAC_ISRPQ_Type                GMAC_ISRPQ[5];  /**< Offset: 0x400 (R/   32) Interrupt Status Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved8[44];
+  __IO GMAC_TBQBAPQ_Type              GMAC_TBQBAPQ[5]; /**< Offset: 0x440 (R/W  32) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved9[44];
+  __IO GMAC_RBQBAPQ_Type              GMAC_RBQBAPQ[5]; /**< Offset: 0x480 (R/W  32) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved10[12];
+  __IO GMAC_RBSRPQ_Type               GMAC_RBSRPQ[5]; /**< Offset: 0x4A0 (R/W  32) Receive Buffer Size Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved11[8];
   __IO GMAC_CBSCR_Type                GMAC_CBSCR;     /**< Offset: 0x4BC (R/W  32) Credit-Based Shaping Control Register */
   __IO GMAC_CBSISQA_Type              GMAC_CBSISQA;   /**< Offset: 0x4C0 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue A */
   __IO GMAC_CBSISQB_Type              GMAC_CBSISQB;   /**< Offset: 0x4C4 (R/W  32) Credit-Based Shaping IdleSlope Register for Queue B */
-  __I  uint32_t                       Reserved12[14];
-  __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue (index = 0) 0 */
-  __I  uint32_t                       Reserved13[12];
-  __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue (index = 0) 0 */
-  __I  uint32_t                       Reserved14[40];
-  __O  GMAC_IERPQ_Type                GMAC_IERPQ[5];  /**< Offset: 0x600 ( /W  32) Interrupt Enable Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved15[3];
-  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[5];  /**< Offset: 0x620 ( /W  32) Interrupt Disable Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved16[3];
-  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[5];  /**< Offset: 0x640 (R/W  32) Interrupt Mask Register Priority Queue (index = 1) 0 */
-  __I  uint32_t                       Reserved17[35];
-  __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register (index = 0) 0 */
-  __I  uint32_t                       Reserved18[4];
-  __IO GMAC_ST2CW00_Type              GMAC_ST2CW00;   /**< Offset: 0x700 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 0) */
-  __IO GMAC_ST2CW10_Type              GMAC_ST2CW10;   /**< Offset: 0x704 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 0) */
-  __IO GMAC_ST2CW01_Type              GMAC_ST2CW01;   /**< Offset: 0x708 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 1) */
-  __IO GMAC_ST2CW11_Type              GMAC_ST2CW11;   /**< Offset: 0x70C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 1) */
-  __IO GMAC_ST2CW02_Type              GMAC_ST2CW02;   /**< Offset: 0x710 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 2) */
-  __IO GMAC_ST2CW12_Type              GMAC_ST2CW12;   /**< Offset: 0x714 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 2) */
-  __IO GMAC_ST2CW03_Type              GMAC_ST2CW03;   /**< Offset: 0x718 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 3) */
-  __IO GMAC_ST2CW13_Type              GMAC_ST2CW13;   /**< Offset: 0x71C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 3) */
-  __IO GMAC_ST2CW04_Type              GMAC_ST2CW04;   /**< Offset: 0x720 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 4) */
-  __IO GMAC_ST2CW14_Type              GMAC_ST2CW14;   /**< Offset: 0x724 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 4) */
-  __IO GMAC_ST2CW05_Type              GMAC_ST2CW05;   /**< Offset: 0x728 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 5) */
-  __IO GMAC_ST2CW15_Type              GMAC_ST2CW15;   /**< Offset: 0x72C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 5) */
-  __IO GMAC_ST2CW06_Type              GMAC_ST2CW06;   /**< Offset: 0x730 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 6) */
-  __IO GMAC_ST2CW16_Type              GMAC_ST2CW16;   /**< Offset: 0x734 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 6) */
-  __IO GMAC_ST2CW07_Type              GMAC_ST2CW07;   /**< Offset: 0x738 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 7) */
-  __IO GMAC_ST2CW17_Type              GMAC_ST2CW17;   /**< Offset: 0x73C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 7) */
-  __IO GMAC_ST2CW08_Type              GMAC_ST2CW08;   /**< Offset: 0x740 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 8) */
-  __IO GMAC_ST2CW18_Type              GMAC_ST2CW18;   /**< Offset: 0x744 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 8) */
-  __IO GMAC_ST2CW09_Type              GMAC_ST2CW09;   /**< Offset: 0x748 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 9) */
-  __IO GMAC_ST2CW19_Type              GMAC_ST2CW19;   /**< Offset: 0x74C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 9) */
-  __IO GMAC_ST2CW010_Type             GMAC_ST2CW010;  /**< Offset: 0x750 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 10) */
-  __IO GMAC_ST2CW110_Type             GMAC_ST2CW110;  /**< Offset: 0x754 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 10) */
-  __IO GMAC_ST2CW011_Type             GMAC_ST2CW011;  /**< Offset: 0x758 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 11) */
-  __IO GMAC_ST2CW111_Type             GMAC_ST2CW111;  /**< Offset: 0x75C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 11) */
-  __IO GMAC_ST2CW012_Type             GMAC_ST2CW012;  /**< Offset: 0x760 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 12) */
-  __IO GMAC_ST2CW112_Type             GMAC_ST2CW112;  /**< Offset: 0x764 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 12) */
-  __IO GMAC_ST2CW013_Type             GMAC_ST2CW013;  /**< Offset: 0x768 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 13) */
-  __IO GMAC_ST2CW113_Type             GMAC_ST2CW113;  /**< Offset: 0x76C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 13) */
-  __IO GMAC_ST2CW014_Type             GMAC_ST2CW014;  /**< Offset: 0x770 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 14) */
-  __IO GMAC_ST2CW114_Type             GMAC_ST2CW114;  /**< Offset: 0x774 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 14) */
-  __IO GMAC_ST2CW015_Type             GMAC_ST2CW015;  /**< Offset: 0x778 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 15) */
-  __IO GMAC_ST2CW115_Type             GMAC_ST2CW115;  /**< Offset: 0x77C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 15) */
-  __IO GMAC_ST2CW016_Type             GMAC_ST2CW016;  /**< Offset: 0x780 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 16) */
-  __IO GMAC_ST2CW116_Type             GMAC_ST2CW116;  /**< Offset: 0x784 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 16) */
-  __IO GMAC_ST2CW017_Type             GMAC_ST2CW017;  /**< Offset: 0x788 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 17) */
-  __IO GMAC_ST2CW117_Type             GMAC_ST2CW117;  /**< Offset: 0x78C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 17) */
-  __IO GMAC_ST2CW018_Type             GMAC_ST2CW018;  /**< Offset: 0x790 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 18) */
-  __IO GMAC_ST2CW118_Type             GMAC_ST2CW118;  /**< Offset: 0x794 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 18) */
-  __IO GMAC_ST2CW019_Type             GMAC_ST2CW019;  /**< Offset: 0x798 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 19) */
-  __IO GMAC_ST2CW119_Type             GMAC_ST2CW119;  /**< Offset: 0x79C (R/W  32) Screening Type 2 Compare Word 1 Register (index = 19) */
-  __IO GMAC_ST2CW020_Type             GMAC_ST2CW020;  /**< Offset: 0x7A0 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 20) */
-  __IO GMAC_ST2CW120_Type             GMAC_ST2CW120;  /**< Offset: 0x7A4 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 20) */
-  __IO GMAC_ST2CW021_Type             GMAC_ST2CW021;  /**< Offset: 0x7A8 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 21) */
-  __IO GMAC_ST2CW121_Type             GMAC_ST2CW121;  /**< Offset: 0x7AC (R/W  32) Screening Type 2 Compare Word 1 Register (index = 21) */
-  __IO GMAC_ST2CW022_Type             GMAC_ST2CW022;  /**< Offset: 0x7B0 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 22) */
-  __IO GMAC_ST2CW122_Type             GMAC_ST2CW122;  /**< Offset: 0x7B4 (R/W  32) Screening Type 2 Compare Word 1 Register (index = 22) */
-  __IO GMAC_ST2CW023_Type             GMAC_ST2CW023;  /**< Offset: 0x7B8 (R/W  32) Screening Type 2 Compare Word 0 Register (index = 23) */
-  __IO GMAC_ST2CW123_Type             GMAC_ST2CW123;  /**< Offset: 0x7BC (R/W  32) Screening Type 2 Compare Word 1 Register (index = 23) */
+  __I  uint8_t                        Reserved12[56];
+  __IO GMAC_ST1RPQ_Type               GMAC_ST1RPQ[4]; /**< Offset: 0x500 (R/W  32) Screening Type 1 Register Priority Queue */
+  __I  uint8_t                        Reserved13[48];
+  __IO GMAC_ST2RPQ_Type               GMAC_ST2RPQ[8]; /**< Offset: 0x540 (R/W  32) Screening Type 2 Register Priority Queue */
+  __I  uint8_t                        Reserved14[160];
+  __O  GMAC_IERPQ_Type                GMAC_IERPQ[5];  /**< Offset: 0x600 ( /W  32) Interrupt Enable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved15[12];
+  __O  GMAC_IDRPQ_Type                GMAC_IDRPQ[5];  /**< Offset: 0x620 ( /W  32) Interrupt Disable Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved16[12];
+  __IO GMAC_IMRPQ_Type                GMAC_IMRPQ[5];  /**< Offset: 0x640 (R/W  32) Interrupt Mask Register Priority Queue (1..5) */
+  __I  uint8_t                        Reserved17[140];
+  __IO GMAC_ST2ER_Type                GMAC_ST2ER[4];  /**< Offset: 0x6E0 (R/W  32) Screening Type 2 Ethertype Register */
+  __I  uint8_t                        Reserved18[16];
+       GmacSt2cw                      GmacSt2cw[24];  /**< Offset: 0x700 Screening Type 2 Compare Word 0 Register */
 } Gmac;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70b/component/gpbr.h
+++ b/asf/sam/include/same70b/component/gpbr.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for GPBR
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_GPBR_COMPONENT_H_
 #define _SAME70_GPBR_COMPONENT_H_
 #define _SAME70_GPBR_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,12 +47,14 @@
 
 /* -------- GPBR_SYS_GPBR : (GPBR Offset: 0x00) (R/W 32) General Purpose Backup Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GPBR_VALUE:32;             /**< bit:  0..31  Value of GPBR x                          */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } GPBR_SYS_GPBR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define GPBR_SYS_GPBR_OFFSET                (0x00)                                        /**<  (GPBR_SYS_GPBR) General Purpose Backup Register 0  Offset */

--- a/asf/sam/include/same70b/component/hsmci.h
+++ b/asf/sam/include/same70b/component/hsmci.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for HSMCI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_HSMCI_COMPONENT_H_
 #define _SAME70_HSMCI_COMPONENT_H_
 #define _SAME70_HSMCI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- HSMCI_CR : (HSMCI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MCIEN:1;                   /**< bit:      0  Multi-Media Interface Enable             */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CR_OFFSET                     (0x00)                                        /**<  (HSMCI_CR) Control Register  Offset */
@@ -82,6 +86,7 @@ typedef union {
 
 /* -------- HSMCI_MR : (HSMCI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLKDIV:8;                  /**< bit:   0..7  Clock Divider                            */
@@ -96,6 +101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_MR_OFFSET                     (0x04)                                        /**<  (HSMCI_MR) Mode Register  Offset */
@@ -127,6 +133,7 @@ typedef union {
 
 /* -------- HSMCI_DTOR : (HSMCI Offset: 0x08) (R/W 32) Data Timeout Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTOCYC:4;                  /**< bit:   0..3  Data Timeout Cycle Number                */
@@ -135,6 +142,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_DTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_DTOR_OFFSET                   (0x08)                                        /**<  (HSMCI_DTOR) Data Timeout Register  Offset */
@@ -167,6 +175,7 @@ typedef union {
 
 /* -------- HSMCI_SDCR : (HSMCI Offset: 0x0c) (R/W 32) SD/SDIO Card Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDCSEL:2;                  /**< bit:   0..1  SDCard/SDIO Slot                         */
@@ -176,6 +185,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_SDCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_SDCR_OFFSET                   (0x0C)                                        /**<  (HSMCI_SDCR) SD/SDIO Card Register  Offset */
@@ -200,12 +210,14 @@ typedef union {
 
 /* -------- HSMCI_ARGR : (HSMCI Offset: 0x10) (R/W 32) Argument Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ARG:32;                    /**< bit:  0..31  Command Argument                         */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_ARGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_ARGR_OFFSET                   (0x10)                                        /**<  (HSMCI_ARGR) Argument Register  Offset */
@@ -219,6 +231,7 @@ typedef union {
 
 /* -------- HSMCI_CMDR : (HSMCI Offset: 0x14) (/W 32) Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDNB:6;                   /**< bit:   0..5  Command Number                           */
@@ -238,6 +251,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CMDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CMDR_OFFSET                   (0x14)                                        /**<  (HSMCI_CMDR) Command Register  Offset */
@@ -343,6 +357,7 @@ typedef union {
 
 /* -------- HSMCI_BLKR : (HSMCI Offset: 0x18) (R/W 32) Block Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BCNT:16;                   /**< bit:  0..15  MMC/SDIO Block Count - SDIO Byte Count   */
@@ -350,6 +365,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_BLKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_BLKR_OFFSET                   (0x18)                                        /**<  (HSMCI_BLKR) Block Register  Offset */
@@ -366,6 +382,7 @@ typedef union {
 
 /* -------- HSMCI_CSTOR : (HSMCI Offset: 0x1c) (R/W 32) Completion Signal Timeout Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSTOCYC:4;                 /**< bit:   0..3  Completion Signal Timeout Cycle Number   */
@@ -374,6 +391,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CSTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CSTOR_OFFSET                  (0x1C)                                        /**<  (HSMCI_CSTOR) Completion Signal Timeout Register  Offset */
@@ -406,12 +424,14 @@ typedef union {
 
 /* -------- HSMCI_RSPR : (HSMCI Offset: 0x20) (R/ 32) Response Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RSP:32;                    /**< bit:  0..31  Response                                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_RSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_RSPR_OFFSET                   (0x20)                                        /**<  (HSMCI_RSPR) Response Register 0  Offset */
@@ -425,12 +445,14 @@ typedef union {
 
 /* -------- HSMCI_RDR : (HSMCI Offset: 0x30) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Read                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_RDR_OFFSET                    (0x30)                                        /**<  (HSMCI_RDR) Receive Data Register  Offset */
@@ -444,12 +466,14 @@ typedef union {
 
 /* -------- HSMCI_TDR : (HSMCI Offset: 0x34) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Write                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_TDR_OFFSET                    (0x34)                                        /**<  (HSMCI_TDR) Transmit Data Register  Offset */
@@ -463,6 +487,7 @@ typedef union {
 
 /* -------- HSMCI_SR : (HSMCI Offset: 0x40) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready (cleared by writing in HSMCI_CMDR) */
@@ -496,6 +521,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_SR_OFFSET                     (0x40)                                        /**<  (HSMCI_SR) Status Register  Offset */
@@ -578,6 +604,7 @@ typedef union {
 
 /* -------- HSMCI_IER : (HSMCI Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Enable           */
@@ -611,6 +638,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IER_OFFSET                    (0x44)                                        /**<  (HSMCI_IER) Interrupt Enable Register  Offset */
@@ -693,6 +721,7 @@ typedef union {
 
 /* -------- HSMCI_IDR : (HSMCI Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Disable          */
@@ -726,6 +755,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IDR_OFFSET                    (0x48)                                        /**<  (HSMCI_IDR) Interrupt Disable Register  Offset */
@@ -808,6 +838,7 @@ typedef union {
 
 /* -------- HSMCI_IMR : (HSMCI Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CMDRDY:1;                  /**< bit:      0  Command Ready Interrupt Mask             */
@@ -841,6 +872,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_IMR_OFFSET                    (0x4C)                                        /**<  (HSMCI_IMR) Interrupt Mask Register  Offset */
@@ -923,6 +955,7 @@ typedef union {
 
 /* -------- HSMCI_DMA : (HSMCI Offset: 0x50) (R/W 32) DMA Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -933,6 +966,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_DMA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_DMA_OFFSET                    (0x50)                                        /**<  (HSMCI_DMA) DMA Configuration Register  Offset */
@@ -959,6 +993,7 @@ typedef union {
 
 /* -------- HSMCI_CFG : (HSMCI Offset: 0x54) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FIFOMODE:1;                /**< bit:      0  HSMCI Internal FIFO control mode         */
@@ -972,6 +1007,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_CFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_CFG_OFFSET                    (0x54)                                        /**<  (HSMCI_CFG) Configuration Register  Offset */
@@ -994,6 +1030,7 @@ typedef union {
 
 /* -------- HSMCI_WPMR : (HSMCI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
@@ -1002,6 +1039,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_WPMR_OFFSET                   (0xE4)                                        /**<  (HSMCI_WPMR) Write Protection Mode Register  Offset */
@@ -1020,6 +1058,7 @@ typedef union {
 
 /* -------- HSMCI_WPSR : (HSMCI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1029,6 +1068,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_WPSR_OFFSET                   (0xE8)                                        /**<  (HSMCI_WPSR) Write Protection Status Register  Offset */
@@ -1045,12 +1085,14 @@ typedef union {
 
 /* -------- HSMCI_FIFO : (HSMCI Offset: 0x200) (R/W 32) FIFO Memory Aperture0 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATA:32;                   /**< bit:  0..31  Data to Read or Data to Write            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } HSMCI_FIFO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define HSMCI_FIFO_OFFSET                   (0x200)                                       /**<  (HSMCI_FIFO) FIFO Memory Aperture0 0  Offset */
@@ -1077,17 +1119,17 @@ typedef struct {
   __I  uint32_t HSMCI_RSPR[4];  /**< (HSMCI Offset: 0x20) Response Register 0 */
   __I  uint32_t HSMCI_RDR;      /**< (HSMCI Offset: 0x30) Receive Data Register */
   __O  uint32_t HSMCI_TDR;      /**< (HSMCI Offset: 0x34) Transmit Data Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __I  uint32_t HSMCI_SR;       /**< (HSMCI Offset: 0x40) Status Register */
   __O  uint32_t HSMCI_IER;      /**< (HSMCI Offset: 0x44) Interrupt Enable Register */
   __O  uint32_t HSMCI_IDR;      /**< (HSMCI Offset: 0x48) Interrupt Disable Register */
   __I  uint32_t HSMCI_IMR;      /**< (HSMCI Offset: 0x4C) Interrupt Mask Register */
   __IO uint32_t HSMCI_DMA;      /**< (HSMCI Offset: 0x50) DMA Configuration Register */
   __IO uint32_t HSMCI_CFG;      /**< (HSMCI Offset: 0x54) Configuration Register */
-  RoReg8  Reserved2[0x8C];
+  __I  uint8_t                        Reserved2[140];
   __IO uint32_t HSMCI_WPMR;     /**< (HSMCI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t HSMCI_WPSR;     /**< (HSMCI Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved3[0x114];
+  __I  uint8_t                        Reserved3[276];
   __IO uint32_t HSMCI_FIFO[256]; /**< (HSMCI Offset: 0x200) FIFO Memory Aperture0 0 */
 } Hsmci;
 
@@ -1105,17 +1147,17 @@ typedef struct {
   __I  HSMCI_RSPR_Type                HSMCI_RSPR[4];  /**< Offset: 0x20 (R/   32) Response Register 0 */
   __I  HSMCI_RDR_Type                 HSMCI_RDR;      /**< Offset: 0x30 (R/   32) Receive Data Register */
   __O  HSMCI_TDR_Type                 HSMCI_TDR;      /**< Offset: 0x34 ( /W  32) Transmit Data Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __I  HSMCI_SR_Type                  HSMCI_SR;       /**< Offset: 0x40 (R/   32) Status Register */
   __O  HSMCI_IER_Type                 HSMCI_IER;      /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
   __O  HSMCI_IDR_Type                 HSMCI_IDR;      /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
   __I  HSMCI_IMR_Type                 HSMCI_IMR;      /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
   __IO HSMCI_DMA_Type                 HSMCI_DMA;      /**< Offset: 0x50 (R/W  32) DMA Configuration Register */
   __IO HSMCI_CFG_Type                 HSMCI_CFG;      /**< Offset: 0x54 (R/W  32) Configuration Register */
-  __I  uint32_t                       Reserved2[35];
+  __I  uint8_t                        Reserved2[140];
   __IO HSMCI_WPMR_Type                HSMCI_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  HSMCI_WPSR_Type                HSMCI_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved3[69];
+  __I  uint8_t                        Reserved3[276];
   __IO HSMCI_FIFO_Type                HSMCI_FIFO[256]; /**< Offset: 0x200 (R/W  32) FIFO Memory Aperture0 0 */
 } Hsmci;
 

--- a/asf/sam/include/same70b/component/i2sc.h
+++ b/asf/sam/include/same70b/component/i2sc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for I2SC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_I2SC_COMPONENT_H_
 #define _SAME70_I2SC_COMPONENT_H_
 #define _SAME70_I2SC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- I2SC_CR : (I2SC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXEN:1;                    /**< bit:      0  Receiver Enable                          */
@@ -59,6 +62,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_CR_OFFSET                      (0x00)                                        /**<  (I2SC_CR) Control Register  Offset */
@@ -90,13 +94,13 @@ typedef union {
 
 /* -------- I2SC_MR : (I2SC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MODE:1;                    /**< bit:      0  Inter-IC Sound Controller Mode           */
     uint32_t :1;                        /**< bit:      1  Reserved */
     uint32_t DATALENGTH:3;              /**< bit:   2..4  Data Word Length                         */
-    uint32_t :1;                        /**< bit:      5  Reserved */
-    uint32_t FORMAT:2;                  /**< bit:   6..7  Data Format                              */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
     uint32_t RXMONO:1;                  /**< bit:      8  Receive Mono                             */
     uint32_t RXDMA:1;                   /**< bit:      9  Single or Multiple DMA Controller Channels for Receiver */
     uint32_t RXLOOP:1;                  /**< bit:     10  Loopback Test Mode                       */
@@ -113,6 +117,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_MR_OFFSET                      (0x04)                                        /**<  (I2SC_MR) Mode Register  Offset */
@@ -143,13 +148,6 @@ typedef union {
 #define I2SC_MR_DATALENGTH_16_BITS_COMPACT  (I2SC_MR_DATALENGTH_16_BITS_COMPACT_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 16-bit compact stereo. Left sample in bits 15:0 and right sample in bits 31:16 of same word. Position  */
 #define I2SC_MR_DATALENGTH_8_BITS           (I2SC_MR_DATALENGTH_8_BITS_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 8 bits Position  */
 #define I2SC_MR_DATALENGTH_8_BITS_COMPACT   (I2SC_MR_DATALENGTH_8_BITS_COMPACT_Val << I2SC_MR_DATALENGTH_Pos)  /**< (I2SC_MR) Data length is set to 8-bit compact stereo. Left sample in bits 7:0 and right sample in bits 15:8 of the same word. Position  */
-#define I2SC_MR_FORMAT_Pos                  6                                              /**< (I2SC_MR) Data Format Position */
-#define I2SC_MR_FORMAT_Msk                  (_U_(0x3) << I2SC_MR_FORMAT_Pos)               /**< (I2SC_MR) Data Format Mask */
-#define I2SC_MR_FORMAT(value)               (I2SC_MR_FORMAT_Msk & ((value) << I2SC_MR_FORMAT_Pos))
-#define   I2SC_MR_FORMAT_I2S_Val            _U_(0x0)                                       /**< (I2SC_MR) I2S format, stereo with I2SC_WS low for left channel, and MSB of sample starting one I2SC_CK period after I2SC_WS edge  */
-#define   I2SC_MR_FORMAT_LJ_Val             _U_(0x1)                                       /**< (I2SC_MR) Left-justified format, stereo with I2SC_WS high for left channel, and MSB of sample starting on I2SC_WS edge  */
-#define I2SC_MR_FORMAT_I2S                  (I2SC_MR_FORMAT_I2S_Val << I2SC_MR_FORMAT_Pos)  /**< (I2SC_MR) I2S format, stereo with I2SC_WS low for left channel, and MSB of sample starting one I2SC_CK period after I2SC_WS edge Position  */
-#define I2SC_MR_FORMAT_LJ                   (I2SC_MR_FORMAT_LJ_Val << I2SC_MR_FORMAT_Pos)  /**< (I2SC_MR) Left-justified format, stereo with I2SC_WS high for left channel, and MSB of sample starting on I2SC_WS edge Position  */
 #define I2SC_MR_RXMONO_Pos                  8                                              /**< (I2SC_MR) Receive Mono Position */
 #define I2SC_MR_RXMONO_Msk                  (_U_(0x1) << I2SC_MR_RXMONO_Pos)               /**< (I2SC_MR) Receive Mono Mask */
 #define I2SC_MR_RXMONO                      I2SC_MR_RXMONO_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_RXMONO_Msk instead */
@@ -204,12 +202,13 @@ typedef union {
 #define I2SC_MR_IWS_Pos                     31                                             /**< (I2SC_MR) I2SC_WS Slot Width Position */
 #define I2SC_MR_IWS_Msk                     (_U_(0x1) << I2SC_MR_IWS_Pos)                  /**< (I2SC_MR) I2SC_WS Slot Width Mask */
 #define I2SC_MR_IWS                         I2SC_MR_IWS_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use I2SC_MR_IWS_Msk instead */
-#define I2SC_MR_MASK                        _U_(0xFF3F77DD)                                /**< \deprecated (I2SC_MR) Register MASK  (Use I2SC_MR_Msk instead)  */
-#define I2SC_MR_Msk                         _U_(0xFF3F77DD)                                /**< (I2SC_MR) Register Mask  */
+#define I2SC_MR_MASK                        _U_(0xFF3F771D)                                /**< \deprecated (I2SC_MR) Register MASK  (Use I2SC_MR_Msk instead)  */
+#define I2SC_MR_Msk                         _U_(0xFF3F771D)                                /**< (I2SC_MR) Register Mask  */
 
 
 /* -------- I2SC_SR : (I2SC Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXEN:1;                    /**< bit:      0  Receiver Enabled                         */
@@ -227,6 +226,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_SR_OFFSET                      (0x08)                                        /**<  (I2SC_SR) Status Register  Offset */
@@ -261,6 +261,7 @@ typedef union {
 
 /* -------- I2SC_SCR : (I2SC Offset: 0x0c) (/W 32) Status Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -275,6 +276,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_SCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_SCR_OFFSET                     (0x0C)                                        /**<  (I2SC_SCR) Status Clear Register  Offset */
@@ -297,6 +299,7 @@ typedef union {
 
 /* -------- I2SC_SSR : (I2SC Offset: 0x10) (/W 32) Status Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -311,6 +314,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_SSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_SSR_OFFSET                     (0x10)                                        /**<  (I2SC_SSR) Status Set Register  Offset */
@@ -333,6 +337,7 @@ typedef union {
 
 /* -------- I2SC_IER : (I2SC Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -345,6 +350,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_IER_OFFSET                     (0x14)                                        /**<  (I2SC_IER) Interrupt Enable Register  Offset */
@@ -367,6 +373,7 @@ typedef union {
 
 /* -------- I2SC_IDR : (I2SC Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -379,6 +386,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_IDR_OFFSET                     (0x18)                                        /**<  (I2SC_IDR) Interrupt Disable Register  Offset */
@@ -401,6 +409,7 @@ typedef union {
 
 /* -------- I2SC_IMR : (I2SC Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -413,6 +422,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_IMR_OFFSET                     (0x1C)                                        /**<  (I2SC_IMR) Interrupt Mask Register  Offset */
@@ -435,12 +445,14 @@ typedef union {
 
 /* -------- I2SC_RHR : (I2SC Offset: 0x20) (R/ 32) Receiver Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHR:32;                    /**< bit:  0..31  Receiver Holding Register                */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_RHR_OFFSET                     (0x20)                                        /**<  (I2SC_RHR) Receiver Holding Register  Offset */
@@ -454,12 +466,14 @@ typedef union {
 
 /* -------- I2SC_THR : (I2SC Offset: 0x24) (/W 32) Transmitter Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t THR:32;                    /**< bit:  0..31  Transmitter Holding Register             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } I2SC_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define I2SC_THR_OFFSET                     (0x24)                                        /**<  (I2SC_THR) Transmitter Holding Register  Offset */

--- a/asf/sam/include/same70b/component/icm.h
+++ b/asf/sam/include/same70b/component/icm.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ICM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ICM_COMPONENT_H_
 #define _SAME70_ICM_COMPONENT_H_
 #define _SAME70_ICM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- ICM_CFG : (ICM Offset: 0x00) (R/W 32) Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WBDIS:1;                   /**< bit:      0  Write Back Disable                       */
@@ -61,6 +64,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_CFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_CFG_OFFSET                      (0x00)                                        /**<  (ICM_CFG) Configuration Register  Offset */
@@ -101,6 +105,7 @@ typedef union {
 
 /* -------- ICM_CTRL : (ICM Offset: 0x04) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  ICM Enable                               */
@@ -114,6 +119,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_CTRL_OFFSET                     (0x04)                                        /**<  (ICM_CTRL) Control Register  Offset */
@@ -142,6 +148,7 @@ typedef union {
 
 /* -------- ICM_SR : (ICM Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  ICM Controller Enable Register           */
@@ -152,6 +159,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_SR_OFFSET                       (0x08)                                        /**<  (ICM_SR) Status Register  Offset */
@@ -171,6 +179,7 @@ typedef union {
 
 /* -------- ICM_IER : (ICM Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Enable   */
@@ -184,6 +193,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IER_OFFSET                      (0x10)                                        /**<  (ICM_IER) Interrupt Enable Register  Offset */
@@ -215,6 +225,7 @@ typedef union {
 
 /* -------- ICM_IDR : (ICM Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Disable  */
@@ -228,6 +239,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IDR_OFFSET                      (0x14)                                        /**<  (ICM_IDR) Interrupt Disable Register  Offset */
@@ -259,6 +271,7 @@ typedef union {
 
 /* -------- ICM_IMR : (ICM Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed Interrupt Mask     */
@@ -272,6 +285,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_IMR_OFFSET                      (0x18)                                        /**<  (ICM_IMR) Interrupt Mask Register  Offset */
@@ -303,6 +317,7 @@ typedef union {
 
 /* -------- ICM_ISR : (ICM Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RHC:4;                     /**< bit:   0..3  Region Hash Completed                    */
@@ -316,6 +331,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_ISR_OFFSET                      (0x1C)                                        /**<  (ICM_ISR) Interrupt Status Register  Offset */
@@ -347,6 +363,7 @@ typedef union {
 
 /* -------- ICM_UASR : (ICM Offset: 0x20) (R/ 32) Undefined Access Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URAT:3;                    /**< bit:   0..2  Undefined Register Access Trace          */
@@ -354,6 +371,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_UASR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_UASR_OFFSET                     (0x20)                                        /**<  (ICM_UASR) Undefined Access Status Register  Offset */
@@ -377,6 +395,7 @@ typedef union {
 
 /* -------- ICM_DSCR : (ICM Offset: 0x30) (R/W 32) Region Descriptor Area Start Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :6;                        /**< bit:   0..5  Reserved */
@@ -384,6 +403,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_DSCR_OFFSET                     (0x30)                                        /**<  (ICM_DSCR) Region Descriptor Area Start Address Register  Offset */
@@ -397,6 +417,7 @@ typedef union {
 
 /* -------- ICM_HASH : (ICM Offset: 0x34) (R/W 32) Region Hash Area Start Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -404,6 +425,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_HASH_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_HASH_OFFSET                     (0x34)                                        /**<  (ICM_HASH) Region Hash Area Start Address Register  Offset */
@@ -417,12 +439,14 @@ typedef union {
 
 /* -------- ICM_UIHVAL : (ICM Offset: 0x38) (/W 32) User Initial Hash Value 0 Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VAL:32;                    /**< bit:  0..31  Initial Hash Value                       */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ICM_UIHVAL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ICM_UIHVAL_OFFSET                   (0x38)                                        /**<  (ICM_UIHVAL) User Initial Hash Value 0 Register 0  Offset */
@@ -441,13 +465,13 @@ typedef struct {
   __IO uint32_t ICM_CFG;        /**< (ICM Offset: 0x00) Configuration Register */
   __O  uint32_t ICM_CTRL;       /**< (ICM Offset: 0x04) Control Register */
   __I  uint32_t ICM_SR;         /**< (ICM Offset: 0x08) Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t ICM_IER;        /**< (ICM Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t ICM_IDR;        /**< (ICM Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t ICM_IMR;        /**< (ICM Offset: 0x18) Interrupt Mask Register */
   __I  uint32_t ICM_ISR;        /**< (ICM Offset: 0x1C) Interrupt Status Register */
   __I  uint32_t ICM_UASR;       /**< (ICM Offset: 0x20) Undefined Access Status Register */
-  RoReg8  Reserved2[0xC];
+  __I  uint8_t                        Reserved2[12];
   __IO uint32_t ICM_DSCR;       /**< (ICM Offset: 0x30) Region Descriptor Area Start Address Register */
   __IO uint32_t ICM_HASH;       /**< (ICM Offset: 0x34) Region Hash Area Start Address Register */
   __O  uint32_t ICM_UIHVAL[8];  /**< (ICM Offset: 0x38) User Initial Hash Value 0 Register 0 */
@@ -459,13 +483,13 @@ typedef struct {
   __IO ICM_CFG_Type                   ICM_CFG;        /**< Offset: 0x00 (R/W  32) Configuration Register */
   __O  ICM_CTRL_Type                  ICM_CTRL;       /**< Offset: 0x04 ( /W  32) Control Register */
   __I  ICM_SR_Type                    ICM_SR;         /**< Offset: 0x08 (R/   32) Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  ICM_IER_Type                   ICM_IER;        /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  ICM_IDR_Type                   ICM_IDR;        /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  ICM_IMR_Type                   ICM_IMR;        /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
   __I  ICM_ISR_Type                   ICM_ISR;        /**< Offset: 0x1C (R/   32) Interrupt Status Register */
   __I  ICM_UASR_Type                  ICM_UASR;       /**< Offset: 0x20 (R/   32) Undefined Access Status Register */
-  __I  uint32_t                       Reserved2[3];
+  __I  uint8_t                        Reserved2[12];
   __IO ICM_DSCR_Type                  ICM_DSCR;       /**< Offset: 0x30 (R/W  32) Region Descriptor Area Start Address Register */
   __IO ICM_HASH_Type                  ICM_HASH;       /**< Offset: 0x34 (R/W  32) Region Hash Area Start Address Register */
   __O  ICM_UIHVAL_Type                ICM_UIHVAL[8];  /**< Offset: 0x38 ( /W  32) User Initial Hash Value 0 Register 0 */

--- a/asf/sam/include/same70b/component/isi.h
+++ b/asf/sam/include/same70b/component/isi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for ISI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ISI_COMPONENT_H_
 #define _SAME70_ISI_COMPONENT_H_
 #define _SAME70_ISI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- ISI_CFG1 : (ISI Offset: 0x00) (R/W 32) ISI Configuration 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CFG1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CFG1_OFFSET                     (0x00)                                        /**<  (ISI_CFG1) ISI Configuration 1 Register  Offset */
@@ -115,6 +119,7 @@ typedef union {
 
 /* -------- ISI_CFG2 : (ISI Offset: 0x04) (R/W 32) ISI Configuration 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IM_VSIZE:11;               /**< bit:  0..10  Vertical Size of the Image Sensor [0..2047] */
@@ -130,6 +135,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CFG2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CFG2_OFFSET                     (0x04)                                        /**<  (ISI_CFG2) ISI Configuration 2 Register  Offset */
@@ -183,6 +189,7 @@ typedef union {
 
 /* -------- ISI_PSIZE : (ISI Offset: 0x08) (R/W 32) ISI Preview Size Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PREV_VSIZE:10;             /**< bit:   0..9  Vertical Size for the Preview Path       */
@@ -192,6 +199,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_PSIZE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_PSIZE_OFFSET                    (0x08)                                        /**<  (ISI_PSIZE) ISI Preview Size Register  Offset */
@@ -208,6 +216,7 @@ typedef union {
 
 /* -------- ISI_PDECF : (ISI Offset: 0x0c) (R/W 32) ISI Preview Decimation Factor Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DEC_FACTOR:8;              /**< bit:   0..7  Decimation Factor                        */
@@ -215,6 +224,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_PDECF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_PDECF_OFFSET                    (0x0C)                                        /**<  (ISI_PDECF) ISI Preview Decimation Factor Register  Offset */
@@ -228,6 +238,7 @@ typedef union {
 
 /* -------- ISI_Y2R_SET0 : (ISI Offset: 0x10) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C0:8;                      /**< bit:   0..7  Color Space Conversion Matrix Coefficient C0 */
@@ -237,6 +248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_Y2R_SET0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_Y2R_SET0_OFFSET                 (0x10)                                        /**<  (ISI_Y2R_SET0) ISI Color Space Conversion YCrCb To RGB Set 0 Register  Offset */
@@ -259,6 +271,7 @@ typedef union {
 
 /* -------- ISI_Y2R_SET1 : (ISI Offset: 0x14) (R/W 32) ISI Color Space Conversion YCrCb To RGB Set 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C4:9;                      /**< bit:   0..8  Color Space Conversion Matrix Coefficient C4 */
@@ -270,6 +283,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_Y2R_SET1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_Y2R_SET1_OFFSET                 (0x14)                                        /**<  (ISI_Y2R_SET1) ISI Color Space Conversion YCrCb To RGB Set 1 Register  Offset */
@@ -292,6 +306,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET0 : (ISI Offset: 0x18) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C0:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C0 */
@@ -305,6 +320,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET0_OFFSET                 (0x18)                                        /**<  (ISI_R2Y_SET0) ISI Color Space Conversion RGB To YCrCb Set 0 Register  Offset */
@@ -327,6 +343,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET1 : (ISI Offset: 0x1c) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C3:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C3 */
@@ -340,6 +357,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET1_OFFSET                 (0x1C)                                        /**<  (ISI_R2Y_SET1) ISI Color Space Conversion RGB To YCrCb Set 1 Register  Offset */
@@ -362,6 +380,7 @@ typedef union {
 
 /* -------- ISI_R2Y_SET2 : (ISI Offset: 0x20) (R/W 32) ISI Color Space Conversion RGB To YCrCb Set 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C6:7;                      /**< bit:   0..6  Color Space Conversion Matrix Coefficient C6 */
@@ -375,6 +394,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_R2Y_SET2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_R2Y_SET2_OFFSET                 (0x20)                                        /**<  (ISI_R2Y_SET2) ISI Color Space Conversion RGB To YCrCb Set 2 Register  Offset */
@@ -397,6 +417,7 @@ typedef union {
 
 /* -------- ISI_CR : (ISI Offset: 0x24) (/W 32) ISI Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ISI_EN:1;                  /**< bit:      0  ISI Module Enable Request                */
@@ -408,6 +429,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_CR_OFFSET                       (0x24)                                        /**<  (ISI_CR) ISI Control Register  Offset */
@@ -430,6 +452,7 @@ typedef union {
 
 /* -------- ISI_SR : (ISI Offset: 0x28) (R/ 32) ISI Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  Module Enable                            */
@@ -453,6 +476,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_SR_OFFSET                       (0x28)                                        /**<  (ISI_SR) ISI Status Register  Offset */
@@ -499,6 +523,7 @@ typedef union {
 
 /* -------- ISI_IER : (ISI Offset: 0x2c) (/W 32) ISI Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -518,6 +543,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IER_OFFSET                      (0x2C)                                        /**<  (ISI_IER) ISI Interrupt Enable Register  Offset */
@@ -555,6 +581,7 @@ typedef union {
 
 /* -------- ISI_IDR : (ISI Offset: 0x30) (/W 32) ISI Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -574,6 +601,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IDR_OFFSET                      (0x30)                                        /**<  (ISI_IDR) ISI Interrupt Disable Register  Offset */
@@ -611,6 +639,7 @@ typedef union {
 
 /* -------- ISI_IMR : (ISI Offset: 0x34) (R/ 32) ISI Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -630,6 +659,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_IMR_OFFSET                      (0x34)                                        /**<  (ISI_IMR) ISI Interrupt Mask Register  Offset */
@@ -667,6 +697,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHER : (ISI Offset: 0x38) (/W 32) DMA Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_EN:1;                 /**< bit:      0  Preview Channel Enable                   */
@@ -675,6 +706,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHER_OFFSET                 (0x38)                                        /**<  (ISI_DMA_CHER) DMA Channel Enable Register  Offset */
@@ -691,6 +723,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHDR : (ISI Offset: 0x3c) (/W 32) DMA Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_DIS:1;                /**< bit:      0  Preview Channel Disable Request          */
@@ -699,6 +732,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHDR_OFFSET                 (0x3C)                                        /**<  (ISI_DMA_CHDR) DMA Channel Disable Register  Offset */
@@ -715,6 +749,7 @@ typedef union {
 
 /* -------- ISI_DMA_CHSR : (ISI Offset: 0x40) (R/ 32) DMA Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_CH_S:1;                  /**< bit:      0  Preview DMA Channel Status               */
@@ -723,6 +758,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_CHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_CHSR_OFFSET                 (0x40)                                        /**<  (ISI_DMA_CHSR) DMA Channel Status Register  Offset */
@@ -739,6 +775,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_ADDR : (ISI Offset: 0x44) (R/W 32) DMA Preview Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -746,6 +783,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_ADDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_ADDR_OFFSET               (0x44)                                        /**<  (ISI_DMA_P_ADDR) DMA Preview Base Address Register  Offset */
@@ -759,6 +797,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_CTRL : (ISI Offset: 0x48) (R/W 32) DMA Preview Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
@@ -769,6 +808,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_CTRL_OFFSET               (0x48)                                        /**<  (ISI_DMA_P_CTRL) DMA Preview Control Register  Offset */
@@ -791,6 +831,7 @@ typedef union {
 
 /* -------- ISI_DMA_P_DSCR : (ISI Offset: 0x4c) (R/W 32) DMA Preview Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -798,6 +839,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_P_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_P_DSCR_OFFSET               (0x4C)                                        /**<  (ISI_DMA_P_DSCR) DMA Preview Descriptor Address Register  Offset */
@@ -811,6 +853,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_ADDR : (ISI Offset: 0x50) (R/W 32) DMA Codec Base Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -818,6 +861,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_ADDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_ADDR_OFFSET               (0x50)                                        /**<  (ISI_DMA_C_ADDR) DMA Codec Base Address Register  Offset */
@@ -831,6 +875,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_CTRL : (ISI Offset: 0x54) (R/W 32) DMA Codec Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t C_FETCH:1;                 /**< bit:      0  Descriptor Fetch Control Bit             */
@@ -841,6 +886,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_CTRL_OFFSET               (0x54)                                        /**<  (ISI_DMA_C_CTRL) DMA Codec Control Register  Offset */
@@ -863,6 +909,7 @@ typedef union {
 
 /* -------- ISI_DMA_C_DSCR : (ISI Offset: 0x58) (R/W 32) DMA Codec Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -870,6 +917,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_DMA_C_DSCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_DMA_C_DSCR_OFFSET               (0x58)                                        /**<  (ISI_DMA_C_DSCR) DMA Codec Descriptor Address Register  Offset */
@@ -883,6 +931,7 @@ typedef union {
 
 /* -------- ISI_WPMR : (ISI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -891,6 +940,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_WPMR_OFFSET                     (0xE4)                                        /**<  (ISI_WPMR) Write Protection Mode Register  Offset */
@@ -909,6 +959,7 @@ typedef union {
 
 /* -------- ISI_WPSR : (ISI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -918,6 +969,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } ISI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define ISI_WPSR_OFFSET                     (0xE8)                                        /**<  (ISI_WPSR) Write Protection Status Register  Offset */
@@ -959,7 +1011,7 @@ typedef struct {
   __IO uint32_t ISI_DMA_C_ADDR; /**< (ISI Offset: 0x50) DMA Codec Base Address Register */
   __IO uint32_t ISI_DMA_C_CTRL; /**< (ISI Offset: 0x54) DMA Codec Control Register */
   __IO uint32_t ISI_DMA_C_DSCR; /**< (ISI Offset: 0x58) DMA Codec Descriptor Address Register */
-  RoReg8  Reserved1[0x88];
+  __I  uint8_t                        Reserved1[136];
   __IO uint32_t ISI_WPMR;       /**< (ISI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t ISI_WPSR;       /**< (ISI Offset: 0xE8) Write Protection Status Register */
 } Isi;
@@ -990,7 +1042,7 @@ typedef struct {
   __IO ISI_DMA_C_ADDR_Type            ISI_DMA_C_ADDR; /**< Offset: 0x50 (R/W  32) DMA Codec Base Address Register */
   __IO ISI_DMA_C_CTRL_Type            ISI_DMA_C_CTRL; /**< Offset: 0x54 (R/W  32) DMA Codec Control Register */
   __IO ISI_DMA_C_DSCR_Type            ISI_DMA_C_DSCR; /**< Offset: 0x58 (R/W  32) DMA Codec Descriptor Address Register */
-  __I  uint32_t                       Reserved1[34];
+  __I  uint8_t                        Reserved1[136];
   __IO ISI_WPMR_Type                  ISI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  ISI_WPSR_Type                  ISI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Isi;

--- a/asf/sam/include/same70b/component/matrix.h
+++ b/asf/sam/include/same70b/component/matrix.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for MATRIX
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_MATRIX_COMPONENT_H_
 #define _SAME70_MATRIX_COMPONENT_H_
 #define _SAME70_MATRIX_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- MATRIX_PRAS : (MATRIX Offset: 0x00) (R/W 32) Priority Register A for Slave 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t M0PR:2;                    /**< bit:   0..1  Master 0 Priority                        */
@@ -64,6 +67,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_PRAS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_PRAS_OFFSET                  (0x00)                                        /**<  (MATRIX_PRAS) Priority Register A for Slave 0  Offset */
@@ -95,6 +99,7 @@ typedef union {
 
 /* -------- MATRIX_PRBS : (MATRIX Offset: 0x04) (R/W 32) Priority Register B for Slave 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t M8PR:2;                    /**< bit:   0..1  Master 8 Priority                        */
@@ -110,6 +115,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_PRBS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_PRBS_OFFSET                  (0x04)                                        /**<  (MATRIX_PRBS) Priority Register B for Slave 0  Offset */
@@ -135,6 +141,7 @@ typedef union {
 
 /* -------- MATRIX_MCFG : (MATRIX Offset: 0x00) (R/W 32) Master Configuration Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ULBT:3;                    /**< bit:   0..2  Undefined Length Burst Type              */
@@ -142,6 +149,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_MCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_MCFG_OFFSET                  (0x00)                                        /**<  (MATRIX_MCFG) Master Configuration Register 0  Offset */
@@ -171,6 +179,7 @@ typedef union {
 
 /* -------- MATRIX_SCFG : (MATRIX Offset: 0x40) (R/W 32) Slave Configuration Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SLOT_CYCLE:9;              /**< bit:   0..8  Maximum Bus Grant Duration for Masters   */
@@ -181,6 +190,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_SCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_SCFG_OFFSET                  (0x40)                                        /**<  (MATRIX_SCFG) Slave Configuration Register 0  Offset */
@@ -206,6 +216,7 @@ typedef union {
 
 /* -------- MATRIX_MRCR : (MATRIX Offset: 0x100) (R/W 32) Master Remap Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RCB0:1;                    /**< bit:      0  Remap Command Bit for Master 0           */
@@ -229,6 +240,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_MRCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_MRCR_OFFSET                  (0x100)                                       /**<  (MATRIX_MRCR) Master Remap Control Register  Offset */
@@ -278,6 +290,7 @@ typedef union {
 
 /* -------- CCFG_CAN0 : (MATRIX Offset: 0x110) (R/W 32) CAN0 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -285,6 +298,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_CAN0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_CAN0_OFFSET                    (0x110)                                       /**<  (CCFG_CAN0) CAN0 Configuration Register  Offset */
@@ -298,6 +312,7 @@ typedef union {
 
 /* -------- CCFG_SYSIO : (MATRIX Offset: 0x114) (R/W 32) System I/O and CAN1 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -317,6 +332,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_SYSIO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_SYSIO_OFFSET                   (0x114)                                       /**<  (CCFG_SYSIO) System I/O and CAN1 Configuration Register  Offset */
@@ -348,6 +364,7 @@ typedef union {
 
 /* -------- CCFG_PCCR : (MATRIX Offset: 0x118) (R/W 32) Peripheral Clock Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :20;                       /**< bit:  0..19  Reserved */
@@ -358,6 +375,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_PCCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_PCCR_OFFSET                    (0x118)                                       /**<  (CCFG_PCCR) Peripheral Clock Configuration Register  Offset */
@@ -377,6 +395,7 @@ typedef union {
 
 /* -------- CCFG_DYNCKG : (MATRIX Offset: 0x11c) (R/W 32) Dynamic Clock Gating Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MATCKG:1;                  /**< bit:      0  MATRIX Dynamic Clock Gating              */
@@ -386,6 +405,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_DYNCKG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_DYNCKG_OFFSET                  (0x11C)                                       /**<  (CCFG_DYNCKG) Dynamic Clock Gating Register  Offset */
@@ -405,6 +425,7 @@ typedef union {
 
 /* -------- CCFG_SMCNFCS : (MATRIX Offset: 0x124) (R/W 32) SMC NAND Flash Chip Select Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMC_NFCS0:1;               /**< bit:      0  SMC NAND Flash Chip Select 0 Assignment  */
@@ -420,6 +441,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } CCFG_SMCNFCS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CCFG_SMCNFCS_OFFSET                 (0x124)                                       /**<  (CCFG_SMCNFCS) SMC NAND Flash Chip Select Configuration Register  Offset */
@@ -448,6 +470,7 @@ typedef union {
 
 /* -------- MATRIX_WPMR : (MATRIX Offset: 0x1e4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -456,6 +479,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_WPMR_OFFSET                  (0x1E4)                                       /**<  (MATRIX_WPMR) Write Protection Mode Register  Offset */
@@ -474,6 +498,7 @@ typedef union {
 
 /* -------- MATRIX_WPSR : (MATRIX Offset: 0x1e8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -483,6 +508,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MATRIX_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MATRIX_WPSR_OFFSET                  (0x1E8)                                       /**<  (MATRIX_WPSR) Write Protection Status Register  Offset */
@@ -509,20 +535,20 @@ typedef struct {
 /** \brief MATRIX hardware registers */
 typedef struct {  
   __IO uint32_t MATRIX_MCFG[13]; /**< (MATRIX Offset: 0x00) Master Configuration Register 0 */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
-  RoReg8  Reserved2[0x1C];
-       MatrixPr MATRIX_PR[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
-  RoReg8  Reserved3[0x38];
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
   __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
-  RoReg8  Reserved4[0xC];
+  __I  uint8_t                        Reserved4[12];
   __IO uint32_t CCFG_CAN0;      /**< (MATRIX Offset: 0x110) CAN0 Configuration Register */
   __IO uint32_t CCFG_SYSIO;     /**< (MATRIX Offset: 0x114) System I/O and CAN1 Configuration Register */
   __IO uint32_t CCFG_PCCR;      /**< (MATRIX Offset: 0x118) Peripheral Clock Configuration Register */
   __IO uint32_t CCFG_DYNCKG;    /**< (MATRIX Offset: 0x11C) Dynamic Clock Gating Register */
-  RoReg8  Reserved5[0x4];
+  __I  uint8_t                        Reserved5[4];
   __IO uint32_t CCFG_SMCNFCS;   /**< (MATRIX Offset: 0x124) SMC NAND Flash Chip Select Configuration Register */
-  RoReg8  Reserved6[0xBC];
+  __I  uint8_t                        Reserved6[188];
   __IO uint32_t MATRIX_WPMR;    /**< (MATRIX Offset: 0x1E4) Write Protection Mode Register */
   __I  uint32_t MATRIX_WPSR;    /**< (MATRIX Offset: 0x1E8) Write Protection Status Register */
 } Matrix;
@@ -537,20 +563,20 @@ typedef struct {
 /** \brief MATRIX hardware registers */
 typedef struct {  
   __IO MATRIX_MCFG_Type               MATRIX_MCFG[13]; /**< Offset: 0x00 (R/W  32) Master Configuration Register 0 */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
-  __I  uint32_t                       Reserved2[7];
-       MatrixPr                       MATRIX_PR[9];   /**< Offset: 0x80 Priority Register A for Slave 0 */
-  __I  uint32_t                       Reserved3[14];
+  __I  uint8_t                        Reserved2[28];
+       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+  __I  uint8_t                        Reserved3[56];
   __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
-  __I  uint32_t                       Reserved4[3];
+  __I  uint8_t                        Reserved4[12];
   __IO CCFG_CAN0_Type                 CCFG_CAN0;      /**< Offset: 0x110 (R/W  32) CAN0 Configuration Register */
   __IO CCFG_SYSIO_Type                CCFG_SYSIO;     /**< Offset: 0x114 (R/W  32) System I/O and CAN1 Configuration Register */
   __IO CCFG_PCCR_Type                 CCFG_PCCR;      /**< Offset: 0x118 (R/W  32) Peripheral Clock Configuration Register */
   __IO CCFG_DYNCKG_Type               CCFG_DYNCKG;    /**< Offset: 0x11C (R/W  32) Dynamic Clock Gating Register */
-  __I  uint32_t                       Reserved5[1];
+  __I  uint8_t                        Reserved5[4];
   __IO CCFG_SMCNFCS_Type              CCFG_SMCNFCS;   /**< Offset: 0x124 (R/W  32) SMC NAND Flash Chip Select Configuration Register */
-  __I  uint32_t                       Reserved6[47];
+  __I  uint8_t                        Reserved6[188];
   __IO MATRIX_WPMR_Type               MATRIX_WPMR;    /**< Offset: 0x1E4 (R/W  32) Write Protection Mode Register */
   __I  MATRIX_WPSR_Type               MATRIX_WPSR;    /**< Offset: 0x1E8 (R/   32) Write Protection Status Register */
 } Matrix;

--- a/asf/sam/include/same70b/component/matrix.h
+++ b/asf/sam/include/same70b/component/matrix.h
@@ -538,7 +538,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[12];
   __IO uint32_t MATRIX_SCFG[9]; /**< (MATRIX Offset: 0x40) Slave Configuration Register 0 */
   __I  uint8_t                        Reserved2[28];
-       MatrixPr MatrixPr[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
+       MatrixPr MATRIX_PR[MATRIXPR_NUMBER]; /**< Offset: 0x80 Priority Register A for Slave 0 */
   __I  uint8_t                        Reserved3[56];
   __IO uint32_t MATRIX_MRCR;    /**< (MATRIX Offset: 0x100) Master Remap Control Register */
   __I  uint8_t                        Reserved4[12];
@@ -566,7 +566,7 @@ typedef struct {
   __I  uint8_t                        Reserved1[12];
   __IO MATRIX_SCFG_Type               MATRIX_SCFG[9]; /**< Offset: 0x40 (R/W  32) Slave Configuration Register 0 */
   __I  uint8_t                        Reserved2[28];
-       MatrixPr                       MatrixPr[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
+       MatrixPr                       MATRIX_PR[9];    /**< Offset: 0x80 Priority Register A for Slave 0 */
   __I  uint8_t                        Reserved3[56];
   __IO MATRIX_MRCR_Type               MATRIX_MRCR;    /**< Offset: 0x100 (R/W  32) Master Remap Control Register */
   __I  uint8_t                        Reserved4[12];

--- a/asf/sam/include/same70b/component/mcan.h
+++ b/asf/sam/include/same70b/component/mcan.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for MCAN
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_MCAN_COMPONENT_H_
 #define _SAME70_MCAN_COMPONENT_H_
 #define _SAME70_MCAN_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -43,8 +45,647 @@
 #define MCAN_11273                      /**< (MCAN) Module ID */
 #define REV_MCAN N                      /**< (MCAN) Module revision */
 
+/* -------- MCAN_RXBE_0 : (MCAN Offset: 0x00) (R/W 32) Rx Buffer Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_0_OFFSET                  (0x00)                                        /**<  (MCAN_RXBE_0) Rx Buffer Element 0  Offset */
+
+#define MCAN_RXBE_0_ID_Pos                  0                                              /**< (MCAN_RXBE_0) Identifier Position */
+#define MCAN_RXBE_0_ID_Msk                  (_U_(0x1FFFFFFF) << MCAN_RXBE_0_ID_Pos)        /**< (MCAN_RXBE_0) Identifier Mask */
+#define MCAN_RXBE_0_ID(value)               (MCAN_RXBE_0_ID_Msk & ((value) << MCAN_RXBE_0_ID_Pos))
+#define MCAN_RXBE_0_RTR_Pos                 29                                             /**< (MCAN_RXBE_0) Remote Transmission Request Position */
+#define MCAN_RXBE_0_RTR_Msk                 (_U_(0x1) << MCAN_RXBE_0_RTR_Pos)              /**< (MCAN_RXBE_0) Remote Transmission Request Mask */
+#define MCAN_RXBE_0_RTR                     MCAN_RXBE_0_RTR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_RTR_Msk instead */
+#define MCAN_RXBE_0_XTD_Pos                 30                                             /**< (MCAN_RXBE_0) Extended Identifier Position */
+#define MCAN_RXBE_0_XTD_Msk                 (_U_(0x1) << MCAN_RXBE_0_XTD_Pos)              /**< (MCAN_RXBE_0) Extended Identifier Mask */
+#define MCAN_RXBE_0_XTD                     MCAN_RXBE_0_XTD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_XTD_Msk instead */
+#define MCAN_RXBE_0_ESI_Pos                 31                                             /**< (MCAN_RXBE_0) Error State Indicator Position */
+#define MCAN_RXBE_0_ESI_Msk                 (_U_(0x1) << MCAN_RXBE_0_ESI_Pos)              /**< (MCAN_RXBE_0) Error State Indicator Mask */
+#define MCAN_RXBE_0_ESI                     MCAN_RXBE_0_ESI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_0_ESI_Msk instead */
+#define MCAN_RXBE_0_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXBE_0) Register MASK  (Use MCAN_RXBE_0_Msk instead)  */
+#define MCAN_RXBE_0_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_RXBE_0) Register Mask  */
+
+
+/* -------- MCAN_RXBE_1 : (MCAN Offset: 0x04) (R/W 32) Rx Buffer Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_1_OFFSET                  (0x04)                                        /**<  (MCAN_RXBE_1) Rx Buffer Element 1  Offset */
+
+#define MCAN_RXBE_1_RXTS_Pos                0                                              /**< (MCAN_RXBE_1) Rx Timestamp Position */
+#define MCAN_RXBE_1_RXTS_Msk                (_U_(0xFFFF) << MCAN_RXBE_1_RXTS_Pos)          /**< (MCAN_RXBE_1) Rx Timestamp Mask */
+#define MCAN_RXBE_1_RXTS(value)             (MCAN_RXBE_1_RXTS_Msk & ((value) << MCAN_RXBE_1_RXTS_Pos))
+#define MCAN_RXBE_1_DLC_Pos                 16                                             /**< (MCAN_RXBE_1) Data Length Code Position */
+#define MCAN_RXBE_1_DLC_Msk                 (_U_(0xF) << MCAN_RXBE_1_DLC_Pos)              /**< (MCAN_RXBE_1) Data Length Code Mask */
+#define MCAN_RXBE_1_DLC(value)              (MCAN_RXBE_1_DLC_Msk & ((value) << MCAN_RXBE_1_DLC_Pos))
+#define MCAN_RXBE_1_BRS_Pos                 20                                             /**< (MCAN_RXBE_1) Bit Rate Switch Position */
+#define MCAN_RXBE_1_BRS_Msk                 (_U_(0x1) << MCAN_RXBE_1_BRS_Pos)              /**< (MCAN_RXBE_1) Bit Rate Switch Mask */
+#define MCAN_RXBE_1_BRS                     MCAN_RXBE_1_BRS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_BRS_Msk instead */
+#define MCAN_RXBE_1_FDF_Pos                 21                                             /**< (MCAN_RXBE_1) FD Format Position */
+#define MCAN_RXBE_1_FDF_Msk                 (_U_(0x1) << MCAN_RXBE_1_FDF_Pos)              /**< (MCAN_RXBE_1) FD Format Mask */
+#define MCAN_RXBE_1_FDF                     MCAN_RXBE_1_FDF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_FDF_Msk instead */
+#define MCAN_RXBE_1_FIDX_Pos                24                                             /**< (MCAN_RXBE_1) Filter Index Position */
+#define MCAN_RXBE_1_FIDX_Msk                (_U_(0x7F) << MCAN_RXBE_1_FIDX_Pos)            /**< (MCAN_RXBE_1) Filter Index Mask */
+#define MCAN_RXBE_1_FIDX(value)             (MCAN_RXBE_1_FIDX_Msk & ((value) << MCAN_RXBE_1_FIDX_Pos))
+#define MCAN_RXBE_1_ANMF_Pos                31                                             /**< (MCAN_RXBE_1) Accepted Non-matching Frame Position */
+#define MCAN_RXBE_1_ANMF_Msk                (_U_(0x1) << MCAN_RXBE_1_ANMF_Pos)             /**< (MCAN_RXBE_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXBE_1_ANMF                    MCAN_RXBE_1_ANMF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXBE_1_ANMF_Msk instead */
+#define MCAN_RXBE_1_MASK                    _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXBE_1) Register MASK  (Use MCAN_RXBE_1_Msk instead)  */
+#define MCAN_RXBE_1_Msk                     _U_(0xFF3FFFFF)                                /**< (MCAN_RXBE_1) Register Mask  */
+
+
+/* -------- MCAN_RXBE_DATA : (MCAN Offset: 0x08) (R/W 32) Rx Buffer Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXBE_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXBE_DATA_OFFSET               (0x08)                                        /**<  (MCAN_RXBE_DATA) Rx Buffer Element Data  Offset */
+
+#define MCAN_RXBE_DATA_DB0_Pos              0                                              /**< (MCAN_RXBE_DATA) Data Byte 0 Position */
+#define MCAN_RXBE_DATA_DB0_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB0_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 0 Mask */
+#define MCAN_RXBE_DATA_DB0(value)           (MCAN_RXBE_DATA_DB0_Msk & ((value) << MCAN_RXBE_DATA_DB0_Pos))
+#define MCAN_RXBE_DATA_DB1_Pos              8                                              /**< (MCAN_RXBE_DATA) Data Byte 1 Position */
+#define MCAN_RXBE_DATA_DB1_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB1_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 1 Mask */
+#define MCAN_RXBE_DATA_DB1(value)           (MCAN_RXBE_DATA_DB1_Msk & ((value) << MCAN_RXBE_DATA_DB1_Pos))
+#define MCAN_RXBE_DATA_DB2_Pos              16                                             /**< (MCAN_RXBE_DATA) Data Byte 2 Position */
+#define MCAN_RXBE_DATA_DB2_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB2_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 2 Mask */
+#define MCAN_RXBE_DATA_DB2(value)           (MCAN_RXBE_DATA_DB2_Msk & ((value) << MCAN_RXBE_DATA_DB2_Pos))
+#define MCAN_RXBE_DATA_DB3_Pos              24                                             /**< (MCAN_RXBE_DATA) Data Byte 3 Position */
+#define MCAN_RXBE_DATA_DB3_Msk              (_U_(0xFF) << MCAN_RXBE_DATA_DB3_Pos)          /**< (MCAN_RXBE_DATA) Data Byte 3 Mask */
+#define MCAN_RXBE_DATA_DB3(value)           (MCAN_RXBE_DATA_DB3_Msk & ((value) << MCAN_RXBE_DATA_DB3_Pos))
+#define MCAN_RXBE_DATA_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXBE_DATA) Register MASK  (Use MCAN_RXBE_DATA_Msk instead)  */
+#define MCAN_RXBE_DATA_Msk                  _U_(0xFFFFFFFF)                                /**< (MCAN_RXBE_DATA) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_0 : (MCAN Offset: 0x00) (R/W 32) Rx FIFO 0 Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_0_OFFSET                 (0x00)                                        /**<  (MCAN_RXF0E_0) Rx FIFO 0 Element 0  Offset */
+
+#define MCAN_RXF0E_0_ID_Pos                 0                                              /**< (MCAN_RXF0E_0) Identifier Position */
+#define MCAN_RXF0E_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_RXF0E_0_ID_Pos)       /**< (MCAN_RXF0E_0) Identifier Mask */
+#define MCAN_RXF0E_0_ID(value)              (MCAN_RXF0E_0_ID_Msk & ((value) << MCAN_RXF0E_0_ID_Pos))
+#define MCAN_RXF0E_0_RTR_Pos                29                                             /**< (MCAN_RXF0E_0) Remote Transmission Request Position */
+#define MCAN_RXF0E_0_RTR_Msk                (_U_(0x1) << MCAN_RXF0E_0_RTR_Pos)             /**< (MCAN_RXF0E_0) Remote Transmission Request Mask */
+#define MCAN_RXF0E_0_RTR                    MCAN_RXF0E_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_RTR_Msk instead */
+#define MCAN_RXF0E_0_XTD_Pos                30                                             /**< (MCAN_RXF0E_0) Extended Identifier Position */
+#define MCAN_RXF0E_0_XTD_Msk                (_U_(0x1) << MCAN_RXF0E_0_XTD_Pos)             /**< (MCAN_RXF0E_0) Extended Identifier Mask */
+#define MCAN_RXF0E_0_XTD                    MCAN_RXF0E_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_XTD_Msk instead */
+#define MCAN_RXF0E_0_ESI_Pos                31                                             /**< (MCAN_RXF0E_0) Error State Indicator Position */
+#define MCAN_RXF0E_0_ESI_Msk                (_U_(0x1) << MCAN_RXF0E_0_ESI_Pos)             /**< (MCAN_RXF0E_0) Error State Indicator Mask */
+#define MCAN_RXF0E_0_ESI                    MCAN_RXF0E_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_0_ESI_Msk instead */
+#define MCAN_RXF0E_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF0E_0) Register MASK  (Use MCAN_RXF0E_0_Msk instead)  */
+#define MCAN_RXF0E_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_RXF0E_0) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_1 : (MCAN Offset: 0x04) (R/W 32) Rx FIFO 0 Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_1_OFFSET                 (0x04)                                        /**<  (MCAN_RXF0E_1) Rx FIFO 0 Element 1  Offset */
+
+#define MCAN_RXF0E_1_RXTS_Pos               0                                              /**< (MCAN_RXF0E_1) Rx Timestamp Position */
+#define MCAN_RXF0E_1_RXTS_Msk               (_U_(0xFFFF) << MCAN_RXF0E_1_RXTS_Pos)         /**< (MCAN_RXF0E_1) Rx Timestamp Mask */
+#define MCAN_RXF0E_1_RXTS(value)            (MCAN_RXF0E_1_RXTS_Msk & ((value) << MCAN_RXF0E_1_RXTS_Pos))
+#define MCAN_RXF0E_1_DLC_Pos                16                                             /**< (MCAN_RXF0E_1) Data Length Code Position */
+#define MCAN_RXF0E_1_DLC_Msk                (_U_(0xF) << MCAN_RXF0E_1_DLC_Pos)             /**< (MCAN_RXF0E_1) Data Length Code Mask */
+#define MCAN_RXF0E_1_DLC(value)             (MCAN_RXF0E_1_DLC_Msk & ((value) << MCAN_RXF0E_1_DLC_Pos))
+#define MCAN_RXF0E_1_BRS_Pos                20                                             /**< (MCAN_RXF0E_1) Bit Rate Switch Position */
+#define MCAN_RXF0E_1_BRS_Msk                (_U_(0x1) << MCAN_RXF0E_1_BRS_Pos)             /**< (MCAN_RXF0E_1) Bit Rate Switch Mask */
+#define MCAN_RXF0E_1_BRS                    MCAN_RXF0E_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_BRS_Msk instead */
+#define MCAN_RXF0E_1_FDF_Pos                21                                             /**< (MCAN_RXF0E_1) FD Format Position */
+#define MCAN_RXF0E_1_FDF_Msk                (_U_(0x1) << MCAN_RXF0E_1_FDF_Pos)             /**< (MCAN_RXF0E_1) FD Format Mask */
+#define MCAN_RXF0E_1_FDF                    MCAN_RXF0E_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_FDF_Msk instead */
+#define MCAN_RXF0E_1_FIDX_Pos               24                                             /**< (MCAN_RXF0E_1) Filter Index Position */
+#define MCAN_RXF0E_1_FIDX_Msk               (_U_(0x7F) << MCAN_RXF0E_1_FIDX_Pos)           /**< (MCAN_RXF0E_1) Filter Index Mask */
+#define MCAN_RXF0E_1_FIDX(value)            (MCAN_RXF0E_1_FIDX_Msk & ((value) << MCAN_RXF0E_1_FIDX_Pos))
+#define MCAN_RXF0E_1_ANMF_Pos               31                                             /**< (MCAN_RXF0E_1) Accepted Non-matching Frame Position */
+#define MCAN_RXF0E_1_ANMF_Msk               (_U_(0x1) << MCAN_RXF0E_1_ANMF_Pos)            /**< (MCAN_RXF0E_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXF0E_1_ANMF                   MCAN_RXF0E_1_ANMF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF0E_1_ANMF_Msk instead */
+#define MCAN_RXF0E_1_MASK                   _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXF0E_1) Register MASK  (Use MCAN_RXF0E_1_Msk instead)  */
+#define MCAN_RXF0E_1_Msk                    _U_(0xFF3FFFFF)                                /**< (MCAN_RXF0E_1) Register Mask  */
+
+
+/* -------- MCAN_RXF0E_DATA : (MCAN Offset: 0x08) (R/W 32) Rx FIFO 0 Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF0E_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF0E_DATA_OFFSET              (0x08)                                        /**<  (MCAN_RXF0E_DATA) Rx FIFO 0 Element Data  Offset */
+
+#define MCAN_RXF0E_DATA_DB0_Pos             0                                              /**< (MCAN_RXF0E_DATA) Data Byte 0 Position */
+#define MCAN_RXF0E_DATA_DB0_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB0_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 0 Mask */
+#define MCAN_RXF0E_DATA_DB0(value)          (MCAN_RXF0E_DATA_DB0_Msk & ((value) << MCAN_RXF0E_DATA_DB0_Pos))
+#define MCAN_RXF0E_DATA_DB1_Pos             8                                              /**< (MCAN_RXF0E_DATA) Data Byte 1 Position */
+#define MCAN_RXF0E_DATA_DB1_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB1_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 1 Mask */
+#define MCAN_RXF0E_DATA_DB1(value)          (MCAN_RXF0E_DATA_DB1_Msk & ((value) << MCAN_RXF0E_DATA_DB1_Pos))
+#define MCAN_RXF0E_DATA_DB2_Pos             16                                             /**< (MCAN_RXF0E_DATA) Data Byte 2 Position */
+#define MCAN_RXF0E_DATA_DB2_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB2_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 2 Mask */
+#define MCAN_RXF0E_DATA_DB2(value)          (MCAN_RXF0E_DATA_DB2_Msk & ((value) << MCAN_RXF0E_DATA_DB2_Pos))
+#define MCAN_RXF0E_DATA_DB3_Pos             24                                             /**< (MCAN_RXF0E_DATA) Data Byte 3 Position */
+#define MCAN_RXF0E_DATA_DB3_Msk             (_U_(0xFF) << MCAN_RXF0E_DATA_DB3_Pos)         /**< (MCAN_RXF0E_DATA) Data Byte 3 Mask */
+#define MCAN_RXF0E_DATA_DB3(value)          (MCAN_RXF0E_DATA_DB3_Msk & ((value) << MCAN_RXF0E_DATA_DB3_Pos))
+#define MCAN_RXF0E_DATA_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF0E_DATA) Register MASK  (Use MCAN_RXF0E_DATA_Msk instead)  */
+#define MCAN_RXF0E_DATA_Msk                 _U_(0xFFFFFFFF)                                /**< (MCAN_RXF0E_DATA) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_0 : (MCAN Offset: 0x00) (R/W 32) Rx FIFO 1 Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_0_OFFSET                 (0x00)                                        /**<  (MCAN_RXF1E_0) Rx FIFO 1 Element 0  Offset */
+
+#define MCAN_RXF1E_0_ID_Pos                 0                                              /**< (MCAN_RXF1E_0) Identifier Position */
+#define MCAN_RXF1E_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_RXF1E_0_ID_Pos)       /**< (MCAN_RXF1E_0) Identifier Mask */
+#define MCAN_RXF1E_0_ID(value)              (MCAN_RXF1E_0_ID_Msk & ((value) << MCAN_RXF1E_0_ID_Pos))
+#define MCAN_RXF1E_0_RTR_Pos                29                                             /**< (MCAN_RXF1E_0) Remote Transmission Request Position */
+#define MCAN_RXF1E_0_RTR_Msk                (_U_(0x1) << MCAN_RXF1E_0_RTR_Pos)             /**< (MCAN_RXF1E_0) Remote Transmission Request Mask */
+#define MCAN_RXF1E_0_RTR                    MCAN_RXF1E_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_RTR_Msk instead */
+#define MCAN_RXF1E_0_XTD_Pos                30                                             /**< (MCAN_RXF1E_0) Extended Identifier Position */
+#define MCAN_RXF1E_0_XTD_Msk                (_U_(0x1) << MCAN_RXF1E_0_XTD_Pos)             /**< (MCAN_RXF1E_0) Extended Identifier Mask */
+#define MCAN_RXF1E_0_XTD                    MCAN_RXF1E_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_XTD_Msk instead */
+#define MCAN_RXF1E_0_ESI_Pos                31                                             /**< (MCAN_RXF1E_0) Error State Indicator Position */
+#define MCAN_RXF1E_0_ESI_Msk                (_U_(0x1) << MCAN_RXF1E_0_ESI_Pos)             /**< (MCAN_RXF1E_0) Error State Indicator Mask */
+#define MCAN_RXF1E_0_ESI                    MCAN_RXF1E_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_0_ESI_Msk instead */
+#define MCAN_RXF1E_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF1E_0) Register MASK  (Use MCAN_RXF1E_0_Msk instead)  */
+#define MCAN_RXF1E_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_RXF1E_0) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_1 : (MCAN Offset: 0x04) (R/W 32) Rx FIFO 1 Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t RXTS:16;                   /**< bit:  0..15  Rx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t FIDX:7;                    /**< bit: 24..30  Filter Index                             */
+    uint32_t ANMF:1;                    /**< bit:     31  Accepted Non-matching Frame              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_1_OFFSET                 (0x04)                                        /**<  (MCAN_RXF1E_1) Rx FIFO 1 Element 1  Offset */
+
+#define MCAN_RXF1E_1_RXTS_Pos               0                                              /**< (MCAN_RXF1E_1) Rx Timestamp Position */
+#define MCAN_RXF1E_1_RXTS_Msk               (_U_(0xFFFF) << MCAN_RXF1E_1_RXTS_Pos)         /**< (MCAN_RXF1E_1) Rx Timestamp Mask */
+#define MCAN_RXF1E_1_RXTS(value)            (MCAN_RXF1E_1_RXTS_Msk & ((value) << MCAN_RXF1E_1_RXTS_Pos))
+#define MCAN_RXF1E_1_DLC_Pos                16                                             /**< (MCAN_RXF1E_1) Data Length Code Position */
+#define MCAN_RXF1E_1_DLC_Msk                (_U_(0xF) << MCAN_RXF1E_1_DLC_Pos)             /**< (MCAN_RXF1E_1) Data Length Code Mask */
+#define MCAN_RXF1E_1_DLC(value)             (MCAN_RXF1E_1_DLC_Msk & ((value) << MCAN_RXF1E_1_DLC_Pos))
+#define MCAN_RXF1E_1_BRS_Pos                20                                             /**< (MCAN_RXF1E_1) Bit Rate Switch Position */
+#define MCAN_RXF1E_1_BRS_Msk                (_U_(0x1) << MCAN_RXF1E_1_BRS_Pos)             /**< (MCAN_RXF1E_1) Bit Rate Switch Mask */
+#define MCAN_RXF1E_1_BRS                    MCAN_RXF1E_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_BRS_Msk instead */
+#define MCAN_RXF1E_1_FDF_Pos                21                                             /**< (MCAN_RXF1E_1) FD Format Position */
+#define MCAN_RXF1E_1_FDF_Msk                (_U_(0x1) << MCAN_RXF1E_1_FDF_Pos)             /**< (MCAN_RXF1E_1) FD Format Mask */
+#define MCAN_RXF1E_1_FDF                    MCAN_RXF1E_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_FDF_Msk instead */
+#define MCAN_RXF1E_1_FIDX_Pos               24                                             /**< (MCAN_RXF1E_1) Filter Index Position */
+#define MCAN_RXF1E_1_FIDX_Msk               (_U_(0x7F) << MCAN_RXF1E_1_FIDX_Pos)           /**< (MCAN_RXF1E_1) Filter Index Mask */
+#define MCAN_RXF1E_1_FIDX(value)            (MCAN_RXF1E_1_FIDX_Msk & ((value) << MCAN_RXF1E_1_FIDX_Pos))
+#define MCAN_RXF1E_1_ANMF_Pos               31                                             /**< (MCAN_RXF1E_1) Accepted Non-matching Frame Position */
+#define MCAN_RXF1E_1_ANMF_Msk               (_U_(0x1) << MCAN_RXF1E_1_ANMF_Pos)            /**< (MCAN_RXF1E_1) Accepted Non-matching Frame Mask */
+#define MCAN_RXF1E_1_ANMF                   MCAN_RXF1E_1_ANMF_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_RXF1E_1_ANMF_Msk instead */
+#define MCAN_RXF1E_1_MASK                   _U_(0xFF3FFFFF)                                /**< \deprecated (MCAN_RXF1E_1) Register MASK  (Use MCAN_RXF1E_1_Msk instead)  */
+#define MCAN_RXF1E_1_Msk                    _U_(0xFF3FFFFF)                                /**< (MCAN_RXF1E_1) Register Mask  */
+
+
+/* -------- MCAN_RXF1E_DATA : (MCAN Offset: 0x08) (R/W 32) Rx FIFO 1 Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_RXF1E_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_RXF1E_DATA_OFFSET              (0x08)                                        /**<  (MCAN_RXF1E_DATA) Rx FIFO 1 Element Data  Offset */
+
+#define MCAN_RXF1E_DATA_DB0_Pos             0                                              /**< (MCAN_RXF1E_DATA) Data Byte 0 Position */
+#define MCAN_RXF1E_DATA_DB0_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB0_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 0 Mask */
+#define MCAN_RXF1E_DATA_DB0(value)          (MCAN_RXF1E_DATA_DB0_Msk & ((value) << MCAN_RXF1E_DATA_DB0_Pos))
+#define MCAN_RXF1E_DATA_DB1_Pos             8                                              /**< (MCAN_RXF1E_DATA) Data Byte 1 Position */
+#define MCAN_RXF1E_DATA_DB1_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB1_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 1 Mask */
+#define MCAN_RXF1E_DATA_DB1(value)          (MCAN_RXF1E_DATA_DB1_Msk & ((value) << MCAN_RXF1E_DATA_DB1_Pos))
+#define MCAN_RXF1E_DATA_DB2_Pos             16                                             /**< (MCAN_RXF1E_DATA) Data Byte 2 Position */
+#define MCAN_RXF1E_DATA_DB2_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB2_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 2 Mask */
+#define MCAN_RXF1E_DATA_DB2(value)          (MCAN_RXF1E_DATA_DB2_Msk & ((value) << MCAN_RXF1E_DATA_DB2_Pos))
+#define MCAN_RXF1E_DATA_DB3_Pos             24                                             /**< (MCAN_RXF1E_DATA) Data Byte 3 Position */
+#define MCAN_RXF1E_DATA_DB3_Msk             (_U_(0xFF) << MCAN_RXF1E_DATA_DB3_Pos)         /**< (MCAN_RXF1E_DATA) Data Byte 3 Mask */
+#define MCAN_RXF1E_DATA_DB3(value)          (MCAN_RXF1E_DATA_DB3_Msk & ((value) << MCAN_RXF1E_DATA_DB3_Pos))
+#define MCAN_RXF1E_DATA_MASK                _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_RXF1E_DATA) Register MASK  (Use MCAN_RXF1E_DATA_Msk instead)  */
+#define MCAN_RXF1E_DATA_Msk                 _U_(0xFFFFFFFF)                                /**< (MCAN_RXF1E_DATA) Register Mask  */
+
+
+/* -------- MCAN_TXBE_0 : (MCAN Offset: 0x00) (R/W 32) Tx Buffer Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_0_OFFSET                  (0x00)                                        /**<  (MCAN_TXBE_0) Tx Buffer Element 0  Offset */
+
+#define MCAN_TXBE_0_ID_Pos                  0                                              /**< (MCAN_TXBE_0) Identifier Position */
+#define MCAN_TXBE_0_ID_Msk                  (_U_(0x1FFFFFFF) << MCAN_TXBE_0_ID_Pos)        /**< (MCAN_TXBE_0) Identifier Mask */
+#define MCAN_TXBE_0_ID(value)               (MCAN_TXBE_0_ID_Msk & ((value) << MCAN_TXBE_0_ID_Pos))
+#define MCAN_TXBE_0_RTR_Pos                 29                                             /**< (MCAN_TXBE_0) Remote Transmission Request Position */
+#define MCAN_TXBE_0_RTR_Msk                 (_U_(0x1) << MCAN_TXBE_0_RTR_Pos)              /**< (MCAN_TXBE_0) Remote Transmission Request Mask */
+#define MCAN_TXBE_0_RTR                     MCAN_TXBE_0_RTR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_RTR_Msk instead */
+#define MCAN_TXBE_0_XTD_Pos                 30                                             /**< (MCAN_TXBE_0) Extended Identifier Position */
+#define MCAN_TXBE_0_XTD_Msk                 (_U_(0x1) << MCAN_TXBE_0_XTD_Pos)              /**< (MCAN_TXBE_0) Extended Identifier Mask */
+#define MCAN_TXBE_0_XTD                     MCAN_TXBE_0_XTD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_XTD_Msk instead */
+#define MCAN_TXBE_0_ESI_Pos                 31                                             /**< (MCAN_TXBE_0) Error State Indicator Position */
+#define MCAN_TXBE_0_ESI_Msk                 (_U_(0x1) << MCAN_TXBE_0_ESI_Pos)              /**< (MCAN_TXBE_0) Error State Indicator Mask */
+#define MCAN_TXBE_0_ESI                     MCAN_TXBE_0_ESI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_0_ESI_Msk instead */
+#define MCAN_TXBE_0_MASK                    _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBE_0) Register MASK  (Use MCAN_TXBE_0_Msk instead)  */
+#define MCAN_TXBE_0_Msk                     _U_(0xFFFFFFFF)                                /**< (MCAN_TXBE_0) Register Mask  */
+
+
+/* -------- MCAN_TXBE_1 : (MCAN Offset: 0x04) (R/W 32) Tx Buffer Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t :1;                        /**< bit:     22  Reserved */
+    uint32_t EFC:1;                     /**< bit:     23  Event FIFO Control                       */
+    uint32_t MM:8;                      /**< bit: 24..31  Message Marker                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_1_OFFSET                  (0x04)                                        /**<  (MCAN_TXBE_1) Tx Buffer Element 1  Offset */
+
+#define MCAN_TXBE_1_DLC_Pos                 16                                             /**< (MCAN_TXBE_1) Data Length Code Position */
+#define MCAN_TXBE_1_DLC_Msk                 (_U_(0xF) << MCAN_TXBE_1_DLC_Pos)              /**< (MCAN_TXBE_1) Data Length Code Mask */
+#define MCAN_TXBE_1_DLC(value)              (MCAN_TXBE_1_DLC_Msk & ((value) << MCAN_TXBE_1_DLC_Pos))
+#define MCAN_TXBE_1_BRS_Pos                 20                                             /**< (MCAN_TXBE_1) Bit Rate Switch Position */
+#define MCAN_TXBE_1_BRS_Msk                 (_U_(0x1) << MCAN_TXBE_1_BRS_Pos)              /**< (MCAN_TXBE_1) Bit Rate Switch Mask */
+#define MCAN_TXBE_1_BRS                     MCAN_TXBE_1_BRS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_BRS_Msk instead */
+#define MCAN_TXBE_1_FDF_Pos                 21                                             /**< (MCAN_TXBE_1) FD Format Position */
+#define MCAN_TXBE_1_FDF_Msk                 (_U_(0x1) << MCAN_TXBE_1_FDF_Pos)              /**< (MCAN_TXBE_1) FD Format Mask */
+#define MCAN_TXBE_1_FDF                     MCAN_TXBE_1_FDF_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_FDF_Msk instead */
+#define MCAN_TXBE_1_EFC_Pos                 23                                             /**< (MCAN_TXBE_1) Event FIFO Control Position */
+#define MCAN_TXBE_1_EFC_Msk                 (_U_(0x1) << MCAN_TXBE_1_EFC_Pos)              /**< (MCAN_TXBE_1) Event FIFO Control Mask */
+#define MCAN_TXBE_1_EFC                     MCAN_TXBE_1_EFC_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXBE_1_EFC_Msk instead */
+#define MCAN_TXBE_1_MM_Pos                  24                                             /**< (MCAN_TXBE_1) Message Marker Position */
+#define MCAN_TXBE_1_MM_Msk                  (_U_(0xFF) << MCAN_TXBE_1_MM_Pos)              /**< (MCAN_TXBE_1) Message Marker Mask */
+#define MCAN_TXBE_1_MM(value)               (MCAN_TXBE_1_MM_Msk & ((value) << MCAN_TXBE_1_MM_Pos))
+#define MCAN_TXBE_1_MASK                    _U_(0xFFBF0000)                                /**< \deprecated (MCAN_TXBE_1) Register MASK  (Use MCAN_TXBE_1_Msk instead)  */
+#define MCAN_TXBE_1_Msk                     _U_(0xFFBF0000)                                /**< (MCAN_TXBE_1) Register Mask  */
+
+
+/* -------- MCAN_TXBE_DATA : (MCAN Offset: 0x08) (R/W 32) Tx Buffer Element Data -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t DB0:8;                     /**< bit:   0..7  Data Byte 0                              */
+    uint32_t DB1:8;                     /**< bit:  8..15  Data Byte 1                              */
+    uint32_t DB2:8;                     /**< bit: 16..23  Data Byte 2                              */
+    uint32_t DB3:8;                     /**< bit: 24..31  Data Byte 3                              */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXBE_DATA_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXBE_DATA_OFFSET               (0x08)                                        /**<  (MCAN_TXBE_DATA) Tx Buffer Element Data  Offset */
+
+#define MCAN_TXBE_DATA_DB0_Pos              0                                              /**< (MCAN_TXBE_DATA) Data Byte 0 Position */
+#define MCAN_TXBE_DATA_DB0_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB0_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 0 Mask */
+#define MCAN_TXBE_DATA_DB0(value)           (MCAN_TXBE_DATA_DB0_Msk & ((value) << MCAN_TXBE_DATA_DB0_Pos))
+#define MCAN_TXBE_DATA_DB1_Pos              8                                              /**< (MCAN_TXBE_DATA) Data Byte 1 Position */
+#define MCAN_TXBE_DATA_DB1_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB1_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 1 Mask */
+#define MCAN_TXBE_DATA_DB1(value)           (MCAN_TXBE_DATA_DB1_Msk & ((value) << MCAN_TXBE_DATA_DB1_Pos))
+#define MCAN_TXBE_DATA_DB2_Pos              16                                             /**< (MCAN_TXBE_DATA) Data Byte 2 Position */
+#define MCAN_TXBE_DATA_DB2_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB2_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 2 Mask */
+#define MCAN_TXBE_DATA_DB2(value)           (MCAN_TXBE_DATA_DB2_Msk & ((value) << MCAN_TXBE_DATA_DB2_Pos))
+#define MCAN_TXBE_DATA_DB3_Pos              24                                             /**< (MCAN_TXBE_DATA) Data Byte 3 Position */
+#define MCAN_TXBE_DATA_DB3_Msk              (_U_(0xFF) << MCAN_TXBE_DATA_DB3_Pos)          /**< (MCAN_TXBE_DATA) Data Byte 3 Mask */
+#define MCAN_TXBE_DATA_DB3(value)           (MCAN_TXBE_DATA_DB3_Msk & ((value) << MCAN_TXBE_DATA_DB3_Pos))
+#define MCAN_TXBE_DATA_MASK                 _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXBE_DATA) Register MASK  (Use MCAN_TXBE_DATA_Msk instead)  */
+#define MCAN_TXBE_DATA_Msk                  _U_(0xFFFFFFFF)                                /**< (MCAN_TXBE_DATA) Register Mask  */
+
+
+/* -------- MCAN_TXEFE_0 : (MCAN Offset: 0x00) (R/W 32) Tx Event FIFO Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t ID:29;                     /**< bit:  0..28  Identifier                               */
+    uint32_t RTR:1;                     /**< bit:     29  Remote Transmission Request              */
+    uint32_t XTD:1;                     /**< bit:     30  Extended Identifier                      */
+    uint32_t ESI:1;                     /**< bit:     31  Error State Indicator                    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_TXEFE_0) Tx Event FIFO Element 0  Offset */
+
+#define MCAN_TXEFE_0_ID_Pos                 0                                              /**< (MCAN_TXEFE_0) Identifier Position */
+#define MCAN_TXEFE_0_ID_Msk                 (_U_(0x1FFFFFFF) << MCAN_TXEFE_0_ID_Pos)       /**< (MCAN_TXEFE_0) Identifier Mask */
+#define MCAN_TXEFE_0_ID(value)              (MCAN_TXEFE_0_ID_Msk & ((value) << MCAN_TXEFE_0_ID_Pos))
+#define MCAN_TXEFE_0_RTR_Pos                29                                             /**< (MCAN_TXEFE_0) Remote Transmission Request Position */
+#define MCAN_TXEFE_0_RTR_Msk                (_U_(0x1) << MCAN_TXEFE_0_RTR_Pos)             /**< (MCAN_TXEFE_0) Remote Transmission Request Mask */
+#define MCAN_TXEFE_0_RTR                    MCAN_TXEFE_0_RTR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_RTR_Msk instead */
+#define MCAN_TXEFE_0_XTD_Pos                30                                             /**< (MCAN_TXEFE_0) Extended Identifier Position */
+#define MCAN_TXEFE_0_XTD_Msk                (_U_(0x1) << MCAN_TXEFE_0_XTD_Pos)             /**< (MCAN_TXEFE_0) Extended Identifier Mask */
+#define MCAN_TXEFE_0_XTD                    MCAN_TXEFE_0_XTD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_XTD_Msk instead */
+#define MCAN_TXEFE_0_ESI_Pos                31                                             /**< (MCAN_TXEFE_0) Error State Indicator Position */
+#define MCAN_TXEFE_0_ESI_Msk                (_U_(0x1) << MCAN_TXEFE_0_ESI_Pos)             /**< (MCAN_TXEFE_0) Error State Indicator Mask */
+#define MCAN_TXEFE_0_ESI                    MCAN_TXEFE_0_ESI_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_0_ESI_Msk instead */
+#define MCAN_TXEFE_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXEFE_0) Register MASK  (Use MCAN_TXEFE_0_Msk instead)  */
+#define MCAN_TXEFE_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_TXEFE_0) Register Mask  */
+
+
+/* -------- MCAN_TXEFE_1 : (MCAN Offset: 0x04) (R/W 32) Tx Event FIFO Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t TXTS:16;                   /**< bit:  0..15  Tx Timestamp                             */
+    uint32_t DLC:4;                     /**< bit: 16..19  Data Length Code                         */
+    uint32_t BRS:1;                     /**< bit:     20  Bit Rate Switch                          */
+    uint32_t FDF:1;                     /**< bit:     21  FD Format                                */
+    uint32_t ET:2;                      /**< bit: 22..23  Event Type                               */
+    uint32_t MM:8;                      /**< bit: 24..31  Message Marker                           */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_TXEFE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_TXEFE_1_OFFSET                 (0x04)                                        /**<  (MCAN_TXEFE_1) Tx Event FIFO Element 1  Offset */
+
+#define MCAN_TXEFE_1_TXTS_Pos               0                                              /**< (MCAN_TXEFE_1) Tx Timestamp Position */
+#define MCAN_TXEFE_1_TXTS_Msk               (_U_(0xFFFF) << MCAN_TXEFE_1_TXTS_Pos)         /**< (MCAN_TXEFE_1) Tx Timestamp Mask */
+#define MCAN_TXEFE_1_TXTS(value)            (MCAN_TXEFE_1_TXTS_Msk & ((value) << MCAN_TXEFE_1_TXTS_Pos))
+#define MCAN_TXEFE_1_DLC_Pos                16                                             /**< (MCAN_TXEFE_1) Data Length Code Position */
+#define MCAN_TXEFE_1_DLC_Msk                (_U_(0xF) << MCAN_TXEFE_1_DLC_Pos)             /**< (MCAN_TXEFE_1) Data Length Code Mask */
+#define MCAN_TXEFE_1_DLC(value)             (MCAN_TXEFE_1_DLC_Msk & ((value) << MCAN_TXEFE_1_DLC_Pos))
+#define MCAN_TXEFE_1_BRS_Pos                20                                             /**< (MCAN_TXEFE_1) Bit Rate Switch Position */
+#define MCAN_TXEFE_1_BRS_Msk                (_U_(0x1) << MCAN_TXEFE_1_BRS_Pos)             /**< (MCAN_TXEFE_1) Bit Rate Switch Mask */
+#define MCAN_TXEFE_1_BRS                    MCAN_TXEFE_1_BRS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_1_BRS_Msk instead */
+#define MCAN_TXEFE_1_FDF_Pos                21                                             /**< (MCAN_TXEFE_1) FD Format Position */
+#define MCAN_TXEFE_1_FDF_Msk                (_U_(0x1) << MCAN_TXEFE_1_FDF_Pos)             /**< (MCAN_TXEFE_1) FD Format Mask */
+#define MCAN_TXEFE_1_FDF                    MCAN_TXEFE_1_FDF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use MCAN_TXEFE_1_FDF_Msk instead */
+#define MCAN_TXEFE_1_ET_Pos                 22                                             /**< (MCAN_TXEFE_1) Event Type Position */
+#define MCAN_TXEFE_1_ET_Msk                 (_U_(0x3) << MCAN_TXEFE_1_ET_Pos)              /**< (MCAN_TXEFE_1) Event Type Mask */
+#define MCAN_TXEFE_1_ET(value)              (MCAN_TXEFE_1_ET_Msk & ((value) << MCAN_TXEFE_1_ET_Pos))
+#define   MCAN_TXEFE_1_ET_TXE_Val           _U_(0x1)                                       /**< (MCAN_TXEFE_1) Tx event  */
+#define   MCAN_TXEFE_1_ET_TXC_Val           _U_(0x2)                                       /**< (MCAN_TXEFE_1) Transmission in spite of cancellation  */
+#define MCAN_TXEFE_1_ET_TXE                 (MCAN_TXEFE_1_ET_TXE_Val << MCAN_TXEFE_1_ET_Pos)  /**< (MCAN_TXEFE_1) Tx event Position  */
+#define MCAN_TXEFE_1_ET_TXC                 (MCAN_TXEFE_1_ET_TXC_Val << MCAN_TXEFE_1_ET_Pos)  /**< (MCAN_TXEFE_1) Transmission in spite of cancellation Position  */
+#define MCAN_TXEFE_1_MM_Pos                 24                                             /**< (MCAN_TXEFE_1) Message Marker Position */
+#define MCAN_TXEFE_1_MM_Msk                 (_U_(0xFF) << MCAN_TXEFE_1_MM_Pos)             /**< (MCAN_TXEFE_1) Message Marker Mask */
+#define MCAN_TXEFE_1_MM(value)              (MCAN_TXEFE_1_MM_Msk & ((value) << MCAN_TXEFE_1_MM_Pos))
+#define MCAN_TXEFE_1_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_TXEFE_1) Register MASK  (Use MCAN_TXEFE_1_Msk instead)  */
+#define MCAN_TXEFE_1_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_TXEFE_1) Register Mask  */
+
+
+/* -------- MCAN_SIDFE_0 : (MCAN Offset: 0x00) (R/W 32) Standard Message ID Filter Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t SFID2:11;                  /**< bit:  0..10  Standard Filter ID 2                     */
+    uint32_t :5;                        /**< bit: 11..15  Reserved */
+    uint32_t SFID1:11;                  /**< bit: 16..26  Standard Filter ID 1                     */
+    uint32_t SFEC:3;                    /**< bit: 27..29  Standard Filter Element Configuration    */
+    uint32_t SFT:2;                     /**< bit: 30..31  Standard Filter Type                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_SIDFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_SIDFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_SIDFE_0) Standard Message ID Filter Element 0  Offset */
+
+#define MCAN_SIDFE_0_SFID2_Pos              0                                              /**< (MCAN_SIDFE_0) Standard Filter ID 2 Position */
+#define MCAN_SIDFE_0_SFID2_Msk              (_U_(0x7FF) << MCAN_SIDFE_0_SFID2_Pos)         /**< (MCAN_SIDFE_0) Standard Filter ID 2 Mask */
+#define MCAN_SIDFE_0_SFID2(value)           (MCAN_SIDFE_0_SFID2_Msk & ((value) << MCAN_SIDFE_0_SFID2_Pos))
+#define MCAN_SIDFE_0_SFID1_Pos              16                                             /**< (MCAN_SIDFE_0) Standard Filter ID 1 Position */
+#define MCAN_SIDFE_0_SFID1_Msk              (_U_(0x7FF) << MCAN_SIDFE_0_SFID1_Pos)         /**< (MCAN_SIDFE_0) Standard Filter ID 1 Mask */
+#define MCAN_SIDFE_0_SFID1(value)           (MCAN_SIDFE_0_SFID1_Msk & ((value) << MCAN_SIDFE_0_SFID1_Pos))
+#define MCAN_SIDFE_0_SFEC_Pos               27                                             /**< (MCAN_SIDFE_0) Standard Filter Element Configuration Position */
+#define MCAN_SIDFE_0_SFEC_Msk               (_U_(0x7) << MCAN_SIDFE_0_SFEC_Pos)            /**< (MCAN_SIDFE_0) Standard Filter Element Configuration Mask */
+#define MCAN_SIDFE_0_SFEC(value)            (MCAN_SIDFE_0_SFEC_Msk & ((value) << MCAN_SIDFE_0_SFEC_Pos))
+#define   MCAN_SIDFE_0_SFEC_DISABLE_Val     _U_(0x0)                                       /**< (MCAN_SIDFE_0) Disable filter element  */
+#define   MCAN_SIDFE_0_SFEC_STF0M_Val       _U_(0x1)                                       /**< (MCAN_SIDFE_0) Store in Rx FIFO 0 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_STF1M_Val       _U_(0x2)                                       /**< (MCAN_SIDFE_0) Store in Rx FIFO 1 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_REJECT_Val      _U_(0x3)                                       /**< (MCAN_SIDFE_0) Reject ID if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIORITY_Val    _U_(0x4)                                       /**< (MCAN_SIDFE_0) Set priority if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIF0M_Val      _U_(0x5)                                       /**< (MCAN_SIDFE_0) Set priority and store in FIFO 0 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_PRIF1M_Val      _U_(0x6)                                       /**< (MCAN_SIDFE_0) Set priority and store in FIFO 1 if filter matches  */
+#define   MCAN_SIDFE_0_SFEC_STRXBUF_Val     _U_(0x7)                                       /**< (MCAN_SIDFE_0) Store into Rx Buffer  */
+#define MCAN_SIDFE_0_SFEC_DISABLE           (MCAN_SIDFE_0_SFEC_DISABLE_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Disable filter element Position  */
+#define MCAN_SIDFE_0_SFEC_STF0M             (MCAN_SIDFE_0_SFEC_STF0M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store in Rx FIFO 0 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_STF1M             (MCAN_SIDFE_0_SFEC_STF1M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store in Rx FIFO 1 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_REJECT            (MCAN_SIDFE_0_SFEC_REJECT_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Reject ID if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIORITY          (MCAN_SIDFE_0_SFEC_PRIORITY_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIF0M            (MCAN_SIDFE_0_SFEC_PRIF0M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority and store in FIFO 0 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_PRIF1M            (MCAN_SIDFE_0_SFEC_PRIF1M_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Set priority and store in FIFO 1 if filter matches Position  */
+#define MCAN_SIDFE_0_SFEC_STRXBUF           (MCAN_SIDFE_0_SFEC_STRXBUF_Val << MCAN_SIDFE_0_SFEC_Pos)  /**< (MCAN_SIDFE_0) Store into Rx Buffer Position  */
+#define MCAN_SIDFE_0_SFT_Pos                30                                             /**< (MCAN_SIDFE_0) Standard Filter Type Position */
+#define MCAN_SIDFE_0_SFT_Msk                (_U_(0x3) << MCAN_SIDFE_0_SFT_Pos)             /**< (MCAN_SIDFE_0) Standard Filter Type Mask */
+#define MCAN_SIDFE_0_SFT(value)             (MCAN_SIDFE_0_SFT_Msk & ((value) << MCAN_SIDFE_0_SFT_Pos))
+#define   MCAN_SIDFE_0_SFT_RANGE_Val        _U_(0x0)                                       /**< (MCAN_SIDFE_0) Range filter from SFID1 to SFID2  */
+#define   MCAN_SIDFE_0_SFT_DUAL_Val         _U_(0x1)                                       /**< (MCAN_SIDFE_0) Dual ID filter for SF1ID or SF2ID  */
+#define   MCAN_SIDFE_0_SFT_CLASSIC_Val      _U_(0x2)                                       /**< (MCAN_SIDFE_0) Classic filter  */
+#define MCAN_SIDFE_0_SFT_RANGE              (MCAN_SIDFE_0_SFT_RANGE_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Range filter from SFID1 to SFID2 Position  */
+#define MCAN_SIDFE_0_SFT_DUAL               (MCAN_SIDFE_0_SFT_DUAL_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Dual ID filter for SF1ID or SF2ID Position  */
+#define MCAN_SIDFE_0_SFT_CLASSIC            (MCAN_SIDFE_0_SFT_CLASSIC_Val << MCAN_SIDFE_0_SFT_Pos)  /**< (MCAN_SIDFE_0) Classic filter Position  */
+#define MCAN_SIDFE_0_MASK                   _U_(0xFFFF07FF)                                /**< \deprecated (MCAN_SIDFE_0) Register MASK  (Use MCAN_SIDFE_0_Msk instead)  */
+#define MCAN_SIDFE_0_Msk                    _U_(0xFFFF07FF)                                /**< (MCAN_SIDFE_0) Register Mask  */
+
+
+/* -------- MCAN_XIDFE_0 : (MCAN Offset: 0x00) (R/W 32) Extended Message ID Filter Element 0 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFID1:29;                  /**< bit:  0..28  Extended Filter ID 1                     */
+    uint32_t EFEC:3;                    /**< bit: 29..31  Extended Filter Element Configuration    */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFE_0_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFE_0_OFFSET                 (0x00)                                        /**<  (MCAN_XIDFE_0) Extended Message ID Filter Element 0  Offset */
+
+#define MCAN_XIDFE_0_EFID1_Pos              0                                              /**< (MCAN_XIDFE_0) Extended Filter ID 1 Position */
+#define MCAN_XIDFE_0_EFID1_Msk              (_U_(0x1FFFFFFF) << MCAN_XIDFE_0_EFID1_Pos)    /**< (MCAN_XIDFE_0) Extended Filter ID 1 Mask */
+#define MCAN_XIDFE_0_EFID1(value)           (MCAN_XIDFE_0_EFID1_Msk & ((value) << MCAN_XIDFE_0_EFID1_Pos))
+#define MCAN_XIDFE_0_EFEC_Pos               29                                             /**< (MCAN_XIDFE_0) Extended Filter Element Configuration Position */
+#define MCAN_XIDFE_0_EFEC_Msk               (_U_(0x7) << MCAN_XIDFE_0_EFEC_Pos)            /**< (MCAN_XIDFE_0) Extended Filter Element Configuration Mask */
+#define MCAN_XIDFE_0_EFEC(value)            (MCAN_XIDFE_0_EFEC_Msk & ((value) << MCAN_XIDFE_0_EFEC_Pos))
+#define   MCAN_XIDFE_0_EFEC_DISABLE_Val     _U_(0x0)                                       /**< (MCAN_XIDFE_0) Disable filter element  */
+#define   MCAN_XIDFE_0_EFEC_STF0M_Val       _U_(0x1)                                       /**< (MCAN_XIDFE_0) Store in Rx FIFO 0 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_STF1M_Val       _U_(0x2)                                       /**< (MCAN_XIDFE_0) Store in Rx FIFO 1 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_REJECT_Val      _U_(0x3)                                       /**< (MCAN_XIDFE_0) Reject ID if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIORITY_Val    _U_(0x4)                                       /**< (MCAN_XIDFE_0) Set priority if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIF0M_Val      _U_(0x5)                                       /**< (MCAN_XIDFE_0) Set priority and store in FIFO 0 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_PRIF1M_Val      _U_(0x6)                                       /**< (MCAN_XIDFE_0) Set priority and store in FIFO 1 if filter matches  */
+#define   MCAN_XIDFE_0_EFEC_STRXBUF_Val     _U_(0x7)                                       /**< (MCAN_XIDFE_0) Store into Rx Buffer  */
+#define MCAN_XIDFE_0_EFEC_DISABLE           (MCAN_XIDFE_0_EFEC_DISABLE_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Disable filter element Position  */
+#define MCAN_XIDFE_0_EFEC_STF0M             (MCAN_XIDFE_0_EFEC_STF0M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store in Rx FIFO 0 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_STF1M             (MCAN_XIDFE_0_EFEC_STF1M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store in Rx FIFO 1 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_REJECT            (MCAN_XIDFE_0_EFEC_REJECT_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Reject ID if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIORITY          (MCAN_XIDFE_0_EFEC_PRIORITY_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIF0M            (MCAN_XIDFE_0_EFEC_PRIF0M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority and store in FIFO 0 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_PRIF1M            (MCAN_XIDFE_0_EFEC_PRIF1M_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Set priority and store in FIFO 1 if filter matches Position  */
+#define MCAN_XIDFE_0_EFEC_STRXBUF           (MCAN_XIDFE_0_EFEC_STRXBUF_Val << MCAN_XIDFE_0_EFEC_Pos)  /**< (MCAN_XIDFE_0) Store into Rx Buffer Position  */
+#define MCAN_XIDFE_0_MASK                   _U_(0xFFFFFFFF)                                /**< \deprecated (MCAN_XIDFE_0) Register MASK  (Use MCAN_XIDFE_0_Msk instead)  */
+#define MCAN_XIDFE_0_Msk                    _U_(0xFFFFFFFF)                                /**< (MCAN_XIDFE_0) Register Mask  */
+
+
+/* -------- MCAN_XIDFE_1 : (MCAN Offset: 0x04) (R/W 32) Extended Message ID Filter Element 1 -------- */
+#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
+typedef union { 
+  struct {
+    uint32_t EFID2:29;                  /**< bit:  0..28  Extended Filter ID 2                     */
+    uint32_t :1;                        /**< bit:     29  Reserved */
+    uint32_t EFT:2;                     /**< bit: 30..31  Extended Filter Type                     */
+  } bit;                                /**< Structure used for bit  access */
+  uint32_t reg;                         /**< Type used for register access */
+} MCAN_XIDFE_1_Type;
+#endif
+#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define MCAN_XIDFE_1_OFFSET                 (0x04)                                        /**<  (MCAN_XIDFE_1) Extended Message ID Filter Element 1  Offset */
+
+#define MCAN_XIDFE_1_EFID2_Pos              0                                              /**< (MCAN_XIDFE_1) Extended Filter ID 2 Position */
+#define MCAN_XIDFE_1_EFID2_Msk              (_U_(0x1FFFFFFF) << MCAN_XIDFE_1_EFID2_Pos)    /**< (MCAN_XIDFE_1) Extended Filter ID 2 Mask */
+#define MCAN_XIDFE_1_EFID2(value)           (MCAN_XIDFE_1_EFID2_Msk & ((value) << MCAN_XIDFE_1_EFID2_Pos))
+#define MCAN_XIDFE_1_EFT_Pos                30                                             /**< (MCAN_XIDFE_1) Extended Filter Type Position */
+#define MCAN_XIDFE_1_EFT_Msk                (_U_(0x3) << MCAN_XIDFE_1_EFT_Pos)             /**< (MCAN_XIDFE_1) Extended Filter Type Mask */
+#define MCAN_XIDFE_1_EFT(value)             (MCAN_XIDFE_1_EFT_Msk & ((value) << MCAN_XIDFE_1_EFT_Pos))
+#define   MCAN_XIDFE_1_EFT_RANGE_Val        _U_(0x0)                                       /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2  */
+#define   MCAN_XIDFE_1_EFT_DUAL_Val         _U_(0x1)                                       /**< (MCAN_XIDFE_1) Dual ID filter for EFID1 or EFID2  */
+#define   MCAN_XIDFE_1_EFT_CLASSIC_Val      _U_(0x2)                                       /**< (MCAN_XIDFE_1) Classic filter  */
+#define   MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM_Val _U_(0x3)                                       /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 with no XIDAM mask  */
+#define MCAN_XIDFE_1_EFT_RANGE              (MCAN_XIDFE_1_EFT_RANGE_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 Position  */
+#define MCAN_XIDFE_1_EFT_DUAL               (MCAN_XIDFE_1_EFT_DUAL_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Dual ID filter for EFID1 or EFID2 Position  */
+#define MCAN_XIDFE_1_EFT_CLASSIC            (MCAN_XIDFE_1_EFT_CLASSIC_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Classic filter Position  */
+#define MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM     (MCAN_XIDFE_1_EFT_RANGE_NO_XIDAM_Val << MCAN_XIDFE_1_EFT_Pos)  /**< (MCAN_XIDFE_1) Range filter from EFID1 to EFID2 with no XIDAM mask Position  */
+#define MCAN_XIDFE_1_MASK                   _U_(0xDFFFFFFF)                                /**< \deprecated (MCAN_XIDFE_1) Register MASK  (Use MCAN_XIDFE_1_Msk instead)  */
+#define MCAN_XIDFE_1_Msk                    _U_(0xDFFFFFFF)                                /**< (MCAN_XIDFE_1) Register Mask  */
+
+
 /* -------- MCAN_CREL : (MCAN Offset: 0x00) (R/ 32) Core Release Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DAY:8;                     /**< bit:   0..7  Timestamp Day                            */
@@ -56,6 +697,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_CREL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_CREL_OFFSET                    (0x00)                                        /**<  (MCAN_CREL) Core Release Register  Offset */
@@ -84,12 +726,14 @@ typedef union {
 
 /* -------- MCAN_ENDN : (MCAN Offset: 0x04) (R/ 32) Endian Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ETV:32;                    /**< bit:  0..31  Endianness Test Value                    */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ENDN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ENDN_OFFSET                    (0x04)                                        /**<  (MCAN_ENDN) Endian Register  Offset */
@@ -103,12 +747,14 @@ typedef union {
 
 /* -------- MCAN_CUST : (MCAN Offset: 0x08) (R/W 32) Customer Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSV:32;                    /**< bit:  0..31  Customer-specific Value                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_CUST_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_CUST_OFFSET                    (0x08)                                        /**<  (MCAN_CUST) Customer Register  Offset */
@@ -122,6 +768,7 @@ typedef union {
 
 /* -------- MCAN_DBTP : (MCAN Offset: 0x0c) (R/W 32) Data Bit Timing and Prescaler Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DSJW:3;                    /**< bit:   0..2  Data (Re) Synchronization Jump Width     */
@@ -136,6 +783,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_DBTP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_DBTP_OFFSET                    (0x0C)                                        /**<  (MCAN_DBTP) Data Bit Timing and Prescaler Register  Offset */
@@ -165,6 +813,7 @@ typedef union {
 
 /* -------- MCAN_TEST : (MCAN Offset: 0x10) (R/W 32) Test Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -175,6 +824,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TEST_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TEST_OFFSET                    (0x10)                                        /**<  (MCAN_TEST) Test Register  Offset */
@@ -206,6 +856,7 @@ typedef union {
 
 /* -------- MCAN_RWD : (MCAN Offset: 0x14) (R/W 32) RAM Watchdog Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDC:8;                     /**< bit:   0..7  Watchdog Configuration (read/write)      */
@@ -214,6 +865,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RWD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RWD_OFFSET                     (0x14)                                        /**<  (MCAN_RWD) RAM Watchdog Register  Offset */
@@ -230,6 +882,7 @@ typedef union {
 
 /* -------- MCAN_CCCR : (MCAN Offset: 0x18) (R/W 32) CC Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INIT:1;                    /**< bit:      0  Initialization (read/write)              */
@@ -251,6 +904,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_CCCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_CCCR_OFFSET                    (0x18)                                        /**<  (MCAN_CCCR) CC Control Register  Offset */
@@ -339,6 +993,7 @@ typedef union {
 
 /* -------- MCAN_NBTP : (MCAN Offset: 0x1c) (R/W 32) Nominal Bit Timing and Prescaler Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NTSEG2:7;                  /**< bit:   0..6  Nominal Time Segment After Sample Point  */
@@ -349,6 +1004,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_NBTP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_NBTP_OFFSET                    (0x1C)                                        /**<  (MCAN_NBTP) Nominal Bit Timing and Prescaler Register  Offset */
@@ -371,6 +1027,7 @@ typedef union {
 
 /* -------- MCAN_TSCC : (MCAN Offset: 0x20) (R/W 32) Timestamp Counter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSS:2;                     /**< bit:   0..1  Timestamp Select                         */
@@ -380,6 +1037,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TSCC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TSCC_OFFSET                    (0x20)                                        /**<  (MCAN_TSCC) Timestamp Counter Configuration Register  Offset */
@@ -402,6 +1060,7 @@ typedef union {
 
 /* -------- MCAN_TSCV : (MCAN Offset: 0x24) (R/W 32) Timestamp Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSC:16;                    /**< bit:  0..15  Timestamp Counter (cleared on write)     */
@@ -409,6 +1068,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TSCV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TSCV_OFFSET                    (0x24)                                        /**<  (MCAN_TSCV) Timestamp Counter Value Register  Offset */
@@ -422,6 +1082,7 @@ typedef union {
 
 /* -------- MCAN_TOCC : (MCAN Offset: 0x28) (R/W 32) Timeout Counter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ETOC:1;                    /**< bit:      0  Enable Timeout Counter                   */
@@ -431,6 +1092,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TOCC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TOCC_OFFSET                    (0x28)                                        /**<  (MCAN_TOCC) Timeout Counter Configuration Register  Offset */
@@ -462,6 +1124,7 @@ typedef union {
 
 /* -------- MCAN_TOCV : (MCAN Offset: 0x2c) (R/W 32) Timeout Counter Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TOC:16;                    /**< bit:  0..15  Timeout Counter (cleared on write)       */
@@ -469,6 +1132,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TOCV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TOCV_OFFSET                    (0x2C)                                        /**<  (MCAN_TOCV) Timeout Counter Value Register  Offset */
@@ -482,6 +1146,7 @@ typedef union {
 
 /* -------- MCAN_ECR : (MCAN Offset: 0x40) (R/ 32) Error Counter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TEC:8;                     /**< bit:   0..7  Transmit Error Counter                   */
@@ -492,6 +1157,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ECR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ECR_OFFSET                     (0x40)                                        /**<  (MCAN_ECR) Error Counter Register  Offset */
@@ -514,6 +1180,7 @@ typedef union {
 
 /* -------- MCAN_PSR : (MCAN Offset: 0x44) (R/ 32) Protocol Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEC:3;                     /**< bit:   0..2  Last Error Code (set to 111 on read)     */
@@ -532,6 +1199,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_PSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_PSR_OFFSET                     (0x44)                                        /**<  (MCAN_PSR) Protocol Status Register  Offset */
@@ -599,6 +1267,7 @@ typedef union {
 
 /* -------- MCAN_TDCR : (MCAN Offset: 0x48) (R/W 32) Transmit Delay Compensation Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TDCF:7;                    /**< bit:   0..6  Transmitter Delay Compensation Filter    */
@@ -608,6 +1277,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TDCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TDCR_OFFSET                    (0x48)                                        /**<  (MCAN_TDCR) Transmit Delay Compensation Register  Offset */
@@ -624,6 +1294,7 @@ typedef union {
 
 /* -------- MCAN_IR : (MCAN Offset: 0x50) (R/W 32) Interrupt Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0N:1;                    /**< bit:      0  Receive FIFO 0 New Message               */
@@ -659,6 +1330,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_IR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_IR_OFFSET                      (0x50)                                        /**<  (MCAN_IR) Interrupt Register  Offset */
@@ -753,6 +1425,7 @@ typedef union {
 
 /* -------- MCAN_IE : (MCAN Offset: 0x54) (R/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0NE:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Enable */
@@ -788,6 +1461,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_IE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_IE_OFFSET                      (0x54)                                        /**<  (MCAN_IE) Interrupt Enable Register  Offset */
@@ -882,6 +1556,7 @@ typedef union {
 
 /* -------- MCAN_ILS : (MCAN Offset: 0x58) (R/W 32) Interrupt Line Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RF0NL:1;                   /**< bit:      0  Receive FIFO 0 New Message Interrupt Line */
@@ -917,6 +1592,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ILS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ILS_OFFSET                     (0x58)                                        /**<  (MCAN_ILS) Interrupt Line Select Register  Offset */
@@ -1011,6 +1687,7 @@ typedef union {
 
 /* -------- MCAN_ILE : (MCAN Offset: 0x5c) (R/W 32) Interrupt Line Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EINT0:1;                   /**< bit:      0  Enable Interrupt Line 0                  */
@@ -1023,6 +1700,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_ILE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_ILE_OFFSET                     (0x5C)                                        /**<  (MCAN_ILE) Interrupt Line Enable Register  Offset */
@@ -1042,6 +1720,7 @@ typedef union {
 
 /* -------- MCAN_GFC : (MCAN Offset: 0x80) (R/W 32) Global Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RRFE:1;                    /**< bit:      0  Reject Remote Frames Extended            */
@@ -1052,6 +1731,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_GFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_GFC_OFFSET                     (0x80)                                        /**<  (MCAN_GFC) Global Filter Configuration Register  Offset */
@@ -1090,6 +1770,7 @@ typedef union {
 
 /* -------- MCAN_SIDFC : (MCAN Offset: 0x84) (R/W 32) Standard ID Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1099,6 +1780,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_SIDFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_SIDFC_OFFSET                   (0x84)                                        /**<  (MCAN_SIDFC) Standard ID Filter Configuration Register  Offset */
@@ -1115,6 +1797,7 @@ typedef union {
 
 /* -------- MCAN_XIDFC : (MCAN Offset: 0x88) (R/W 32) Extended ID Filter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1124,6 +1807,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_XIDFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_XIDFC_OFFSET                   (0x88)                                        /**<  (MCAN_XIDFC) Extended ID Filter Configuration Register  Offset */
@@ -1140,6 +1824,7 @@ typedef union {
 
 /* -------- MCAN_XIDAM : (MCAN Offset: 0x90) (R/W 32) Extended ID AND Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EIDM:29;                   /**< bit:  0..28  Extended ID Mask                         */
@@ -1147,6 +1832,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_XIDAM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_XIDAM_OFFSET                   (0x90)                                        /**<  (MCAN_XIDAM) Extended ID AND Mask Register  Offset */
@@ -1160,6 +1846,7 @@ typedef union {
 
 /* -------- MCAN_HPMS : (MCAN Offset: 0x94) (R/ 32) High Priority Message Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIDX:6;                    /**< bit:   0..5  Buffer Index                             */
@@ -1170,6 +1857,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_HPMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_HPMS_OFFSET                    (0x94)                                        /**<  (MCAN_HPMS) High Priority Message Status Register  Offset */
@@ -1200,6 +1888,7 @@ typedef union {
 
 /* -------- MCAN_NDAT1 : (MCAN Offset: 0x98) (R/W 32) New Data 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ND0:1;                     /**< bit:      0  New Data                                 */
@@ -1240,6 +1929,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_NDAT1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_NDAT1_OFFSET                   (0x98)                                        /**<  (MCAN_NDAT1) New Data 1 Register  Offset */
@@ -1349,6 +2039,7 @@ typedef union {
 
 /* -------- MCAN_NDAT2 : (MCAN Offset: 0x9c) (R/W 32) New Data 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ND32:1;                    /**< bit:      0  New Data                                 */
@@ -1389,6 +2080,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_NDAT2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_NDAT2_OFFSET                   (0x9C)                                        /**<  (MCAN_NDAT2) New Data 2 Register  Offset */
@@ -1498,6 +2190,7 @@ typedef union {
 
 /* -------- MCAN_RXF0C : (MCAN Offset: 0xa0) (R/W 32) Receive FIFO 0 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1509,6 +2202,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0C_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0C_OFFSET                   (0xA0)                                        /**<  (MCAN_RXF0C) Receive FIFO 0 Configuration Register  Offset */
@@ -1531,6 +2225,7 @@ typedef union {
 
 /* -------- MCAN_RXF0S : (MCAN Offset: 0xa4) (R/ 32) Receive FIFO 0 Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0FL:7;                    /**< bit:   0..6  Receive FIFO 0 Fill Level                */
@@ -1545,6 +2240,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0S_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0S_OFFSET                   (0xA4)                                        /**<  (MCAN_RXF0S) Receive FIFO 0 Status Register  Offset */
@@ -1570,6 +2266,7 @@ typedef union {
 
 /* -------- MCAN_RXF0A : (MCAN Offset: 0xa8) (R/W 32) Receive FIFO 0 Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0AI:6;                    /**< bit:   0..5  Receive FIFO 0 Acknowledge Index         */
@@ -1577,6 +2274,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF0A_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF0A_OFFSET                   (0xA8)                                        /**<  (MCAN_RXF0A) Receive FIFO 0 Acknowledge Register  Offset */
@@ -1590,6 +2288,7 @@ typedef union {
 
 /* -------- MCAN_RXBC : (MCAN Offset: 0xac) (R/W 32) Receive Rx Buffer Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1598,6 +2297,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXBC_OFFSET                    (0xAC)                                        /**<  (MCAN_RXBC) Receive Rx Buffer Configuration Register  Offset */
@@ -1611,6 +2311,7 @@ typedef union {
 
 /* -------- MCAN_RXF1C : (MCAN Offset: 0xb0) (R/W 32) Receive FIFO 1 Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1622,6 +2323,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1C_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1C_OFFSET                   (0xB0)                                        /**<  (MCAN_RXF1C) Receive FIFO 1 Configuration Register  Offset */
@@ -1644,6 +2346,7 @@ typedef union {
 
 /* -------- MCAN_RXF1S : (MCAN Offset: 0xb4) (R/ 32) Receive FIFO 1 Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F1FL:7;                    /**< bit:   0..6  Receive FIFO 1 Fill Level                */
@@ -1659,6 +2362,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1S_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1S_OFFSET                   (0xB4)                                        /**<  (MCAN_RXF1S) Receive FIFO 1 Status Register  Offset */
@@ -1695,6 +2399,7 @@ typedef union {
 
 /* -------- MCAN_RXF1A : (MCAN Offset: 0xb8) (R/W 32) Receive FIFO 1 Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F1AI:6;                    /**< bit:   0..5  Receive FIFO 1 Acknowledge Index         */
@@ -1702,6 +2407,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXF1A_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXF1A_OFFSET                   (0xB8)                                        /**<  (MCAN_RXF1A) Receive FIFO 1 Acknowledge Register  Offset */
@@ -1715,6 +2421,7 @@ typedef union {
 
 /* -------- MCAN_RXESC : (MCAN Offset: 0xbc) (R/W 32) Receive Buffer / FIFO Element Size Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t F0DS:3;                    /**< bit:   0..2  Receive FIFO 0 Data Field Size           */
@@ -1726,6 +2433,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_RXESC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_RXESC_OFFSET                   (0xBC)                                        /**<  (MCAN_RXESC) Receive Buffer / FIFO Element Size Configuration Register  Offset */
@@ -1793,6 +2501,7 @@ typedef union {
 
 /* -------- MCAN_TXBC : (MCAN Offset: 0xc0) (R/W 32) Transmit Buffer Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -1805,6 +2514,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBC_OFFSET                    (0xC0)                                        /**<  (MCAN_TXBC) Transmit Buffer Configuration Register  Offset */
@@ -1827,6 +2537,7 @@ typedef union {
 
 /* -------- MCAN_TXFQS : (MCAN Offset: 0xc4) (R/ 32) Transmit FIFO/Queue Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TFFL:6;                    /**< bit:   0..5  Tx FIFO Free Level                       */
@@ -1839,6 +2550,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXFQS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXFQS_OFFSET                   (0xC4)                                        /**<  (MCAN_TXFQS) Transmit FIFO/Queue Status Register  Offset */
@@ -1861,6 +2573,7 @@ typedef union {
 
 /* -------- MCAN_TXESC : (MCAN Offset: 0xc8) (R/W 32) Transmit Buffer Element Size Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TBDS:3;                    /**< bit:   0..2  Tx Buffer Data Field Size                */
@@ -1868,6 +2581,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXESC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXESC_OFFSET                   (0xC8)                                        /**<  (MCAN_TXESC) Transmit Buffer Element Size Configuration Register  Offset */
@@ -1881,7 +2595,7 @@ typedef union {
 #define   MCAN_TXESC_TBDS_20_BYTE_Val       _U_(0x3)                                       /**< (MCAN_TXESC) 20-byte data field  */
 #define   MCAN_TXESC_TBDS_24_BYTE_Val       _U_(0x4)                                       /**< (MCAN_TXESC) 24-byte data field  */
 #define   MCAN_TXESC_TBDS_32_BYTE_Val       _U_(0x5)                                       /**< (MCAN_TXESC) 32-byte data field  */
-#define   MCAN_TXESC_TBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_TXESC) 48- byte data field  */
+#define   MCAN_TXESC_TBDS_48_BYTE_Val       _U_(0x6)                                       /**< (MCAN_TXESC) 48-byte data field  */
 #define   MCAN_TXESC_TBDS_64_BYTE_Val       _U_(0x7)                                       /**< (MCAN_TXESC) 64-byte data field  */
 #define MCAN_TXESC_TBDS_8_BYTE              (MCAN_TXESC_TBDS_8_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 8-byte data field Position  */
 #define MCAN_TXESC_TBDS_12_BYTE             (MCAN_TXESC_TBDS_12_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 12-byte data field Position  */
@@ -1889,7 +2603,7 @@ typedef union {
 #define MCAN_TXESC_TBDS_20_BYTE             (MCAN_TXESC_TBDS_20_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 20-byte data field Position  */
 #define MCAN_TXESC_TBDS_24_BYTE             (MCAN_TXESC_TBDS_24_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 24-byte data field Position  */
 #define MCAN_TXESC_TBDS_32_BYTE             (MCAN_TXESC_TBDS_32_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 32-byte data field Position  */
-#define MCAN_TXESC_TBDS_48_BYTE             (MCAN_TXESC_TBDS_48_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 48- byte data field Position  */
+#define MCAN_TXESC_TBDS_48_BYTE             (MCAN_TXESC_TBDS_48_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 48-byte data field Position  */
 #define MCAN_TXESC_TBDS_64_BYTE             (MCAN_TXESC_TBDS_64_BYTE_Val << MCAN_TXESC_TBDS_Pos)  /**< (MCAN_TXESC) 64-byte data field Position  */
 #define MCAN_TXESC_MASK                     _U_(0x07)                                      /**< \deprecated (MCAN_TXESC) Register MASK  (Use MCAN_TXESC_Msk instead)  */
 #define MCAN_TXESC_Msk                      _U_(0x07)                                      /**< (MCAN_TXESC) Register Mask  */
@@ -1897,6 +2611,7 @@ typedef union {
 
 /* -------- MCAN_TXBRP : (MCAN Offset: 0xcc) (R/ 32) Transmit Buffer Request Pending Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRP0:1;                    /**< bit:      0  Transmission Request Pending for Buffer 0 */
@@ -1937,6 +2652,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBRP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBRP_OFFSET                   (0xCC)                                        /**<  (MCAN_TXBRP) Transmit Buffer Request Pending Register  Offset */
@@ -2046,6 +2762,7 @@ typedef union {
 
 /* -------- MCAN_TXBAR : (MCAN Offset: 0xd0) (R/W 32) Transmit Buffer Add Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AR0:1;                     /**< bit:      0  Add Request for Transmit Buffer 0        */
@@ -2086,6 +2803,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBAR_OFFSET                   (0xD0)                                        /**<  (MCAN_TXBAR) Transmit Buffer Add Request Register  Offset */
@@ -2195,6 +2913,7 @@ typedef union {
 
 /* -------- MCAN_TXBCR : (MCAN Offset: 0xd4) (R/W 32) Transmit Buffer Cancellation Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CR0:1;                     /**< bit:      0  Cancellation Request for Transmit Buffer 0 */
@@ -2235,6 +2954,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCR_OFFSET                   (0xD4)                                        /**<  (MCAN_TXBCR) Transmit Buffer Cancellation Request Register  Offset */
@@ -2344,6 +3064,7 @@ typedef union {
 
 /* -------- MCAN_TXBTO : (MCAN Offset: 0xd8) (R/ 32) Transmit Buffer Transmission Occurred Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TO0:1;                     /**< bit:      0  Transmission Occurred for Buffer 0       */
@@ -2384,6 +3105,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBTO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBTO_OFFSET                   (0xD8)                                        /**<  (MCAN_TXBTO) Transmit Buffer Transmission Occurred Register  Offset */
@@ -2493,6 +3215,7 @@ typedef union {
 
 /* -------- MCAN_TXBCF : (MCAN Offset: 0xdc) (R/ 32) Transmit Buffer Cancellation Finished Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CF0:1;                     /**< bit:      0  Cancellation Finished for Transmit Buffer 0 */
@@ -2533,6 +3256,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCF_OFFSET                   (0xDC)                                        /**<  (MCAN_TXBCF) Transmit Buffer Cancellation Finished Register  Offset */
@@ -2642,6 +3366,7 @@ typedef union {
 
 /* -------- MCAN_TXBTIE : (MCAN Offset: 0xe0) (R/W 32) Transmit Buffer Transmission Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TIE0:1;                    /**< bit:      0  Transmission Interrupt Enable for Buffer 0 */
@@ -2682,6 +3407,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBTIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBTIE_OFFSET                  (0xE0)                                        /**<  (MCAN_TXBTIE) Transmit Buffer Transmission Interrupt Enable Register  Offset */
@@ -2791,6 +3517,7 @@ typedef union {
 
 /* -------- MCAN_TXBCIE : (MCAN Offset: 0xe4) (R/W 32) Transmit Buffer Cancellation Finished Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CFIE0:1;                   /**< bit:      0  Cancellation Finished Interrupt Enable for Transmit Buffer 0 */
@@ -2831,6 +3558,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXBCIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXBCIE_OFFSET                  (0xE4)                                        /**<  (MCAN_TXBCIE) Transmit Buffer Cancellation Finished Interrupt Enable Register  Offset */
@@ -2940,6 +3668,7 @@ typedef union {
 
 /* -------- MCAN_TXEFC : (MCAN Offset: 0xf0) (R/W 32) Transmit Event FIFO Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -2951,6 +3680,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFC_OFFSET                   (0xF0)                                        /**<  (MCAN_TXEFC) Transmit Event FIFO Configuration Register  Offset */
@@ -2970,6 +3700,7 @@ typedef union {
 
 /* -------- MCAN_TXEFS : (MCAN Offset: 0xf4) (R/ 32) Transmit Event FIFO Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EFFL:6;                    /**< bit:   0..5  Event FIFO Fill Level                    */
@@ -2984,6 +3715,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFS_OFFSET                   (0xF4)                                        /**<  (MCAN_TXEFS) Transmit Event FIFO Status Register  Offset */
@@ -3009,6 +3741,7 @@ typedef union {
 
 /* -------- MCAN_TXEFA : (MCAN Offset: 0xf8) (R/W 32) Transmit Event FIFO Acknowledge Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EFAI:5;                    /**< bit:   0..4  Event FIFO Acknowledge Index             */
@@ -3016,6 +3749,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } MCAN_TXEFA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define MCAN_TXEFA_OFFSET                   (0xF8)                                        /**<  (MCAN_TXEFA) Transmit Event FIFO Acknowledge Register  Offset */
@@ -3029,6 +3763,79 @@ typedef union {
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'R'
+/** \brief MCAN_RXBE hardware registers */
+typedef struct {  /* Rx Buffer Element */
+  __IO uint32_t MCAN_RXBE_0;    /**< (MCAN_RXBE Offset: 0x00) Rx Buffer Element 0 */
+  __IO uint32_t MCAN_RXBE_1;    /**< (MCAN_RXBE Offset: 0x04) Rx Buffer Element 1 */
+  __IO uint32_t MCAN_RXBE_DATA; /**< (MCAN_RXBE Offset: 0x08) Rx Buffer Element Data */
+} McanRxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF0E hardware registers */
+typedef struct {  /* Rx FIFO 0 Element */
+  __IO uint32_t MCAN_RXF0E_0;   /**< (MCAN_RXF0E Offset: 0x00) Rx FIFO 0 Element 0 */
+  __IO uint32_t MCAN_RXF0E_1;   /**< (MCAN_RXF0E Offset: 0x04) Rx FIFO 0 Element 1 */
+  __IO uint32_t MCAN_RXF0E_DATA; /**< (MCAN_RXF0E Offset: 0x08) Rx FIFO 0 Element Data */
+} McanRxf0e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF1E hardware registers */
+typedef struct {  /* Rx FIFO 1 Element */
+  __IO uint32_t MCAN_RXF1E_0;   /**< (MCAN_RXF1E Offset: 0x00) Rx FIFO 1 Element 0 */
+  __IO uint32_t MCAN_RXF1E_1;   /**< (MCAN_RXF1E Offset: 0x04) Rx FIFO 1 Element 1 */
+  __IO uint32_t MCAN_RXF1E_DATA; /**< (MCAN_RXF1E Offset: 0x08) Rx FIFO 1 Element Data */
+} McanRxf1e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXBE hardware registers */
+typedef struct {  /* Tx Buffer Element */
+  __IO uint32_t MCAN_TXBE_0;    /**< (MCAN_TXBE Offset: 0x00) Tx Buffer Element 0 */
+  __IO uint32_t MCAN_TXBE_1;    /**< (MCAN_TXBE Offset: 0x04) Tx Buffer Element 1 */
+  __IO uint32_t MCAN_TXBE_DATA; /**< (MCAN_TXBE Offset: 0x08) Tx Buffer Element Data */
+} McanTxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXEFE hardware registers */
+typedef struct {  /* Tx Event FIFO Element */
+  __IO uint32_t MCAN_TXEFE_0;   /**< (MCAN_TXEFE Offset: 0x00) Tx Event FIFO Element 0 */
+  __IO uint32_t MCAN_TXEFE_1;   /**< (MCAN_TXEFE Offset: 0x04) Tx Event FIFO Element 1 */
+} McanTxefe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_SIDFE hardware registers */
+typedef struct {  /* Standard Message ID Filter Element */
+  __IO uint32_t MCAN_SIDFE_0;   /**< (MCAN_SIDFE Offset: 0x00) Standard Message ID Filter Element 0 */
+} McanSidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_XIDFE hardware registers */
+typedef struct {  /* Extended Message ID Filter Element */
+  __IO uint32_t MCAN_XIDFE_0;   /**< (MCAN_XIDFE Offset: 0x00) Extended Message ID Filter Element 0 */
+  __IO uint32_t MCAN_XIDFE_1;   /**< (MCAN_XIDFE Offset: 0x04) Extended Message ID Filter Element 1 */
+} McanXidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
 /** \brief MCAN hardware registers */
 typedef struct {  
   __I  uint32_t MCAN_CREL;      /**< (MCAN Offset: 0x00) Core Release Register */
@@ -3043,20 +3850,20 @@ typedef struct {
   __IO uint32_t MCAN_TSCV;      /**< (MCAN Offset: 0x24) Timestamp Counter Value Register */
   __IO uint32_t MCAN_TOCC;      /**< (MCAN Offset: 0x28) Timeout Counter Configuration Register */
   __IO uint32_t MCAN_TOCV;      /**< (MCAN Offset: 0x2C) Timeout Counter Value Register */
-  RoReg8  Reserved1[0x10];
+  __I  uint8_t                        Reserved1[16];
   __I  uint32_t MCAN_ECR;       /**< (MCAN Offset: 0x40) Error Counter Register */
   __I  uint32_t MCAN_PSR;       /**< (MCAN Offset: 0x44) Protocol Status Register */
   __IO uint32_t MCAN_TDCR;      /**< (MCAN Offset: 0x48) Transmit Delay Compensation Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t MCAN_IR;        /**< (MCAN Offset: 0x50) Interrupt Register */
   __IO uint32_t MCAN_IE;        /**< (MCAN Offset: 0x54) Interrupt Enable Register */
   __IO uint32_t MCAN_ILS;       /**< (MCAN Offset: 0x58) Interrupt Line Select Register */
   __IO uint32_t MCAN_ILE;       /**< (MCAN Offset: 0x5C) Interrupt Line Enable Register */
-  RoReg8  Reserved3[0x20];
+  __I  uint8_t                        Reserved3[32];
   __IO uint32_t MCAN_GFC;       /**< (MCAN Offset: 0x80) Global Filter Configuration Register */
   __IO uint32_t MCAN_SIDFC;     /**< (MCAN Offset: 0x84) Standard ID Filter Configuration Register */
   __IO uint32_t MCAN_XIDFC;     /**< (MCAN Offset: 0x88) Extended ID Filter Configuration Register */
-  RoReg8  Reserved4[0x4];
+  __I  uint8_t                        Reserved4[4];
   __IO uint32_t MCAN_XIDAM;     /**< (MCAN Offset: 0x90) Extended ID AND Mask Register */
   __I  uint32_t MCAN_HPMS;      /**< (MCAN Offset: 0x94) High Priority Message Status Register */
   __IO uint32_t MCAN_NDAT1;     /**< (MCAN Offset: 0x98) New Data 1 Register */
@@ -3079,13 +3886,86 @@ typedef struct {
   __I  uint32_t MCAN_TXBCF;     /**< (MCAN Offset: 0xDC) Transmit Buffer Cancellation Finished Register */
   __IO uint32_t MCAN_TXBTIE;    /**< (MCAN Offset: 0xE0) Transmit Buffer Transmission Interrupt Enable Register */
   __IO uint32_t MCAN_TXBCIE;    /**< (MCAN Offset: 0xE4) Transmit Buffer Cancellation Finished Interrupt Enable Register */
-  RoReg8  Reserved5[0x8];
+  __I  uint8_t                        Reserved5[8];
   __IO uint32_t MCAN_TXEFC;     /**< (MCAN Offset: 0xF0) Transmit Event FIFO Configuration Register */
   __I  uint32_t MCAN_TXEFS;     /**< (MCAN Offset: 0xF4) Transmit Event FIFO Status Register */
   __IO uint32_t MCAN_TXEFA;     /**< (MCAN Offset: 0xF8) Transmit Event FIFO Acknowledge Register */
 } Mcan;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
+/** \brief MCAN_RXBE hardware registers */
+typedef struct {  /* Rx Buffer Element */
+  __IO MCAN_RXBE_0_Type               MCAN_RXBE_0;    /**< Offset: 0x00 (R/W  32) Rx Buffer Element 0 */
+  __IO MCAN_RXBE_1_Type               MCAN_RXBE_1;    /**< Offset: 0x04 (R/W  32) Rx Buffer Element 1 */
+  __IO MCAN_RXBE_DATA_Type            MCAN_RXBE_DATA; /**< Offset: 0x08 (R/W  32) Rx Buffer Element Data */
+} McanRxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF0E hardware registers */
+typedef struct {  /* Rx FIFO 0 Element */
+  __IO MCAN_RXF0E_0_Type              MCAN_RXF0E_0;   /**< Offset: 0x00 (R/W  32) Rx FIFO 0 Element 0 */
+  __IO MCAN_RXF0E_1_Type              MCAN_RXF0E_1;   /**< Offset: 0x04 (R/W  32) Rx FIFO 0 Element 1 */
+  __IO MCAN_RXF0E_DATA_Type           MCAN_RXF0E_DATA; /**< Offset: 0x08 (R/W  32) Rx FIFO 0 Element Data */
+} McanRxf0e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_RXF1E hardware registers */
+typedef struct {  /* Rx FIFO 1 Element */
+  __IO MCAN_RXF1E_0_Type              MCAN_RXF1E_0;   /**< Offset: 0x00 (R/W  32) Rx FIFO 1 Element 0 */
+  __IO MCAN_RXF1E_1_Type              MCAN_RXF1E_1;   /**< Offset: 0x04 (R/W  32) Rx FIFO 1 Element 1 */
+  __IO MCAN_RXF1E_DATA_Type           MCAN_RXF1E_DATA; /**< Offset: 0x08 (R/W  32) Rx FIFO 1 Element Data */
+} McanRxf1e
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXBE hardware registers */
+typedef struct {  /* Tx Buffer Element */
+  __IO MCAN_TXBE_0_Type               MCAN_TXBE_0;    /**< Offset: 0x00 (R/W  32) Tx Buffer Element 0 */
+  __IO MCAN_TXBE_1_Type               MCAN_TXBE_1;    /**< Offset: 0x04 (R/W  32) Tx Buffer Element 1 */
+  __IO MCAN_TXBE_DATA_Type            MCAN_TXBE_DATA; /**< Offset: 0x08 (R/W  32) Tx Buffer Element Data */
+} McanTxbe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_TXEFE hardware registers */
+typedef struct {  /* Tx Event FIFO Element */
+  __IO MCAN_TXEFE_0_Type              MCAN_TXEFE_0;   /**< Offset: 0x00 (R/W  32) Tx Event FIFO Element 0 */
+  __IO MCAN_TXEFE_1_Type              MCAN_TXEFE_1;   /**< Offset: 0x04 (R/W  32) Tx Event FIFO Element 1 */
+} McanTxefe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_SIDFE hardware registers */
+typedef struct {  /* Standard Message ID Filter Element */
+  __IO MCAN_SIDFE_0_Type              MCAN_SIDFE_0;   /**< Offset: 0x00 (R/W  32) Standard Message ID Filter Element 0 */
+} McanSidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
+/** \brief MCAN_XIDFE hardware registers */
+typedef struct {  /* Extended Message ID Filter Element */
+  __IO MCAN_XIDFE_0_Type              MCAN_XIDFE_0;   /**< Offset: 0x00 (R/W  32) Extended Message ID Filter Element 0 */
+  __IO MCAN_XIDFE_1_Type              MCAN_XIDFE_1;   /**< Offset: 0x04 (R/W  32) Extended Message ID Filter Element 1 */
+} McanXidfe
+#ifdef __GNUC__
+  __attribute__ ((aligned (4)))
+#endif
+;
+
 /** \brief MCAN hardware registers */
 typedef struct {  
   __I  MCAN_CREL_Type                 MCAN_CREL;      /**< Offset: 0x00 (R/   32) Core Release Register */
@@ -3100,20 +3980,20 @@ typedef struct {
   __IO MCAN_TSCV_Type                 MCAN_TSCV;      /**< Offset: 0x24 (R/W  32) Timestamp Counter Value Register */
   __IO MCAN_TOCC_Type                 MCAN_TOCC;      /**< Offset: 0x28 (R/W  32) Timeout Counter Configuration Register */
   __IO MCAN_TOCV_Type                 MCAN_TOCV;      /**< Offset: 0x2C (R/W  32) Timeout Counter Value Register */
-  __I  uint32_t                       Reserved1[4];
+  __I  uint8_t                        Reserved1[16];
   __I  MCAN_ECR_Type                  MCAN_ECR;       /**< Offset: 0x40 (R/   32) Error Counter Register */
   __I  MCAN_PSR_Type                  MCAN_PSR;       /**< Offset: 0x44 (R/   32) Protocol Status Register */
   __IO MCAN_TDCR_Type                 MCAN_TDCR;      /**< Offset: 0x48 (R/W  32) Transmit Delay Compensation Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO MCAN_IR_Type                   MCAN_IR;        /**< Offset: 0x50 (R/W  32) Interrupt Register */
   __IO MCAN_IE_Type                   MCAN_IE;        /**< Offset: 0x54 (R/W  32) Interrupt Enable Register */
   __IO MCAN_ILS_Type                  MCAN_ILS;       /**< Offset: 0x58 (R/W  32) Interrupt Line Select Register */
   __IO MCAN_ILE_Type                  MCAN_ILE;       /**< Offset: 0x5C (R/W  32) Interrupt Line Enable Register */
-  __I  uint32_t                       Reserved3[8];
+  __I  uint8_t                        Reserved3[32];
   __IO MCAN_GFC_Type                  MCAN_GFC;       /**< Offset: 0x80 (R/W  32) Global Filter Configuration Register */
   __IO MCAN_SIDFC_Type                MCAN_SIDFC;     /**< Offset: 0x84 (R/W  32) Standard ID Filter Configuration Register */
   __IO MCAN_XIDFC_Type                MCAN_XIDFC;     /**< Offset: 0x88 (R/W  32) Extended ID Filter Configuration Register */
-  __I  uint32_t                       Reserved4[1];
+  __I  uint8_t                        Reserved4[4];
   __IO MCAN_XIDAM_Type                MCAN_XIDAM;     /**< Offset: 0x90 (R/W  32) Extended ID AND Mask Register */
   __I  MCAN_HPMS_Type                 MCAN_HPMS;      /**< Offset: 0x94 (R/   32) High Priority Message Status Register */
   __IO MCAN_NDAT1_Type                MCAN_NDAT1;     /**< Offset: 0x98 (R/W  32) New Data 1 Register */
@@ -3136,7 +4016,7 @@ typedef struct {
   __I  MCAN_TXBCF_Type                MCAN_TXBCF;     /**< Offset: 0xDC (R/   32) Transmit Buffer Cancellation Finished Register */
   __IO MCAN_TXBTIE_Type               MCAN_TXBTIE;    /**< Offset: 0xE0 (R/W  32) Transmit Buffer Transmission Interrupt Enable Register */
   __IO MCAN_TXBCIE_Type               MCAN_TXBCIE;    /**< Offset: 0xE4 (R/W  32) Transmit Buffer Cancellation Finished Interrupt Enable Register */
-  __I  uint32_t                       Reserved5[2];
+  __I  uint8_t                        Reserved5[8];
   __IO MCAN_TXEFC_Type                MCAN_TXEFC;     /**< Offset: 0xF0 (R/W  32) Transmit Event FIFO Configuration Register */
   __I  MCAN_TXEFS_Type                MCAN_TXEFS;     /**< Offset: 0xF4 (R/   32) Transmit Event FIFO Status Register */
   __IO MCAN_TXEFA_Type                MCAN_TXEFA;     /**< Offset: 0xF8 (R/W  32) Transmit Event FIFO Acknowledge Register */

--- a/asf/sam/include/same70b/component/pio.h
+++ b/asf/sam/include/same70b/component/pio.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PIO
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIO_COMPONENT_H_
 #define _SAME70_PIO_COMPONENT_H_
 #define _SAME70_PIO_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define PIO_11004                      /**< (PIO) Module ID */
-#define REV_PIO U                      /**< (PIO) Module revision */
+#define REV_PIO V                      /**< (PIO) Module revision */
 
 /* -------- PIO_PER : (PIO Offset: 0x00) (/W 32) PIO Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Enable                               */
@@ -85,6 +88,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PER_OFFSET                      (0x00)                                        /**<  (PIO_PER) PIO Enable Register  Offset */
@@ -194,6 +198,7 @@ typedef union {
 
 /* -------- PIO_PDR : (PIO Offset: 0x04) (/W 32) PIO Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Disable                              */
@@ -234,6 +239,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PDR_OFFSET                      (0x04)                                        /**<  (PIO_PDR) PIO Disable Register  Offset */
@@ -343,6 +349,7 @@ typedef union {
 
 /* -------- PIO_PSR : (PIO Offset: 0x08) (R/ 32) PIO Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  PIO Status                               */
@@ -383,6 +390,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PSR_OFFSET                      (0x08)                                        /**<  (PIO_PSR) PIO Status Register  Offset */
@@ -492,6 +500,7 @@ typedef union {
 
 /* -------- PIO_OER : (PIO Offset: 0x10) (/W 32) Output Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Enable                            */
@@ -532,6 +541,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OER_OFFSET                      (0x10)                                        /**<  (PIO_OER) Output Enable Register  Offset */
@@ -641,6 +651,7 @@ typedef union {
 
 /* -------- PIO_ODR : (PIO Offset: 0x14) (/W 32) Output Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Disable                           */
@@ -681,6 +692,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ODR_OFFSET                      (0x14)                                        /**<  (PIO_ODR) Output Disable Register  Offset */
@@ -790,6 +802,7 @@ typedef union {
 
 /* -------- PIO_OSR : (PIO Offset: 0x18) (R/ 32) Output Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Status                            */
@@ -830,6 +843,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OSR_OFFSET                      (0x18)                                        /**<  (PIO_OSR) Output Status Register  Offset */
@@ -939,6 +953,7 @@ typedef union {
 
 /* -------- PIO_IFER : (PIO Offset: 0x20) (/W 32) Glitch Input Filter Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Enable                      */
@@ -979,6 +994,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFER_OFFSET                     (0x20)                                        /**<  (PIO_IFER) Glitch Input Filter Enable Register  Offset */
@@ -1088,6 +1104,7 @@ typedef union {
 
 /* -------- PIO_IFDR : (PIO Offset: 0x24) (/W 32) Glitch Input Filter Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Disable                     */
@@ -1128,6 +1145,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFDR_OFFSET                     (0x24)                                        /**<  (PIO_IFDR) Glitch Input Filter Disable Register  Offset */
@@ -1237,6 +1255,7 @@ typedef union {
 
 /* -------- PIO_IFSR : (PIO Offset: 0x28) (R/ 32) Glitch Input Filter Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Filter Status                      */
@@ -1277,6 +1296,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSR_OFFSET                     (0x28)                                        /**<  (PIO_IFSR) Glitch Input Filter Status Register  Offset */
@@ -1386,6 +1406,7 @@ typedef union {
 
 /* -------- PIO_SODR : (PIO Offset: 0x30) (/W 32) Set Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Set Output Data                          */
@@ -1426,6 +1447,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SODR_OFFSET                     (0x30)                                        /**<  (PIO_SODR) Set Output Data Register  Offset */
@@ -1535,6 +1557,7 @@ typedef union {
 
 /* -------- PIO_CODR : (PIO Offset: 0x34) (/W 32) Clear Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Clear Output Data                        */
@@ -1575,6 +1598,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_CODR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_CODR_OFFSET                     (0x34)                                        /**<  (PIO_CODR) Clear Output Data Register  Offset */
@@ -1684,6 +1708,7 @@ typedef union {
 
 /* -------- PIO_ODSR : (PIO Offset: 0x38) (R/W 32) Output Data Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
@@ -1724,6 +1749,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ODSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ODSR_OFFSET                     (0x38)                                        /**<  (PIO_ODSR) Output Data Status Register  Offset */
@@ -1833,6 +1859,7 @@ typedef union {
 
 /* -------- PIO_PDSR : (PIO Offset: 0x3c) (R/ 32) Pin Data Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Data Status                       */
@@ -1873,6 +1900,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PDSR_OFFSET                     (0x3C)                                        /**<  (PIO_PDSR) Pin Data Status Register  Offset */
@@ -1982,6 +2010,7 @@ typedef union {
 
 /* -------- PIO_IER : (PIO Offset: 0x40) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Enable            */
@@ -2022,6 +2051,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IER_OFFSET                      (0x40)                                        /**<  (PIO_IER) Interrupt Enable Register  Offset */
@@ -2131,6 +2161,7 @@ typedef union {
 
 /* -------- PIO_IDR : (PIO Offset: 0x44) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Disable           */
@@ -2171,6 +2202,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IDR_OFFSET                      (0x44)                                        /**<  (PIO_IDR) Interrupt Disable Register  Offset */
@@ -2280,6 +2312,7 @@ typedef union {
 
 /* -------- PIO_IMR : (PIO Offset: 0x48) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Mask              */
@@ -2320,6 +2353,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IMR_OFFSET                      (0x48)                                        /**<  (PIO_IMR) Interrupt Mask Register  Offset */
@@ -2429,6 +2463,7 @@ typedef union {
 
 /* -------- PIO_ISR : (PIO Offset: 0x4c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Input Change Interrupt Status            */
@@ -2469,6 +2504,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ISR_OFFSET                      (0x4C)                                        /**<  (PIO_ISR) Interrupt Status Register  Offset */
@@ -2578,6 +2614,7 @@ typedef union {
 
 /* -------- PIO_MDER : (PIO Offset: 0x50) (/W 32) Multi-driver Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Enable                       */
@@ -2618,6 +2655,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDER_OFFSET                     (0x50)                                        /**<  (PIO_MDER) Multi-driver Enable Register  Offset */
@@ -2727,6 +2765,7 @@ typedef union {
 
 /* -------- PIO_MDDR : (PIO Offset: 0x54) (/W 32) Multi-driver Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Disable                      */
@@ -2767,6 +2806,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDDR_OFFSET                     (0x54)                                        /**<  (PIO_MDDR) Multi-driver Disable Register  Offset */
@@ -2876,6 +2916,7 @@ typedef union {
 
 /* -------- PIO_MDSR : (PIO Offset: 0x58) (R/ 32) Multi-driver Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Multi-drive Status                       */
@@ -2916,6 +2957,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_MDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_MDSR_OFFSET                     (0x58)                                        /**<  (PIO_MDSR) Multi-driver Status Register  Offset */
@@ -3025,6 +3067,7 @@ typedef union {
 
 /* -------- PIO_PUDR : (PIO Offset: 0x60) (/W 32) Pull-up Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Disable                          */
@@ -3065,6 +3108,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUDR_OFFSET                     (0x60)                                        /**<  (PIO_PUDR) Pull-up Disable Register  Offset */
@@ -3174,6 +3218,7 @@ typedef union {
 
 /* -------- PIO_PUER : (PIO Offset: 0x64) (/W 32) Pull-up Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Enable                           */
@@ -3214,6 +3259,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUER_OFFSET                     (0x64)                                        /**<  (PIO_PUER) Pull-up Enable Register  Offset */
@@ -3323,6 +3369,7 @@ typedef union {
 
 /* -------- PIO_PUSR : (PIO Offset: 0x68) (R/ 32) Pad Pull-up Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Up Status                           */
@@ -3363,6 +3410,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PUSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PUSR_OFFSET                     (0x68)                                        /**<  (PIO_PUSR) Pad Pull-up Status Register  Offset */
@@ -3472,6 +3520,7 @@ typedef union {
 
 /* -------- PIO_ABCDSR : (PIO Offset: 0x70) (R/W 32) Peripheral ABCD Select Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Peripheral Select                        */
@@ -3512,6 +3561,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ABCDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ABCDSR_OFFSET                   (0x70)                                        /**<  (PIO_ABCDSR) Peripheral ABCD Select Register 0  Offset */
@@ -3621,6 +3671,7 @@ typedef union {
 
 /* -------- PIO_IFSCDR : (PIO Offset: 0x80) (/W 32) Input Filter Slow Clock Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Peripheral Clock Glitch Filtering Select */
@@ -3661,6 +3712,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCDR_OFFSET                   (0x80)                                        /**<  (PIO_IFSCDR) Input Filter Slow Clock Disable Register  Offset */
@@ -3770,6 +3822,7 @@ typedef union {
 
 /* -------- PIO_IFSCER : (PIO Offset: 0x84) (/W 32) Input Filter Slow Clock Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Slow Clock Debouncing Filtering Select   */
@@ -3810,6 +3863,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCER_OFFSET                   (0x84)                                        /**<  (PIO_IFSCER) Input Filter Slow Clock Enable Register  Offset */
@@ -3919,6 +3973,7 @@ typedef union {
 
 /* -------- PIO_IFSCSR : (PIO Offset: 0x88) (R/ 32) Input Filter Slow Clock Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Glitch or Debouncing Filter Selection Status */
@@ -3959,6 +4014,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_IFSCSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_IFSCSR_OFFSET                   (0x88)                                        /**<  (PIO_IFSCSR) Input Filter Slow Clock Status Register  Offset */
@@ -4068,6 +4124,7 @@ typedef union {
 
 /* -------- PIO_SCDR : (PIO Offset: 0x8c) (R/W 32) Slow Clock Divider Debouncing Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIV:14;                    /**< bit:  0..13  Slow Clock Divider Selection for Debouncing */
@@ -4075,6 +4132,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SCDR_OFFSET                     (0x8C)                                        /**<  (PIO_SCDR) Slow Clock Divider Debouncing Register  Offset */
@@ -4088,6 +4146,7 @@ typedef union {
 
 /* -------- PIO_PPDDR : (PIO Offset: 0x90) (/W 32) Pad Pull-down Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Disable                        */
@@ -4128,6 +4187,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDDR_OFFSET                    (0x90)                                        /**<  (PIO_PPDDR) Pad Pull-down Disable Register  Offset */
@@ -4237,6 +4297,7 @@ typedef union {
 
 /* -------- PIO_PPDER : (PIO Offset: 0x94) (/W 32) Pad Pull-down Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Enable                         */
@@ -4277,6 +4338,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDER_OFFSET                    (0x94)                                        /**<  (PIO_PPDER) Pad Pull-down Enable Register  Offset */
@@ -4386,6 +4448,7 @@ typedef union {
 
 /* -------- PIO_PPDSR : (PIO Offset: 0x98) (R/ 32) Pad Pull-down Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Pull-Down Status                         */
@@ -4426,6 +4489,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PPDSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PPDSR_OFFSET                    (0x98)                                        /**<  (PIO_PPDSR) Pad Pull-down Status Register  Offset */
@@ -4535,6 +4599,7 @@ typedef union {
 
 /* -------- PIO_OWER : (PIO Offset: 0xa0) (/W 32) Output Write Enable -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Enable                      */
@@ -4575,6 +4640,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWER_OFFSET                     (0xA0)                                        /**<  (PIO_OWER) Output Write Enable  Offset */
@@ -4684,6 +4750,7 @@ typedef union {
 
 /* -------- PIO_OWDR : (PIO Offset: 0xa4) (/W 32) Output Write Disable -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Disable                     */
@@ -4724,6 +4791,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWDR_OFFSET                     (0xA4)                                        /**<  (PIO_OWDR) Output Write Disable  Offset */
@@ -4833,6 +4901,7 @@ typedef union {
 
 /* -------- PIO_OWSR : (PIO Offset: 0xa8) (R/ 32) Output Write Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Output Write Status                      */
@@ -4873,6 +4942,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_OWSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_OWSR_OFFSET                     (0xA8)                                        /**<  (PIO_OWSR) Output Write Status Register  Offset */
@@ -4982,6 +5052,7 @@ typedef union {
 
 /* -------- PIO_AIMER : (PIO Offset: 0xb0) (/W 32) Additional Interrupt Modes Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Enable        */
@@ -5022,6 +5093,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMER_OFFSET                    (0xB0)                                        /**<  (PIO_AIMER) Additional Interrupt Modes Enable Register  Offset */
@@ -5131,6 +5203,7 @@ typedef union {
 
 /* -------- PIO_AIMDR : (PIO Offset: 0xb4) (/W 32) Additional Interrupt Modes Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Additional Interrupt Modes Disable       */
@@ -5171,6 +5244,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMDR_OFFSET                    (0xB4)                                        /**<  (PIO_AIMDR) Additional Interrupt Modes Disable Register  Offset */
@@ -5280,6 +5354,7 @@ typedef union {
 
 /* -------- PIO_AIMMR : (PIO Offset: 0xb8) (R/ 32) Additional Interrupt Modes Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  IO Line Index                            */
@@ -5320,6 +5395,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_AIMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_AIMMR_OFFSET                    (0xB8)                                        /**<  (PIO_AIMMR) Additional Interrupt Modes Mask Register  Offset */
@@ -5429,6 +5505,7 @@ typedef union {
 
 /* -------- PIO_ESR : (PIO Offset: 0xc0) (/W 32) Edge Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge Interrupt Selection                 */
@@ -5469,6 +5546,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ESR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ESR_OFFSET                      (0xC0)                                        /**<  (PIO_ESR) Edge Select Register  Offset */
@@ -5578,6 +5656,7 @@ typedef union {
 
 /* -------- PIO_LSR : (PIO Offset: 0xc4) (/W 32) Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Level Interrupt Selection                */
@@ -5618,6 +5697,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_LSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_LSR_OFFSET                      (0xC4)                                        /**<  (PIO_LSR) Level Select Register  Offset */
@@ -5727,6 +5807,7 @@ typedef union {
 
 /* -------- PIO_ELSR : (PIO Offset: 0xc8) (R/ 32) Edge/Level Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
@@ -5767,6 +5848,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_ELSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_ELSR_OFFSET                     (0xC8)                                        /**<  (PIO_ELSR) Edge/Level Status Register  Offset */
@@ -5876,6 +5958,7 @@ typedef union {
 
 /* -------- PIO_FELLSR : (PIO Offset: 0xd0) (/W 32) Falling Edge/Low-Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Falling Edge/Low-Level Interrupt Selection */
@@ -5916,6 +5999,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_FELLSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_FELLSR_OFFSET                   (0xD0)                                        /**<  (PIO_FELLSR) Falling Edge/Low-Level Select Register  Offset */
@@ -6025,6 +6109,7 @@ typedef union {
 
 /* -------- PIO_REHLSR : (PIO Offset: 0xd4) (/W 32) Rising Edge/High-Level Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Rising Edge/High-Level Interrupt Selection */
@@ -6065,6 +6150,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_REHLSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_REHLSR_OFFSET                   (0xD4)                                        /**<  (PIO_REHLSR) Rising Edge/High-Level Select Register  Offset */
@@ -6174,6 +6260,7 @@ typedef union {
 
 /* -------- PIO_FRLHSR : (PIO Offset: 0xd8) (R/ 32) Fall/Rise - Low/High Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Edge/Level Interrupt Source Selection    */
@@ -6214,6 +6301,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_FRLHSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_FRLHSR_OFFSET                   (0xD8)                                        /**<  (PIO_FRLHSR) Fall/Rise - Low/High Status Register  Offset */
@@ -6323,6 +6411,7 @@ typedef union {
 
 /* -------- PIO_LOCKSR : (PIO Offset: 0xe0) (R/ 32) Lock Status -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t P0:1;                      /**< bit:      0  Lock Status                              */
@@ -6363,6 +6452,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_LOCKSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_LOCKSR_OFFSET                   (0xE0)                                        /**<  (PIO_LOCKSR) Lock Status  Offset */
@@ -6472,6 +6562,7 @@ typedef union {
 
 /* -------- PIO_WPMR : (PIO Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -6480,6 +6571,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_WPMR_OFFSET                     (0xE4)                                        /**<  (PIO_WPMR) Write Protection Mode Register  Offset */
@@ -6490,14 +6582,15 @@ typedef union {
 #define PIO_WPMR_WPKEY_Pos                  8                                              /**< (PIO_WPMR) Write Protection Key Position */
 #define PIO_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << PIO_WPMR_WPKEY_Pos)          /**< (PIO_WPMR) Write Protection Key Mask */
 #define PIO_WPMR_WPKEY(value)               (PIO_WPMR_WPKEY_Msk & ((value) << PIO_WPMR_WPKEY_Pos))
-#define   PIO_WPMR_WPKEY_PASSWD_Val         _U_(0x50494F)                                  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0.  */
-#define PIO_WPMR_WPKEY_PASSWD               (PIO_WPMR_WPKEY_PASSWD_Val << PIO_WPMR_WPKEY_Pos)  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit. Always reads as 0. Position  */
+#define   PIO_WPMR_WPKEY_PASSWD_Val         _U_(0x50494F)                                  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
+#define PIO_WPMR_WPKEY_PASSWD               (PIO_WPMR_WPKEY_PASSWD_Val << PIO_WPMR_WPKEY_Pos)  /**< (PIO_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
 #define PIO_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (PIO_WPMR) Register MASK  (Use PIO_WPMR_Msk instead)  */
 #define PIO_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (PIO_WPMR) Register Mask  */
 
 
 /* -------- PIO_WPSR : (PIO Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -6507,6 +6600,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_WPSR_OFFSET                     (0xE8)                                        /**<  (PIO_WPSR) Write Protection Status Register  Offset */
@@ -6523,6 +6617,7 @@ typedef union {
 
 /* -------- PIO_SCHMITT : (PIO Offset: 0x100) (R/W 32) Schmitt Trigger Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCHMITT0:1;                /**< bit:      0  Schmitt Trigger Control                  */
@@ -6563,6 +6658,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_SCHMITT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_SCHMITT_OFFSET                  (0x100)                                       /**<  (PIO_SCHMITT) Schmitt Trigger Register  Offset */
@@ -6672,6 +6768,7 @@ typedef union {
 
 /* -------- PIO_DRIVER : (PIO Offset: 0x118) (R/W 32) I/O Drive Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LINE0:1;                   /**< bit:      0  Drive of PIO Line 0                      */
@@ -6712,6 +6809,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_DRIVER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_DRIVER_OFFSET                   (0x118)                                       /**<  (PIO_DRIVER) I/O Drive Register  Offset */
@@ -6949,6 +7047,7 @@ typedef union {
 
 /* -------- PIO_PCMR : (PIO Offset: 0x150) (R/W 32) Parallel Capture Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PCEN:1;                    /**< bit:      0  Parallel Capture Mode Enable             */
@@ -6962,6 +7061,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCMR_OFFSET                     (0x150)                                       /**<  (PIO_PCMR) Parallel Capture Mode Register  Offset */
@@ -6993,6 +7093,7 @@ typedef union {
 
 /* -------- PIO_PCIER : (PIO Offset: 0x154) (/W 32) Parallel Capture Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Enable */
@@ -7003,6 +7104,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIER_OFFSET                    (0x154)                                       /**<  (PIO_PCIER) Parallel Capture Interrupt Enable Register  Offset */
@@ -7025,6 +7127,7 @@ typedef union {
 
 /* -------- PIO_PCIDR : (PIO Offset: 0x158) (/W 32) Parallel Capture Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Disable */
@@ -7035,6 +7138,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIDR_OFFSET                    (0x158)                                       /**<  (PIO_PCIDR) Parallel Capture Interrupt Disable Register  Offset */
@@ -7057,6 +7161,7 @@ typedef union {
 
 /* -------- PIO_PCIMR : (PIO Offset: 0x15c) (R/ 32) Parallel Capture Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready Interrupt Mask */
@@ -7067,6 +7172,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCIMR_OFFSET                    (0x15C)                                       /**<  (PIO_PCIMR) Parallel Capture Interrupt Mask Register  Offset */
@@ -7089,6 +7195,7 @@ typedef union {
 
 /* -------- PIO_PCISR : (PIO Offset: 0x160) (R/ 32) Parallel Capture Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DRDY:1;                    /**< bit:      0  Parallel Capture Mode Data Ready         */
@@ -7097,6 +7204,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCISR_OFFSET                    (0x160)                                       /**<  (PIO_PCISR) Parallel Capture Interrupt Status Register  Offset */
@@ -7113,12 +7221,14 @@ typedef union {
 
 /* -------- PIO_PCRHR : (PIO Offset: 0x164) (R/ 32) Parallel Capture Reception Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDATA:32;                  /**< bit:  0..31  Parallel Capture Mode Reception Data     */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PIO_PCRHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PIO_PCRHR_OFFSET                    (0x164)                                       /**<  (PIO_PCRHR) Parallel Capture Reception Holding Register  Offset */
@@ -7137,15 +7247,15 @@ typedef struct {
   __O  uint32_t PIO_PER;        /**< (PIO Offset: 0x00) PIO Enable Register */
   __O  uint32_t PIO_PDR;        /**< (PIO Offset: 0x04) PIO Disable Register */
   __I  uint32_t PIO_PSR;        /**< (PIO Offset: 0x08) PIO Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t PIO_OER;        /**< (PIO Offset: 0x10) Output Enable Register */
   __O  uint32_t PIO_ODR;        /**< (PIO Offset: 0x14) Output Disable Register */
   __I  uint32_t PIO_OSR;        /**< (PIO Offset: 0x18) Output Status Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __O  uint32_t PIO_IFER;       /**< (PIO Offset: 0x20) Glitch Input Filter Enable Register */
   __O  uint32_t PIO_IFDR;       /**< (PIO Offset: 0x24) Glitch Input Filter Disable Register */
   __I  uint32_t PIO_IFSR;       /**< (PIO Offset: 0x28) Glitch Input Filter Status Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __O  uint32_t PIO_SODR;       /**< (PIO Offset: 0x30) Set Output Data Register */
   __O  uint32_t PIO_CODR;       /**< (PIO Offset: 0x34) Clear Output Data Register */
   __IO uint32_t PIO_ODSR;       /**< (PIO Offset: 0x38) Output Data Status Register */
@@ -7157,13 +7267,13 @@ typedef struct {
   __O  uint32_t PIO_MDER;       /**< (PIO Offset: 0x50) Multi-driver Enable Register */
   __O  uint32_t PIO_MDDR;       /**< (PIO Offset: 0x54) Multi-driver Disable Register */
   __I  uint32_t PIO_MDSR;       /**< (PIO Offset: 0x58) Multi-driver Status Register */
-  RoReg8  Reserved4[0x4];
+  __I  uint8_t                        Reserved4[4];
   __O  uint32_t PIO_PUDR;       /**< (PIO Offset: 0x60) Pull-up Disable Register */
   __O  uint32_t PIO_PUER;       /**< (PIO Offset: 0x64) Pull-up Enable Register */
   __I  uint32_t PIO_PUSR;       /**< (PIO Offset: 0x68) Pad Pull-up Status Register */
-  RoReg8  Reserved5[0x4];
+  __I  uint8_t                        Reserved5[4];
   __IO uint32_t PIO_ABCDSR[2];  /**< (PIO Offset: 0x70) Peripheral ABCD Select Register 0 */
-  RoReg8  Reserved6[0x8];
+  __I  uint8_t                        Reserved6[8];
   __O  uint32_t PIO_IFSCDR;     /**< (PIO Offset: 0x80) Input Filter Slow Clock Disable Register */
   __O  uint32_t PIO_IFSCER;     /**< (PIO Offset: 0x84) Input Filter Slow Clock Enable Register */
   __I  uint32_t PIO_IFSCSR;     /**< (PIO Offset: 0x88) Input Filter Slow Clock Status Register */
@@ -7171,31 +7281,31 @@ typedef struct {
   __O  uint32_t PIO_PPDDR;      /**< (PIO Offset: 0x90) Pad Pull-down Disable Register */
   __O  uint32_t PIO_PPDER;      /**< (PIO Offset: 0x94) Pad Pull-down Enable Register */
   __I  uint32_t PIO_PPDSR;      /**< (PIO Offset: 0x98) Pad Pull-down Status Register */
-  RoReg8  Reserved7[0x4];
+  __I  uint8_t                        Reserved7[4];
   __O  uint32_t PIO_OWER;       /**< (PIO Offset: 0xA0) Output Write Enable */
   __O  uint32_t PIO_OWDR;       /**< (PIO Offset: 0xA4) Output Write Disable */
   __I  uint32_t PIO_OWSR;       /**< (PIO Offset: 0xA8) Output Write Status Register */
-  RoReg8  Reserved8[0x4];
+  __I  uint8_t                        Reserved8[4];
   __O  uint32_t PIO_AIMER;      /**< (PIO Offset: 0xB0) Additional Interrupt Modes Enable Register */
   __O  uint32_t PIO_AIMDR;      /**< (PIO Offset: 0xB4) Additional Interrupt Modes Disable Register */
   __I  uint32_t PIO_AIMMR;      /**< (PIO Offset: 0xB8) Additional Interrupt Modes Mask Register */
-  RoReg8  Reserved9[0x4];
+  __I  uint8_t                        Reserved9[4];
   __O  uint32_t PIO_ESR;        /**< (PIO Offset: 0xC0) Edge Select Register */
   __O  uint32_t PIO_LSR;        /**< (PIO Offset: 0xC4) Level Select Register */
   __I  uint32_t PIO_ELSR;       /**< (PIO Offset: 0xC8) Edge/Level Status Register */
-  RoReg8  Reserved10[0x4];
+  __I  uint8_t                        Reserved10[4];
   __O  uint32_t PIO_FELLSR;     /**< (PIO Offset: 0xD0) Falling Edge/Low-Level Select Register */
   __O  uint32_t PIO_REHLSR;     /**< (PIO Offset: 0xD4) Rising Edge/High-Level Select Register */
   __I  uint32_t PIO_FRLHSR;     /**< (PIO Offset: 0xD8) Fall/Rise - Low/High Status Register */
-  RoReg8  Reserved11[0x4];
+  __I  uint8_t                        Reserved11[4];
   __I  uint32_t PIO_LOCKSR;     /**< (PIO Offset: 0xE0) Lock Status */
   __IO uint32_t PIO_WPMR;       /**< (PIO Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t PIO_WPSR;       /**< (PIO Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved12[0x14];
+  __I  uint8_t                        Reserved12[20];
   __IO uint32_t PIO_SCHMITT;    /**< (PIO Offset: 0x100) Schmitt Trigger Register */
-  RoReg8  Reserved13[0x14];
+  __I  uint8_t                        Reserved13[20];
   __IO uint32_t PIO_DRIVER;     /**< (PIO Offset: 0x118) I/O Drive Register */
-  RoReg8  Reserved14[0x34];
+  __I  uint8_t                        Reserved14[52];
   __IO uint32_t PIO_PCMR;       /**< (PIO Offset: 0x150) Parallel Capture Mode Register */
   __O  uint32_t PIO_PCIER;      /**< (PIO Offset: 0x154) Parallel Capture Interrupt Enable Register */
   __O  uint32_t PIO_PCIDR;      /**< (PIO Offset: 0x158) Parallel Capture Interrupt Disable Register */
@@ -7210,15 +7320,15 @@ typedef struct {
   __O  PIO_PER_Type                   PIO_PER;        /**< Offset: 0x00 ( /W  32) PIO Enable Register */
   __O  PIO_PDR_Type                   PIO_PDR;        /**< Offset: 0x04 ( /W  32) PIO Disable Register */
   __I  PIO_PSR_Type                   PIO_PSR;        /**< Offset: 0x08 (R/   32) PIO Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  PIO_OER_Type                   PIO_OER;        /**< Offset: 0x10 ( /W  32) Output Enable Register */
   __O  PIO_ODR_Type                   PIO_ODR;        /**< Offset: 0x14 ( /W  32) Output Disable Register */
   __I  PIO_OSR_Type                   PIO_OSR;        /**< Offset: 0x18 (R/   32) Output Status Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __O  PIO_IFER_Type                  PIO_IFER;       /**< Offset: 0x20 ( /W  32) Glitch Input Filter Enable Register */
   __O  PIO_IFDR_Type                  PIO_IFDR;       /**< Offset: 0x24 ( /W  32) Glitch Input Filter Disable Register */
   __I  PIO_IFSR_Type                  PIO_IFSR;       /**< Offset: 0x28 (R/   32) Glitch Input Filter Status Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __O  PIO_SODR_Type                  PIO_SODR;       /**< Offset: 0x30 ( /W  32) Set Output Data Register */
   __O  PIO_CODR_Type                  PIO_CODR;       /**< Offset: 0x34 ( /W  32) Clear Output Data Register */
   __IO PIO_ODSR_Type                  PIO_ODSR;       /**< Offset: 0x38 (R/W  32) Output Data Status Register */
@@ -7230,13 +7340,13 @@ typedef struct {
   __O  PIO_MDER_Type                  PIO_MDER;       /**< Offset: 0x50 ( /W  32) Multi-driver Enable Register */
   __O  PIO_MDDR_Type                  PIO_MDDR;       /**< Offset: 0x54 ( /W  32) Multi-driver Disable Register */
   __I  PIO_MDSR_Type                  PIO_MDSR;       /**< Offset: 0x58 (R/   32) Multi-driver Status Register */
-  __I  uint32_t                       Reserved4[1];
+  __I  uint8_t                        Reserved4[4];
   __O  PIO_PUDR_Type                  PIO_PUDR;       /**< Offset: 0x60 ( /W  32) Pull-up Disable Register */
   __O  PIO_PUER_Type                  PIO_PUER;       /**< Offset: 0x64 ( /W  32) Pull-up Enable Register */
   __I  PIO_PUSR_Type                  PIO_PUSR;       /**< Offset: 0x68 (R/   32) Pad Pull-up Status Register */
-  __I  uint32_t                       Reserved5[1];
+  __I  uint8_t                        Reserved5[4];
   __IO PIO_ABCDSR_Type                PIO_ABCDSR[2];  /**< Offset: 0x70 (R/W  32) Peripheral ABCD Select Register 0 */
-  __I  uint32_t                       Reserved6[2];
+  __I  uint8_t                        Reserved6[8];
   __O  PIO_IFSCDR_Type                PIO_IFSCDR;     /**< Offset: 0x80 ( /W  32) Input Filter Slow Clock Disable Register */
   __O  PIO_IFSCER_Type                PIO_IFSCER;     /**< Offset: 0x84 ( /W  32) Input Filter Slow Clock Enable Register */
   __I  PIO_IFSCSR_Type                PIO_IFSCSR;     /**< Offset: 0x88 (R/   32) Input Filter Slow Clock Status Register */
@@ -7244,31 +7354,31 @@ typedef struct {
   __O  PIO_PPDDR_Type                 PIO_PPDDR;      /**< Offset: 0x90 ( /W  32) Pad Pull-down Disable Register */
   __O  PIO_PPDER_Type                 PIO_PPDER;      /**< Offset: 0x94 ( /W  32) Pad Pull-down Enable Register */
   __I  PIO_PPDSR_Type                 PIO_PPDSR;      /**< Offset: 0x98 (R/   32) Pad Pull-down Status Register */
-  __I  uint32_t                       Reserved7[1];
+  __I  uint8_t                        Reserved7[4];
   __O  PIO_OWER_Type                  PIO_OWER;       /**< Offset: 0xA0 ( /W  32) Output Write Enable */
   __O  PIO_OWDR_Type                  PIO_OWDR;       /**< Offset: 0xA4 ( /W  32) Output Write Disable */
   __I  PIO_OWSR_Type                  PIO_OWSR;       /**< Offset: 0xA8 (R/   32) Output Write Status Register */
-  __I  uint32_t                       Reserved8[1];
+  __I  uint8_t                        Reserved8[4];
   __O  PIO_AIMER_Type                 PIO_AIMER;      /**< Offset: 0xB0 ( /W  32) Additional Interrupt Modes Enable Register */
   __O  PIO_AIMDR_Type                 PIO_AIMDR;      /**< Offset: 0xB4 ( /W  32) Additional Interrupt Modes Disable Register */
   __I  PIO_AIMMR_Type                 PIO_AIMMR;      /**< Offset: 0xB8 (R/   32) Additional Interrupt Modes Mask Register */
-  __I  uint32_t                       Reserved9[1];
+  __I  uint8_t                        Reserved9[4];
   __O  PIO_ESR_Type                   PIO_ESR;        /**< Offset: 0xC0 ( /W  32) Edge Select Register */
   __O  PIO_LSR_Type                   PIO_LSR;        /**< Offset: 0xC4 ( /W  32) Level Select Register */
   __I  PIO_ELSR_Type                  PIO_ELSR;       /**< Offset: 0xC8 (R/   32) Edge/Level Status Register */
-  __I  uint32_t                       Reserved10[1];
+  __I  uint8_t                        Reserved10[4];
   __O  PIO_FELLSR_Type                PIO_FELLSR;     /**< Offset: 0xD0 ( /W  32) Falling Edge/Low-Level Select Register */
   __O  PIO_REHLSR_Type                PIO_REHLSR;     /**< Offset: 0xD4 ( /W  32) Rising Edge/High-Level Select Register */
   __I  PIO_FRLHSR_Type                PIO_FRLHSR;     /**< Offset: 0xD8 (R/   32) Fall/Rise - Low/High Status Register */
-  __I  uint32_t                       Reserved11[1];
+  __I  uint8_t                        Reserved11[4];
   __I  PIO_LOCKSR_Type                PIO_LOCKSR;     /**< Offset: 0xE0 (R/   32) Lock Status */
   __IO PIO_WPMR_Type                  PIO_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  PIO_WPSR_Type                  PIO_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved12[5];
+  __I  uint8_t                        Reserved12[20];
   __IO PIO_SCHMITT_Type               PIO_SCHMITT;    /**< Offset: 0x100 (R/W  32) Schmitt Trigger Register */
-  __I  uint32_t                       Reserved13[5];
+  __I  uint8_t                        Reserved13[20];
   __IO PIO_DRIVER_Type                PIO_DRIVER;     /**< Offset: 0x118 (R/W  32) I/O Drive Register */
-  __I  uint32_t                       Reserved14[13];
+  __I  uint8_t                        Reserved14[52];
   __IO PIO_PCMR_Type                  PIO_PCMR;       /**< Offset: 0x150 (R/W  32) Parallel Capture Mode Register */
   __O  PIO_PCIER_Type                 PIO_PCIER;      /**< Offset: 0x154 ( /W  32) Parallel Capture Interrupt Enable Register */
   __O  PIO_PCIDR_Type                 PIO_PCIDR;      /**< Offset: 0x158 ( /W  32) Parallel Capture Interrupt Disable Register */

--- a/asf/sam/include/same70b/component/pmc.h
+++ b/asf/sam/include/same70b/component/pmc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PMC_COMPONENT_H_
 #define _SAME70_PMC_COMPONENT_H_
 #define _SAME70_PMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- PMC_SCER : (PMC Offset: 0x00) (/W 32) System Clock Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :5;                        /**< bit:   0..4  Reserved */
@@ -57,15 +60,17 @@ typedef union {
     uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Enable       */
     uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Enable       */
     uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Enable       */
-    uint32_t :17;                       /**< bit: 15..31  Reserved */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Enable       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Enable       */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Enable       */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCER_OFFSET                     (0x00)                                        /**<  (PMC_SCER) System Clock Enable Register  Offset */
@@ -94,15 +99,19 @@ typedef union {
 #define PMC_SCER_PCK6_Pos                   14                                             /**< (PMC_SCER) Programmable Clock 6 Output Enable Position */
 #define PMC_SCER_PCK6_Msk                   (_U_(0x1) << PMC_SCER_PCK6_Pos)                /**< (PMC_SCER) Programmable Clock 6 Output Enable Mask */
 #define PMC_SCER_PCK6                       PMC_SCER_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK6_Msk instead */
-#define PMC_SCER_MASK                       _U_(0x7F20)                                    /**< \deprecated (PMC_SCER) Register MASK  (Use PMC_SCER_Msk instead)  */
-#define PMC_SCER_Msk                        _U_(0x7F20)                                    /**< (PMC_SCER) Register Mask  */
+#define PMC_SCER_PCK7_Pos                   15                                             /**< (PMC_SCER) Programmable Clock 7 Output Enable Position */
+#define PMC_SCER_PCK7_Msk                   (_U_(0x1) << PMC_SCER_PCK7_Pos)                /**< (PMC_SCER) Programmable Clock 7 Output Enable Mask */
+#define PMC_SCER_PCK7                       PMC_SCER_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCER_PCK7_Msk instead */
+#define PMC_SCER_MASK                       _U_(0xFF20)                                    /**< \deprecated (PMC_SCER) Register MASK  (Use PMC_SCER_Msk instead)  */
+#define PMC_SCER_Msk                        _U_(0xFF20)                                    /**< (PMC_SCER) Register Mask  */
 
-#define PMC_SCER_PCK_Pos                    8                                              /**< (PMC_SCER Position) Programmable Clock 6 Output Enable */
-#define PMC_SCER_PCK_Msk                    (_U_(0x7F) << PMC_SCER_PCK_Pos)                /**< (PMC_SCER Mask) PCK */
+#define PMC_SCER_PCK_Pos                    8                                              /**< (PMC_SCER Position) Programmable Clock 7 Output Enable */
+#define PMC_SCER_PCK_Msk                    (_U_(0xFF) << PMC_SCER_PCK_Pos)                /**< (PMC_SCER Mask) PCK */
 #define PMC_SCER_PCK(value)                 (PMC_SCER_PCK_Msk & ((value) << PMC_SCER_PCK_Pos))  
 
 /* -------- PMC_SCDR : (PMC Offset: 0x04) (/W 32) System Clock Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :5;                        /**< bit:   0..4  Reserved */
@@ -115,15 +124,17 @@ typedef union {
     uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Disable      */
     uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Disable      */
     uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Disable      */
-    uint32_t :17;                       /**< bit: 15..31  Reserved */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Disable      */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Disable      */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Disable      */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCDR_OFFSET                     (0x04)                                        /**<  (PMC_SCDR) System Clock Disable Register  Offset */
@@ -152,15 +163,19 @@ typedef union {
 #define PMC_SCDR_PCK6_Pos                   14                                             /**< (PMC_SCDR) Programmable Clock 6 Output Disable Position */
 #define PMC_SCDR_PCK6_Msk                   (_U_(0x1) << PMC_SCDR_PCK6_Pos)                /**< (PMC_SCDR) Programmable Clock 6 Output Disable Mask */
 #define PMC_SCDR_PCK6                       PMC_SCDR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK6_Msk instead */
-#define PMC_SCDR_MASK                       _U_(0x7F20)                                    /**< \deprecated (PMC_SCDR) Register MASK  (Use PMC_SCDR_Msk instead)  */
-#define PMC_SCDR_Msk                        _U_(0x7F20)                                    /**< (PMC_SCDR) Register Mask  */
+#define PMC_SCDR_PCK7_Pos                   15                                             /**< (PMC_SCDR) Programmable Clock 7 Output Disable Position */
+#define PMC_SCDR_PCK7_Msk                   (_U_(0x1) << PMC_SCDR_PCK7_Pos)                /**< (PMC_SCDR) Programmable Clock 7 Output Disable Mask */
+#define PMC_SCDR_PCK7                       PMC_SCDR_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCDR_PCK7_Msk instead */
+#define PMC_SCDR_MASK                       _U_(0xFF20)                                    /**< \deprecated (PMC_SCDR) Register MASK  (Use PMC_SCDR_Msk instead)  */
+#define PMC_SCDR_Msk                        _U_(0xFF20)                                    /**< (PMC_SCDR) Register Mask  */
 
-#define PMC_SCDR_PCK_Pos                    8                                              /**< (PMC_SCDR Position) Programmable Clock 6 Output Disable */
-#define PMC_SCDR_PCK_Msk                    (_U_(0x7F) << PMC_SCDR_PCK_Pos)                /**< (PMC_SCDR Mask) PCK */
+#define PMC_SCDR_PCK_Pos                    8                                              /**< (PMC_SCDR Position) Programmable Clock 7 Output Disable */
+#define PMC_SCDR_PCK_Msk                    (_U_(0xFF) << PMC_SCDR_PCK_Pos)                /**< (PMC_SCDR Mask) PCK */
 #define PMC_SCDR_PCK(value)                 (PMC_SCDR_PCK_Msk & ((value) << PMC_SCDR_PCK_Pos))  
 
 /* -------- PMC_SCSR : (PMC Offset: 0x08) (R/ 32) System Clock Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HCLKS:1;                   /**< bit:      0  HCLK Status                              */
@@ -174,15 +189,17 @@ typedef union {
     uint32_t PCK4:1;                    /**< bit:     12  Programmable Clock 4 Output Status       */
     uint32_t PCK5:1;                    /**< bit:     13  Programmable Clock 5 Output Status       */
     uint32_t PCK6:1;                    /**< bit:     14  Programmable Clock 6 Output Status       */
-    uint32_t :17;                       /**< bit: 15..31  Reserved */
+    uint32_t PCK7:1;                    /**< bit:     15  Programmable Clock 7 Output Status       */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCK:7;                     /**< bit:  8..14  Programmable Clock 6 Output Status       */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCK:8;                     /**< bit:  8..15  Programmable Clock 7 Output Status       */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SCSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SCSR_OFFSET                     (0x08)                                        /**<  (PMC_SCSR) System Clock Status Register  Offset */
@@ -214,21 +231,31 @@ typedef union {
 #define PMC_SCSR_PCK6_Pos                   14                                             /**< (PMC_SCSR) Programmable Clock 6 Output Status Position */
 #define PMC_SCSR_PCK6_Msk                   (_U_(0x1) << PMC_SCSR_PCK6_Pos)                /**< (PMC_SCSR) Programmable Clock 6 Output Status Mask */
 #define PMC_SCSR_PCK6                       PMC_SCSR_PCK6_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK6_Msk instead */
-#define PMC_SCSR_MASK                       _U_(0x7F21)                                    /**< \deprecated (PMC_SCSR) Register MASK  (Use PMC_SCSR_Msk instead)  */
-#define PMC_SCSR_Msk                        _U_(0x7F21)                                    /**< (PMC_SCSR) Register Mask  */
+#define PMC_SCSR_PCK7_Pos                   15                                             /**< (PMC_SCSR) Programmable Clock 7 Output Status Position */
+#define PMC_SCSR_PCK7_Msk                   (_U_(0x1) << PMC_SCSR_PCK7_Pos)                /**< (PMC_SCSR) Programmable Clock 7 Output Status Mask */
+#define PMC_SCSR_PCK7                       PMC_SCSR_PCK7_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SCSR_PCK7_Msk instead */
+#define PMC_SCSR_MASK                       _U_(0xFF21)                                    /**< \deprecated (PMC_SCSR) Register MASK  (Use PMC_SCSR_Msk instead)  */
+#define PMC_SCSR_Msk                        _U_(0xFF21)                                    /**< (PMC_SCSR) Register Mask  */
 
-#define PMC_SCSR_PCK_Pos                    8                                              /**< (PMC_SCSR Position) Programmable Clock 6 Output Status */
-#define PMC_SCSR_PCK_Msk                    (_U_(0x7F) << PMC_SCSR_PCK_Pos)                /**< (PMC_SCSR Mask) PCK */
+#define PMC_SCSR_PCK_Pos                    8                                              /**< (PMC_SCSR Position) Programmable Clock 7 Output Status */
+#define PMC_SCSR_PCK_Msk                    (_U_(0xFF) << PMC_SCSR_PCK_Pos)                /**< (PMC_SCSR Mask) PCK */
 #define PMC_SCSR_PCK(value)                 (PMC_SCSR_PCK_Msk & ((value) << PMC_SCSR_PCK_Pos))  
 
 /* -------- PMC_PCER0 : (PMC Offset: 0x10) (/W 32) Peripheral Clock Enable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Enable                */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Enable                */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Enable                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Enable               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Enable               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Enable               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Enable               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Enable               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Enable               */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Enable               */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Enable               */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Enable               */
@@ -248,11 +275,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Enable               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Enable               */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCER0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCER0_OFFSET                    (0x10)                                        /**<  (PMC_PCER0) Peripheral Clock Enable Register 0  Offset */
@@ -263,6 +290,27 @@ typedef union {
 #define PMC_PCER0_PID8_Pos                  8                                              /**< (PMC_PCER0) Peripheral Clock 8 Enable Position */
 #define PMC_PCER0_PID8_Msk                  (_U_(0x1) << PMC_PCER0_PID8_Pos)               /**< (PMC_PCER0) Peripheral Clock 8 Enable Mask */
 #define PMC_PCER0_PID8                      PMC_PCER0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID8_Msk instead */
+#define PMC_PCER0_PID9_Pos                  9                                              /**< (PMC_PCER0) Peripheral Clock 9 Enable Position */
+#define PMC_PCER0_PID9_Msk                  (_U_(0x1) << PMC_PCER0_PID9_Pos)               /**< (PMC_PCER0) Peripheral Clock 9 Enable Mask */
+#define PMC_PCER0_PID9                      PMC_PCER0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID9_Msk instead */
+#define PMC_PCER0_PID10_Pos                 10                                             /**< (PMC_PCER0) Peripheral Clock 10 Enable Position */
+#define PMC_PCER0_PID10_Msk                 (_U_(0x1) << PMC_PCER0_PID10_Pos)              /**< (PMC_PCER0) Peripheral Clock 10 Enable Mask */
+#define PMC_PCER0_PID10                     PMC_PCER0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID10_Msk instead */
+#define PMC_PCER0_PID11_Pos                 11                                             /**< (PMC_PCER0) Peripheral Clock 11 Enable Position */
+#define PMC_PCER0_PID11_Msk                 (_U_(0x1) << PMC_PCER0_PID11_Pos)              /**< (PMC_PCER0) Peripheral Clock 11 Enable Mask */
+#define PMC_PCER0_PID11                     PMC_PCER0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID11_Msk instead */
+#define PMC_PCER0_PID12_Pos                 12                                             /**< (PMC_PCER0) Peripheral Clock 12 Enable Position */
+#define PMC_PCER0_PID12_Msk                 (_U_(0x1) << PMC_PCER0_PID12_Pos)              /**< (PMC_PCER0) Peripheral Clock 12 Enable Mask */
+#define PMC_PCER0_PID12                     PMC_PCER0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID12_Msk instead */
+#define PMC_PCER0_PID13_Pos                 13                                             /**< (PMC_PCER0) Peripheral Clock 13 Enable Position */
+#define PMC_PCER0_PID13_Msk                 (_U_(0x1) << PMC_PCER0_PID13_Pos)              /**< (PMC_PCER0) Peripheral Clock 13 Enable Mask */
+#define PMC_PCER0_PID13                     PMC_PCER0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID13_Msk instead */
+#define PMC_PCER0_PID14_Pos                 14                                             /**< (PMC_PCER0) Peripheral Clock 14 Enable Position */
+#define PMC_PCER0_PID14_Msk                 (_U_(0x1) << PMC_PCER0_PID14_Pos)              /**< (PMC_PCER0) Peripheral Clock 14 Enable Mask */
+#define PMC_PCER0_PID14                     PMC_PCER0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID14_Msk instead */
+#define PMC_PCER0_PID15_Pos                 15                                             /**< (PMC_PCER0) Peripheral Clock 15 Enable Position */
+#define PMC_PCER0_PID15_Msk                 (_U_(0x1) << PMC_PCER0_PID15_Pos)              /**< (PMC_PCER0) Peripheral Clock 15 Enable Mask */
+#define PMC_PCER0_PID15                     PMC_PCER0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID15_Msk instead */
 #define PMC_PCER0_PID16_Pos                 16                                             /**< (PMC_PCER0) Peripheral Clock 16 Enable Position */
 #define PMC_PCER0_PID16_Msk                 (_U_(0x1) << PMC_PCER0_PID16_Pos)              /**< (PMC_PCER0) Peripheral Clock 16 Enable Mask */
 #define PMC_PCER0_PID16                     PMC_PCER0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID16_Msk instead */
@@ -311,21 +359,28 @@ typedef union {
 #define PMC_PCER0_PID31_Pos                 31                                             /**< (PMC_PCER0) Peripheral Clock 31 Enable Position */
 #define PMC_PCER0_PID31_Msk                 (_U_(0x1) << PMC_PCER0_PID31_Pos)              /**< (PMC_PCER0) Peripheral Clock 31 Enable Mask */
 #define PMC_PCER0_PID31                     PMC_PCER0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER0_PID31_Msk instead */
-#define PMC_PCER0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
-#define PMC_PCER0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCER0) Register Mask  */
+#define PMC_PCER0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCER0) Register MASK  (Use PMC_PCER0_Msk instead)  */
+#define PMC_PCER0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCER0) Register Mask  */
 
 #define PMC_PCER0_PID_Pos                   7                                              /**< (PMC_PCER0 Position) Peripheral Clock 3x Enable */
-#define PMC_PCER0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCER0_PID_Pos)            /**< (PMC_PCER0 Mask) PID */
+#define PMC_PCER0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER0_PID_Pos)          /**< (PMC_PCER0 Mask) PID */
 #define PMC_PCER0_PID(value)                (PMC_PCER0_PID_Msk & ((value) << PMC_PCER0_PID_Pos))  
 
 /* -------- PMC_PCDR0 : (PMC Offset: 0x14) (/W 32) Peripheral Clock Disable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Disable               */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Disable               */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Disable               */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Disable              */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Disable              */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Disable              */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Disable              */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Disable              */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Disable              */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Disable              */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Disable              */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Disable              */
@@ -345,11 +400,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Disable              */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Disable              */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCDR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCDR0_OFFSET                    (0x14)                                        /**<  (PMC_PCDR0) Peripheral Clock Disable Register 0  Offset */
@@ -360,6 +415,27 @@ typedef union {
 #define PMC_PCDR0_PID8_Pos                  8                                              /**< (PMC_PCDR0) Peripheral Clock 8 Disable Position */
 #define PMC_PCDR0_PID8_Msk                  (_U_(0x1) << PMC_PCDR0_PID8_Pos)               /**< (PMC_PCDR0) Peripheral Clock 8 Disable Mask */
 #define PMC_PCDR0_PID8                      PMC_PCDR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID8_Msk instead */
+#define PMC_PCDR0_PID9_Pos                  9                                              /**< (PMC_PCDR0) Peripheral Clock 9 Disable Position */
+#define PMC_PCDR0_PID9_Msk                  (_U_(0x1) << PMC_PCDR0_PID9_Pos)               /**< (PMC_PCDR0) Peripheral Clock 9 Disable Mask */
+#define PMC_PCDR0_PID9                      PMC_PCDR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID9_Msk instead */
+#define PMC_PCDR0_PID10_Pos                 10                                             /**< (PMC_PCDR0) Peripheral Clock 10 Disable Position */
+#define PMC_PCDR0_PID10_Msk                 (_U_(0x1) << PMC_PCDR0_PID10_Pos)              /**< (PMC_PCDR0) Peripheral Clock 10 Disable Mask */
+#define PMC_PCDR0_PID10                     PMC_PCDR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID10_Msk instead */
+#define PMC_PCDR0_PID11_Pos                 11                                             /**< (PMC_PCDR0) Peripheral Clock 11 Disable Position */
+#define PMC_PCDR0_PID11_Msk                 (_U_(0x1) << PMC_PCDR0_PID11_Pos)              /**< (PMC_PCDR0) Peripheral Clock 11 Disable Mask */
+#define PMC_PCDR0_PID11                     PMC_PCDR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID11_Msk instead */
+#define PMC_PCDR0_PID12_Pos                 12                                             /**< (PMC_PCDR0) Peripheral Clock 12 Disable Position */
+#define PMC_PCDR0_PID12_Msk                 (_U_(0x1) << PMC_PCDR0_PID12_Pos)              /**< (PMC_PCDR0) Peripheral Clock 12 Disable Mask */
+#define PMC_PCDR0_PID12                     PMC_PCDR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID12_Msk instead */
+#define PMC_PCDR0_PID13_Pos                 13                                             /**< (PMC_PCDR0) Peripheral Clock 13 Disable Position */
+#define PMC_PCDR0_PID13_Msk                 (_U_(0x1) << PMC_PCDR0_PID13_Pos)              /**< (PMC_PCDR0) Peripheral Clock 13 Disable Mask */
+#define PMC_PCDR0_PID13                     PMC_PCDR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID13_Msk instead */
+#define PMC_PCDR0_PID14_Pos                 14                                             /**< (PMC_PCDR0) Peripheral Clock 14 Disable Position */
+#define PMC_PCDR0_PID14_Msk                 (_U_(0x1) << PMC_PCDR0_PID14_Pos)              /**< (PMC_PCDR0) Peripheral Clock 14 Disable Mask */
+#define PMC_PCDR0_PID14                     PMC_PCDR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID14_Msk instead */
+#define PMC_PCDR0_PID15_Pos                 15                                             /**< (PMC_PCDR0) Peripheral Clock 15 Disable Position */
+#define PMC_PCDR0_PID15_Msk                 (_U_(0x1) << PMC_PCDR0_PID15_Pos)              /**< (PMC_PCDR0) Peripheral Clock 15 Disable Mask */
+#define PMC_PCDR0_PID15                     PMC_PCDR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID15_Msk instead */
 #define PMC_PCDR0_PID16_Pos                 16                                             /**< (PMC_PCDR0) Peripheral Clock 16 Disable Position */
 #define PMC_PCDR0_PID16_Msk                 (_U_(0x1) << PMC_PCDR0_PID16_Pos)              /**< (PMC_PCDR0) Peripheral Clock 16 Disable Mask */
 #define PMC_PCDR0_PID16                     PMC_PCDR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID16_Msk instead */
@@ -408,21 +484,28 @@ typedef union {
 #define PMC_PCDR0_PID31_Pos                 31                                             /**< (PMC_PCDR0) Peripheral Clock 31 Disable Position */
 #define PMC_PCDR0_PID31_Msk                 (_U_(0x1) << PMC_PCDR0_PID31_Pos)              /**< (PMC_PCDR0) Peripheral Clock 31 Disable Mask */
 #define PMC_PCDR0_PID31                     PMC_PCDR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR0_PID31_Msk instead */
-#define PMC_PCDR0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
-#define PMC_PCDR0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCDR0) Register Mask  */
+#define PMC_PCDR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCDR0) Register MASK  (Use PMC_PCDR0_Msk instead)  */
+#define PMC_PCDR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCDR0) Register Mask  */
 
 #define PMC_PCDR0_PID_Pos                   7                                              /**< (PMC_PCDR0 Position) Peripheral Clock 3x Disable */
-#define PMC_PCDR0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCDR0_PID_Pos)            /**< (PMC_PCDR0 Mask) PID */
+#define PMC_PCDR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR0_PID_Pos)          /**< (PMC_PCDR0 Mask) PID */
 #define PMC_PCDR0_PID(value)                (PMC_PCDR0_PID_Msk & ((value) << PMC_PCDR0_PID_Pos))  
 
 /* -------- PMC_PCSR0 : (PMC Offset: 0x18) (R/ 32) Peripheral Clock Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
     uint32_t PID7:1;                    /**< bit:      7  Peripheral Clock 7 Status                */
     uint32_t PID8:1;                    /**< bit:      8  Peripheral Clock 8 Status                */
-    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t PID9:1;                    /**< bit:      9  Peripheral Clock 9 Status                */
+    uint32_t PID10:1;                   /**< bit:     10  Peripheral Clock 10 Status               */
+    uint32_t PID11:1;                   /**< bit:     11  Peripheral Clock 11 Status               */
+    uint32_t PID12:1;                   /**< bit:     12  Peripheral Clock 12 Status               */
+    uint32_t PID13:1;                   /**< bit:     13  Peripheral Clock 13 Status               */
+    uint32_t PID14:1;                   /**< bit:     14  Peripheral Clock 14 Status               */
+    uint32_t PID15:1;                   /**< bit:     15  Peripheral Clock 15 Status               */
     uint32_t PID16:1;                   /**< bit:     16  Peripheral Clock 16 Status               */
     uint32_t PID17:1;                   /**< bit:     17  Peripheral Clock 17 Status               */
     uint32_t PID18:1;                   /**< bit:     18  Peripheral Clock 18 Status               */
@@ -442,11 +525,11 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
-    uint32_t PID:18;                    /**< bit:  7..24  Peripheral Clock 3x Status               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:25;                    /**< bit:  7..31  Peripheral Clock 3x Status               */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCSR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCSR0_OFFSET                    (0x18)                                        /**<  (PMC_PCSR0) Peripheral Clock Status Register 0  Offset */
@@ -457,6 +540,27 @@ typedef union {
 #define PMC_PCSR0_PID8_Pos                  8                                              /**< (PMC_PCSR0) Peripheral Clock 8 Status Position */
 #define PMC_PCSR0_PID8_Msk                  (_U_(0x1) << PMC_PCSR0_PID8_Pos)               /**< (PMC_PCSR0) Peripheral Clock 8 Status Mask */
 #define PMC_PCSR0_PID8                      PMC_PCSR0_PID8_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID8_Msk instead */
+#define PMC_PCSR0_PID9_Pos                  9                                              /**< (PMC_PCSR0) Peripheral Clock 9 Status Position */
+#define PMC_PCSR0_PID9_Msk                  (_U_(0x1) << PMC_PCSR0_PID9_Pos)               /**< (PMC_PCSR0) Peripheral Clock 9 Status Mask */
+#define PMC_PCSR0_PID9                      PMC_PCSR0_PID9_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID9_Msk instead */
+#define PMC_PCSR0_PID10_Pos                 10                                             /**< (PMC_PCSR0) Peripheral Clock 10 Status Position */
+#define PMC_PCSR0_PID10_Msk                 (_U_(0x1) << PMC_PCSR0_PID10_Pos)              /**< (PMC_PCSR0) Peripheral Clock 10 Status Mask */
+#define PMC_PCSR0_PID10                     PMC_PCSR0_PID10_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID10_Msk instead */
+#define PMC_PCSR0_PID11_Pos                 11                                             /**< (PMC_PCSR0) Peripheral Clock 11 Status Position */
+#define PMC_PCSR0_PID11_Msk                 (_U_(0x1) << PMC_PCSR0_PID11_Pos)              /**< (PMC_PCSR0) Peripheral Clock 11 Status Mask */
+#define PMC_PCSR0_PID11                     PMC_PCSR0_PID11_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID11_Msk instead */
+#define PMC_PCSR0_PID12_Pos                 12                                             /**< (PMC_PCSR0) Peripheral Clock 12 Status Position */
+#define PMC_PCSR0_PID12_Msk                 (_U_(0x1) << PMC_PCSR0_PID12_Pos)              /**< (PMC_PCSR0) Peripheral Clock 12 Status Mask */
+#define PMC_PCSR0_PID12                     PMC_PCSR0_PID12_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID12_Msk instead */
+#define PMC_PCSR0_PID13_Pos                 13                                             /**< (PMC_PCSR0) Peripheral Clock 13 Status Position */
+#define PMC_PCSR0_PID13_Msk                 (_U_(0x1) << PMC_PCSR0_PID13_Pos)              /**< (PMC_PCSR0) Peripheral Clock 13 Status Mask */
+#define PMC_PCSR0_PID13                     PMC_PCSR0_PID13_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID13_Msk instead */
+#define PMC_PCSR0_PID14_Pos                 14                                             /**< (PMC_PCSR0) Peripheral Clock 14 Status Position */
+#define PMC_PCSR0_PID14_Msk                 (_U_(0x1) << PMC_PCSR0_PID14_Pos)              /**< (PMC_PCSR0) Peripheral Clock 14 Status Mask */
+#define PMC_PCSR0_PID14                     PMC_PCSR0_PID14_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID14_Msk instead */
+#define PMC_PCSR0_PID15_Pos                 15                                             /**< (PMC_PCSR0) Peripheral Clock 15 Status Position */
+#define PMC_PCSR0_PID15_Msk                 (_U_(0x1) << PMC_PCSR0_PID15_Pos)              /**< (PMC_PCSR0) Peripheral Clock 15 Status Mask */
+#define PMC_PCSR0_PID15                     PMC_PCSR0_PID15_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID15_Msk instead */
 #define PMC_PCSR0_PID16_Pos                 16                                             /**< (PMC_PCSR0) Peripheral Clock 16 Status Position */
 #define PMC_PCSR0_PID16_Msk                 (_U_(0x1) << PMC_PCSR0_PID16_Pos)              /**< (PMC_PCSR0) Peripheral Clock 16 Status Mask */
 #define PMC_PCSR0_PID16                     PMC_PCSR0_PID16_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID16_Msk instead */
@@ -505,15 +609,16 @@ typedef union {
 #define PMC_PCSR0_PID31_Pos                 31                                             /**< (PMC_PCSR0) Peripheral Clock 31 Status Position */
 #define PMC_PCSR0_PID31_Msk                 (_U_(0x1) << PMC_PCSR0_PID31_Pos)              /**< (PMC_PCSR0) Peripheral Clock 31 Status Mask */
 #define PMC_PCSR0_PID31                     PMC_PCSR0_PID31_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR0_PID31_Msk instead */
-#define PMC_PCSR0_MASK                      _U_(0xFFFF0180)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
-#define PMC_PCSR0_Msk                       _U_(0xFFFF0180)                                /**< (PMC_PCSR0) Register Mask  */
+#define PMC_PCSR0_MASK                      _U_(0xFFFFFF80)                                /**< \deprecated (PMC_PCSR0) Register MASK  (Use PMC_PCSR0_Msk instead)  */
+#define PMC_PCSR0_Msk                       _U_(0xFFFFFF80)                                /**< (PMC_PCSR0) Register Mask  */
 
 #define PMC_PCSR0_PID_Pos                   7                                              /**< (PMC_PCSR0 Position) Peripheral Clock 3x Status */
-#define PMC_PCSR0_PID_Msk                   (_U_(0x3FFFF) << PMC_PCSR0_PID_Pos)            /**< (PMC_PCSR0 Mask) PID */
+#define PMC_PCSR0_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR0_PID_Pos)          /**< (PMC_PCSR0 Mask) PID */
 #define PMC_PCSR0_PID(value)                (PMC_PCSR0_PID_Msk & ((value) << PMC_PCSR0_PID_Pos))  
 
 /* -------- CKGR_UCKR : (PMC Offset: 0x1c) (R/W 32) UTMI Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -524,6 +629,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_UCKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_UCKR_OFFSET                    (0x1C)                                        /**<  (CKGR_UCKR) UTMI Clock Register  Offset */
@@ -540,6 +646,7 @@ typedef union {
 
 /* -------- CKGR_MOR : (PMC Offset: 0x20) (R/W 32) Main Oscillator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTEN:1;                /**< bit:      0  Main Crystal Oscillator Enable           */
@@ -557,6 +664,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_MOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_MOR_OFFSET                     (0x20)                                        /**<  (CKGR_MOR) Main Oscillator Register  Offset */
@@ -605,6 +713,7 @@ typedef union {
 
 /* -------- CKGR_MCFR : (PMC Offset: 0x24) (R/W 32) Main Clock Frequency Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAINF:16;                  /**< bit:  0..15  Main Clock Frequency                     */
@@ -617,6 +726,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_MCFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_MCFR_OFFSET                    (0x24)                                        /**<  (CKGR_MCFR) Main Clock Frequency Register  Offset */
@@ -639,6 +749,7 @@ typedef union {
 
 /* -------- CKGR_PLLAR : (PMC Offset: 0x28) (R/W 32) PLLA Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIVA:8;                    /**< bit:   0..7  PLLA Front End Divider                   */
@@ -651,6 +762,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } CKGR_PLLAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define CKGR_PLLAR_OFFSET                   (0x28)                                        /**<  (CKGR_PLLAR) PLLA Register  Offset */
@@ -677,6 +789,7 @@ typedef union {
 
 /* -------- PMC_MCKR : (PMC Offset: 0x30) (R/W 32) Master Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSS:2;                     /**< bit:   0..1  Master Clock Source Selection            */
@@ -688,8 +801,14 @@ typedef union {
     uint32_t UPLLDIV2:1;                /**< bit:     13  UPLL Divider by 2                        */
     uint32_t :18;                       /**< bit: 14..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t UPLLDIV:1;                 /**< bit:     13  UPLL Divider by 2                        */
+    uint32_t :18;                       /**< bit: 14..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_MCKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_MCKR_OFFSET                     (0x30)                                        /**<  (PMC_MCKR) Master Clock Register  Offset */
@@ -741,9 +860,13 @@ typedef union {
 #define PMC_MCKR_MASK                       _U_(0x2373)                                    /**< \deprecated (PMC_MCKR) Register MASK  (Use PMC_MCKR_Msk instead)  */
 #define PMC_MCKR_Msk                        _U_(0x2373)                                    /**< (PMC_MCKR) Register Mask  */
 
+#define PMC_MCKR_UPLLDIV_Pos                13                                             /**< (PMC_MCKR Position) UPLL Divider by 2 */
+#define PMC_MCKR_UPLLDIV_Msk                (_U_(0x1) << PMC_MCKR_UPLLDIV_Pos)             /**< (PMC_MCKR Mask) UPLLDIV */
+#define PMC_MCKR_UPLLDIV(value)             (PMC_MCKR_UPLLDIV_Msk & ((value) << PMC_MCKR_UPLLDIV_Pos))  
 
 /* -------- PMC_USB : (PMC Offset: 0x38) (R/W 32) USB Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USBS:1;                    /**< bit:      0  USB Input Clock Selection                */
@@ -753,6 +876,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_USB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_USB_OFFSET                      (0x38)                                        /**<  (PMC_USB) USB Clock Register  Offset */
@@ -769,6 +893,7 @@ typedef union {
 
 /* -------- PMC_PCK : (PMC Offset: 0x40) (R/W 32) Programmable Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSS:3;                     /**< bit:   0..2  Programmable Clock Source Selection      */
@@ -778,6 +903,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCK_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCK_OFFSET                      (0x40)                                        /**<  (PMC_PCK) Programmable Clock Register  Offset */
@@ -804,6 +930,7 @@ typedef union {
 
 /* -------- PMC_IER : (PMC Offset: 0x60) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Enable */
@@ -820,7 +947,7 @@ typedef union {
     uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Enable */
     uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Enable */
     uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Enable */
-    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Enable */
     uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Enable */
     uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status Interrupt Enable */
     uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Enable */
@@ -830,11 +957,12 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Enable */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Enable */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IER_OFFSET                      (0x60)                                        /**<  (PMC_IER) Interrupt Enable Register  Offset */
@@ -872,6 +1000,9 @@ typedef union {
 #define PMC_IER_PCKRDY6_Pos                 14                                             /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Position */
 #define PMC_IER_PCKRDY6_Msk                 (_U_(0x1) << PMC_IER_PCKRDY6_Pos)              /**< (PMC_IER) Programmable Clock Ready 6 Interrupt Enable Mask */
 #define PMC_IER_PCKRDY6                     PMC_IER_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY6_Msk instead */
+#define PMC_IER_PCKRDY7_Pos                 15                                             /**< (PMC_IER) Programmable Clock Ready 7 Interrupt Enable Position */
+#define PMC_IER_PCKRDY7_Msk                 (_U_(0x1) << PMC_IER_PCKRDY7_Pos)              /**< (PMC_IER) Programmable Clock Ready 7 Interrupt Enable Mask */
+#define PMC_IER_PCKRDY7                     PMC_IER_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_PCKRDY7_Msk instead */
 #define PMC_IER_MOSCSELS_Pos                16                                             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Position */
 #define PMC_IER_MOSCSELS_Msk                (_U_(0x1) << PMC_IER_MOSCSELS_Pos)             /**< (PMC_IER) Main Clock Source Oscillator Selection Status Interrupt Enable Mask */
 #define PMC_IER_MOSCSELS                    PMC_IER_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_MOSCSELS_Msk instead */
@@ -884,15 +1015,16 @@ typedef union {
 #define PMC_IER_XT32KERR_Pos                21                                             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Position */
 #define PMC_IER_XT32KERR_Msk                (_U_(0x1) << PMC_IER_XT32KERR_Pos)             /**< (PMC_IER) 32.768 kHz Crystal Oscillator Error Interrupt Enable Mask */
 #define PMC_IER_XT32KERR                    PMC_IER_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IER_XT32KERR_Msk instead */
-#define PMC_IER_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IER) Register MASK  (Use PMC_IER_Msk instead)  */
-#define PMC_IER_Msk                         _U_(0x277F4B)                                  /**< (PMC_IER) Register Mask  */
+#define PMC_IER_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IER) Register MASK  (Use PMC_IER_Msk instead)  */
+#define PMC_IER_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IER) Register Mask  */
 
 #define PMC_IER_PCKRDY_Pos                  8                                              /**< (PMC_IER Position) Programmable Clock Ready x Interrupt Enable */
-#define PMC_IER_PCKRDY_Msk                  (_U_(0x7F) << PMC_IER_PCKRDY_Pos)              /**< (PMC_IER Mask) PCKRDY */
+#define PMC_IER_PCKRDY_Msk                  (_U_(0xFF) << PMC_IER_PCKRDY_Pos)              /**< (PMC_IER Mask) PCKRDY */
 #define PMC_IER_PCKRDY(value)               (PMC_IER_PCKRDY_Msk & ((value) << PMC_IER_PCKRDY_Pos))  
 
 /* -------- PMC_IDR : (PMC Offset: 0x64) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Disable */
@@ -909,7 +1041,7 @@ typedef union {
     uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Disable */
     uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Disable */
     uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Disable */
-    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Disable */
     uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Disable */
     uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Disable         */
     uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Disable */
@@ -919,11 +1051,12 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Disable */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Disable */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IDR_OFFSET                      (0x64)                                        /**<  (PMC_IDR) Interrupt Disable Register  Offset */
@@ -961,6 +1094,9 @@ typedef union {
 #define PMC_IDR_PCKRDY6_Pos                 14                                             /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Position */
 #define PMC_IDR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY6_Pos)              /**< (PMC_IDR) Programmable Clock Ready 6 Interrupt Disable Mask */
 #define PMC_IDR_PCKRDY6                     PMC_IDR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY6_Msk instead */
+#define PMC_IDR_PCKRDY7_Pos                 15                                             /**< (PMC_IDR) Programmable Clock Ready 7 Interrupt Disable Position */
+#define PMC_IDR_PCKRDY7_Msk                 (_U_(0x1) << PMC_IDR_PCKRDY7_Pos)              /**< (PMC_IDR) Programmable Clock Ready 7 Interrupt Disable Mask */
+#define PMC_IDR_PCKRDY7                     PMC_IDR_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_PCKRDY7_Msk instead */
 #define PMC_IDR_MOSCSELS_Pos                16                                             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Position */
 #define PMC_IDR_MOSCSELS_Msk                (_U_(0x1) << PMC_IDR_MOSCSELS_Pos)             /**< (PMC_IDR) Main Clock Source Oscillator Selection Status Interrupt Disable Mask */
 #define PMC_IDR_MOSCSELS                    PMC_IDR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_MOSCSELS_Msk instead */
@@ -973,15 +1109,16 @@ typedef union {
 #define PMC_IDR_XT32KERR_Pos                21                                             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Position */
 #define PMC_IDR_XT32KERR_Msk                (_U_(0x1) << PMC_IDR_XT32KERR_Pos)             /**< (PMC_IDR) 32.768 kHz Crystal Oscillator Error Interrupt Disable Mask */
 #define PMC_IDR_XT32KERR                    PMC_IDR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IDR_XT32KERR_Msk instead */
-#define PMC_IDR_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IDR) Register MASK  (Use PMC_IDR_Msk instead)  */
-#define PMC_IDR_Msk                         _U_(0x277F4B)                                  /**< (PMC_IDR) Register Mask  */
+#define PMC_IDR_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IDR) Register MASK  (Use PMC_IDR_Msk instead)  */
+#define PMC_IDR_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IDR) Register Mask  */
 
 #define PMC_IDR_PCKRDY_Pos                  8                                              /**< (PMC_IDR Position) Programmable Clock Ready x Interrupt Disable */
-#define PMC_IDR_PCKRDY_Msk                  (_U_(0x7F) << PMC_IDR_PCKRDY_Pos)              /**< (PMC_IDR Mask) PCKRDY */
+#define PMC_IDR_PCKRDY_Msk                  (_U_(0xFF) << PMC_IDR_PCKRDY_Pos)              /**< (PMC_IDR Mask) PCKRDY */
 #define PMC_IDR_PCKRDY(value)               (PMC_IDR_PCKRDY_Msk & ((value) << PMC_IDR_PCKRDY_Pos))  
 
 /* -------- PMC_SR : (PMC Offset: 0x68) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status           */
@@ -998,7 +1135,7 @@ typedef union {
     uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Status        */
     uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Status        */
     uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Status        */
-    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Status        */
     uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status */
     uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Oscillator Status                */
     uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event             */
@@ -1009,11 +1146,12 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Status        */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Status        */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SR_OFFSET                       (0x68)                                        /**<  (PMC_SR) Status Register  Offset */
@@ -1054,6 +1192,9 @@ typedef union {
 #define PMC_SR_PCKRDY6_Pos                  14                                             /**< (PMC_SR) Programmable Clock Ready 6 Status Position */
 #define PMC_SR_PCKRDY6_Msk                  (_U_(0x1) << PMC_SR_PCKRDY6_Pos)               /**< (PMC_SR) Programmable Clock Ready 6 Status Mask */
 #define PMC_SR_PCKRDY6                      PMC_SR_PCKRDY6_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY6_Msk instead */
+#define PMC_SR_PCKRDY7_Pos                  15                                             /**< (PMC_SR) Programmable Clock Ready 7 Status Position */
+#define PMC_SR_PCKRDY7_Msk                  (_U_(0x1) << PMC_SR_PCKRDY7_Pos)               /**< (PMC_SR) Programmable Clock Ready 7 Status Mask */
+#define PMC_SR_PCKRDY7                      PMC_SR_PCKRDY7_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_PCKRDY7_Msk instead */
 #define PMC_SR_MOSCSELS_Pos                 16                                             /**< (PMC_SR) Main Clock Source Oscillator Selection Status Position */
 #define PMC_SR_MOSCSELS_Msk                 (_U_(0x1) << PMC_SR_MOSCSELS_Pos)              /**< (PMC_SR) Main Clock Source Oscillator Selection Status Mask */
 #define PMC_SR_MOSCSELS                     PMC_SR_MOSCSELS_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_MOSCSELS_Msk instead */
@@ -1072,15 +1213,16 @@ typedef union {
 #define PMC_SR_XT32KERR_Pos                 21                                             /**< (PMC_SR) Slow Crystal Oscillator Error Position */
 #define PMC_SR_XT32KERR_Msk                 (_U_(0x1) << PMC_SR_XT32KERR_Pos)              /**< (PMC_SR) Slow Crystal Oscillator Error Mask */
 #define PMC_SR_XT32KERR                     PMC_SR_XT32KERR_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SR_XT32KERR_Msk instead */
-#define PMC_SR_MASK                         _U_(0x3F7FCB)                                  /**< \deprecated (PMC_SR) Register MASK  (Use PMC_SR_Msk instead)  */
-#define PMC_SR_Msk                          _U_(0x3F7FCB)                                  /**< (PMC_SR) Register Mask  */
+#define PMC_SR_MASK                         _U_(0x3FFFCB)                                  /**< \deprecated (PMC_SR) Register MASK  (Use PMC_SR_Msk instead)  */
+#define PMC_SR_Msk                          _U_(0x3FFFCB)                                  /**< (PMC_SR) Register Mask  */
 
 #define PMC_SR_PCKRDY_Pos                   8                                              /**< (PMC_SR Position) Programmable Clock Ready x Status */
-#define PMC_SR_PCKRDY_Msk                   (_U_(0x7F) << PMC_SR_PCKRDY_Pos)               /**< (PMC_SR Mask) PCKRDY */
+#define PMC_SR_PCKRDY_Msk                   (_U_(0xFF) << PMC_SR_PCKRDY_Pos)               /**< (PMC_SR Mask) PCKRDY */
 #define PMC_SR_PCKRDY(value)                (PMC_SR_PCKRDY_Msk & ((value) << PMC_SR_PCKRDY_Pos))  
 
 /* -------- PMC_IMR : (PMC Offset: 0x6c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MOSCXTS:1;                 /**< bit:      0  Main Crystal Oscillator Status Interrupt Mask */
@@ -1097,7 +1239,7 @@ typedef union {
     uint32_t PCKRDY4:1;                 /**< bit:     12  Programmable Clock Ready 4 Interrupt Mask */
     uint32_t PCKRDY5:1;                 /**< bit:     13  Programmable Clock Ready 5 Interrupt Mask */
     uint32_t PCKRDY6:1;                 /**< bit:     14  Programmable Clock Ready 6 Interrupt Mask */
-    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t PCKRDY7:1;                 /**< bit:     15  Programmable Clock Ready 7 Interrupt Mask */
     uint32_t MOSCSELS:1;                /**< bit:     16  Main Clock Source Oscillator Selection Status Interrupt Mask */
     uint32_t MOSCRCS:1;                 /**< bit:     17  Main RC Status Interrupt Mask            */
     uint32_t CFDEV:1;                   /**< bit:     18  Clock Failure Detector Event Interrupt Mask */
@@ -1107,11 +1249,12 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PCKRDY:7;                  /**< bit:  8..14  Programmable Clock Ready x Interrupt Mask */
-    uint32_t :17;                       /**< bit: 15..31 Reserved */
+    uint32_t PCKRDY:8;                  /**< bit:  8..15  Programmable Clock Ready x Interrupt Mask */
+    uint32_t :16;                       /**< bit: 16..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_IMR_OFFSET                      (0x6C)                                        /**<  (PMC_IMR) Interrupt Mask Register  Offset */
@@ -1149,6 +1292,9 @@ typedef union {
 #define PMC_IMR_PCKRDY6_Pos                 14                                             /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Position */
 #define PMC_IMR_PCKRDY6_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY6_Pos)              /**< (PMC_IMR) Programmable Clock Ready 6 Interrupt Mask Mask */
 #define PMC_IMR_PCKRDY6                     PMC_IMR_PCKRDY6_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY6_Msk instead */
+#define PMC_IMR_PCKRDY7_Pos                 15                                             /**< (PMC_IMR) Programmable Clock Ready 7 Interrupt Mask Position */
+#define PMC_IMR_PCKRDY7_Msk                 (_U_(0x1) << PMC_IMR_PCKRDY7_Pos)              /**< (PMC_IMR) Programmable Clock Ready 7 Interrupt Mask Mask */
+#define PMC_IMR_PCKRDY7                     PMC_IMR_PCKRDY7_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_PCKRDY7_Msk instead */
 #define PMC_IMR_MOSCSELS_Pos                16                                             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Position */
 #define PMC_IMR_MOSCSELS_Msk                (_U_(0x1) << PMC_IMR_MOSCSELS_Pos)             /**< (PMC_IMR) Main Clock Source Oscillator Selection Status Interrupt Mask Mask */
 #define PMC_IMR_MOSCSELS                    PMC_IMR_MOSCSELS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_MOSCSELS_Msk instead */
@@ -1161,15 +1307,16 @@ typedef union {
 #define PMC_IMR_XT32KERR_Pos                21                                             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Position */
 #define PMC_IMR_XT32KERR_Msk                (_U_(0x1) << PMC_IMR_XT32KERR_Pos)             /**< (PMC_IMR) 32.768 kHz Crystal Oscillator Error Interrupt Mask Mask */
 #define PMC_IMR_XT32KERR                    PMC_IMR_XT32KERR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_IMR_XT32KERR_Msk instead */
-#define PMC_IMR_MASK                        _U_(0x277F4B)                                  /**< \deprecated (PMC_IMR) Register MASK  (Use PMC_IMR_Msk instead)  */
-#define PMC_IMR_Msk                         _U_(0x277F4B)                                  /**< (PMC_IMR) Register Mask  */
+#define PMC_IMR_MASK                        _U_(0x27FF4B)                                  /**< \deprecated (PMC_IMR) Register MASK  (Use PMC_IMR_Msk instead)  */
+#define PMC_IMR_Msk                         _U_(0x27FF4B)                                  /**< (PMC_IMR) Register Mask  */
 
 #define PMC_IMR_PCKRDY_Pos                  8                                              /**< (PMC_IMR Position) Programmable Clock Ready x Interrupt Mask */
-#define PMC_IMR_PCKRDY_Msk                  (_U_(0x7F) << PMC_IMR_PCKRDY_Pos)              /**< (PMC_IMR Mask) PCKRDY */
+#define PMC_IMR_PCKRDY_Msk                  (_U_(0xFF) << PMC_IMR_PCKRDY_Pos)              /**< (PMC_IMR Mask) PCKRDY */
 #define PMC_IMR_PCKRDY(value)               (PMC_IMR_PCKRDY_Msk & ((value) << PMC_IMR_PCKRDY_Pos))  
 
 /* -------- PMC_FSMR : (PMC Offset: 0x70) (R/W 32) Fast Startup Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FSTT0:1;                   /**< bit:      0  Fast Startup Input Enable 0              */
@@ -1203,6 +1350,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FSMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FSMR_OFFSET                     (0x70)                                        /**<  (PMC_FSMR) Fast Startup Mode Register  Offset */
@@ -1288,6 +1436,7 @@ typedef union {
 
 /* -------- PMC_FSPR : (PMC Offset: 0x74) (R/W 32) Fast Startup Polarity Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FSTP0:1;                   /**< bit:      0  Fast Startup Input Polarity 0            */
@@ -1314,6 +1463,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FSPR_OFFSET                     (0x74)                                        /**<  (PMC_FSPR) Fast Startup Polarity Register  Offset */
@@ -1375,6 +1525,7 @@ typedef union {
 
 /* -------- PMC_FOCR : (PMC Offset: 0x78) (/W 32) Fault Output Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FOCLR:1;                   /**< bit:      0  Fault Output Clear                       */
@@ -1382,6 +1533,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_FOCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_FOCR_OFFSET                     (0x78)                                        /**<  (PMC_FOCR) Fault Output Clear Register  Offset */
@@ -1395,6 +1547,7 @@ typedef union {
 
 /* -------- PMC_WPMR : (PMC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1403,6 +1556,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_WPMR_OFFSET                     (0xE4)                                        /**<  (PMC_WPMR) Write Protection Mode Register  Offset */
@@ -1421,6 +1575,7 @@ typedef union {
 
 /* -------- PMC_WPSR : (PMC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1430,6 +1585,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_WPSR_OFFSET                     (0xE8)                                        /**<  (PMC_WPSR) Write Protection Status Register  Offset */
@@ -1446,6 +1602,7 @@ typedef union {
 
 /* -------- PMC_PCER1 : (PMC Offset: 0x100) (/W 32) Peripheral Clock Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Enable               */
@@ -1469,8 +1626,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Enable               */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Enable               */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Enable               */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Enable               */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Enable               */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Enable               */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Enable               */
@@ -1479,11 +1635,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Enable               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral Clock 6x Enable               */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCER1_OFFSET                    (0x100)                                       /**<  (PMC_PCER1) Peripheral Clock Enable Register 1  Offset */
@@ -1545,9 +1702,6 @@ typedef union {
 #define PMC_PCER1_PID52_Pos                 20                                             /**< (PMC_PCER1) Peripheral Clock 52 Enable Position */
 #define PMC_PCER1_PID52_Msk                 (_U_(0x1) << PMC_PCER1_PID52_Pos)              /**< (PMC_PCER1) Peripheral Clock 52 Enable Mask */
 #define PMC_PCER1_PID52                     PMC_PCER1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID52_Msk instead */
-#define PMC_PCER1_PID53_Pos                 21                                             /**< (PMC_PCER1) Peripheral Clock 53 Enable Position */
-#define PMC_PCER1_PID53_Msk                 (_U_(0x1) << PMC_PCER1_PID53_Pos)              /**< (PMC_PCER1) Peripheral Clock 53 Enable Mask */
-#define PMC_PCER1_PID53                     PMC_PCER1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID53_Msk instead */
 #define PMC_PCER1_PID56_Pos                 24                                             /**< (PMC_PCER1) Peripheral Clock 56 Enable Position */
 #define PMC_PCER1_PID56_Msk                 (_U_(0x1) << PMC_PCER1_PID56_Pos)              /**< (PMC_PCER1) Peripheral Clock 56 Enable Mask */
 #define PMC_PCER1_PID56                     PMC_PCER1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID56_Msk instead */
@@ -1563,15 +1717,16 @@ typedef union {
 #define PMC_PCER1_PID60_Pos                 28                                             /**< (PMC_PCER1) Peripheral Clock 60 Enable Position */
 #define PMC_PCER1_PID60_Msk                 (_U_(0x1) << PMC_PCER1_PID60_Pos)              /**< (PMC_PCER1) Peripheral Clock 60 Enable Mask */
 #define PMC_PCER1_PID60                     PMC_PCER1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCER1_PID60_Msk instead */
-#define PMC_PCER1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCER1) Register MASK  (Use PMC_PCER1_Msk instead)  */
-#define PMC_PCER1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCER1) Register Mask  */
+#define PMC_PCER1_MASK                      _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_PCER1) Register MASK  (Use PMC_PCER1_Msk instead)  */
+#define PMC_PCER1_Msk                       _U_(0x1F1FFFAF)                                /**< (PMC_PCER1) Register Mask  */
 
 #define PMC_PCER1_PID_Pos                   0                                              /**< (PMC_PCER1 Position) Peripheral Clock 6x Enable */
-#define PMC_PCER1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCER1_PID_Pos)          /**< (PMC_PCER1 Mask) PID */
+#define PMC_PCER1_PID_Msk                   (_U_(0xFFFFFF) << PMC_PCER1_PID_Pos)           /**< (PMC_PCER1 Mask) PID */
 #define PMC_PCER1_PID(value)                (PMC_PCER1_PID_Msk & ((value) << PMC_PCER1_PID_Pos))  
 
 /* -------- PMC_PCDR1 : (PMC Offset: 0x104) (/W 32) Peripheral Clock Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Disable              */
@@ -1595,8 +1750,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Disable              */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Disable              */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Disable              */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Disable              */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Disable              */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Disable              */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Disable              */
@@ -1605,11 +1759,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Disable              */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral Clock 6x Disable              */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCDR1_OFFSET                    (0x104)                                       /**<  (PMC_PCDR1) Peripheral Clock Disable Register 1  Offset */
@@ -1671,9 +1826,6 @@ typedef union {
 #define PMC_PCDR1_PID52_Pos                 20                                             /**< (PMC_PCDR1) Peripheral Clock 52 Disable Position */
 #define PMC_PCDR1_PID52_Msk                 (_U_(0x1) << PMC_PCDR1_PID52_Pos)              /**< (PMC_PCDR1) Peripheral Clock 52 Disable Mask */
 #define PMC_PCDR1_PID52                     PMC_PCDR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID52_Msk instead */
-#define PMC_PCDR1_PID53_Pos                 21                                             /**< (PMC_PCDR1) Peripheral Clock 53 Disable Position */
-#define PMC_PCDR1_PID53_Msk                 (_U_(0x1) << PMC_PCDR1_PID53_Pos)              /**< (PMC_PCDR1) Peripheral Clock 53 Disable Mask */
-#define PMC_PCDR1_PID53                     PMC_PCDR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID53_Msk instead */
 #define PMC_PCDR1_PID56_Pos                 24                                             /**< (PMC_PCDR1) Peripheral Clock 56 Disable Position */
 #define PMC_PCDR1_PID56_Msk                 (_U_(0x1) << PMC_PCDR1_PID56_Pos)              /**< (PMC_PCDR1) Peripheral Clock 56 Disable Mask */
 #define PMC_PCDR1_PID56                     PMC_PCDR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID56_Msk instead */
@@ -1689,15 +1841,16 @@ typedef union {
 #define PMC_PCDR1_PID60_Pos                 28                                             /**< (PMC_PCDR1) Peripheral Clock 60 Disable Position */
 #define PMC_PCDR1_PID60_Msk                 (_U_(0x1) << PMC_PCDR1_PID60_Pos)              /**< (PMC_PCDR1) Peripheral Clock 60 Disable Mask */
 #define PMC_PCDR1_PID60                     PMC_PCDR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCDR1_PID60_Msk instead */
-#define PMC_PCDR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCDR1) Register MASK  (Use PMC_PCDR1_Msk instead)  */
-#define PMC_PCDR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCDR1) Register Mask  */
+#define PMC_PCDR1_MASK                      _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_PCDR1) Register MASK  (Use PMC_PCDR1_Msk instead)  */
+#define PMC_PCDR1_Msk                       _U_(0x1F1FFFAF)                                /**< (PMC_PCDR1) Register Mask  */
 
 #define PMC_PCDR1_PID_Pos                   0                                              /**< (PMC_PCDR1 Position) Peripheral Clock 6x Disable */
-#define PMC_PCDR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCDR1_PID_Pos)          /**< (PMC_PCDR1 Mask) PID */
+#define PMC_PCDR1_PID_Msk                   (_U_(0xFFFFFF) << PMC_PCDR1_PID_Pos)           /**< (PMC_PCDR1 Mask) PID */
 #define PMC_PCDR1_PID(value)                (PMC_PCDR1_PID_Msk & ((value) << PMC_PCDR1_PID_Pos))  
 
 /* -------- PMC_PCSR1 : (PMC Offset: 0x108) (R/ 32) Peripheral Clock Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral Clock 32 Status               */
@@ -1721,8 +1874,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral Clock 50 Status               */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral Clock 51 Status               */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral Clock 52 Status               */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral Clock 53 Status               */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral Clock 56 Status               */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral Clock 57 Status               */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral Clock 58 Status               */
@@ -1731,11 +1883,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral Clock 6x Status               */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral Clock 6x Status               */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCSR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCSR1_OFFSET                    (0x108)                                       /**<  (PMC_PCSR1) Peripheral Clock Status Register 1  Offset */
@@ -1797,9 +1950,6 @@ typedef union {
 #define PMC_PCSR1_PID52_Pos                 20                                             /**< (PMC_PCSR1) Peripheral Clock 52 Status Position */
 #define PMC_PCSR1_PID52_Msk                 (_U_(0x1) << PMC_PCSR1_PID52_Pos)              /**< (PMC_PCSR1) Peripheral Clock 52 Status Mask */
 #define PMC_PCSR1_PID52                     PMC_PCSR1_PID52_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID52_Msk instead */
-#define PMC_PCSR1_PID53_Pos                 21                                             /**< (PMC_PCSR1) Peripheral Clock 53 Status Position */
-#define PMC_PCSR1_PID53_Msk                 (_U_(0x1) << PMC_PCSR1_PID53_Pos)              /**< (PMC_PCSR1) Peripheral Clock 53 Status Mask */
-#define PMC_PCSR1_PID53                     PMC_PCSR1_PID53_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID53_Msk instead */
 #define PMC_PCSR1_PID56_Pos                 24                                             /**< (PMC_PCSR1) Peripheral Clock 56 Status Position */
 #define PMC_PCSR1_PID56_Msk                 (_U_(0x1) << PMC_PCSR1_PID56_Pos)              /**< (PMC_PCSR1) Peripheral Clock 56 Status Mask */
 #define PMC_PCSR1_PID56                     PMC_PCSR1_PID56_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID56_Msk instead */
@@ -1815,15 +1965,16 @@ typedef union {
 #define PMC_PCSR1_PID60_Pos                 28                                             /**< (PMC_PCSR1) Peripheral Clock 60 Status Position */
 #define PMC_PCSR1_PID60_Msk                 (_U_(0x1) << PMC_PCSR1_PID60_Pos)              /**< (PMC_PCSR1) Peripheral Clock 60 Status Mask */
 #define PMC_PCSR1_PID60                     PMC_PCSR1_PID60_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_PCSR1_PID60_Msk instead */
-#define PMC_PCSR1_MASK                      _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_PCSR1) Register MASK  (Use PMC_PCSR1_Msk instead)  */
-#define PMC_PCSR1_Msk                       _U_(0x1F3FFFAF)                                /**< (PMC_PCSR1) Register Mask  */
+#define PMC_PCSR1_MASK                      _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_PCSR1) Register MASK  (Use PMC_PCSR1_Msk instead)  */
+#define PMC_PCSR1_Msk                       _U_(0x1F1FFFAF)                                /**< (PMC_PCSR1) Register Mask  */
 
 #define PMC_PCSR1_PID_Pos                   0                                              /**< (PMC_PCSR1 Position) Peripheral Clock 6x Status */
-#define PMC_PCSR1_PID_Msk                   (_U_(0x1FFFFFF) << PMC_PCSR1_PID_Pos)          /**< (PMC_PCSR1 Mask) PID */
+#define PMC_PCSR1_PID_Msk                   (_U_(0xFFFFFF) << PMC_PCSR1_PID_Pos)           /**< (PMC_PCSR1 Mask) PID */
 #define PMC_PCSR1_PID(value)                (PMC_PCSR1_PID_Msk & ((value) << PMC_PCSR1_PID_Pos))  
 
 /* -------- PMC_PCR : (PMC Offset: 0x10c) (R/W 32) Peripheral Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID:7;                     /**< bit:   0..6  Peripheral ID                            */
@@ -1839,6 +1990,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PCR_OFFSET                      (0x10C)                                       /**<  (PMC_PCR) Peripheral Control Register  Offset */
@@ -1877,6 +2029,7 @@ typedef union {
 
 /* -------- PMC_OCR : (PMC Offset: 0x110) (R/W 32) Oscillator Calibration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CAL4:7;                    /**< bit:   0..6  Main RC Oscillator Calibration Bits for 4 MHz */
@@ -1889,6 +2042,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_OCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_OCR_OFFSET                      (0x110)                                       /**<  (PMC_OCR) Oscillator Calibration Register  Offset */
@@ -1917,6 +2071,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ER0 : (PMC Offset: 0x114) (/W 32) SleepWalking Enable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -1952,6 +2107,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ER0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ER0_OFFSET                (0x114)                                       /**<  (PMC_SLPWK_ER0) SleepWalking Enable Register 0  Offset */
@@ -2040,6 +2196,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_DR0 : (PMC Offset: 0x118) (/W 32) SleepWalking Disable Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2075,6 +2232,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_DR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_DR0_OFFSET                (0x118)                                       /**<  (PMC_SLPWK_DR0) SleepWalking Disable Register 0  Offset */
@@ -2163,6 +2321,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_SR0 : (PMC Offset: 0x11c) (R/ 32) SleepWalking Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2198,6 +2357,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_SR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_SR0_OFFSET                (0x11C)                                       /**<  (PMC_SLPWK_SR0) SleepWalking Status Register 0  Offset */
@@ -2286,6 +2446,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ASR0 : (PMC Offset: 0x120) (R/ 32) SleepWalking Activity Status Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :7;                        /**< bit:   0..6  Reserved */
@@ -2321,6 +2482,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ASR0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ASR0_OFFSET               (0x120)                                       /**<  (PMC_SLPWK_ASR0) SleepWalking Activity Status Register 0  Offset */
@@ -2409,6 +2571,7 @@ typedef union {
 
 /* -------- PMC_PMMR : (PMC Offset: 0x130) (R/W 32) PLL Maximum Multiplier Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PLLA_MMAX:11;              /**< bit:  0..10  PLLA Maximum Allowed Multiplier Value    */
@@ -2416,6 +2579,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_PMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_PMMR_OFFSET                     (0x130)                                       /**<  (PMC_PMMR) PLL Maximum Multiplier Value Register  Offset */
@@ -2429,6 +2593,7 @@ typedef union {
 
 /* -------- PMC_SLPWK_ER1 : (PMC Offset: 0x134) (/W 32) SleepWalking Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Enable        */
@@ -2452,8 +2617,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Enable        */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Enable        */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Enable        */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Enable        */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Enable        */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Enable        */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Enable        */
@@ -2462,11 +2626,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Enable        */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral 6x SleepWalking Enable        */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ER1_OFFSET                (0x134)                                       /**<  (PMC_SLPWK_ER1) SleepWalking Enable Register 1  Offset */
@@ -2528,9 +2693,6 @@ typedef union {
 #define PMC_SLPWK_ER1_PID52_Pos             20                                             /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Position */
 #define PMC_SLPWK_ER1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID52_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 52 SleepWalking Enable Mask */
 #define PMC_SLPWK_ER1_PID52                 PMC_SLPWK_ER1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID52_Msk instead */
-#define PMC_SLPWK_ER1_PID53_Pos             21                                             /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Position */
-#define PMC_SLPWK_ER1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID53_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 53 SleepWalking Enable Mask */
-#define PMC_SLPWK_ER1_PID53                 PMC_SLPWK_ER1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID53_Msk instead */
 #define PMC_SLPWK_ER1_PID56_Pos             24                                             /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Position */
 #define PMC_SLPWK_ER1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID56_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 56 SleepWalking Enable Mask */
 #define PMC_SLPWK_ER1_PID56                 PMC_SLPWK_ER1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID56_Msk instead */
@@ -2546,15 +2708,16 @@ typedef union {
 #define PMC_SLPWK_ER1_PID60_Pos             28                                             /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Position */
 #define PMC_SLPWK_ER1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_ER1_PID60_Pos)          /**< (PMC_SLPWK_ER1) Peripheral 60 SleepWalking Enable Mask */
 #define PMC_SLPWK_ER1_PID60                 PMC_SLPWK_ER1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ER1_PID60_Msk instead */
-#define PMC_SLPWK_ER1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ER1) Register MASK  (Use PMC_SLPWK_ER1_Msk instead)  */
-#define PMC_SLPWK_ER1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ER1) Register Mask  */
+#define PMC_SLPWK_ER1_MASK                  _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_SLPWK_ER1) Register MASK  (Use PMC_SLPWK_ER1_Msk instead)  */
+#define PMC_SLPWK_ER1_Msk                   _U_(0x1F1FFFAF)                                /**< (PMC_SLPWK_ER1) Register Mask  */
 
 #define PMC_SLPWK_ER1_PID_Pos               0                                              /**< (PMC_SLPWK_ER1 Position) Peripheral 6x SleepWalking Enable */
-#define PMC_SLPWK_ER1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_ER1_PID_Pos)      /**< (PMC_SLPWK_ER1 Mask) PID */
+#define PMC_SLPWK_ER1_PID_Msk               (_U_(0xFFFFFF) << PMC_SLPWK_ER1_PID_Pos)       /**< (PMC_SLPWK_ER1 Mask) PID */
 #define PMC_SLPWK_ER1_PID(value)            (PMC_SLPWK_ER1_PID_Msk & ((value) << PMC_SLPWK_ER1_PID_Pos))  
 
 /* -------- PMC_SLPWK_DR1 : (PMC Offset: 0x138) (/W 32) SleepWalking Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Disable       */
@@ -2578,8 +2741,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Disable       */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Disable       */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Disable       */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Disable       */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Disable       */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Disable       */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Disable       */
@@ -2588,11 +2750,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Disable       */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral 6x SleepWalking Disable       */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_DR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_DR1_OFFSET                (0x138)                                       /**<  (PMC_SLPWK_DR1) SleepWalking Disable Register 1  Offset */
@@ -2654,9 +2817,6 @@ typedef union {
 #define PMC_SLPWK_DR1_PID52_Pos             20                                             /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Position */
 #define PMC_SLPWK_DR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID52_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 52 SleepWalking Disable Mask */
 #define PMC_SLPWK_DR1_PID52                 PMC_SLPWK_DR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID52_Msk instead */
-#define PMC_SLPWK_DR1_PID53_Pos             21                                             /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Position */
-#define PMC_SLPWK_DR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID53_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 53 SleepWalking Disable Mask */
-#define PMC_SLPWK_DR1_PID53                 PMC_SLPWK_DR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID53_Msk instead */
 #define PMC_SLPWK_DR1_PID56_Pos             24                                             /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Position */
 #define PMC_SLPWK_DR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID56_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 56 SleepWalking Disable Mask */
 #define PMC_SLPWK_DR1_PID56                 PMC_SLPWK_DR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID56_Msk instead */
@@ -2672,15 +2832,16 @@ typedef union {
 #define PMC_SLPWK_DR1_PID60_Pos             28                                             /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Position */
 #define PMC_SLPWK_DR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_DR1_PID60_Pos)          /**< (PMC_SLPWK_DR1) Peripheral 60 SleepWalking Disable Mask */
 #define PMC_SLPWK_DR1_PID60                 PMC_SLPWK_DR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_DR1_PID60_Msk instead */
-#define PMC_SLPWK_DR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_DR1) Register MASK  (Use PMC_SLPWK_DR1_Msk instead)  */
-#define PMC_SLPWK_DR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_DR1) Register Mask  */
+#define PMC_SLPWK_DR1_MASK                  _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_SLPWK_DR1) Register MASK  (Use PMC_SLPWK_DR1_Msk instead)  */
+#define PMC_SLPWK_DR1_Msk                   _U_(0x1F1FFFAF)                                /**< (PMC_SLPWK_DR1) Register Mask  */
 
 #define PMC_SLPWK_DR1_PID_Pos               0                                              /**< (PMC_SLPWK_DR1 Position) Peripheral 6x SleepWalking Disable */
-#define PMC_SLPWK_DR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_DR1_PID_Pos)      /**< (PMC_SLPWK_DR1 Mask) PID */
+#define PMC_SLPWK_DR1_PID_Msk               (_U_(0xFFFFFF) << PMC_SLPWK_DR1_PID_Pos)       /**< (PMC_SLPWK_DR1 Mask) PID */
 #define PMC_SLPWK_DR1_PID(value)            (PMC_SLPWK_DR1_PID_Msk & ((value) << PMC_SLPWK_DR1_PID_Pos))  
 
 /* -------- PMC_SLPWK_SR1 : (PMC Offset: 0x13c) (R/ 32) SleepWalking Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 SleepWalking Status        */
@@ -2704,8 +2865,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 SleepWalking Status        */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 SleepWalking Status        */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 SleepWalking Status        */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 SleepWalking Status        */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 SleepWalking Status        */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 SleepWalking Status        */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 SleepWalking Status        */
@@ -2714,11 +2874,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x SleepWalking Status        */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral 6x SleepWalking Status        */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_SR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_SR1_OFFSET                (0x13C)                                       /**<  (PMC_SLPWK_SR1) SleepWalking Status Register 1  Offset */
@@ -2780,9 +2941,6 @@ typedef union {
 #define PMC_SLPWK_SR1_PID52_Pos             20                                             /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Position */
 #define PMC_SLPWK_SR1_PID52_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID52_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 52 SleepWalking Status Mask */
 #define PMC_SLPWK_SR1_PID52                 PMC_SLPWK_SR1_PID52_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID52_Msk instead */
-#define PMC_SLPWK_SR1_PID53_Pos             21                                             /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Position */
-#define PMC_SLPWK_SR1_PID53_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID53_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 53 SleepWalking Status Mask */
-#define PMC_SLPWK_SR1_PID53                 PMC_SLPWK_SR1_PID53_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID53_Msk instead */
 #define PMC_SLPWK_SR1_PID56_Pos             24                                             /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Position */
 #define PMC_SLPWK_SR1_PID56_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID56_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 56 SleepWalking Status Mask */
 #define PMC_SLPWK_SR1_PID56                 PMC_SLPWK_SR1_PID56_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID56_Msk instead */
@@ -2798,15 +2956,16 @@ typedef union {
 #define PMC_SLPWK_SR1_PID60_Pos             28                                             /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Position */
 #define PMC_SLPWK_SR1_PID60_Msk             (_U_(0x1) << PMC_SLPWK_SR1_PID60_Pos)          /**< (PMC_SLPWK_SR1) Peripheral 60 SleepWalking Status Mask */
 #define PMC_SLPWK_SR1_PID60                 PMC_SLPWK_SR1_PID60_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_SR1_PID60_Msk instead */
-#define PMC_SLPWK_SR1_MASK                  _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_SR1) Register MASK  (Use PMC_SLPWK_SR1_Msk instead)  */
-#define PMC_SLPWK_SR1_Msk                   _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_SR1) Register Mask  */
+#define PMC_SLPWK_SR1_MASK                  _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_SLPWK_SR1) Register MASK  (Use PMC_SLPWK_SR1_Msk instead)  */
+#define PMC_SLPWK_SR1_Msk                   _U_(0x1F1FFFAF)                                /**< (PMC_SLPWK_SR1) Register Mask  */
 
 #define PMC_SLPWK_SR1_PID_Pos               0                                              /**< (PMC_SLPWK_SR1 Position) Peripheral 6x SleepWalking Status */
-#define PMC_SLPWK_SR1_PID_Msk               (_U_(0x1FFFFFF) << PMC_SLPWK_SR1_PID_Pos)      /**< (PMC_SLPWK_SR1 Mask) PID */
+#define PMC_SLPWK_SR1_PID_Msk               (_U_(0xFFFFFF) << PMC_SLPWK_SR1_PID_Pos)       /**< (PMC_SLPWK_SR1 Mask) PID */
 #define PMC_SLPWK_SR1_PID(value)            (PMC_SLPWK_SR1_PID_Msk & ((value) << PMC_SLPWK_SR1_PID_Pos))  
 
 /* -------- PMC_SLPWK_ASR1 : (PMC Offset: 0x140) (R/ 32) SleepWalking Activity Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PID32:1;                   /**< bit:      0  Peripheral 32 Activity Status            */
@@ -2830,8 +2989,7 @@ typedef union {
     uint32_t PID50:1;                   /**< bit:     18  Peripheral 50 Activity Status            */
     uint32_t PID51:1;                   /**< bit:     19  Peripheral 51 Activity Status            */
     uint32_t PID52:1;                   /**< bit:     20  Peripheral 52 Activity Status            */
-    uint32_t PID53:1;                   /**< bit:     21  Peripheral 53 Activity Status            */
-    uint32_t :2;                        /**< bit: 22..23  Reserved */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
     uint32_t PID56:1;                   /**< bit:     24  Peripheral 56 Activity Status            */
     uint32_t PID57:1;                   /**< bit:     25  Peripheral 57 Activity Status            */
     uint32_t PID58:1;                   /**< bit:     26  Peripheral 58 Activity Status            */
@@ -2840,11 +2998,12 @@ typedef union {
     uint32_t :3;                        /**< bit: 29..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   struct {
-    uint32_t PID:25;                    /**< bit:  0..24  Peripheral 6x Activity Status            */
-    uint32_t :7;                        /**< bit: 25..31 Reserved */
+    uint32_t PID:24;                    /**< bit:  0..23  Peripheral 6x Activity Status            */
+    uint32_t :8;                        /**< bit: 24..31 Reserved */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_ASR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_ASR1_OFFSET               (0x140)                                       /**<  (PMC_SLPWK_ASR1) SleepWalking Activity Status Register 1  Offset */
@@ -2906,9 +3065,6 @@ typedef union {
 #define PMC_SLPWK_ASR1_PID52_Pos            20                                             /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Position */
 #define PMC_SLPWK_ASR1_PID52_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID52_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 52 Activity Status Mask */
 #define PMC_SLPWK_ASR1_PID52                PMC_SLPWK_ASR1_PID52_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID52_Msk instead */
-#define PMC_SLPWK_ASR1_PID53_Pos            21                                             /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Position */
-#define PMC_SLPWK_ASR1_PID53_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID53_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 53 Activity Status Mask */
-#define PMC_SLPWK_ASR1_PID53                PMC_SLPWK_ASR1_PID53_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID53_Msk instead */
 #define PMC_SLPWK_ASR1_PID56_Pos            24                                             /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Position */
 #define PMC_SLPWK_ASR1_PID56_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID56_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 56 Activity Status Mask */
 #define PMC_SLPWK_ASR1_PID56                PMC_SLPWK_ASR1_PID56_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID56_Msk instead */
@@ -2924,15 +3080,16 @@ typedef union {
 #define PMC_SLPWK_ASR1_PID60_Pos            28                                             /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Position */
 #define PMC_SLPWK_ASR1_PID60_Msk            (_U_(0x1) << PMC_SLPWK_ASR1_PID60_Pos)         /**< (PMC_SLPWK_ASR1) Peripheral 60 Activity Status Mask */
 #define PMC_SLPWK_ASR1_PID60                PMC_SLPWK_ASR1_PID60_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use PMC_SLPWK_ASR1_PID60_Msk instead */
-#define PMC_SLPWK_ASR1_MASK                 _U_(0x1F3FFFAF)                                /**< \deprecated (PMC_SLPWK_ASR1) Register MASK  (Use PMC_SLPWK_ASR1_Msk instead)  */
-#define PMC_SLPWK_ASR1_Msk                  _U_(0x1F3FFFAF)                                /**< (PMC_SLPWK_ASR1) Register Mask  */
+#define PMC_SLPWK_ASR1_MASK                 _U_(0x1F1FFFAF)                                /**< \deprecated (PMC_SLPWK_ASR1) Register MASK  (Use PMC_SLPWK_ASR1_Msk instead)  */
+#define PMC_SLPWK_ASR1_Msk                  _U_(0x1F1FFFAF)                                /**< (PMC_SLPWK_ASR1) Register Mask  */
 
 #define PMC_SLPWK_ASR1_PID_Pos              0                                              /**< (PMC_SLPWK_ASR1 Position) Peripheral 6x Activity Status */
-#define PMC_SLPWK_ASR1_PID_Msk              (_U_(0x1FFFFFF) << PMC_SLPWK_ASR1_PID_Pos)     /**< (PMC_SLPWK_ASR1 Mask) PID */
+#define PMC_SLPWK_ASR1_PID_Msk              (_U_(0xFFFFFF) << PMC_SLPWK_ASR1_PID_Pos)      /**< (PMC_SLPWK_ASR1 Mask) PID */
 #define PMC_SLPWK_ASR1_PID(value)           (PMC_SLPWK_ASR1_PID_Msk & ((value) << PMC_SLPWK_ASR1_PID_Pos))  
 
 /* -------- PMC_SLPWK_AIPR : (PMC Offset: 0x144) (R/ 32) SleepWalking Activity In Progress Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t AIP:1;                     /**< bit:      0  Activity In Progress                     */
@@ -2940,6 +3097,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PMC_SLPWK_AIPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PMC_SLPWK_AIPR_OFFSET               (0x144)                                       /**<  (PMC_SLPWK_AIPR) SleepWalking Activity In Progress Register  Offset */
@@ -2958,7 +3116,7 @@ typedef struct {
   __O  uint32_t PMC_SCER;       /**< (PMC Offset: 0x00) System Clock Enable Register */
   __O  uint32_t PMC_SCDR;       /**< (PMC Offset: 0x04) System Clock Disable Register */
   __I  uint32_t PMC_SCSR;       /**< (PMC Offset: 0x08) System Clock Status Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __O  uint32_t PMC_PCER0;      /**< (PMC Offset: 0x10) Peripheral Clock Enable Register 0 */
   __O  uint32_t PMC_PCDR0;      /**< (PMC Offset: 0x14) Peripheral Clock Disable Register 0 */
   __I  uint32_t PMC_PCSR0;      /**< (PMC Offset: 0x18) Peripheral Clock Status Register 0 */
@@ -2966,11 +3124,11 @@ typedef struct {
   __IO uint32_t CKGR_MOR;       /**< (PMC Offset: 0x20) Main Oscillator Register */
   __IO uint32_t CKGR_MCFR;      /**< (PMC Offset: 0x24) Main Clock Frequency Register */
   __IO uint32_t CKGR_PLLAR;     /**< (PMC Offset: 0x28) PLLA Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t PMC_MCKR;       /**< (PMC Offset: 0x30) Master Clock Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __IO uint32_t PMC_USB;        /**< (PMC Offset: 0x38) USB Clock Register */
-  RoReg8  Reserved4[0x4];
+  __I  uint8_t                        Reserved4[4];
   __IO uint32_t PMC_PCK[8];     /**< (PMC Offset: 0x40) Programmable Clock Register */
   __O  uint32_t PMC_IER;        /**< (PMC Offset: 0x60) Interrupt Enable Register */
   __O  uint32_t PMC_IDR;        /**< (PMC Offset: 0x64) Interrupt Disable Register */
@@ -2979,10 +3137,10 @@ typedef struct {
   __IO uint32_t PMC_FSMR;       /**< (PMC Offset: 0x70) Fast Startup Mode Register */
   __IO uint32_t PMC_FSPR;       /**< (PMC Offset: 0x74) Fast Startup Polarity Register */
   __O  uint32_t PMC_FOCR;       /**< (PMC Offset: 0x78) Fault Output Clear Register */
-  RoReg8  Reserved5[0x68];
+  __I  uint8_t                        Reserved5[104];
   __IO uint32_t PMC_WPMR;       /**< (PMC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t PMC_WPSR;       /**< (PMC Offset: 0xE8) Write Protection Status Register */
-  RoReg8  Reserved6[0x14];
+  __I  uint8_t                        Reserved6[20];
   __O  uint32_t PMC_PCER1;      /**< (PMC Offset: 0x100) Peripheral Clock Enable Register 1 */
   __O  uint32_t PMC_PCDR1;      /**< (PMC Offset: 0x104) Peripheral Clock Disable Register 1 */
   __I  uint32_t PMC_PCSR1;      /**< (PMC Offset: 0x108) Peripheral Clock Status Register 1 */
@@ -2992,7 +3150,7 @@ typedef struct {
   __O  uint32_t PMC_SLPWK_DR0;  /**< (PMC Offset: 0x118) SleepWalking Disable Register 0 */
   __I  uint32_t PMC_SLPWK_SR0;  /**< (PMC Offset: 0x11C) SleepWalking Status Register 0 */
   __I  uint32_t PMC_SLPWK_ASR0; /**< (PMC Offset: 0x120) SleepWalking Activity Status Register 0 */
-  RoReg8  Reserved7[0xC];
+  __I  uint8_t                        Reserved7[12];
   __IO uint32_t PMC_PMMR;       /**< (PMC Offset: 0x130) PLL Maximum Multiplier Value Register */
   __O  uint32_t PMC_SLPWK_ER1;  /**< (PMC Offset: 0x134) SleepWalking Enable Register 1 */
   __O  uint32_t PMC_SLPWK_DR1;  /**< (PMC Offset: 0x138) SleepWalking Disable Register 1 */
@@ -3007,7 +3165,7 @@ typedef struct {
   __O  PMC_SCER_Type                  PMC_SCER;       /**< Offset: 0x00 ( /W  32) System Clock Enable Register */
   __O  PMC_SCDR_Type                  PMC_SCDR;       /**< Offset: 0x04 ( /W  32) System Clock Disable Register */
   __I  PMC_SCSR_Type                  PMC_SCSR;       /**< Offset: 0x08 (R/   32) System Clock Status Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __O  PMC_PCER0_Type                 PMC_PCER0;      /**< Offset: 0x10 ( /W  32) Peripheral Clock Enable Register 0 */
   __O  PMC_PCDR0_Type                 PMC_PCDR0;      /**< Offset: 0x14 ( /W  32) Peripheral Clock Disable Register 0 */
   __I  PMC_PCSR0_Type                 PMC_PCSR0;      /**< Offset: 0x18 (R/   32) Peripheral Clock Status Register 0 */
@@ -3015,11 +3173,11 @@ typedef struct {
   __IO CKGR_MOR_Type                  CKGR_MOR;       /**< Offset: 0x20 (R/W  32) Main Oscillator Register */
   __IO CKGR_MCFR_Type                 CKGR_MCFR;      /**< Offset: 0x24 (R/W  32) Main Clock Frequency Register */
   __IO CKGR_PLLAR_Type                CKGR_PLLAR;     /**< Offset: 0x28 (R/W  32) PLLA Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO PMC_MCKR_Type                  PMC_MCKR;       /**< Offset: 0x30 (R/W  32) Master Clock Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __IO PMC_USB_Type                   PMC_USB;        /**< Offset: 0x38 (R/W  32) USB Clock Register */
-  __I  uint32_t                       Reserved4[1];
+  __I  uint8_t                        Reserved4[4];
   __IO PMC_PCK_Type                   PMC_PCK[8];     /**< Offset: 0x40 (R/W  32) Programmable Clock Register */
   __O  PMC_IER_Type                   PMC_IER;        /**< Offset: 0x60 ( /W  32) Interrupt Enable Register */
   __O  PMC_IDR_Type                   PMC_IDR;        /**< Offset: 0x64 ( /W  32) Interrupt Disable Register */
@@ -3028,10 +3186,10 @@ typedef struct {
   __IO PMC_FSMR_Type                  PMC_FSMR;       /**< Offset: 0x70 (R/W  32) Fast Startup Mode Register */
   __IO PMC_FSPR_Type                  PMC_FSPR;       /**< Offset: 0x74 (R/W  32) Fast Startup Polarity Register */
   __O  PMC_FOCR_Type                  PMC_FOCR;       /**< Offset: 0x78 ( /W  32) Fault Output Clear Register */
-  __I  uint32_t                       Reserved5[26];
+  __I  uint8_t                        Reserved5[104];
   __IO PMC_WPMR_Type                  PMC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  PMC_WPSR_Type                  PMC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
-  __I  uint32_t                       Reserved6[5];
+  __I  uint8_t                        Reserved6[20];
   __O  PMC_PCER1_Type                 PMC_PCER1;      /**< Offset: 0x100 ( /W  32) Peripheral Clock Enable Register 1 */
   __O  PMC_PCDR1_Type                 PMC_PCDR1;      /**< Offset: 0x104 ( /W  32) Peripheral Clock Disable Register 1 */
   __I  PMC_PCSR1_Type                 PMC_PCSR1;      /**< Offset: 0x108 (R/   32) Peripheral Clock Status Register 1 */
@@ -3041,7 +3199,7 @@ typedef struct {
   __O  PMC_SLPWK_DR0_Type             PMC_SLPWK_DR0;  /**< Offset: 0x118 ( /W  32) SleepWalking Disable Register 0 */
   __I  PMC_SLPWK_SR0_Type             PMC_SLPWK_SR0;  /**< Offset: 0x11C (R/   32) SleepWalking Status Register 0 */
   __I  PMC_SLPWK_ASR0_Type            PMC_SLPWK_ASR0; /**< Offset: 0x120 (R/   32) SleepWalking Activity Status Register 0 */
-  __I  uint32_t                       Reserved7[3];
+  __I  uint8_t                        Reserved7[12];
   __IO PMC_PMMR_Type                  PMC_PMMR;       /**< Offset: 0x130 (R/W  32) PLL Maximum Multiplier Value Register */
   __O  PMC_SLPWK_ER1_Type             PMC_SLPWK_ER1;  /**< Offset: 0x134 ( /W  32) SleepWalking Enable Register 1 */
   __O  PMC_SLPWK_DR1_Type             PMC_SLPWK_DR1;  /**< Offset: 0x138 ( /W  32) SleepWalking Disable Register 1 */

--- a/asf/sam/include/same70b/component/pwm.h
+++ b/asf/sam/include/same70b/component/pwm.h
@@ -2763,7 +2763,7 @@ typedef struct {
   __I  uint8_t                        Reserved6[68];
        PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
-       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register */
+       PwmChNum PWM_CH_NUM[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register */
   __I  uint8_t                        Reserved8[384];
   __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
   __I  uint8_t                        Reserved9[28];
@@ -2846,7 +2846,7 @@ typedef struct {
   __I  uint8_t                        Reserved6[68];
        PwmCmp                         PWM_CMP[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
-       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register */
+       PwmChNum                       PWM_CH_NUM[4];    /**< Offset: 0x200 PWM Channel Mode Register */
   __I  uint8_t                        Reserved8[384];
   __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
   __I  uint8_t                        Reserved9[28];

--- a/asf/sam/include/same70b/component/pwm.h
+++ b/asf/sam/include/same70b/component/pwm.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for PWM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PWM_COMPONENT_H_
 #define _SAME70_PWM_COMPONENT_H_
 #define _SAME70_PWM_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define PWM_6343                       /**< (PWM) Module ID */
-#define REV_PWM U                      /**< (PWM) Module revision */
+#define REV_PWM Y                      /**< (PWM) Module revision */
 
-/* -------- PWM_CMR : (PWM Offset: 0x00) (R/W 32) PWM Channel Mode Register (ch_num = 0) -------- */
+/* -------- PWM_CMR : (PWM Offset: 0x00) (R/W 32) PWM Channel Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRE:4;                    /**< bit:   0..3  Channel Pre-scaler                       */
@@ -64,9 +67,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CMR_OFFSET                      (0x00)                                        /**<  (PWM_CMR) PWM Channel Mode Register (ch_num = 0)  Offset */
+#define PWM_CMR_OFFSET                      (0x00)                                        /**<  (PWM_CMR) PWM Channel Mode Register  Offset */
 
 #define PWM_CMR_CPRE_Pos                    0                                              /**< (PWM_CMR) Channel Pre-scaler Position */
 #define PWM_CMR_CPRE_Msk                    (_U_(0xF) << PWM_CMR_CPRE_Pos)                 /**< (PWM_CMR) Channel Pre-scaler Mask */
@@ -100,15 +104,31 @@ typedef union {
 #define PWM_CMR_CALG_Pos                    8                                              /**< (PWM_CMR) Channel Alignment Position */
 #define PWM_CMR_CALG_Msk                    (_U_(0x1) << PWM_CMR_CALG_Pos)                 /**< (PWM_CMR) Channel Alignment Mask */
 #define PWM_CMR_CALG                        PWM_CMR_CALG_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CALG_Msk instead */
+#define   PWM_CMR_CALG_LEFT_ALIGNED_Val     _U_(0x0)                                       /**< (PWM_CMR) Left aligned  */
+#define   PWM_CMR_CALG_CENTER_ALIGNED_Val   _U_(0x1)                                       /**< (PWM_CMR) Center aligned  */
+#define PWM_CMR_CALG_LEFT_ALIGNED           (PWM_CMR_CALG_LEFT_ALIGNED_Val << PWM_CMR_CALG_Pos)  /**< (PWM_CMR) Left aligned Position  */
+#define PWM_CMR_CALG_CENTER_ALIGNED         (PWM_CMR_CALG_CENTER_ALIGNED_Val << PWM_CMR_CALG_Pos)  /**< (PWM_CMR) Center aligned Position  */
 #define PWM_CMR_CPOL_Pos                    9                                              /**< (PWM_CMR) Channel Polarity Position */
 #define PWM_CMR_CPOL_Msk                    (_U_(0x1) << PWM_CMR_CPOL_Pos)                 /**< (PWM_CMR) Channel Polarity Mask */
 #define PWM_CMR_CPOL                        PWM_CMR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CPOL_Msk instead */
+#define   PWM_CMR_CPOL_LOW_POLARITY_Val     _U_(0x0)                                       /**< (PWM_CMR) Waveform starts at low level  */
+#define   PWM_CMR_CPOL_HIGH_POLARITY_Val    _U_(0x1)                                       /**< (PWM_CMR) Waveform starts at high level  */
+#define PWM_CMR_CPOL_LOW_POLARITY           (PWM_CMR_CPOL_LOW_POLARITY_Val << PWM_CMR_CPOL_Pos)  /**< (PWM_CMR) Waveform starts at low level Position  */
+#define PWM_CMR_CPOL_HIGH_POLARITY          (PWM_CMR_CPOL_HIGH_POLARITY_Val << PWM_CMR_CPOL_Pos)  /**< (PWM_CMR) Waveform starts at high level Position  */
 #define PWM_CMR_CES_Pos                     10                                             /**< (PWM_CMR) Counter Event Selection Position */
 #define PWM_CMR_CES_Msk                     (_U_(0x1) << PWM_CMR_CES_Pos)                  /**< (PWM_CMR) Counter Event Selection Mask */
 #define PWM_CMR_CES                         PWM_CMR_CES_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_CES_Msk instead */
+#define   PWM_CMR_CES_SINGLE_EVENT_Val      _U_(0x0)                                       /**< (PWM_CMR) At the end of PWM period  */
+#define   PWM_CMR_CES_DOUBLE_EVENT_Val      _U_(0x1)                                       /**< (PWM_CMR) At half of PWM period AND at the end of PWM period  */
+#define PWM_CMR_CES_SINGLE_EVENT            (PWM_CMR_CES_SINGLE_EVENT_Val << PWM_CMR_CES_Pos)  /**< (PWM_CMR) At the end of PWM period Position  */
+#define PWM_CMR_CES_DOUBLE_EVENT            (PWM_CMR_CES_DOUBLE_EVENT_Val << PWM_CMR_CES_Pos)  /**< (PWM_CMR) At half of PWM period AND at the end of PWM period Position  */
 #define PWM_CMR_UPDS_Pos                    11                                             /**< (PWM_CMR) Update Selection Position */
 #define PWM_CMR_UPDS_Msk                    (_U_(0x1) << PWM_CMR_UPDS_Pos)                 /**< (PWM_CMR) Update Selection Mask */
 #define PWM_CMR_UPDS                        PWM_CMR_UPDS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_UPDS_Msk instead */
+#define   PWM_CMR_UPDS_UPDATE_AT_PERIOD_Val _U_(0x0)                                       /**< (PWM_CMR) At the next end of PWM period  */
+#define   PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD_Val _U_(0x1)                                       /**< (PWM_CMR) At the next end of Half PWM period  */
+#define PWM_CMR_UPDS_UPDATE_AT_PERIOD       (PWM_CMR_UPDS_UPDATE_AT_PERIOD_Val << PWM_CMR_UPDS_Pos)  /**< (PWM_CMR) At the next end of PWM period Position  */
+#define PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD  (PWM_CMR_UPDS_UPDATE_AT_HALF_PERIOD_Val << PWM_CMR_UPDS_Pos)  /**< (PWM_CMR) At the next end of Half PWM period Position  */
 #define PWM_CMR_DPOLI_Pos                   12                                             /**< (PWM_CMR) Disabled Polarity Inverted Position */
 #define PWM_CMR_DPOLI_Msk                   (_U_(0x1) << PWM_CMR_DPOLI_Pos)                /**< (PWM_CMR) Disabled Polarity Inverted Mask */
 #define PWM_CMR_DPOLI                       PWM_CMR_DPOLI_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMR_DPOLI_Msk instead */
@@ -131,8 +151,9 @@ typedef union {
 #define PWM_CMR_Msk                         _U_(0xF3F0F)                                   /**< (PWM_CMR) Register Mask  */
 
 
-/* -------- PWM_CDTY : (PWM Offset: 0x04) (R/W 32) PWM Channel Duty Cycle Register (ch_num = 0) -------- */
+/* -------- PWM_CDTY : (PWM Offset: 0x04) (R/W 32) PWM Channel Duty Cycle Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CDTY:24;                   /**< bit:  0..23  Channel Duty-Cycle                       */
@@ -140,9 +161,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CDTY_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CDTY_OFFSET                     (0x04)                                        /**<  (PWM_CDTY) PWM Channel Duty Cycle Register (ch_num = 0)  Offset */
+#define PWM_CDTY_OFFSET                     (0x04)                                        /**<  (PWM_CDTY) PWM Channel Duty Cycle Register  Offset */
 
 #define PWM_CDTY_CDTY_Pos                   0                                              /**< (PWM_CDTY) Channel Duty-Cycle Position */
 #define PWM_CDTY_CDTY_Msk                   (_U_(0xFFFFFF) << PWM_CDTY_CDTY_Pos)           /**< (PWM_CDTY) Channel Duty-Cycle Mask */
@@ -151,8 +173,9 @@ typedef union {
 #define PWM_CDTY_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CDTY) Register Mask  */
 
 
-/* -------- PWM_CDTYUPD : (PWM Offset: 0x08) (/W 32) PWM Channel Duty Cycle Update Register (ch_num = 0) -------- */
+/* -------- PWM_CDTYUPD : (PWM Offset: 0x08) (/W 32) PWM Channel Duty Cycle Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CDTYUPD:24;                /**< bit:  0..23  Channel Duty-Cycle Update                */
@@ -160,9 +183,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CDTYUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CDTYUPD_OFFSET                  (0x08)                                        /**<  (PWM_CDTYUPD) PWM Channel Duty Cycle Update Register (ch_num = 0)  Offset */
+#define PWM_CDTYUPD_OFFSET                  (0x08)                                        /**<  (PWM_CDTYUPD) PWM Channel Duty Cycle Update Register  Offset */
 
 #define PWM_CDTYUPD_CDTYUPD_Pos             0                                              /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Position */
 #define PWM_CDTYUPD_CDTYUPD_Msk             (_U_(0xFFFFFF) << PWM_CDTYUPD_CDTYUPD_Pos)     /**< (PWM_CDTYUPD) Channel Duty-Cycle Update Mask */
@@ -171,8 +195,9 @@ typedef union {
 #define PWM_CDTYUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CDTYUPD) Register Mask  */
 
 
-/* -------- PWM_CPRD : (PWM Offset: 0x0c) (R/W 32) PWM Channel Period Register (ch_num = 0) -------- */
+/* -------- PWM_CPRD : (PWM Offset: 0x0c) (R/W 32) PWM Channel Period Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRD:24;                   /**< bit:  0..23  Channel Period                           */
@@ -180,9 +205,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CPRD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CPRD_OFFSET                     (0x0C)                                        /**<  (PWM_CPRD) PWM Channel Period Register (ch_num = 0)  Offset */
+#define PWM_CPRD_OFFSET                     (0x0C)                                        /**<  (PWM_CPRD) PWM Channel Period Register  Offset */
 
 #define PWM_CPRD_CPRD_Pos                   0                                              /**< (PWM_CPRD) Channel Period Position */
 #define PWM_CPRD_CPRD_Msk                   (_U_(0xFFFFFF) << PWM_CPRD_CPRD_Pos)           /**< (PWM_CPRD) Channel Period Mask */
@@ -191,8 +217,9 @@ typedef union {
 #define PWM_CPRD_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CPRD) Register Mask  */
 
 
-/* -------- PWM_CPRDUPD : (PWM Offset: 0x10) (/W 32) PWM Channel Period Update Register (ch_num = 0) -------- */
+/* -------- PWM_CPRDUPD : (PWM Offset: 0x10) (/W 32) PWM Channel Period Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPRDUPD:24;                /**< bit:  0..23  Channel Period Update                    */
@@ -200,9 +227,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CPRDUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CPRDUPD_OFFSET                  (0x10)                                        /**<  (PWM_CPRDUPD) PWM Channel Period Update Register (ch_num = 0)  Offset */
+#define PWM_CPRDUPD_OFFSET                  (0x10)                                        /**<  (PWM_CPRDUPD) PWM Channel Period Update Register  Offset */
 
 #define PWM_CPRDUPD_CPRDUPD_Pos             0                                              /**< (PWM_CPRDUPD) Channel Period Update Position */
 #define PWM_CPRDUPD_CPRDUPD_Msk             (_U_(0xFFFFFF) << PWM_CPRDUPD_CPRDUPD_Pos)     /**< (PWM_CPRDUPD) Channel Period Update Mask */
@@ -211,8 +239,9 @@ typedef union {
 #define PWM_CPRDUPD_Msk                     _U_(0xFFFFFF)                                  /**< (PWM_CPRDUPD) Register Mask  */
 
 
-/* -------- PWM_CCNT : (PWM Offset: 0x14) (R/ 32) PWM Channel Counter Register (ch_num = 0) -------- */
+/* -------- PWM_CCNT : (PWM Offset: 0x14) (R/ 32) PWM Channel Counter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CNT:24;                    /**< bit:  0..23  Channel Counter Register                 */
@@ -220,9 +249,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CCNT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_CCNT_OFFSET                     (0x14)                                        /**<  (PWM_CCNT) PWM Channel Counter Register (ch_num = 0)  Offset */
+#define PWM_CCNT_OFFSET                     (0x14)                                        /**<  (PWM_CCNT) PWM Channel Counter Register  Offset */
 
 #define PWM_CCNT_CNT_Pos                    0                                              /**< (PWM_CCNT) Channel Counter Register Position */
 #define PWM_CCNT_CNT_Msk                    (_U_(0xFFFFFF) << PWM_CCNT_CNT_Pos)            /**< (PWM_CCNT) Channel Counter Register Mask */
@@ -231,8 +261,9 @@ typedef union {
 #define PWM_CCNT_Msk                        _U_(0xFFFFFF)                                  /**< (PWM_CCNT) Register Mask  */
 
 
-/* -------- PWM_DT : (PWM Offset: 0x18) (R/W 32) PWM Channel Dead Time Register (ch_num = 0) -------- */
+/* -------- PWM_DT : (PWM Offset: 0x18) (R/W 32) PWM Channel Dead Time Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTH:16;                    /**< bit:  0..15  Dead-Time Value for PWMHx Output         */
@@ -240,9 +271,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_DT_OFFSET                       (0x18)                                        /**<  (PWM_DT) PWM Channel Dead Time Register (ch_num = 0)  Offset */
+#define PWM_DT_OFFSET                       (0x18)                                        /**<  (PWM_DT) PWM Channel Dead Time Register  Offset */
 
 #define PWM_DT_DTH_Pos                      0                                              /**< (PWM_DT) Dead-Time Value for PWMHx Output Position */
 #define PWM_DT_DTH_Msk                      (_U_(0xFFFF) << PWM_DT_DTH_Pos)                /**< (PWM_DT) Dead-Time Value for PWMHx Output Mask */
@@ -254,8 +286,9 @@ typedef union {
 #define PWM_DT_Msk                          _U_(0xFFFFFFFF)                                /**< (PWM_DT) Register Mask  */
 
 
-/* -------- PWM_DTUPD : (PWM Offset: 0x1c) (/W 32) PWM Channel Dead Time Update Register (ch_num = 0) -------- */
+/* -------- PWM_DTUPD : (PWM Offset: 0x1c) (/W 32) PWM Channel Dead Time Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DTHUPD:16;                 /**< bit:  0..15  Dead-Time Value Update for PWMHx Output  */
@@ -263,9 +296,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DTUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define PWM_DTUPD_OFFSET                    (0x1C)                                        /**<  (PWM_DTUPD) PWM Channel Dead Time Update Register (ch_num = 0)  Offset */
+#define PWM_DTUPD_OFFSET                    (0x1C)                                        /**<  (PWM_DTUPD) PWM Channel Dead Time Update Register  Offset */
 
 #define PWM_DTUPD_DTHUPD_Pos                0                                              /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Position */
 #define PWM_DTUPD_DTHUPD_Msk                (_U_(0xFFFF) << PWM_DTUPD_DTHUPD_Pos)          /**< (PWM_DTUPD) Dead-Time Value Update for PWMHx Output Mask */
@@ -279,6 +313,7 @@ typedef union {
 
 /* -------- PWM_CMPV : (PWM Offset: 0x00) (R/W 32) PWM Comparison 0 Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CV:24;                     /**< bit:  0..23  Comparison x Value                       */
@@ -287,6 +322,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPV_OFFSET                     (0x00)                                        /**<  (PWM_CMPV) PWM Comparison 0 Value Register  Offset */
@@ -297,12 +333,17 @@ typedef union {
 #define PWM_CMPV_CVM_Pos                    24                                             /**< (PWM_CMPV) Comparison x Value Mode Position */
 #define PWM_CMPV_CVM_Msk                    (_U_(0x1) << PWM_CMPV_CVM_Pos)                 /**< (PWM_CMPV) Comparison x Value Mode Mask */
 #define PWM_CMPV_CVM                        PWM_CMPV_CVM_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use PWM_CMPV_CVM_Msk instead */
+#define   PWM_CMPV_CVM_COMPARE_AT_INCREMENT_Val _U_(0x0)                                       /**< (PWM_CMPV) Compare when counter is incrementing  */
+#define   PWM_CMPV_CVM_COMPARE_AT_DECREMENT_Val _U_(0x1)                                       /**< (PWM_CMPV) Compare when counter is decrementing  */
+#define PWM_CMPV_CVM_COMPARE_AT_INCREMENT   (PWM_CMPV_CVM_COMPARE_AT_INCREMENT_Val << PWM_CMPV_CVM_Pos)  /**< (PWM_CMPV) Compare when counter is incrementing Position  */
+#define PWM_CMPV_CVM_COMPARE_AT_DECREMENT   (PWM_CMPV_CVM_COMPARE_AT_DECREMENT_Val << PWM_CMPV_CVM_Pos)  /**< (PWM_CMPV) Compare when counter is decrementing Position  */
 #define PWM_CMPV_MASK                       _U_(0x1FFFFFF)                                 /**< \deprecated (PWM_CMPV) Register MASK  (Use PWM_CMPV_Msk instead)  */
 #define PWM_CMPV_Msk                        _U_(0x1FFFFFF)                                 /**< (PWM_CMPV) Register Mask  */
 
 
 /* -------- PWM_CMPVUPD : (PWM Offset: 0x04) (/W 32) PWM Comparison 0 Value Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CVUPD:24;                  /**< bit:  0..23  Comparison x Value Update                */
@@ -311,6 +352,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPVUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPVUPD_OFFSET                  (0x04)                                        /**<  (PWM_CMPVUPD) PWM Comparison 0 Value Update Register  Offset */
@@ -327,6 +369,7 @@ typedef union {
 
 /* -------- PWM_CMPM : (PWM Offset: 0x08) (R/W 32) PWM Comparison 0 Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CEN:1;                     /**< bit:      0  Comparison x Enable                      */
@@ -340,6 +383,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPM_OFFSET                     (0x08)                                        /**<  (PWM_CMPM) PWM Comparison 0 Mode Register  Offset */
@@ -368,6 +412,7 @@ typedef union {
 
 /* -------- PWM_CMPMUPD : (PWM Offset: 0x0c) (/W 32) PWM Comparison 0 Mode Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CENUPD:1;                  /**< bit:      0  Comparison x Enable Update               */
@@ -380,6 +425,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMPMUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMPMUPD_OFFSET                  (0x0C)                                        /**<  (PWM_CMPMUPD) PWM Comparison 0 Mode Update Register  Offset */
@@ -402,6 +448,7 @@ typedef union {
 
 /* -------- PWM_CLK : (PWM Offset: 0x00) (R/W 32) PWM Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIVA:8;                    /**< bit:   0..7  CLKA Divide Factor                       */
@@ -413,6 +460,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CLK_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CLK_OFFSET                      (0x00)                                        /**<  (PWM_CLK) PWM Clock Register  Offset */
@@ -487,6 +535,7 @@ typedef union {
 
 /* -------- PWM_ENA : (PWM Offset: 0x04) (/W 32) PWM Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -501,6 +550,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ENA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ENA_OFFSET                      (0x04)                                        /**<  (PWM_ENA) PWM Enable Register  Offset */
@@ -526,6 +576,7 @@ typedef union {
 
 /* -------- PWM_DIS : (PWM Offset: 0x08) (/W 32) PWM Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -540,6 +591,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DIS_OFFSET                      (0x08)                                        /**<  (PWM_DIS) PWM Disable Register  Offset */
@@ -565,6 +617,7 @@ typedef union {
 
 /* -------- PWM_SR : (PWM Offset: 0x0c) (R/ 32) PWM Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Channel ID                               */
@@ -579,6 +632,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SR_OFFSET                       (0x0C)                                        /**<  (PWM_SR) PWM Status Register  Offset */
@@ -604,6 +658,7 @@ typedef union {
 
 /* -------- PWM_IER1 : (PWM Offset: 0x10) (/W 32) PWM Interrupt Enable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Enable */
@@ -625,6 +680,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IER1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IER1_OFFSET                     (0x10)                                        /**<  (PWM_IER1) PWM Interrupt Enable Register 1  Offset */
@@ -665,6 +721,7 @@ typedef union {
 
 /* -------- PWM_IDR1 : (PWM Offset: 0x14) (/W 32) PWM Interrupt Disable Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Disable */
@@ -686,6 +743,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IDR1_OFFSET                     (0x14)                                        /**<  (PWM_IDR1) PWM Interrupt Disable Register 1  Offset */
@@ -726,6 +784,7 @@ typedef union {
 
 /* -------- PWM_IMR1 : (PWM Offset: 0x18) (R/ 32) PWM Interrupt Mask Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0 Interrupt Mask */
@@ -747,6 +806,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IMR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IMR1_OFFSET                     (0x18)                                        /**<  (PWM_IMR1) PWM Interrupt Mask Register 1  Offset */
@@ -787,6 +847,7 @@ typedef union {
 
 /* -------- PWM_ISR1 : (PWM Offset: 0x1c) (R/ 32) PWM Interrupt Status Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHID0:1;                   /**< bit:      0  Counter Event on Channel 0               */
@@ -808,6 +869,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ISR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ISR1_OFFSET                     (0x1C)                                        /**<  (PWM_ISR1) PWM Interrupt Status Register 1  Offset */
@@ -848,6 +910,7 @@ typedef union {
 
 /* -------- PWM_SCM : (PWM Offset: 0x20) (R/W 32) PWM Sync Channels Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SYNC0:1;                   /**< bit:      0  Synchronous Channel 0                    */
@@ -867,6 +930,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCM_OFFSET                      (0x20)                                        /**<  (PWM_SCM) PWM Sync Channels Mode Register  Offset */
@@ -907,6 +971,7 @@ typedef union {
 
 /* -------- PWM_DMAR : (PWM Offset: 0x24) (/W 32) PWM DMA Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DMADUTY:24;                /**< bit:  0..23  Duty-Cycle Holding Register for DMA Access */
@@ -914,6 +979,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_DMAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_DMAR_OFFSET                     (0x24)                                        /**<  (PWM_DMAR) PWM DMA Register  Offset */
@@ -927,6 +993,7 @@ typedef union {
 
 /* -------- PWM_SCUC : (PWM Offset: 0x28) (R/W 32) PWM Sync Channels Update Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPDULOCK:1;                /**< bit:      0  Synchronous Channels Update Unlock       */
@@ -934,6 +1001,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUC_OFFSET                     (0x28)                                        /**<  (PWM_SCUC) PWM Sync Channels Update Control Register  Offset */
@@ -947,6 +1015,7 @@ typedef union {
 
 /* -------- PWM_SCUP : (PWM Offset: 0x2c) (R/W 32) PWM Sync Channels Update Period Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPR:4;                     /**< bit:   0..3  Update Period                            */
@@ -955,6 +1024,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUP_OFFSET                     (0x2C)                                        /**<  (PWM_SCUP) PWM Sync Channels Update Period Register  Offset */
@@ -971,6 +1041,7 @@ typedef union {
 
 /* -------- PWM_SCUPUPD : (PWM Offset: 0x30) (/W 32) PWM Sync Channels Update Period Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPRUPD:4;                  /**< bit:   0..3  Update Period Update                     */
@@ -978,6 +1049,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SCUPUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SCUPUPD_OFFSET                  (0x30)                                        /**<  (PWM_SCUPUPD) PWM Sync Channels Update Period Update Register  Offset */
@@ -991,6 +1063,7 @@ typedef union {
 
 /* -------- PWM_IER2 : (PWM Offset: 0x34) (/W 32) PWM Interrupt Enable Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Enable */
@@ -1023,6 +1096,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IER2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IER2_OFFSET                     (0x34)                                        /**<  (PWM_IER2) PWM Interrupt Enable Register 2  Offset */
@@ -1093,6 +1167,7 @@ typedef union {
 
 /* -------- PWM_IDR2 : (PWM Offset: 0x38) (/W 32) PWM Interrupt Disable Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Disable */
@@ -1125,6 +1200,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IDR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IDR2_OFFSET                     (0x38)                                        /**<  (PWM_IDR2) PWM Interrupt Disable Register 2  Offset */
@@ -1195,6 +1271,7 @@ typedef union {
 
 /* -------- PWM_IMR2 : (PWM Offset: 0x3c) (R/ 32) PWM Interrupt Mask Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update Interrupt Mask */
@@ -1227,6 +1304,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_IMR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_IMR2_OFFSET                     (0x3C)                                        /**<  (PWM_IMR2) PWM Interrupt Mask Register 2  Offset */
@@ -1297,6 +1375,7 @@ typedef union {
 
 /* -------- PWM_ISR2 : (PWM Offset: 0x40) (R/ 32) PWM Interrupt Status Register 2 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WRDY:1;                    /**< bit:      0  Write Ready for Synchronous Channels Update */
@@ -1329,6 +1408,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ISR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ISR2_OFFSET                     (0x40)                                        /**<  (PWM_ISR2) PWM Interrupt Status Register 2  Offset */
@@ -1399,6 +1479,7 @@ typedef union {
 
 /* -------- PWM_OOV : (PWM Offset: 0x44) (R/W 32) PWM Output Override Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OOVH0:1;                   /**< bit:      0  Output Override Value for PWMH output of the channel 0 */
@@ -1420,6 +1501,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OOV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OOV_OFFSET                      (0x44)                                        /**<  (PWM_OOV) PWM Output Override Value Register  Offset */
@@ -1460,6 +1542,7 @@ typedef union {
 
 /* -------- PWM_OS : (PWM Offset: 0x48) (R/W 32) PWM Output Selection Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSH0:1;                    /**< bit:      0  Output Selection for PWMH output of the channel 0 */
@@ -1481,6 +1564,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OS_OFFSET                       (0x48)                                        /**<  (PWM_OS) PWM Output Selection Register  Offset */
@@ -1521,6 +1605,7 @@ typedef union {
 
 /* -------- PWM_OSS : (PWM Offset: 0x4c) (/W 32) PWM Output Selection Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSSH0:1;                   /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
@@ -1542,6 +1627,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSS_OFFSET                      (0x4C)                                        /**<  (PWM_OSS) PWM Output Selection Set Register  Offset */
@@ -1582,6 +1668,7 @@ typedef union {
 
 /* -------- PWM_OSC : (PWM Offset: 0x50) (/W 32) PWM Output Selection Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSCH0:1;                   /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
@@ -1603,6 +1690,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSC_OFFSET                      (0x50)                                        /**<  (PWM_OSC) PWM Output Selection Clear Register  Offset */
@@ -1643,6 +1731,7 @@ typedef union {
 
 /* -------- PWM_OSSUPD : (PWM Offset: 0x54) (/W 32) PWM Output Selection Set Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSSUPH0:1;                 /**< bit:      0  Output Selection Set for PWMH output of the channel 0 */
@@ -1664,6 +1753,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSSUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSSUPD_OFFSET                   (0x54)                                        /**<  (PWM_OSSUPD) PWM Output Selection Set Update Register  Offset */
@@ -1704,6 +1794,7 @@ typedef union {
 
 /* -------- PWM_OSCUPD : (PWM Offset: 0x58) (/W 32) PWM Output Selection Clear Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t OSCUPH0:1;                 /**< bit:      0  Output Selection Clear for PWMH output of the channel 0 */
@@ -1725,6 +1816,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_OSCUPD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_OSCUPD_OFFSET                   (0x58)                                        /**<  (PWM_OSCUPD) PWM Output Selection Clear Update Register  Offset */
@@ -1765,6 +1857,7 @@ typedef union {
 
 /* -------- PWM_FMR : (PWM Offset: 0x5c) (R/W 32) PWM Fault Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPOL:8;                    /**< bit:   0..7  Fault Polarity                           */
@@ -1774,6 +1867,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FMR_OFFSET                      (0x5C)                                        /**<  (PWM_FMR) PWM Fault Mode Register  Offset */
@@ -1793,6 +1887,7 @@ typedef union {
 
 /* -------- PWM_FSR : (PWM Offset: 0x60) (R/ 32) PWM Fault Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FIV:8;                     /**< bit:   0..7  Fault Input Value                        */
@@ -1801,6 +1896,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FSR_OFFSET                      (0x60)                                        /**<  (PWM_FSR) PWM Fault Status Register  Offset */
@@ -1817,6 +1913,7 @@ typedef union {
 
 /* -------- PWM_FCR : (PWM Offset: 0x64) (/W 32) PWM Fault Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FCLR:8;                    /**< bit:   0..7  Fault Clear                              */
@@ -1824,6 +1921,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FCR_OFFSET                      (0x64)                                        /**<  (PWM_FCR) PWM Fault Clear Register  Offset */
@@ -1837,6 +1935,7 @@ typedef union {
 
 /* -------- PWM_FPV1 : (PWM Offset: 0x68) (R/W 32) PWM Fault Protection Value Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPVH0:1;                   /**< bit:      0  Fault Protection Value for PWMH output on channel 0 */
@@ -1858,6 +1957,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPV1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPV1_OFFSET                     (0x68)                                        /**<  (PWM_FPV1) PWM Fault Protection Value Register 1  Offset */
@@ -1898,6 +1998,7 @@ typedef union {
 
 /* -------- PWM_FPE : (PWM Offset: 0x6c) (R/W 32) PWM Fault Protection Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPE0:8;                    /**< bit:   0..7  Fault Protection Enable for channel 0    */
@@ -1907,6 +2008,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPE_OFFSET                      (0x6C)                                        /**<  (PWM_FPE) PWM Fault Protection Enable Register  Offset */
@@ -1929,6 +2031,7 @@ typedef union {
 
 /* -------- PWM_ELMR : (PWM Offset: 0x7c) (R/W 32) PWM Event Line 0 Mode Register 0 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CSEL0:1;                   /**< bit:      0  Comparison 0 Selection                   */
@@ -1947,6 +2050,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ELMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ELMR_OFFSET                     (0x7C)                                        /**<  (PWM_ELMR) PWM Event Line 0 Mode Register 0  Offset */
@@ -1984,6 +2088,7 @@ typedef union {
 
 /* -------- PWM_SSPR : (PWM Offset: 0xa0) (R/W 32) PWM Spread Spectrum Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPRD:24;                   /**< bit:  0..23  Spread Spectrum Limit Value              */
@@ -1992,6 +2097,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SSPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SSPR_OFFSET                     (0xA0)                                        /**<  (PWM_SSPR) PWM Spread Spectrum Register  Offset */
@@ -2008,6 +2114,7 @@ typedef union {
 
 /* -------- PWM_SSPUP : (PWM Offset: 0xa4) (/W 32) PWM Spread Spectrum Update Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPRDUP:24;                 /**< bit:  0..23  Spread Spectrum Limit Value Update       */
@@ -2015,6 +2122,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SSPUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SSPUP_OFFSET                    (0xA4)                                        /**<  (PWM_SSPUP) PWM Spread Spectrum Update Register  Offset */
@@ -2028,6 +2136,7 @@ typedef union {
 
 /* -------- PWM_SMMR : (PWM Offset: 0xb0) (R/W 32) PWM Stepper Motor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GCEN0:1;                   /**< bit:      0  Gray Count ENable                        */
@@ -2045,6 +2154,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_SMMR_OFFSET                     (0xB0)                                        /**<  (PWM_SMMR) PWM Stepper Motor Mode Register  Offset */
@@ -2073,6 +2183,7 @@ typedef union {
 
 /* -------- PWM_FPV2 : (PWM Offset: 0xc0) (R/W 32) PWM Fault Protection Value 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FPZH0:1;                   /**< bit:      0  Fault Protection to Hi-Z for PWMH output on channel 0 */
@@ -2094,6 +2205,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_FPV2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_FPV2_OFFSET                     (0xC0)                                        /**<  (PWM_FPV2) PWM Fault Protection Value 2 Register  Offset */
@@ -2134,6 +2246,7 @@ typedef union {
 
 /* -------- PWM_WPCR : (PWM Offset: 0xe4) (/W 32) PWM Write Protection Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPCMD:2;                   /**< bit:   0..1  Write Protection Command                 */
@@ -2152,6 +2265,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_WPCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_WPCR_OFFSET                     (0xE4)                                        /**<  (PWM_WPCR) PWM Write Protection Control Register  Offset */
@@ -2197,6 +2311,7 @@ typedef union {
 
 /* -------- PWM_WPSR : (PWM Offset: 0xe8) (R/ 32) PWM Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPSWS0:1;                  /**< bit:      0  Write Protect SW Status                  */
@@ -2224,6 +2339,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_WPSR_OFFSET                     (0xE8)                                        /**<  (PWM_WPSR) PWM Write Protection Status Register  Offset */
@@ -2282,6 +2398,7 @@ typedef union {
 
 /* -------- PWM_CMUPD0 : (PWM Offset: 0x400) (/W 32) PWM Channel Mode Update Register (ch_num = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2292,6 +2409,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD0_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD0_OFFSET                   (0x400)                                       /**<  (PWM_CMUPD0) PWM Channel Mode Update Register (ch_num = 0)  Offset */
@@ -2308,6 +2426,7 @@ typedef union {
 
 /* -------- PWM_CMUPD1 : (PWM Offset: 0x420) (/W 32) PWM Channel Mode Update Register (ch_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2318,6 +2437,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD1_OFFSET                   (0x420)                                       /**<  (PWM_CMUPD1) PWM Channel Mode Update Register (ch_num = 1)  Offset */
@@ -2334,6 +2454,7 @@ typedef union {
 
 /* -------- PWM_ETRG1 : (PWM Offset: 0x42c) (R/W 32) PWM External Trigger Register (trg_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
@@ -2346,6 +2467,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ETRG1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ETRG1_OFFSET                    (0x42C)                                       /**<  (PWM_ETRG1) PWM External Trigger Register (trg_num = 1)  Offset */
@@ -2386,6 +2508,7 @@ typedef union {
 
 /* -------- PWM_LEBR1 : (PWM Offset: 0x430) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 1) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
@@ -2398,6 +2521,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_LEBR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_LEBR1_OFFSET                    (0x430)                                       /**<  (PWM_LEBR1) PWM Leading-Edge Blanking Register (trg_num = 1)  Offset */
@@ -2423,6 +2547,7 @@ typedef union {
 
 /* -------- PWM_CMUPD2 : (PWM Offset: 0x440) (/W 32) PWM Channel Mode Update Register (ch_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2433,6 +2558,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD2_OFFSET                   (0x440)                                       /**<  (PWM_CMUPD2) PWM Channel Mode Update Register (ch_num = 2)  Offset */
@@ -2449,6 +2575,7 @@ typedef union {
 
 /* -------- PWM_ETRG2 : (PWM Offset: 0x44c) (R/W 32) PWM External Trigger Register (trg_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MAXCNT:24;                 /**< bit:  0..23  Maximum Counter value                    */
@@ -2461,6 +2588,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_ETRG2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_ETRG2_OFFSET                    (0x44C)                                       /**<  (PWM_ETRG2) PWM External Trigger Register (trg_num = 2)  Offset */
@@ -2501,6 +2629,7 @@ typedef union {
 
 /* -------- PWM_LEBR2 : (PWM Offset: 0x450) (R/W 32) PWM Leading-Edge Blanking Register (trg_num = 2) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LEBDELAY:7;                /**< bit:   0..6  Leading-Edge Blanking Delay for TRGINx   */
@@ -2513,6 +2642,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_LEBR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_LEBR2_OFFSET                    (0x450)                                       /**<  (PWM_LEBR2) PWM Leading-Edge Blanking Register (trg_num = 2)  Offset */
@@ -2538,6 +2668,7 @@ typedef union {
 
 /* -------- PWM_CMUPD3 : (PWM Offset: 0x460) (/W 32) PWM Channel Mode Update Register (ch_num = 3) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :9;                        /**< bit:   0..8  Reserved */
@@ -2548,6 +2679,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } PWM_CMUPD3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define PWM_CMUPD3_OFFSET                   (0x460)                                       /**<  (PWM_CMUPD3) PWM Channel Mode Update Register (ch_num = 3)  Offset */
@@ -2566,14 +2698,14 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief PWM_CH_NUM hardware registers */
 typedef struct {  
-  __IO uint32_t PWM_CMR;        /**< (PWM_CH_NUM Offset: 0x00) PWM Channel Mode Register (ch_num = 0) */
-  __IO uint32_t PWM_CDTY;       /**< (PWM_CH_NUM Offset: 0x04) PWM Channel Duty Cycle Register (ch_num = 0) */
-  __O  uint32_t PWM_CDTYUPD;    /**< (PWM_CH_NUM Offset: 0x08) PWM Channel Duty Cycle Update Register (ch_num = 0) */
-  __IO uint32_t PWM_CPRD;       /**< (PWM_CH_NUM Offset: 0x0C) PWM Channel Period Register (ch_num = 0) */
-  __O  uint32_t PWM_CPRDUPD;    /**< (PWM_CH_NUM Offset: 0x10) PWM Channel Period Update Register (ch_num = 0) */
-  __I  uint32_t PWM_CCNT;       /**< (PWM_CH_NUM Offset: 0x14) PWM Channel Counter Register (ch_num = 0) */
-  __IO uint32_t PWM_DT;         /**< (PWM_CH_NUM Offset: 0x18) PWM Channel Dead Time Register (ch_num = 0) */
-  __O  uint32_t PWM_DTUPD;      /**< (PWM_CH_NUM Offset: 0x1C) PWM Channel Dead Time Update Register (ch_num = 0) */
+  __IO uint32_t PWM_CMR;        /**< (PWM_CH_NUM Offset: 0x00) PWM Channel Mode Register */
+  __IO uint32_t PWM_CDTY;       /**< (PWM_CH_NUM Offset: 0x04) PWM Channel Duty Cycle Register */
+  __O  uint32_t PWM_CDTYUPD;    /**< (PWM_CH_NUM Offset: 0x08) PWM Channel Duty Cycle Update Register */
+  __IO uint32_t PWM_CPRD;       /**< (PWM_CH_NUM Offset: 0x0C) PWM Channel Period Register */
+  __O  uint32_t PWM_CPRDUPD;    /**< (PWM_CH_NUM Offset: 0x10) PWM Channel Period Update Register */
+  __I  uint32_t PWM_CCNT;       /**< (PWM_CH_NUM Offset: 0x14) PWM Channel Counter Register */
+  __IO uint32_t PWM_DT;         /**< (PWM_CH_NUM Offset: 0x18) PWM Channel Dead Time Register */
+  __O  uint32_t PWM_DTUPD;      /**< (PWM_CH_NUM Offset: 0x1C) PWM Channel Dead Time Update Register */
 } PwmChNum;
 
 /** \brief PWM_CMP hardware registers */
@@ -2616,49 +2748,49 @@ typedef struct {
   __O  uint32_t PWM_FCR;        /**< (PWM Offset: 0x64) PWM Fault Clear Register */
   __IO uint32_t PWM_FPV1;       /**< (PWM Offset: 0x68) PWM Fault Protection Value Register 1 */
   __IO uint32_t PWM_FPE;        /**< (PWM Offset: 0x6C) PWM Fault Protection Enable Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __IO uint32_t PWM_ELMR[2];    /**< (PWM Offset: 0x7C) PWM Event Line 0 Mode Register 0 */
-  RoReg8  Reserved2[0x1C];
+  __I  uint8_t                        Reserved2[28];
   __IO uint32_t PWM_SSPR;       /**< (PWM Offset: 0xA0) PWM Spread Spectrum Register */
   __O  uint32_t PWM_SSPUP;      /**< (PWM Offset: 0xA4) PWM Spread Spectrum Update Register */
-  RoReg8  Reserved3[0x8];
+  __I  uint8_t                        Reserved3[8];
   __IO uint32_t PWM_SMMR;       /**< (PWM Offset: 0xB0) PWM Stepper Motor Mode Register */
-  RoReg8  Reserved4[0xC];
+  __I  uint8_t                        Reserved4[12];
   __IO uint32_t PWM_FPV2;       /**< (PWM Offset: 0xC0) PWM Fault Protection Value 2 Register */
-  RoReg8  Reserved5[0x20];
+  __I  uint8_t                        Reserved5[32];
   __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
   __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
-  RoReg8  Reserved6[0x44];
-       PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
-  RoReg8  Reserved7[0x50];
-       PwmChNum PWM_CH_NUM[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
-  RoReg8  Reserved8[0x180];
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register */
+  __I  uint8_t                        Reserved8[384];
   __O  uint32_t PWM_CMUPD0;     /**< (PWM Offset: 0x400) PWM Channel Mode Update Register (ch_num = 0) */
-  RoReg8  Reserved9[0x1C];
+  __I  uint8_t                        Reserved9[28];
   __O  uint32_t PWM_CMUPD1;     /**< (PWM Offset: 0x420) PWM Channel Mode Update Register (ch_num = 1) */
-  RoReg8  Reserved10[0x8];
+  __I  uint8_t                        Reserved10[8];
   __IO uint32_t PWM_ETRG1;      /**< (PWM Offset: 0x42C) PWM External Trigger Register (trg_num = 1) */
   __IO uint32_t PWM_LEBR1;      /**< (PWM Offset: 0x430) PWM Leading-Edge Blanking Register (trg_num = 1) */
-  RoReg8  Reserved11[0xC];
+  __I  uint8_t                        Reserved11[12];
   __O  uint32_t PWM_CMUPD2;     /**< (PWM Offset: 0x440) PWM Channel Mode Update Register (ch_num = 2) */
-  RoReg8  Reserved12[0x8];
+  __I  uint8_t                        Reserved12[8];
   __IO uint32_t PWM_ETRG2;      /**< (PWM Offset: 0x44C) PWM External Trigger Register (trg_num = 2) */
   __IO uint32_t PWM_LEBR2;      /**< (PWM Offset: 0x450) PWM Leading-Edge Blanking Register (trg_num = 2) */
-  RoReg8  Reserved13[0xC];
+  __I  uint8_t                        Reserved13[12];
   __O  uint32_t PWM_CMUPD3;     /**< (PWM Offset: 0x460) PWM Channel Mode Update Register (ch_num = 3) */
 } Pwm;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief PWM_CH_NUM hardware registers */
 typedef struct {  
-  __IO PWM_CMR_Type                   PWM_CMR;        /**< Offset: 0x00 (R/W  32) PWM Channel Mode Register (ch_num = 0) */
-  __IO PWM_CDTY_Type                  PWM_CDTY;       /**< Offset: 0x04 (R/W  32) PWM Channel Duty Cycle Register (ch_num = 0) */
-  __O  PWM_CDTYUPD_Type               PWM_CDTYUPD;    /**< Offset: 0x08 ( /W  32) PWM Channel Duty Cycle Update Register (ch_num = 0) */
-  __IO PWM_CPRD_Type                  PWM_CPRD;       /**< Offset: 0x0C (R/W  32) PWM Channel Period Register (ch_num = 0) */
-  __O  PWM_CPRDUPD_Type               PWM_CPRDUPD;    /**< Offset: 0x10 ( /W  32) PWM Channel Period Update Register (ch_num = 0) */
-  __I  PWM_CCNT_Type                  PWM_CCNT;       /**< Offset: 0x14 (R/   32) PWM Channel Counter Register (ch_num = 0) */
-  __IO PWM_DT_Type                    PWM_DT;         /**< Offset: 0x18 (R/W  32) PWM Channel Dead Time Register (ch_num = 0) */
-  __O  PWM_DTUPD_Type                 PWM_DTUPD;      /**< Offset: 0x1C ( /W  32) PWM Channel Dead Time Update Register (ch_num = 0) */
+  __IO PWM_CMR_Type                   PWM_CMR;        /**< Offset: 0x00 (R/W  32) PWM Channel Mode Register */
+  __IO PWM_CDTY_Type                  PWM_CDTY;       /**< Offset: 0x04 (R/W  32) PWM Channel Duty Cycle Register */
+  __O  PWM_CDTYUPD_Type               PWM_CDTYUPD;    /**< Offset: 0x08 ( /W  32) PWM Channel Duty Cycle Update Register */
+  __IO PWM_CPRD_Type                  PWM_CPRD;       /**< Offset: 0x0C (R/W  32) PWM Channel Period Register */
+  __O  PWM_CPRDUPD_Type               PWM_CPRDUPD;    /**< Offset: 0x10 ( /W  32) PWM Channel Period Update Register */
+  __I  PWM_CCNT_Type                  PWM_CCNT;       /**< Offset: 0x14 (R/   32) PWM Channel Counter Register */
+  __IO PWM_DT_Type                    PWM_DT;         /**< Offset: 0x18 (R/W  32) PWM Channel Dead Time Register */
+  __O  PWM_DTUPD_Type                 PWM_DTUPD;      /**< Offset: 0x1C ( /W  32) PWM Channel Dead Time Update Register */
 } PwmChNum;
 
 /** \brief PWM_CMP hardware registers */
@@ -2699,35 +2831,35 @@ typedef struct {
   __O  PWM_FCR_Type                   PWM_FCR;        /**< Offset: 0x64 ( /W  32) PWM Fault Clear Register */
   __IO PWM_FPV1_Type                  PWM_FPV1;       /**< Offset: 0x68 (R/W  32) PWM Fault Protection Value Register 1 */
   __IO PWM_FPE_Type                   PWM_FPE;        /**< Offset: 0x6C (R/W  32) PWM Fault Protection Enable Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __IO PWM_ELMR_Type                  PWM_ELMR[2];    /**< Offset: 0x7C (R/W  32) PWM Event Line 0 Mode Register 0 */
-  __I  uint32_t                       Reserved2[7];
+  __I  uint8_t                        Reserved2[28];
   __IO PWM_SSPR_Type                  PWM_SSPR;       /**< Offset: 0xA0 (R/W  32) PWM Spread Spectrum Register */
   __O  PWM_SSPUP_Type                 PWM_SSPUP;      /**< Offset: 0xA4 ( /W  32) PWM Spread Spectrum Update Register */
-  __I  uint32_t                       Reserved3[2];
+  __I  uint8_t                        Reserved3[8];
   __IO PWM_SMMR_Type                  PWM_SMMR;       /**< Offset: 0xB0 (R/W  32) PWM Stepper Motor Mode Register */
-  __I  uint32_t                       Reserved4[3];
+  __I  uint8_t                        Reserved4[12];
   __IO PWM_FPV2_Type                  PWM_FPV2;       /**< Offset: 0xC0 (R/W  32) PWM Fault Protection Value 2 Register */
-  __I  uint32_t                       Reserved5[8];
+  __I  uint8_t                        Reserved5[32];
   __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
   __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
-  __I  uint32_t                       Reserved6[17];
-       PwmCmp                         PWM_CMP[8];     /**< Offset: 0x130 PWM Comparison 0 Value Register */
-  __I  uint32_t                       Reserved7[20];
-       PwmChNum                       PWM_CH_NUM[4];  /**< Offset: 0x200 PWM Channel Mode Register (ch_num = 0) */
-  __I  uint32_t                       Reserved8[96];
+  __I  uint8_t                        Reserved6[68];
+       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+  __I  uint8_t                        Reserved7[80];
+       PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register */
+  __I  uint8_t                        Reserved8[384];
   __O  PWM_CMUPD0_Type                PWM_CMUPD0;     /**< Offset: 0x400 ( /W  32) PWM Channel Mode Update Register (ch_num = 0) */
-  __I  uint32_t                       Reserved9[7];
+  __I  uint8_t                        Reserved9[28];
   __O  PWM_CMUPD1_Type                PWM_CMUPD1;     /**< Offset: 0x420 ( /W  32) PWM Channel Mode Update Register (ch_num = 1) */
-  __I  uint32_t                       Reserved10[2];
+  __I  uint8_t                        Reserved10[8];
   __IO PWM_ETRG1_Type                 PWM_ETRG1;      /**< Offset: 0x42C (R/W  32) PWM External Trigger Register (trg_num = 1) */
   __IO PWM_LEBR1_Type                 PWM_LEBR1;      /**< Offset: 0x430 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 1) */
-  __I  uint32_t                       Reserved11[3];
+  __I  uint8_t                        Reserved11[12];
   __O  PWM_CMUPD2_Type                PWM_CMUPD2;     /**< Offset: 0x440 ( /W  32) PWM Channel Mode Update Register (ch_num = 2) */
-  __I  uint32_t                       Reserved12[2];
+  __I  uint8_t                        Reserved12[8];
   __IO PWM_ETRG2_Type                 PWM_ETRG2;      /**< Offset: 0x44C (R/W  32) PWM External Trigger Register (trg_num = 2) */
   __IO PWM_LEBR2_Type                 PWM_LEBR2;      /**< Offset: 0x450 (R/W  32) PWM Leading-Edge Blanking Register (trg_num = 2) */
-  __I  uint32_t                       Reserved13[3];
+  __I  uint8_t                        Reserved13[12];
   __O  PWM_CMUPD3_Type                PWM_CMUPD3;     /**< Offset: 0x460 ( /W  32) PWM Channel Mode Update Register (ch_num = 3) */
 } Pwm;
 

--- a/asf/sam/include/same70b/component/pwm.h
+++ b/asf/sam/include/same70b/component/pwm.h
@@ -2761,7 +2761,7 @@ typedef struct {
   __O  uint32_t PWM_WPCR;       /**< (PWM Offset: 0xE4) PWM Write Protection Control Register */
   __I  uint32_t PWM_WPSR;       /**< (PWM Offset: 0xE8) PWM Write Protection Status Register */
   __I  uint8_t                        Reserved6[68];
-       PwmCmp   PwmCmp[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
+       PwmCmp   PWM_CMP[PWMCMP_NUMBER]; /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
        PwmChNum PwmChNum[PWMCHNUM_NUMBER]; /**< Offset: 0x200 PWM Channel Mode Register */
   __I  uint8_t                        Reserved8[384];
@@ -2844,7 +2844,7 @@ typedef struct {
   __O  PWM_WPCR_Type                  PWM_WPCR;       /**< Offset: 0xE4 ( /W  32) PWM Write Protection Control Register */
   __I  PWM_WPSR_Type                  PWM_WPSR;       /**< Offset: 0xE8 (R/   32) PWM Write Protection Status Register */
   __I  uint8_t                        Reserved6[68];
-       PwmCmp                         PwmCmp[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
+       PwmCmp                         PWM_CMP[8];      /**< Offset: 0x130 PWM Comparison 0 Value Register */
   __I  uint8_t                        Reserved7[80];
        PwmChNum                       PwmChNum[4];    /**< Offset: 0x200 PWM Channel Mode Register */
   __I  uint8_t                        Reserved8[384];

--- a/asf/sam/include/same70b/component/qspi.h
+++ b/asf/sam/include/same70b/component/qspi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for QSPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_QSPI_COMPONENT_H_
 #define _SAME70_QSPI_COMPONENT_H_
 #define _SAME70_QSPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- QSPI_CR : (QSPI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t QSPIEN:1;                  /**< bit:      0  QSPI Enable                              */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_CR_OFFSET                      (0x00)                                        /**<  (QSPI_CR) Control Register  Offset */
@@ -79,6 +83,7 @@ typedef union {
 
 /* -------- QSPI_MR : (QSPI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMM:1;                     /**< bit:      0  Serial Memory Mode                       */
@@ -94,6 +99,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_MR_OFFSET                      (0x04)                                        /**<  (QSPI_MR) Mode Register  Offset */
@@ -147,6 +153,7 @@ typedef union {
 
 /* -------- QSPI_RDR : (QSPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
@@ -154,6 +161,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_RDR_OFFSET                     (0x08)                                        /**<  (QSPI_RDR) Receive Data Register  Offset */
@@ -167,6 +175,7 @@ typedef union {
 
 /* -------- QSPI_TDR : (QSPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
@@ -174,6 +183,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_TDR_OFFSET                     (0x0C)                                        /**<  (QSPI_TDR) Transmit Data Register  Offset */
@@ -187,6 +197,7 @@ typedef union {
 
 /* -------- QSPI_SR : (QSPI Offset: 0x10) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
@@ -203,6 +214,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SR_OFFSET                      (0x10)                                        /**<  (QSPI_SR) Status Register  Offset */
@@ -237,6 +249,7 @@ typedef union {
 
 /* -------- QSPI_IER : (QSPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
@@ -251,6 +264,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IER_OFFSET                     (0x14)                                        /**<  (QSPI_IER) Interrupt Enable Register  Offset */
@@ -282,6 +296,7 @@ typedef union {
 
 /* -------- QSPI_IDR : (QSPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
@@ -296,6 +311,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IDR_OFFSET                     (0x18)                                        /**<  (QSPI_IDR) Interrupt Disable Register  Offset */
@@ -327,6 +343,7 @@ typedef union {
 
 /* -------- QSPI_IMR : (QSPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
@@ -341,6 +358,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IMR_OFFSET                     (0x1C)                                        /**<  (QSPI_IMR) Interrupt Mask Register  Offset */
@@ -372,6 +390,7 @@ typedef union {
 
 /* -------- QSPI_SCR : (QSPI Offset: 0x20) (R/W 32) Serial Clock Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
@@ -383,6 +402,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SCR_OFFSET                     (0x20)                                        /**<  (QSPI_SCR) Serial Clock Register  Offset */
@@ -405,12 +425,14 @@ typedef union {
 
 /* -------- QSPI_IAR : (QSPI Offset: 0x30) (R/W 32) Instruction Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ADDR:32;                   /**< bit:  0..31  Address                                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IAR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IAR_OFFSET                     (0x30)                                        /**<  (QSPI_IAR) Instruction Address Register  Offset */
@@ -424,6 +446,7 @@ typedef union {
 
 /* -------- QSPI_ICR : (QSPI Offset: 0x34) (R/W 32) Instruction Code Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INST:8;                    /**< bit:   0..7  Instruction Code                         */
@@ -433,6 +456,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_ICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_ICR_OFFSET                     (0x34)                                        /**<  (QSPI_ICR) Instruction Code Register  Offset */
@@ -449,6 +473,7 @@ typedef union {
 
 /* -------- QSPI_IFR : (QSPI Offset: 0x38) (R/W 32) Instruction Frame Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WIDTH:3;                   /**< bit:   0..2  Width of Instruction Code, Address, Option Code and Data */
@@ -468,6 +493,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_IFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_IFR_OFFSET                     (0x38)                                        /**<  (QSPI_IFR) Instruction Frame Register  Offset */
@@ -546,6 +572,7 @@ typedef union {
 
 /* -------- QSPI_SMR : (QSPI Offset: 0x40) (R/W 32) Scrambling Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SCREN:1;                   /**< bit:      0  Scrambling/Unscrambling Enable           */
@@ -554,6 +581,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SMR_OFFSET                     (0x40)                                        /**<  (QSPI_SMR) Scrambling Mode Register  Offset */
@@ -574,18 +602,20 @@ typedef union {
 
 /* -------- QSPI_SKR : (QSPI Offset: 0x44) (/W 32) Scrambling Key Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t USRK:32;                   /**< bit:  0..31  Scrambling User Key                      */
+    uint32_t USRK:32;                   /**< bit:  0..31  User Scrambling Key                      */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_SKR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_SKR_OFFSET                     (0x44)                                        /**<  (QSPI_SKR) Scrambling Key Register  Offset */
 
-#define QSPI_SKR_USRK_Pos                   0                                              /**< (QSPI_SKR) Scrambling User Key Position */
-#define QSPI_SKR_USRK_Msk                   (_U_(0xFFFFFFFF) << QSPI_SKR_USRK_Pos)         /**< (QSPI_SKR) Scrambling User Key Mask */
+#define QSPI_SKR_USRK_Pos                   0                                              /**< (QSPI_SKR) User Scrambling Key Position */
+#define QSPI_SKR_USRK_Msk                   (_U_(0xFFFFFFFF) << QSPI_SKR_USRK_Pos)         /**< (QSPI_SKR) User Scrambling Key Mask */
 #define QSPI_SKR_USRK(value)                (QSPI_SKR_USRK_Msk & ((value) << QSPI_SKR_USRK_Pos))
 #define QSPI_SKR_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (QSPI_SKR) Register MASK  (Use QSPI_SKR_Msk instead)  */
 #define QSPI_SKR_Msk                        _U_(0xFFFFFFFF)                                /**< (QSPI_SKR) Register Mask  */
@@ -593,6 +623,7 @@ typedef union {
 
 /* -------- QSPI_WPMR : (QSPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -601,6 +632,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_WPMR_OFFSET                    (0xE4)                                        /**<  (QSPI_WPMR) Write Protection Mode Register  Offset */
@@ -619,6 +651,7 @@ typedef union {
 
 /* -------- QSPI_WPSR : (QSPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -628,6 +661,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } QSPI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define QSPI_WPSR_OFFSET                    (0xE8)                                        /**<  (QSPI_WPSR) Write Protection Status Register  Offset */
@@ -655,14 +689,14 @@ typedef struct {
   __O  uint32_t QSPI_IDR;       /**< (QSPI Offset: 0x18) Interrupt Disable Register */
   __I  uint32_t QSPI_IMR;       /**< (QSPI Offset: 0x1C) Interrupt Mask Register */
   __IO uint32_t QSPI_SCR;       /**< (QSPI Offset: 0x20) Serial Clock Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __IO uint32_t QSPI_IAR;       /**< (QSPI Offset: 0x30) Instruction Address Register */
   __IO uint32_t QSPI_ICR;       /**< (QSPI Offset: 0x34) Instruction Code Register */
   __IO uint32_t QSPI_IFR;       /**< (QSPI Offset: 0x38) Instruction Frame Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t QSPI_SMR;       /**< (QSPI Offset: 0x40) Scrambling Mode Register */
   __O  uint32_t QSPI_SKR;       /**< (QSPI Offset: 0x44) Scrambling Key Register */
-  RoReg8  Reserved3[0x9C];
+  __I  uint8_t                        Reserved3[156];
   __IO uint32_t QSPI_WPMR;      /**< (QSPI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t QSPI_WPSR;      /**< (QSPI Offset: 0xE8) Write Protection Status Register */
 } Qspi;
@@ -679,14 +713,14 @@ typedef struct {
   __O  QSPI_IDR_Type                  QSPI_IDR;       /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
   __I  QSPI_IMR_Type                  QSPI_IMR;       /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
   __IO QSPI_SCR_Type                  QSPI_SCR;       /**< Offset: 0x20 (R/W  32) Serial Clock Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __IO QSPI_IAR_Type                  QSPI_IAR;       /**< Offset: 0x30 (R/W  32) Instruction Address Register */
   __IO QSPI_ICR_Type                  QSPI_ICR;       /**< Offset: 0x34 (R/W  32) Instruction Code Register */
   __IO QSPI_IFR_Type                  QSPI_IFR;       /**< Offset: 0x38 (R/W  32) Instruction Frame Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO QSPI_SMR_Type                  QSPI_SMR;       /**< Offset: 0x40 (R/W  32) Scrambling Mode Register */
   __O  QSPI_SKR_Type                  QSPI_SKR;       /**< Offset: 0x44 ( /W  32) Scrambling Key Register */
-  __I  uint32_t                       Reserved3[39];
+  __I  uint8_t                        Reserved3[156];
   __IO QSPI_WPMR_Type                 QSPI_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  QSPI_WPSR_Type                 QSPI_WPSR;      /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Qspi;

--- a/asf/sam/include/same70b/component/rstc.h
+++ b/asf/sam/include/same70b/component/rstc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RSTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RSTC_COMPONENT_H_
 #define _SAME70_RSTC_COMPONENT_H_
 #define _SAME70_RSTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- RSTC_CR : (RSTC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PROCRST:1;                 /**< bit:      0  Processor Reset                          */
@@ -55,6 +58,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_CR_OFFSET                      (0x00)                                        /**<  (RSTC_CR) Control Register  Offset */
@@ -76,6 +80,7 @@ typedef union {
 
 /* -------- RSTC_SR : (RSTC Offset: 0x04) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URSTS:1;                   /**< bit:      0  User Reset Status                        */
@@ -88,6 +93,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_SR_OFFSET                      (0x04)                                        /**<  (RSTC_SR) Status Register  Offset */
@@ -120,6 +126,7 @@ typedef union {
 
 /* -------- RSTC_MR : (RSTC Offset: 0x08) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t URSTEN:1;                  /**< bit:      0  User Reset Enable                        */
@@ -132,6 +139,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSTC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSTC_MR_OFFSET                      (0x08)                                        /**<  (RSTC_MR) Mode Register  Offset */

--- a/asf/sam/include/same70b/component/rswdt.h
+++ b/asf/sam/include/same70b/component/rswdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RSWDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RSWDT_COMPONENT_H_
 #define _SAME70_RSWDT_COMPONENT_H_
 #define _SAME70_RSWDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- RSWDT_CR : (RSWDT Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_CR_OFFSET                     (0x00)                                        /**<  (RSWDT_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- RSWDT_MR : (RSWDT Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
@@ -85,6 +90,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_MR_OFFSET                     (0x04)                                        /**<  (RSWDT_MR) Mode Register  Offset */
@@ -116,6 +122,7 @@ typedef union {
 
 /* -------- RSWDT_SR : (RSWDT Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow                       */
@@ -123,6 +130,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RSWDT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RSWDT_SR_OFFSET                     (0x08)                                        /**<  (RSWDT_SR) Status Register  Offset */

--- a/asf/sam/include/same70b/component/rtc.h
+++ b/asf/sam/include/same70b/component/rtc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RTC_COMPONENT_H_
 #define _SAME70_RTC_COMPONENT_H_
 #define _SAME70_RTC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- RTC_CR : (RTC Offset: 0x00) (R/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UPDTIM:1;                  /**< bit:      0  Update Request Time Register             */
@@ -57,6 +60,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CR_OFFSET                       (0x00)                                        /**<  (RTC_CR) Control Register  Offset */
@@ -93,6 +97,7 @@ typedef union {
 
 /* -------- RTC_MR : (RTC Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HRMOD:1;                   /**< bit:      0  12-/24-hour Mode                         */
@@ -113,6 +118,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_MR_OFFSET                       (0x04)                                        /**<  (RTC_MR) Mode Register  Offset */
@@ -206,6 +212,7 @@ typedef union {
 
 /* -------- RTC_TIMR : (RTC Offset: 0x08) (R/W 32) Time Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:7;                     /**< bit:   0..6  Current Second                           */
@@ -218,6 +225,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_TIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_TIMR_OFFSET                     (0x08)                                        /**<  (RTC_TIMR) Time Register  Offset */
@@ -240,6 +248,7 @@ typedef union {
 
 /* -------- RTC_CALR : (RTC Offset: 0x0c) (R/W 32) Calendar Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CENT:7;                    /**< bit:   0..6  Current Century                          */
@@ -252,6 +261,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CALR_OFFSET                     (0x0C)                                        /**<  (RTC_CALR) Calendar Register  Offset */
@@ -277,6 +287,7 @@ typedef union {
 
 /* -------- RTC_TIMALR : (RTC Offset: 0x10) (R/W 32) Time Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SEC:7;                     /**< bit:   0..6  Second Alarm                             */
@@ -290,6 +301,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_TIMALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_TIMALR_OFFSET                   (0x10)                                        /**<  (RTC_TIMALR) Time Alarm Register  Offset */
@@ -321,6 +333,7 @@ typedef union {
 
 /* -------- RTC_CALALR : (RTC Offset: 0x14) (R/W 32) Calendar Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :16;                       /**< bit:  0..15  Reserved */
@@ -333,6 +346,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_CALALR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_CALALR_OFFSET                   (0x14)                                        /**<  (RTC_CALALR) Calendar Alarm Register  Offset */
@@ -355,6 +369,7 @@ typedef union {
 
 /* -------- RTC_SR : (RTC Offset: 0x18) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKUPD:1;                  /**< bit:      0  Acknowledge for Update                   */
@@ -367,6 +382,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_SR_OFFSET                       (0x18)                                        /**<  (RTC_SR) Status Register  Offset */
@@ -419,6 +435,7 @@ typedef union {
 
 /* -------- RTC_SCCR : (RTC Offset: 0x1c) (/W 32) Status Clear Command Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKCLR:1;                  /**< bit:      0  Acknowledge Clear                        */
@@ -431,6 +448,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_SCCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_SCCR_OFFSET                     (0x1C)                                        /**<  (RTC_SCCR) Status Clear Command Register  Offset */
@@ -459,6 +477,7 @@ typedef union {
 
 /* -------- RTC_IER : (RTC Offset: 0x20) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKEN:1;                   /**< bit:      0  Acknowledge Update Interrupt Enable      */
@@ -471,6 +490,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IER_OFFSET                      (0x20)                                        /**<  (RTC_IER) Interrupt Enable Register  Offset */
@@ -499,6 +519,7 @@ typedef union {
 
 /* -------- RTC_IDR : (RTC Offset: 0x24) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACKDIS:1;                  /**< bit:      0  Acknowledge Update Interrupt Disable     */
@@ -511,6 +532,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IDR_OFFSET                      (0x24)                                        /**<  (RTC_IDR) Interrupt Disable Register  Offset */
@@ -539,6 +561,7 @@ typedef union {
 
 /* -------- RTC_IMR : (RTC Offset: 0x28) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ACK:1;                     /**< bit:      0  Acknowledge Update Interrupt Mask        */
@@ -551,6 +574,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_IMR_OFFSET                      (0x28)                                        /**<  (RTC_IMR) Interrupt Mask Register  Offset */
@@ -579,6 +603,7 @@ typedef union {
 
 /* -------- RTC_VER : (RTC Offset: 0x2c) (R/ 32) Valid Entry Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NVTIM:1;                   /**< bit:      0  Non-valid Time                           */
@@ -589,6 +614,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTC_VER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTC_VER_OFFSET                      (0x2C)                                        /**<  (RTC_VER) Valid Entry Register  Offset */
@@ -609,32 +635,6 @@ typedef union {
 #define RTC_VER_Msk                         _U_(0x0F)                                      /**< (RTC_VER) Register Mask  */
 
 
-/* -------- RTC_WPMR : (RTC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
-#if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
-typedef union { 
-  struct {
-    uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
-    uint32_t :7;                        /**< bit:   1..7  Reserved */
-    uint32_t WPKEY:24;                  /**< bit:  8..31  Write Protection Key                     */
-  } bit;                                /**< Structure used for bit  access */
-  uint32_t reg;                         /**< Type used for register access */
-} RTC_WPMR_Type;
-#endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
-
-#define RTC_WPMR_OFFSET                     (0xE4)                                        /**<  (RTC_WPMR) Write Protection Mode Register  Offset */
-
-#define RTC_WPMR_WPEN_Pos                   0                                              /**< (RTC_WPMR) Write Protection Enable Position */
-#define RTC_WPMR_WPEN_Msk                   (_U_(0x1) << RTC_WPMR_WPEN_Pos)                /**< (RTC_WPMR) Write Protection Enable Mask */
-#define RTC_WPMR_WPEN                       RTC_WPMR_WPEN_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use RTC_WPMR_WPEN_Msk instead */
-#define RTC_WPMR_WPKEY_Pos                  8                                              /**< (RTC_WPMR) Write Protection Key Position */
-#define RTC_WPMR_WPKEY_Msk                  (_U_(0xFFFFFF) << RTC_WPMR_WPKEY_Pos)          /**< (RTC_WPMR) Write Protection Key Mask */
-#define RTC_WPMR_WPKEY(value)               (RTC_WPMR_WPKEY_Msk & ((value) << RTC_WPMR_WPKEY_Pos))
-#define   RTC_WPMR_WPKEY_PASSWD_Val         _U_(0x525443)                                  /**< (RTC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0.  */
-#define RTC_WPMR_WPKEY_PASSWD               (RTC_WPMR_WPKEY_PASSWD_Val << RTC_WPMR_WPKEY_Pos)  /**< (RTC_WPMR) Writing any other value in this field aborts the write operation of the WPEN bit.Always reads as 0. Position  */
-#define RTC_WPMR_MASK                       _U_(0xFFFFFF01)                                /**< \deprecated (RTC_WPMR) Register MASK  (Use RTC_WPMR_Msk instead)  */
-#define RTC_WPMR_Msk                        _U_(0xFFFFFF01)                                /**< (RTC_WPMR) Register Mask  */
-
-
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief RTC hardware registers */
@@ -651,8 +651,6 @@ typedef struct {
   __O  uint32_t RTC_IDR;        /**< (RTC Offset: 0x24) Interrupt Disable Register */
   __I  uint32_t RTC_IMR;        /**< (RTC Offset: 0x28) Interrupt Mask Register */
   __I  uint32_t RTC_VER;        /**< (RTC Offset: 0x2C) Valid Entry Register */
-  RoReg8  Reserved1[0xB4];
-  __IO uint32_t RTC_WPMR;       /**< (RTC Offset: 0xE4) Write Protection Mode Register */
 } Rtc;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -670,8 +668,6 @@ typedef struct {
   __O  RTC_IDR_Type                   RTC_IDR;        /**< Offset: 0x24 ( /W  32) Interrupt Disable Register */
   __I  RTC_IMR_Type                   RTC_IMR;        /**< Offset: 0x28 (R/   32) Interrupt Mask Register */
   __I  RTC_VER_Type                   RTC_VER;        /**< Offset: 0x2C (R/   32) Valid Entry Register */
-  __I  uint32_t                       Reserved1[45];
-  __IO RTC_WPMR_Type                  RTC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Rtc;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70b/component/rtt.h
+++ b/asf/sam/include/same70b/component/rtt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for RTT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RTT_COMPONENT_H_
 #define _SAME70_RTT_COMPONENT_H_
 #define _SAME70_RTT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- RTT_MR : (RTT Offset: 0x00) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RTPRES:16;                 /**< bit:  0..15  Real-time Timer Prescaler Value          */
@@ -59,6 +62,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_MR_OFFSET                       (0x00)                                        /**<  (RTT_MR) Mode Register  Offset */
@@ -87,12 +91,14 @@ typedef union {
 
 /* -------- RTT_AR : (RTT Offset: 0x04) (R/W 32) Alarm Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ALMV:32;                   /**< bit:  0..31  Alarm Value                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_AR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_AR_OFFSET                       (0x04)                                        /**<  (RTT_AR) Alarm Register  Offset */
@@ -106,12 +112,14 @@ typedef union {
 
 /* -------- RTT_VR : (RTT Offset: 0x08) (R/ 32) Value Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CRTV:32;                   /**< bit:  0..31  Current Real-time Value                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_VR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_VR_OFFSET                       (0x08)                                        /**<  (RTT_VR) Value Register  Offset */
@@ -125,6 +133,7 @@ typedef union {
 
 /* -------- RTT_SR : (RTT Offset: 0x0c) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ALMS:1;                    /**< bit:      0  Real-time Alarm Status (cleared on read) */
@@ -133,6 +142,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } RTT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define RTT_SR_OFFSET                       (0x0C)                                        /**<  (RTT_SR) Status Register  Offset */

--- a/asf/sam/include/same70b/component/sdramc.h
+++ b/asf/sam/include/same70b/component/sdramc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SDRAMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SDRAMC_COMPONENT_H_
 #define _SAME70_SDRAMC_COMPONENT_H_
 #define _SAME70_SDRAMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- SDRAMC_MR : (SDRAMC Offset: 0x00) (R/W 32) SDRAMC Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MODE:3;                    /**< bit:   0..2  SDRAMC Command Mode                      */
@@ -52,6 +55,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_MR_OFFSET                    (0x00)                                        /**<  (SDRAMC_MR) SDRAMC Mode Register  Offset */
@@ -59,26 +63,27 @@ typedef union {
 #define SDRAMC_MR_MODE_Pos                  0                                              /**< (SDRAMC_MR) SDRAMC Command Mode Position */
 #define SDRAMC_MR_MODE_Msk                  (_U_(0x7) << SDRAMC_MR_MODE_Pos)               /**< (SDRAMC_MR) SDRAMC Command Mode Mask */
 #define SDRAMC_MR_MODE(value)               (SDRAMC_MR_MODE_Msk & ((value) << SDRAMC_MR_MODE_Pos))
-#define   SDRAMC_MR_MODE_NORMAL_Val         _U_(0x0)                                       /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, command must be followed by a write to the SDRAM.  */
-#define   SDRAMC_MR_MODE_NOP_Val            _U_(0x1)                                       /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM.  */
-#define   SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val _U_(0x2)                                       /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM.  */
-#define   SDRAMC_MR_MODE_LOAD_MODEREG_Val   _U_(0x3)                                       /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM.  */
-#define   SDRAMC_MR_MODE_AUTO_REFRESH_Val   _U_(0x4)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_NORMAL_Val         _U_(0x0)                                       /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_NOP_Val            _U_(0x1)                                       /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val _U_(0x2)                                       /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_LOAD_MODEREG_Val   _U_(0x3)                                       /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM.  */
+#define   SDRAMC_MR_MODE_AUTO_REFRESH_Val   _U_(0x4)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM.  */
 #define   SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val _U_(0x5)                                       /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1.  */
-#define   SDRAMC_MR_MODE_DEEP_POWERDOWN_Val _U_(0x6)                                       /**< (SDRAMC_MR) Deep power-down mode. Enters deep power-down mode.  */
-#define SDRAMC_MR_MODE_NORMAL               (SDRAMC_MR_MODE_NORMAL_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, command must be followed by a write to the SDRAM. Position  */
-#define SDRAMC_MR_MODE_NOP                  (SDRAMC_MR_MODE_NOP_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM. Position  */
-#define SDRAMC_MR_MODE_ALLBANKS_PRECHARGE   (SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM. Position  */
-#define SDRAMC_MR_MODE_LOAD_MODEREG         (SDRAMC_MR_MODE_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, command must be followed by a write to the SDRAM. Position  */
-#define SDRAMC_MR_MODE_AUTO_REFRESH         (SDRAMC_MR_MODE_AUTO_REFRESH_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, command must be followed by a write to the SDRAM. Position  */
+#define   SDRAMC_MR_MODE_DEEP_POWERDOWN_Val _U_(0x6)                                       /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode.  */
+#define SDRAMC_MR_MODE_NORMAL               (SDRAMC_MR_MODE_NORMAL_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Normal mode. Any access to the SDRAM is decoded normally. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_NOP                  (SDRAMC_MR_MODE_NOP_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a NOP command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_ALLBANKS_PRECHARGE   (SDRAMC_MR_MODE_ALLBANKS_PRECHARGE_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "All Banks Precharge" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_LOAD_MODEREG         (SDRAMC_MR_MODE_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues a "Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
+#define SDRAMC_MR_MODE_AUTO_REFRESH         (SDRAMC_MR_MODE_AUTO_REFRESH_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Auto-Refresh" Command when the SDRAM device is accessed regardless of the cycle. Previously, an "All Banks Precharge" command must be issued. To activate this mode, the command must be followed by a write to the SDRAM. Position  */
 #define SDRAMC_MR_MODE_EXT_LOAD_MODEREG     (SDRAMC_MR_MODE_EXT_LOAD_MODEREG_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) The SDRAMC issues an "Extended Load Mode Register" command when the SDRAM device is accessed regardless of the cycle. To activate this mode, the "Extended Load Mode Register" command must be followed by a write to the SDRAM. The write in the SDRAM must be done in the appropriate bank; most low-power SDRAM devices use the bank 1. Position  */
-#define SDRAMC_MR_MODE_DEEP_POWERDOWN       (SDRAMC_MR_MODE_DEEP_POWERDOWN_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Deep power-down mode. Enters deep power-down mode. Position  */
+#define SDRAMC_MR_MODE_DEEP_POWERDOWN       (SDRAMC_MR_MODE_DEEP_POWERDOWN_Val << SDRAMC_MR_MODE_Pos)  /**< (SDRAMC_MR) Deep Power-down mode. Enters Deep Power-down mode. Position  */
 #define SDRAMC_MR_MASK                      _U_(0x07)                                      /**< \deprecated (SDRAMC_MR) Register MASK  (Use SDRAMC_MR_Msk instead)  */
 #define SDRAMC_MR_Msk                       _U_(0x07)                                      /**< (SDRAMC_MR) Register Mask  */
 
 
 /* -------- SDRAMC_TR : (SDRAMC Offset: 0x04) (R/W 32) SDRAMC Refresh Timer Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COUNT:12;                  /**< bit:  0..11  SDRAMC Refresh Timer Count               */
@@ -86,6 +91,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_TR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_TR_OFFSET                    (0x04)                                        /**<  (SDRAMC_TR) SDRAMC Refresh Timer Register  Offset */
@@ -99,6 +105,7 @@ typedef union {
 
 /* -------- SDRAMC_CR : (SDRAMC Offset: 0x08) (R/W 32) SDRAMC Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NC:2;                      /**< bit:   0..1  Number of Column Bits                    */
@@ -111,10 +118,11 @@ typedef union {
     uint32_t TRP:4;                     /**< bit: 16..19  Row Precharge Delay                      */
     uint32_t TRCD:4;                    /**< bit: 20..23  Row to Column Delay                      */
     uint32_t TRAS:4;                    /**< bit: 24..27  Active to Precharge Delay                */
-    uint32_t TXSR:4;                    /**< bit: 28..31  Exit Self Refresh to Active Delay        */
+    uint32_t TXSR:4;                    /**< bit: 28..31  Exit Self-Refresh to Active Delay        */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_CR_OFFSET                    (0x08)                                        /**<  (SDRAMC_CR) SDRAMC Configuration Register  Offset */
@@ -173,8 +181,8 @@ typedef union {
 #define SDRAMC_CR_TRAS_Pos                  24                                             /**< (SDRAMC_CR) Active to Precharge Delay Position */
 #define SDRAMC_CR_TRAS_Msk                  (_U_(0xF) << SDRAMC_CR_TRAS_Pos)               /**< (SDRAMC_CR) Active to Precharge Delay Mask */
 #define SDRAMC_CR_TRAS(value)               (SDRAMC_CR_TRAS_Msk & ((value) << SDRAMC_CR_TRAS_Pos))
-#define SDRAMC_CR_TXSR_Pos                  28                                             /**< (SDRAMC_CR) Exit Self Refresh to Active Delay Position */
-#define SDRAMC_CR_TXSR_Msk                  (_U_(0xF) << SDRAMC_CR_TXSR_Pos)               /**< (SDRAMC_CR) Exit Self Refresh to Active Delay Mask */
+#define SDRAMC_CR_TXSR_Pos                  28                                             /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Position */
+#define SDRAMC_CR_TXSR_Msk                  (_U_(0xF) << SDRAMC_CR_TXSR_Pos)               /**< (SDRAMC_CR) Exit Self-Refresh to Active Delay Mask */
 #define SDRAMC_CR_TXSR(value)               (SDRAMC_CR_TXSR_Msk & ((value) << SDRAMC_CR_TXSR_Pos))
 #define SDRAMC_CR_MASK                      _U_(0xFFFFFFFF)                                /**< \deprecated (SDRAMC_CR) Register MASK  (Use SDRAMC_CR_Msk instead)  */
 #define SDRAMC_CR_Msk                       _U_(0xFFFFFFFF)                                /**< (SDRAMC_CR) Register Mask  */
@@ -182,6 +190,7 @@ typedef union {
 
 /* -------- SDRAMC_LPR : (SDRAMC Offset: 0x10) (R/W 32) SDRAMC Low Power Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LPCB:2;                    /**< bit:   0..1  Low-power Configuration Bits             */
@@ -195,6 +204,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_LPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_LPR_OFFSET                   (0x10)                                        /**<  (SDRAMC_LPR) SDRAMC Low Power Register  Offset */
@@ -202,13 +212,13 @@ typedef union {
 #define SDRAMC_LPR_LPCB_Pos                 0                                              /**< (SDRAMC_LPR) Low-power Configuration Bits Position */
 #define SDRAMC_LPR_LPCB_Msk                 (_U_(0x3) << SDRAMC_LPR_LPCB_Pos)              /**< (SDRAMC_LPR) Low-power Configuration Bits Mask */
 #define SDRAMC_LPR_LPCB(value)              (SDRAMC_LPR_LPCB_Msk & ((value) << SDRAMC_LPR_LPCB_Pos))
-#define   SDRAMC_LPR_LPCB_DISABLED_Val      _U_(0x0)                                       /**< (SDRAMC_LPR) Low Power Feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device.  */
-#define   SDRAMC_LPR_LPCB_SELF_REFRESH_Val  _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self Refresh Mode when accessed and enters it after the access.  */
-#define   SDRAMC_LPR_LPCB_POWER_DOWN_Val    _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down Mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_DISABLED_Val      _U_(0x0)                                       /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device.  */
+#define   SDRAMC_LPR_LPCB_SELF_REFRESH_Val  _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access.  */
+#define   SDRAMC_LPR_LPCB_POWER_DOWN_Val    _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access.  */
 #define   SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val _U_(0x3)                                       /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM.  */
-#define SDRAMC_LPR_LPCB_DISABLED            (SDRAMC_LPR_LPCB_DISABLED_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) Low Power Feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device. Position  */
-#define SDRAMC_LPR_LPCB_SELF_REFRESH        (SDRAMC_LPR_LPCB_SELF_REFRESH_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self Refresh Mode when accessed and enters it after the access. Position  */
-#define SDRAMC_LPR_LPCB_POWER_DOWN          (SDRAMC_LPR_LPCB_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down Mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_DISABLED            (SDRAMC_LPR_LPCB_DISABLED_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The low-power feature is inhibited: no Power-down, Self-refresh or Deep Power-down command is issued to the SDRAM device. Position  */
+#define SDRAMC_LPR_LPCB_SELF_REFRESH        (SDRAMC_LPR_LPCB_SELF_REFRESH_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Self-refresh command to the SDRAM device, the SDCK clock is deactivated and the SDCKE signal is set low. The SDRAM device leaves the Self-refresh mode when accessed and enters it after the access. Position  */
+#define SDRAMC_LPR_LPCB_POWER_DOWN          (SDRAMC_LPR_LPCB_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Power-down Command to the SDRAM device after each access, the SDCKE signal is set to low. The SDRAM device leaves the Power-down mode when accessed and enters it after the access. Position  */
 #define SDRAMC_LPR_LPCB_DEEP_POWER_DOWN     (SDRAMC_LPR_LPCB_DEEP_POWER_DOWN_Val << SDRAMC_LPR_LPCB_Pos)  /**< (SDRAMC_LPR) The SDRAMC issues a Deep Power-down command to the SDRAM device. This mode is unique to low-power SDRAM. Position  */
 #define SDRAMC_LPR_PASR_Pos                 4                                              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Position */
 #define SDRAMC_LPR_PASR_Msk                 (_U_(0x7) << SDRAMC_LPR_PASR_Pos)              /**< (SDRAMC_LPR) Partial Array Self-refresh (only for low-power SDRAM) Mask */
@@ -222,31 +232,33 @@ typedef union {
 #define SDRAMC_LPR_TIMEOUT_Pos              12                                             /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Position */
 #define SDRAMC_LPR_TIMEOUT_Msk              (_U_(0x3) << SDRAMC_LPR_TIMEOUT_Pos)           /**< (SDRAMC_LPR) Time to Define When Low-power Mode Is Enabled Mask */
 #define SDRAMC_LPR_TIMEOUT(value)           (SDRAMC_LPR_TIMEOUT_Msk & ((value) << SDRAMC_LPR_TIMEOUT_Pos))
-#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val _U_(0x0)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode immediately after the end of the last transfer.  */
-#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode 64 clock cycles after the end of the last transfer.  */
-#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode 128 clock cycles after the end of the last transfer.  */
-#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER     (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode immediately after the end of the last transfer. Position  */
-#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64  (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode 64 clock cycles after the end of the last transfer. Position  */
-#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128 (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM low-power mode 128 clock cycles after the end of the last transfer. Position  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val _U_(0x0)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val _U_(0x1)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer.  */
+#define   SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val _U_(0x2)                                       /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer.  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER     (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode immediately after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64  (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_64_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 64 clock cycles after the end of the last transfer. Position  */
+#define SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128 (SDRAMC_LPR_TIMEOUT_LP_LAST_XFER_128_Val << SDRAMC_LPR_TIMEOUT_Pos)  /**< (SDRAMC_LPR) The SDRAMC activates the SDRAM Low-power mode 128 clock cycles after the end of the last transfer. Position  */
 #define SDRAMC_LPR_MASK                     _U_(0x3F73)                                    /**< \deprecated (SDRAMC_LPR) Register MASK  (Use SDRAMC_LPR_Msk instead)  */
 #define SDRAMC_LPR_Msk                      _U_(0x3F73)                                    /**< (SDRAMC_LPR) Register Mask  */
 
 
 /* -------- SDRAMC_IER : (SDRAMC Offset: 0x14) (/W 32) SDRAMC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Enable           */
     uint32_t :31;                       /**< bit:  1..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IER_OFFSET                   (0x14)                                        /**<  (SDRAMC_IER) SDRAMC Interrupt Enable Register  Offset */
 
-#define SDRAMC_IER_RES_Pos                  0                                              /**< (SDRAMC_IER) Refresh Error Status Position */
-#define SDRAMC_IER_RES_Msk                  (_U_(0x1) << SDRAMC_IER_RES_Pos)               /**< (SDRAMC_IER) Refresh Error Status Mask */
+#define SDRAMC_IER_RES_Pos                  0                                              /**< (SDRAMC_IER) Refresh Error Interrupt Enable Position */
+#define SDRAMC_IER_RES_Msk                  (_U_(0x1) << SDRAMC_IER_RES_Pos)               /**< (SDRAMC_IER) Refresh Error Interrupt Enable Mask */
 #define SDRAMC_IER_RES                      SDRAMC_IER_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IER_RES_Msk instead */
 #define SDRAMC_IER_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IER) Register MASK  (Use SDRAMC_IER_Msk instead)  */
 #define SDRAMC_IER_Msk                      _U_(0x01)                                      /**< (SDRAMC_IER) Register Mask  */
@@ -254,19 +266,21 @@ typedef union {
 
 /* -------- SDRAMC_IDR : (SDRAMC Offset: 0x18) (/W 32) SDRAMC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Disable          */
     uint32_t :31;                       /**< bit:  1..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IDR_OFFSET                   (0x18)                                        /**<  (SDRAMC_IDR) SDRAMC Interrupt Disable Register  Offset */
 
-#define SDRAMC_IDR_RES_Pos                  0                                              /**< (SDRAMC_IDR) Refresh Error Status Position */
-#define SDRAMC_IDR_RES_Msk                  (_U_(0x1) << SDRAMC_IDR_RES_Pos)               /**< (SDRAMC_IDR) Refresh Error Status Mask */
+#define SDRAMC_IDR_RES_Pos                  0                                              /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Position */
+#define SDRAMC_IDR_RES_Msk                  (_U_(0x1) << SDRAMC_IDR_RES_Pos)               /**< (SDRAMC_IDR) Refresh Error Interrupt Disable Mask */
 #define SDRAMC_IDR_RES                      SDRAMC_IDR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IDR_RES_Msk instead */
 #define SDRAMC_IDR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IDR) Register MASK  (Use SDRAMC_IDR_Msk instead)  */
 #define SDRAMC_IDR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IDR) Register Mask  */
@@ -274,19 +288,21 @@ typedef union {
 
 /* -------- SDRAMC_IMR : (SDRAMC Offset: 0x1c) (R/ 32) SDRAMC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t RES:1;                     /**< bit:      0  Refresh Error Status                     */
+    uint32_t RES:1;                     /**< bit:      0  Refresh Error Interrupt Mask             */
     uint32_t :31;                       /**< bit:  1..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_IMR_OFFSET                   (0x1C)                                        /**<  (SDRAMC_IMR) SDRAMC Interrupt Mask Register  Offset */
 
-#define SDRAMC_IMR_RES_Pos                  0                                              /**< (SDRAMC_IMR) Refresh Error Status Position */
-#define SDRAMC_IMR_RES_Msk                  (_U_(0x1) << SDRAMC_IMR_RES_Pos)               /**< (SDRAMC_IMR) Refresh Error Status Mask */
+#define SDRAMC_IMR_RES_Pos                  0                                              /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Position */
+#define SDRAMC_IMR_RES_Msk                  (_U_(0x1) << SDRAMC_IMR_RES_Pos)               /**< (SDRAMC_IMR) Refresh Error Interrupt Mask Mask */
 #define SDRAMC_IMR_RES                      SDRAMC_IMR_RES_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SDRAMC_IMR_RES_Msk instead */
 #define SDRAMC_IMR_MASK                     _U_(0x01)                                      /**< \deprecated (SDRAMC_IMR) Register MASK  (Use SDRAMC_IMR_Msk instead)  */
 #define SDRAMC_IMR_Msk                      _U_(0x01)                                      /**< (SDRAMC_IMR) Register Mask  */
@@ -294,6 +310,7 @@ typedef union {
 
 /* -------- SDRAMC_ISR : (SDRAMC Offset: 0x20) (R/ 32) SDRAMC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES:1;                     /**< bit:      0  Refresh Error Status (cleared on read)   */
@@ -301,6 +318,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_ISR_OFFSET                   (0x20)                                        /**<  (SDRAMC_ISR) SDRAMC Interrupt Status Register  Offset */
@@ -314,6 +332,7 @@ typedef union {
 
 /* -------- SDRAMC_MDR : (SDRAMC Offset: 0x24) (R/W 32) SDRAMC Memory Device Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MD:2;                      /**< bit:   0..1  Memory Device Type                       */
@@ -321,6 +340,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_MDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_MDR_OFFSET                   (0x24)                                        /**<  (SDRAMC_MDR) SDRAMC Memory Device Register  Offset */
@@ -338,6 +358,7 @@ typedef union {
 
 /* -------- SDRAMC_CFR1 : (SDRAMC Offset: 0x28) (R/W 32) SDRAMC Configuration Register 1 -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TMRD:4;                    /**< bit:   0..3  Load Mode Register Command to Active or Refresh Command */
@@ -347,6 +368,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_CFR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_CFR1_OFFSET                  (0x28)                                        /**<  (SDRAMC_CFR1) SDRAMC Configuration Register 1  Offset */
@@ -367,6 +389,7 @@ typedef union {
 
 /* -------- SDRAMC_OCMS : (SDRAMC Offset: 0x2c) (R/W 32) SDRAMC OCMS Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDR_SE:1;                  /**< bit:      0  SDRAM Memory Controller Scrambling Enable */
@@ -374,6 +397,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_OFFSET                  (0x2C)                                        /**<  (SDRAMC_OCMS) SDRAMC OCMS Register  Offset */
@@ -387,12 +411,14 @@ typedef union {
 
 /* -------- SDRAMC_OCMS_KEY1 : (SDRAMC Offset: 0x30) (/W 32) SDRAMC OCMS KEY1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY1:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 1 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_KEY1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_KEY1_OFFSET             (0x30)                                        /**<  (SDRAMC_OCMS_KEY1) SDRAMC OCMS KEY1 Register  Offset */
@@ -406,12 +432,14 @@ typedef union {
 
 /* -------- SDRAMC_OCMS_KEY2 : (SDRAMC Offset: 0x34) (/W 32) SDRAMC OCMS KEY2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t KEY2:32;                   /**< bit:  0..31  Off-chip Memory Scrambling (OCMS) Key Part 2 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SDRAMC_OCMS_KEY2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SDRAMC_OCMS_KEY2_OFFSET             (0x34)                                        /**<  (SDRAMC_OCMS_KEY2) SDRAMC OCMS KEY2 Register  Offset */
@@ -430,7 +458,7 @@ typedef struct {
   __IO uint32_t SDRAMC_MR;      /**< (SDRAMC Offset: 0x00) SDRAMC Mode Register */
   __IO uint32_t SDRAMC_TR;      /**< (SDRAMC Offset: 0x04) SDRAMC Refresh Timer Register */
   __IO uint32_t SDRAMC_CR;      /**< (SDRAMC Offset: 0x08) SDRAMC Configuration Register */
-  RoReg8  Reserved1[0x4];
+  __I  uint8_t                        Reserved1[4];
   __IO uint32_t SDRAMC_LPR;     /**< (SDRAMC Offset: 0x10) SDRAMC Low Power Register */
   __O  uint32_t SDRAMC_IER;     /**< (SDRAMC Offset: 0x14) SDRAMC Interrupt Enable Register */
   __O  uint32_t SDRAMC_IDR;     /**< (SDRAMC Offset: 0x18) SDRAMC Interrupt Disable Register */
@@ -449,7 +477,7 @@ typedef struct {
   __IO SDRAMC_MR_Type                 SDRAMC_MR;      /**< Offset: 0x00 (R/W  32) SDRAMC Mode Register */
   __IO SDRAMC_TR_Type                 SDRAMC_TR;      /**< Offset: 0x04 (R/W  32) SDRAMC Refresh Timer Register */
   __IO SDRAMC_CR_Type                 SDRAMC_CR;      /**< Offset: 0x08 (R/W  32) SDRAMC Configuration Register */
-  __I  uint32_t                       Reserved1[1];
+  __I  uint8_t                        Reserved1[4];
   __IO SDRAMC_LPR_Type                SDRAMC_LPR;     /**< Offset: 0x10 (R/W  32) SDRAMC Low Power Register */
   __O  SDRAMC_IER_Type                SDRAMC_IER;     /**< Offset: 0x14 ( /W  32) SDRAMC Interrupt Enable Register */
   __O  SDRAMC_IDR_Type                SDRAMC_IDR;     /**< Offset: 0x18 ( /W  32) SDRAMC Interrupt Disable Register */

--- a/asf/sam/include/same70b/component/smc.h
+++ b/asf/sam/include/same70b/component/smc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SMC_COMPONENT_H_
 #define _SAME70_SMC_COMPONENT_H_
 #define _SAME70_SMC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define SMC_6498                       /**< (SMC) Module ID */
-#define REV_SMC H                      /**< (SMC) Module revision */
+#define REV_SMC J                      /**< (SMC) Module revision */
 
-/* -------- SMC_SETUP : (SMC Offset: 0x00) (R/W 32) SMC Setup Register (CS_number = 0) -------- */
+/* -------- SMC_SETUP : (SMC Offset: 0x00) (R/W 32) SMC Setup Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_SETUP:6;               /**< bit:   0..5  NWE Setup Length                         */
@@ -58,9 +61,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_SETUP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_SETUP_OFFSET                    (0x00)                                        /**<  (SMC_SETUP) SMC Setup Register (CS_number = 0)  Offset */
+#define SMC_SETUP_OFFSET                    (0x00)                                        /**<  (SMC_SETUP) SMC Setup Register  Offset */
 
 #define SMC_SETUP_NWE_SETUP_Pos             0                                              /**< (SMC_SETUP) NWE Setup Length Position */
 #define SMC_SETUP_NWE_SETUP_Msk             (_U_(0x3F) << SMC_SETUP_NWE_SETUP_Pos)         /**< (SMC_SETUP) NWE Setup Length Mask */
@@ -78,8 +82,9 @@ typedef union {
 #define SMC_SETUP_Msk                       _U_(0x3F3F3F3F)                                /**< (SMC_SETUP) Register Mask  */
 
 
-/* -------- SMC_PULSE : (SMC Offset: 0x04) (R/W 32) SMC Pulse Register (CS_number = 0) -------- */
+/* -------- SMC_PULSE : (SMC Offset: 0x04) (R/W 32) SMC Pulse Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_PULSE:7;               /**< bit:   0..6  NWE Pulse Length                         */
@@ -93,9 +98,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_PULSE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_PULSE_OFFSET                    (0x04)                                        /**<  (SMC_PULSE) SMC Pulse Register (CS_number = 0)  Offset */
+#define SMC_PULSE_OFFSET                    (0x04)                                        /**<  (SMC_PULSE) SMC Pulse Register  Offset */
 
 #define SMC_PULSE_NWE_PULSE_Pos             0                                              /**< (SMC_PULSE) NWE Pulse Length Position */
 #define SMC_PULSE_NWE_PULSE_Msk             (_U_(0x7F) << SMC_PULSE_NWE_PULSE_Pos)         /**< (SMC_PULSE) NWE Pulse Length Mask */
@@ -113,8 +119,9 @@ typedef union {
 #define SMC_PULSE_Msk                       _U_(0x7F7F7F7F)                                /**< (SMC_PULSE) Register Mask  */
 
 
-/* -------- SMC_CYCLE : (SMC Offset: 0x08) (R/W 32) SMC Cycle Register (CS_number = 0) -------- */
+/* -------- SMC_CYCLE : (SMC Offset: 0x08) (R/W 32) SMC Cycle Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NWE_CYCLE:9;               /**< bit:   0..8  Total Write Cycle Length                 */
@@ -124,9 +131,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_CYCLE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_CYCLE_OFFSET                    (0x08)                                        /**<  (SMC_CYCLE) SMC Cycle Register (CS_number = 0)  Offset */
+#define SMC_CYCLE_OFFSET                    (0x08)                                        /**<  (SMC_CYCLE) SMC Cycle Register  Offset */
 
 #define SMC_CYCLE_NWE_CYCLE_Pos             0                                              /**< (SMC_CYCLE) Total Write Cycle Length Position */
 #define SMC_CYCLE_NWE_CYCLE_Msk             (_U_(0x1FF) << SMC_CYCLE_NWE_CYCLE_Pos)        /**< (SMC_CYCLE) Total Write Cycle Length Mask */
@@ -138,8 +146,9 @@ typedef union {
 #define SMC_CYCLE_Msk                       _U_(0x1FF01FF)                                 /**< (SMC_CYCLE) Register Mask  */
 
 
-/* -------- SMC_MODE : (SMC Offset: 0x0c) (R/W 32) SMC MODE Register (CS_number = 0) -------- */
+/* -------- SMC_MODE : (SMC Offset: 0x0c) (R/W 32) SMC Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t READ_MODE:1;               /**< bit:      0  Read Mode                                */
@@ -161,9 +170,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_MODE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_MODE_OFFSET                     (0x0C)                                        /**<  (SMC_MODE) SMC MODE Register (CS_number = 0)  Offset */
+#define SMC_MODE_OFFSET                     (0x0C)                                        /**<  (SMC_MODE) SMC Mode Register  Offset */
 
 #define SMC_MODE_READ_MODE_Pos              0                                              /**< (SMC_MODE) Read Mode Position */
 #define SMC_MODE_READ_MODE_Msk              (_U_(0x1) << SMC_MODE_READ_MODE_Pos)           /**< (SMC_MODE) Read Mode Mask */
@@ -174,12 +184,12 @@ typedef union {
 #define SMC_MODE_EXNW_MODE_Pos              4                                              /**< (SMC_MODE) NWAIT Mode Position */
 #define SMC_MODE_EXNW_MODE_Msk              (_U_(0x3) << SMC_MODE_EXNW_MODE_Pos)           /**< (SMC_MODE) NWAIT Mode Mask */
 #define SMC_MODE_EXNW_MODE(value)           (SMC_MODE_EXNW_MODE_Msk & ((value) << SMC_MODE_EXNW_MODE_Pos))
-#define   SMC_MODE_EXNW_MODE_DISABLED_Val   _U_(0x0)                                       /**< (SMC_MODE) Disabled  */
-#define   SMC_MODE_EXNW_MODE_FROZEN_Val     _U_(0x2)                                       /**< (SMC_MODE) Frozen Mode  */
-#define   SMC_MODE_EXNW_MODE_READY_Val      _U_(0x3)                                       /**< (SMC_MODE) Ready Mode  */
-#define SMC_MODE_EXNW_MODE_DISABLED         (SMC_MODE_EXNW_MODE_DISABLED_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Disabled Position  */
-#define SMC_MODE_EXNW_MODE_FROZEN           (SMC_MODE_EXNW_MODE_FROZEN_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Frozen Mode Position  */
-#define SMC_MODE_EXNW_MODE_READY            (SMC_MODE_EXNW_MODE_READY_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Ready Mode Position  */
+#define   SMC_MODE_EXNW_MODE_DISABLED_Val   _U_(0x0)                                       /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select.  */
+#define   SMC_MODE_EXNW_MODE_FROZEN_Val     _U_(0x2)                                       /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped.  */
+#define   SMC_MODE_EXNW_MODE_READY_Val      _U_(0x3)                                       /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high.  */
+#define SMC_MODE_EXNW_MODE_DISABLED         (SMC_MODE_EXNW_MODE_DISABLED_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Disabled-The NWAIT input signal is ignored on the corresponding chip select. Position  */
+#define SMC_MODE_EXNW_MODE_FROZEN           (SMC_MODE_EXNW_MODE_FROZEN_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Frozen Mode-If asserted, the NWAIT signal freezes the current read or write cycle. After deassertion, the read/write cycle is resumed from the point where it was stopped. Position  */
+#define SMC_MODE_EXNW_MODE_READY            (SMC_MODE_EXNW_MODE_READY_Val << SMC_MODE_EXNW_MODE_Pos)  /**< (SMC_MODE) Ready Mode-The NWAIT signal indicates the availability of the external device at the end of the pulse of the controlling read or write signal, to complete the access. If high, the access normally completes. If low, the access is extended until NWAIT returns high. Position  */
 #define SMC_MODE_BAT_Pos                    8                                              /**< (SMC_MODE) Byte Access Type Position */
 #define SMC_MODE_BAT_Msk                    (_U_(0x1) << SMC_MODE_BAT_Pos)                 /**< (SMC_MODE) Byte Access Type Mask */
 #define SMC_MODE_BAT                        SMC_MODE_BAT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_MODE_BAT_Msk instead */
@@ -218,76 +228,82 @@ typedef union {
 #define SMC_MODE_Msk                        _U_(0x311F1133)                                /**< (SMC_MODE) Register Mask  */
 
 
-/* -------- SMC_OCMS : (SMC Offset: 0x80) (R/W 32) SMC OCMS MODE Register -------- */
+/* -------- SMC_OCMS : (SMC Offset: 0x80) (R/W 32) SMC Off-Chip Memory Scrambling Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMSE:1;                    /**< bit:      0  Static Memory Controller Scrambling Enable */
     uint32_t :7;                        /**< bit:   1..7  Reserved */
-    uint32_t CS0SE:1;                   /**< bit:      8  Chip Select 0 Scrambling Enable          */
-    uint32_t CS1SE:1;                   /**< bit:      9  Chip Select 1 Scrambling Enable          */
-    uint32_t CS2SE:1;                   /**< bit:     10  Chip Select 2 Scrambling Enable          */
-    uint32_t CS3SE:1;                   /**< bit:     11  Chip Select 3 Scrambling Enable          */
+    uint32_t CS0SE:1;                   /**< bit:      8  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS1SE:1;                   /**< bit:      9  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS2SE:1;                   /**< bit:     10  Chip Select (x = 0 to 3) Scrambling Enable */
+    uint32_t CS3SE:1;                   /**< bit:     11  Chip Select (x = 0 to 3) Scrambling Enable */
     uint32_t :20;                       /**< bit: 12..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_OCMS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_OCMS_OFFSET                     (0x80)                                        /**<  (SMC_OCMS) SMC OCMS MODE Register  Offset */
+#define SMC_OCMS_OFFSET                     (0x80)                                        /**<  (SMC_OCMS) SMC Off-Chip Memory Scrambling Register  Offset */
 
 #define SMC_OCMS_SMSE_Pos                   0                                              /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Position */
 #define SMC_OCMS_SMSE_Msk                   (_U_(0x1) << SMC_OCMS_SMSE_Pos)                /**< (SMC_OCMS) Static Memory Controller Scrambling Enable Mask */
 #define SMC_OCMS_SMSE                       SMC_OCMS_SMSE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_SMSE_Msk instead */
-#define SMC_OCMS_CS0SE_Pos                  8                                              /**< (SMC_OCMS) Chip Select 0 Scrambling Enable Position */
-#define SMC_OCMS_CS0SE_Msk                  (_U_(0x1) << SMC_OCMS_CS0SE_Pos)               /**< (SMC_OCMS) Chip Select 0 Scrambling Enable Mask */
+#define SMC_OCMS_CS0SE_Pos                  8                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS0SE_Msk                  (_U_(0x1) << SMC_OCMS_CS0SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
 #define SMC_OCMS_CS0SE                      SMC_OCMS_CS0SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS0SE_Msk instead */
-#define SMC_OCMS_CS1SE_Pos                  9                                              /**< (SMC_OCMS) Chip Select 1 Scrambling Enable Position */
-#define SMC_OCMS_CS1SE_Msk                  (_U_(0x1) << SMC_OCMS_CS1SE_Pos)               /**< (SMC_OCMS) Chip Select 1 Scrambling Enable Mask */
+#define SMC_OCMS_CS1SE_Pos                  9                                              /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS1SE_Msk                  (_U_(0x1) << SMC_OCMS_CS1SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
 #define SMC_OCMS_CS1SE                      SMC_OCMS_CS1SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS1SE_Msk instead */
-#define SMC_OCMS_CS2SE_Pos                  10                                             /**< (SMC_OCMS) Chip Select 2 Scrambling Enable Position */
-#define SMC_OCMS_CS2SE_Msk                  (_U_(0x1) << SMC_OCMS_CS2SE_Pos)               /**< (SMC_OCMS) Chip Select 2 Scrambling Enable Mask */
+#define SMC_OCMS_CS2SE_Pos                  10                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS2SE_Msk                  (_U_(0x1) << SMC_OCMS_CS2SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
 #define SMC_OCMS_CS2SE                      SMC_OCMS_CS2SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS2SE_Msk instead */
-#define SMC_OCMS_CS3SE_Pos                  11                                             /**< (SMC_OCMS) Chip Select 3 Scrambling Enable Position */
-#define SMC_OCMS_CS3SE_Msk                  (_U_(0x1) << SMC_OCMS_CS3SE_Pos)               /**< (SMC_OCMS) Chip Select 3 Scrambling Enable Mask */
+#define SMC_OCMS_CS3SE_Pos                  11                                             /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Position */
+#define SMC_OCMS_CS3SE_Msk                  (_U_(0x1) << SMC_OCMS_CS3SE_Pos)               /**< (SMC_OCMS) Chip Select (x = 0 to 3) Scrambling Enable Mask */
 #define SMC_OCMS_CS3SE                      SMC_OCMS_CS3SE_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SMC_OCMS_CS3SE_Msk instead */
 #define SMC_OCMS_MASK                       _U_(0xF01)                                     /**< \deprecated (SMC_OCMS) Register MASK  (Use SMC_OCMS_Msk instead)  */
 #define SMC_OCMS_Msk                        _U_(0xF01)                                     /**< (SMC_OCMS) Register Mask  */
 
 
-/* -------- SMC_KEY1 : (SMC Offset: 0x84) (/W 32) SMC OCMS KEY1 Register -------- */
+/* -------- SMC_KEY1 : (SMC Offset: 0x84) (/W 32) SMC Off-Chip Memory Scrambling KEY1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t KEY1:32;                   /**< bit:  0..31  Off Chip Memory Scrambling (OCMS) Key Part 1 */
+    uint32_t KEY1:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 1 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_KEY1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_KEY1_OFFSET                     (0x84)                                        /**<  (SMC_KEY1) SMC OCMS KEY1 Register  Offset */
+#define SMC_KEY1_OFFSET                     (0x84)                                        /**<  (SMC_KEY1) SMC Off-Chip Memory Scrambling KEY1 Register  Offset */
 
-#define SMC_KEY1_KEY1_Pos                   0                                              /**< (SMC_KEY1) Off Chip Memory Scrambling (OCMS) Key Part 1 Position */
-#define SMC_KEY1_KEY1_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY1_KEY1_Pos)         /**< (SMC_KEY1) Off Chip Memory Scrambling (OCMS) Key Part 1 Mask */
+#define SMC_KEY1_KEY1_Pos                   0                                              /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Position */
+#define SMC_KEY1_KEY1_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY1_KEY1_Pos)         /**< (SMC_KEY1) Off-Chip Memory Scrambling (OCMS) Key Part 1 Mask */
 #define SMC_KEY1_KEY1(value)                (SMC_KEY1_KEY1_Msk & ((value) << SMC_KEY1_KEY1_Pos))
 #define SMC_KEY1_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY1) Register MASK  (Use SMC_KEY1_Msk instead)  */
 #define SMC_KEY1_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY1) Register Mask  */
 
 
-/* -------- SMC_KEY2 : (SMC Offset: 0x88) (/W 32) SMC OCMS KEY2 Register -------- */
+/* -------- SMC_KEY2 : (SMC Offset: 0x88) (/W 32) SMC Off-Chip Memory Scrambling KEY2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t KEY2:32;                   /**< bit:  0..31  Off Chip Memory Scrambling (OCMS) Key Part 2 */
+    uint32_t KEY2:32;                   /**< bit:  0..31  Off-Chip Memory Scrambling (OCMS) Key Part 2 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_KEY2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SMC_KEY2_OFFSET                     (0x88)                                        /**<  (SMC_KEY2) SMC OCMS KEY2 Register  Offset */
+#define SMC_KEY2_OFFSET                     (0x88)                                        /**<  (SMC_KEY2) SMC Off-Chip Memory Scrambling KEY2 Register  Offset */
 
-#define SMC_KEY2_KEY2_Pos                   0                                              /**< (SMC_KEY2) Off Chip Memory Scrambling (OCMS) Key Part 2 Position */
-#define SMC_KEY2_KEY2_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY2_KEY2_Pos)         /**< (SMC_KEY2) Off Chip Memory Scrambling (OCMS) Key Part 2 Mask */
+#define SMC_KEY2_KEY2_Pos                   0                                              /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Position */
+#define SMC_KEY2_KEY2_Msk                   (_U_(0xFFFFFFFF) << SMC_KEY2_KEY2_Pos)         /**< (SMC_KEY2) Off-Chip Memory Scrambling (OCMS) Key Part 2 Mask */
 #define SMC_KEY2_KEY2(value)                (SMC_KEY2_KEY2_Msk & ((value) << SMC_KEY2_KEY2_Pos))
 #define SMC_KEY2_MASK                       _U_(0xFFFFFFFF)                                /**< \deprecated (SMC_KEY2) Register MASK  (Use SMC_KEY2_Msk instead)  */
 #define SMC_KEY2_Msk                        _U_(0xFFFFFFFF)                                /**< (SMC_KEY2) Register Mask  */
@@ -295,6 +311,7 @@ typedef union {
 
 /* -------- SMC_WPMR : (SMC Offset: 0xe4) (R/W 32) SMC Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protect Enable                     */
@@ -303,6 +320,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_WPMR_OFFSET                     (0xE4)                                        /**<  (SMC_WPMR) SMC Write Protection Mode Register  Offset */
@@ -321,6 +339,7 @@ typedef union {
 
 /* -------- SMC_WPSR : (SMC Offset: 0xe8) (R/ 32) SMC Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -330,6 +349,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SMC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SMC_WPSR_OFFSET                     (0xE8)                                        /**<  (SMC_WPSR) SMC Write Protection Status Register  Offset */
@@ -348,21 +368,21 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief SMC_CS_NUMBER hardware registers */
 typedef struct {  
-  __IO uint32_t SMC_SETUP;      /**< (SMC_CS_NUMBER Offset: 0x00) SMC Setup Register (CS_number = 0) */
-  __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register (CS_number = 0) */
-  __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register (CS_number = 0) */
-  __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC MODE Register (CS_number = 0) */
+  __IO uint32_t SMC_SETUP;      /**< (SMC_CS_NUMBER Offset: 0x00) SMC Setup Register */
+  __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register */
+  __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register */
+  __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register */
 } SmcCsNumber;
 
 #define SMCCSNUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
-  RoReg8  Reserved1[0x40];
-  __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC OCMS MODE Register */
-  __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC OCMS KEY1 Register */
-  __O  uint32_t SMC_KEY2;       /**< (SMC Offset: 0x88) SMC OCMS KEY2 Register */
-  RoReg8  Reserved2[0x58];
+       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
+  __I  uint8_t                        Reserved1[64];
+  __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
+  __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  uint32_t SMC_KEY2;       /**< (SMC Offset: 0x88) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
   __IO uint32_t SMC_WPMR;       /**< (SMC Offset: 0xE4) SMC Write Protection Mode Register */
   __I  uint32_t SMC_WPSR;       /**< (SMC Offset: 0xE8) SMC Write Protection Status Register */
 } Smc;
@@ -370,20 +390,20 @@ typedef struct {
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief SMC_CS_NUMBER hardware registers */
 typedef struct {  
-  __IO SMC_SETUP_Type                 SMC_SETUP;      /**< Offset: 0x00 (R/W  32) SMC Setup Register (CS_number = 0) */
-  __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register (CS_number = 0) */
-  __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register (CS_number = 0) */
-  __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC MODE Register (CS_number = 0) */
+  __IO SMC_SETUP_Type                 SMC_SETUP;      /**< Offset: 0x00 (R/W  32) SMC Setup Register */
+  __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register */
+  __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register */
+  __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register */
 } SmcCsNumber;
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
-  __I  uint32_t                       Reserved1[16];
-  __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC OCMS MODE Register */
-  __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC OCMS KEY1 Register */
-  __O  SMC_KEY2_Type                  SMC_KEY2;       /**< Offset: 0x88 ( /W  32) SMC OCMS KEY2 Register */
-  __I  uint32_t                       Reserved2[22];
+       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register */
+  __I  uint8_t                        Reserved1[64];
+  __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
+  __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */
+  __O  SMC_KEY2_Type                  SMC_KEY2;       /**< Offset: 0x88 ( /W  32) SMC Off-Chip Memory Scrambling KEY2 Register */
+  __I  uint8_t                        Reserved2[88];
   __IO SMC_WPMR_Type                  SMC_WPMR;       /**< Offset: 0xE4 (R/W  32) SMC Write Protection Mode Register */
   __I  SMC_WPSR_Type                  SMC_WPSR;       /**< Offset: 0xE8 (R/   32) SMC Write Protection Status Register */
 } Smc;

--- a/asf/sam/include/same70b/component/smc.h
+++ b/asf/sam/include/same70b/component/smc.h
@@ -377,7 +377,7 @@ typedef struct {
 #define SMCCSNUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
@@ -398,7 +398,7 @@ typedef struct {
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */

--- a/asf/sam/include/same70b/component/spi.h
+++ b/asf/sam/include/same70b/component/spi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SPI_COMPONENT_H_
 #define _SAME70_SPI_COMPONENT_H_
 #define _SAME70_SPI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- SPI_CR : (SPI Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SPIEN:1;                   /**< bit:      0  SPI Enable                               */
@@ -59,6 +62,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_CR_OFFSET                       (0x00)                                        /**<  (SPI_CR) Control Register  Offset */
@@ -84,6 +88,7 @@ typedef union {
 
 /* -------- SPI_MR : (SPI Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MSTR:1;                    /**< bit:      0  Master/Slave Mode                        */
@@ -101,6 +106,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_MR_OFFSET                       (0x04)                                        /**<  (SPI_MR) Mode Register  Offset */
@@ -108,6 +114,10 @@ typedef union {
 #define SPI_MR_MSTR_Pos                     0                                              /**< (SPI_MR) Master/Slave Mode Position */
 #define SPI_MR_MSTR_Msk                     (_U_(0x1) << SPI_MR_MSTR_Pos)                  /**< (SPI_MR) Master/Slave Mode Mask */
 #define SPI_MR_MSTR                         SPI_MR_MSTR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_MSTR_Msk instead */
+#define   SPI_MR_MSTR_MASTER_Val            _U_(0x1)                                       /**< (SPI_MR) Master  */
+#define   SPI_MR_MSTR_SLAVE_Val             _U_(0x0)                                       /**< (SPI_MR) Slave  */
+#define SPI_MR_MSTR_MASTER                  (SPI_MR_MSTR_MASTER_Val << SPI_MR_MSTR_Pos)    /**< (SPI_MR) Master Position  */
+#define SPI_MR_MSTR_SLAVE                   (SPI_MR_MSTR_SLAVE_Val << SPI_MR_MSTR_Pos)     /**< (SPI_MR) Slave Position  */
 #define SPI_MR_PS_Pos                       1                                              /**< (SPI_MR) Peripheral Select Position */
 #define SPI_MR_PS_Msk                       (_U_(0x1) << SPI_MR_PS_Pos)                    /**< (SPI_MR) Peripheral Select Mask */
 #define SPI_MR_PS                           SPI_MR_PS_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_MR_PS_Msk instead */
@@ -126,6 +136,14 @@ typedef union {
 #define SPI_MR_PCS_Pos                      16                                             /**< (SPI_MR) Peripheral Chip Select Position */
 #define SPI_MR_PCS_Msk                      (_U_(0xF) << SPI_MR_PCS_Pos)                   /**< (SPI_MR) Peripheral Chip Select Mask */
 #define SPI_MR_PCS(value)                   (SPI_MR_PCS_Msk & ((value) << SPI_MR_PCS_Pos))
+#define   SPI_MR_PCS_NPCS0_Val              _U_(0xE)                                       /**< (SPI_MR) NPCS0 as Chip Select  */
+#define   SPI_MR_PCS_NPCS1_Val              _U_(0xD)                                       /**< (SPI_MR) NPCS1 as Chip Select  */
+#define   SPI_MR_PCS_NPCS2_Val              _U_(0xB)                                       /**< (SPI_MR) NPCS2 as Chip Select  */
+#define   SPI_MR_PCS_NPCS3_Val              _U_(0x7)                                       /**< (SPI_MR) NPCS3 as Chip Select  */
+#define SPI_MR_PCS_NPCS0                    (SPI_MR_PCS_NPCS0_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS0 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS1                    (SPI_MR_PCS_NPCS1_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS1 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS2                    (SPI_MR_PCS_NPCS2_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS2 as Chip Select Position  */
+#define SPI_MR_PCS_NPCS3                    (SPI_MR_PCS_NPCS3_Val << SPI_MR_PCS_Pos)       /**< (SPI_MR) NPCS3 as Chip Select Position  */
 #define SPI_MR_DLYBCS_Pos                   24                                             /**< (SPI_MR) Delay Between Chip Selects Position */
 #define SPI_MR_DLYBCS_Msk                   (_U_(0xFF) << SPI_MR_DLYBCS_Pos)               /**< (SPI_MR) Delay Between Chip Selects Mask */
 #define SPI_MR_DLYBCS(value)                (SPI_MR_DLYBCS_Msk & ((value) << SPI_MR_DLYBCS_Pos))
@@ -135,6 +153,7 @@ typedef union {
 
 /* -------- SPI_RDR : (SPI Offset: 0x08) (R/ 32) Receive Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RD:16;                     /**< bit:  0..15  Receive Data                             */
@@ -143,6 +162,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_RDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_RDR_OFFSET                      (0x08)                                        /**<  (SPI_RDR) Receive Data Register  Offset */
@@ -159,6 +179,7 @@ typedef union {
 
 /* -------- SPI_TDR : (SPI Offset: 0x0c) (/W 32) Transmit Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TD:16;                     /**< bit:  0..15  Transmit Data                            */
@@ -169,6 +190,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_TDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_TDR_OFFSET                      (0x0C)                                        /**<  (SPI_TDR) Transmit Data Register  Offset */
@@ -179,6 +201,14 @@ typedef union {
 #define SPI_TDR_PCS_Pos                     16                                             /**< (SPI_TDR) Peripheral Chip Select Position */
 #define SPI_TDR_PCS_Msk                     (_U_(0xF) << SPI_TDR_PCS_Pos)                  /**< (SPI_TDR) Peripheral Chip Select Mask */
 #define SPI_TDR_PCS(value)                  (SPI_TDR_PCS_Msk & ((value) << SPI_TDR_PCS_Pos))
+#define   SPI_TDR_PCS_NPCS0_Val             _U_(0xE)                                       /**< (SPI_TDR) NPCS0 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS1_Val             _U_(0xD)                                       /**< (SPI_TDR) NPCS1 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS2_Val             _U_(0xB)                                       /**< (SPI_TDR) NPCS2 as Chip Select  */
+#define   SPI_TDR_PCS_NPCS3_Val             _U_(0x7)                                       /**< (SPI_TDR) NPCS3 as Chip Select  */
+#define SPI_TDR_PCS_NPCS0                   (SPI_TDR_PCS_NPCS0_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS0 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS1                   (SPI_TDR_PCS_NPCS1_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS1 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS2                   (SPI_TDR_PCS_NPCS2_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS2 as Chip Select Position  */
+#define SPI_TDR_PCS_NPCS3                   (SPI_TDR_PCS_NPCS3_Val << SPI_TDR_PCS_Pos)     /**< (SPI_TDR) NPCS3 as Chip Select Position  */
 #define SPI_TDR_LASTXFER_Pos                24                                             /**< (SPI_TDR) Last Transfer Position */
 #define SPI_TDR_LASTXFER_Msk                (_U_(0x1) << SPI_TDR_LASTXFER_Pos)             /**< (SPI_TDR) Last Transfer Mask */
 #define SPI_TDR_LASTXFER                    SPI_TDR_LASTXFER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_TDR_LASTXFER_Msk instead */
@@ -188,6 +218,7 @@ typedef union {
 
 /* -------- SPI_SR : (SPI Offset: 0x10) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full (cleared by reading SPI_RDR) */
@@ -204,6 +235,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_SR_OFFSET                       (0x10)                                        /**<  (SPI_SR) Status Register  Offset */
@@ -238,6 +270,7 @@ typedef union {
 
 /* -------- SPI_IER : (SPI Offset: 0x14) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Enable */
@@ -252,6 +285,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IER_OFFSET                      (0x14)                                        /**<  (SPI_IER) Interrupt Enable Register  Offset */
@@ -283,6 +317,7 @@ typedef union {
 
 /* -------- SPI_IDR : (SPI Offset: 0x18) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Disable */
@@ -297,6 +332,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IDR_OFFSET                      (0x18)                                        /**<  (SPI_IDR) Interrupt Disable Register  Offset */
@@ -328,6 +364,7 @@ typedef union {
 
 /* -------- SPI_IMR : (SPI Offset: 0x1c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDRF:1;                    /**< bit:      0  Receive Data Register Full Interrupt Mask */
@@ -342,6 +379,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_IMR_OFFSET                      (0x1C)                                        /**<  (SPI_IMR) Interrupt Mask Register  Offset */
@@ -371,8 +409,9 @@ typedef union {
 #define SPI_IMR_Msk                         _U_(0x70F)                                     /**< (SPI_IMR) Register Mask  */
 
 
-/* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register 0 -------- */
+/* -------- SPI_CSR : (SPI Offset: 0x30) (R/W 32) Chip Select Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CPOL:1;                    /**< bit:      0  Clock Polarity                           */
@@ -386,16 +425,25 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_CSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define SPI_CSR_OFFSET                      (0x30)                                        /**<  (SPI_CSR) Chip Select Register 0  Offset */
+#define SPI_CSR_OFFSET                      (0x30)                                        /**<  (SPI_CSR) Chip Select Register  Offset */
 
 #define SPI_CSR_CPOL_Pos                    0                                              /**< (SPI_CSR) Clock Polarity Position */
 #define SPI_CSR_CPOL_Msk                    (_U_(0x1) << SPI_CSR_CPOL_Pos)                 /**< (SPI_CSR) Clock Polarity Mask */
 #define SPI_CSR_CPOL                        SPI_CSR_CPOL_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CPOL_Msk instead */
+#define   SPI_CSR_CPOL_IDLE_LOW_Val         _U_(0x0)                                       /**< (SPI_CSR) Clock is low when inactive (CPOL=0)  */
+#define   SPI_CSR_CPOL_IDLE_HIGH_Val        _U_(0x1)                                       /**< (SPI_CSR) Clock is high when inactive (CPOL=1)  */
+#define SPI_CSR_CPOL_IDLE_LOW               (SPI_CSR_CPOL_IDLE_LOW_Val << SPI_CSR_CPOL_Pos)  /**< (SPI_CSR) Clock is low when inactive (CPOL=0) Position  */
+#define SPI_CSR_CPOL_IDLE_HIGH              (SPI_CSR_CPOL_IDLE_HIGH_Val << SPI_CSR_CPOL_Pos)  /**< (SPI_CSR) Clock is high when inactive (CPOL=1) Position  */
 #define SPI_CSR_NCPHA_Pos                   1                                              /**< (SPI_CSR) Clock Phase Position */
 #define SPI_CSR_NCPHA_Msk                   (_U_(0x1) << SPI_CSR_NCPHA_Pos)                /**< (SPI_CSR) Clock Phase Mask */
 #define SPI_CSR_NCPHA                       SPI_CSR_NCPHA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_NCPHA_Msk instead */
+#define   SPI_CSR_NCPHA_VALID_LEADING_EDGE_Val _U_(0x1)                                       /**< (SPI_CSR) Data is valid on clock leading edge (CPHA=0)  */
+#define   SPI_CSR_NCPHA_VALID_TRAILING_EDGE_Val _U_(0x0)                                       /**< (SPI_CSR) Data is valid on clock trailing edge (CPHA=1)  */
+#define SPI_CSR_NCPHA_VALID_LEADING_EDGE    (SPI_CSR_NCPHA_VALID_LEADING_EDGE_Val << SPI_CSR_NCPHA_Pos)  /**< (SPI_CSR) Data is valid on clock leading edge (CPHA=0) Position  */
+#define SPI_CSR_NCPHA_VALID_TRAILING_EDGE   (SPI_CSR_NCPHA_VALID_TRAILING_EDGE_Val << SPI_CSR_NCPHA_Pos)  /**< (SPI_CSR) Data is valid on clock trailing edge (CPHA=1) Position  */
 #define SPI_CSR_CSNAAT_Pos                  2                                              /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Position */
 #define SPI_CSR_CSNAAT_Msk                  (_U_(0x1) << SPI_CSR_CSNAAT_Pos)               /**< (SPI_CSR) Chip Select Not Active After Transfer (Ignored if CSAAT = 1) Mask */
 #define SPI_CSR_CSNAAT                      SPI_CSR_CSNAAT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use SPI_CSR_CSNAAT_Msk instead */
@@ -438,6 +486,7 @@ typedef union {
 
 /* -------- SPI_WPMR : (SPI Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -446,6 +495,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPMR_OFFSET                     (0xE4)                                        /**<  (SPI_WPMR) Write Protection Mode Register  Offset */
@@ -464,6 +514,7 @@ typedef union {
 
 /* -------- SPI_WPSR : (SPI Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -473,6 +524,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SPI_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SPI_WPSR_OFFSET                     (0xE8)                                        /**<  (SPI_WPSR) Write Protection Status Register  Offset */
@@ -499,9 +551,9 @@ typedef struct {
   __O  uint32_t SPI_IER;        /**< (SPI Offset: 0x14) Interrupt Enable Register */
   __O  uint32_t SPI_IDR;        /**< (SPI Offset: 0x18) Interrupt Disable Register */
   __I  uint32_t SPI_IMR;        /**< (SPI Offset: 0x1C) Interrupt Mask Register */
-  RoReg8  Reserved1[0x10];
-  __IO uint32_t SPI_CSR[4];     /**< (SPI Offset: 0x30) Chip Select Register 0 */
-  RoReg8  Reserved2[0xA4];
+  __I  uint8_t                        Reserved1[16];
+  __IO uint32_t SPI_CSR[4];     /**< (SPI Offset: 0x30) Chip Select Register */
+  __I  uint8_t                        Reserved2[164];
   __IO uint32_t SPI_WPMR;       /**< (SPI Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t SPI_WPSR;       /**< (SPI Offset: 0xE8) Write Protection Status Register */
 } Spi;
@@ -517,9 +569,9 @@ typedef struct {
   __O  SPI_IER_Type                   SPI_IER;        /**< Offset: 0x14 ( /W  32) Interrupt Enable Register */
   __O  SPI_IDR_Type                   SPI_IDR;        /**< Offset: 0x18 ( /W  32) Interrupt Disable Register */
   __I  SPI_IMR_Type                   SPI_IMR;        /**< Offset: 0x1C (R/   32) Interrupt Mask Register */
-  __I  uint32_t                       Reserved1[4];
-  __IO SPI_CSR_Type                   SPI_CSR[4];     /**< Offset: 0x30 (R/W  32) Chip Select Register 0 */
-  __I  uint32_t                       Reserved2[41];
+  __I  uint8_t                        Reserved1[16];
+  __IO SPI_CSR_Type                   SPI_CSR[4];     /**< Offset: 0x30 (R/W  32) Chip Select Register */
+  __I  uint8_t                        Reserved2[164];
   __IO SPI_WPMR_Type                  SPI_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  SPI_WPSR_Type                  SPI_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Spi;

--- a/asf/sam/include/same70b/component/ssc.h
+++ b/asf/sam/include/same70b/component/ssc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SSC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SSC_COMPONENT_H_
 #define _SAME70_SSC_COMPONENT_H_
 #define _SAME70_SSC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- SSC_CR : (SSC Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXEN:1;                    /**< bit:      0  Receive Enable                           */
@@ -58,6 +61,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_CR_OFFSET                       (0x00)                                        /**<  (SSC_CR) Control Register  Offset */
@@ -83,6 +87,7 @@ typedef union {
 
 /* -------- SSC_CMR : (SSC Offset: 0x04) (R/W 32) Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DIV:12;                    /**< bit:  0..11  Clock Divider                            */
@@ -90,6 +95,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_CMR_OFFSET                      (0x04)                                        /**<  (SSC_CMR) Clock Mode Register  Offset */
@@ -103,6 +109,7 @@ typedef union {
 
 /* -------- SSC_RCMR : (SSC Offset: 0x10) (R/W 32) Receive Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CKS:2;                     /**< bit:   0..1  Receive Clock Selection                  */
@@ -117,6 +124,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RCMR_OFFSET                     (0x10)                                        /**<  (SSC_RCMR) Receive Clock Mode Register  Offset */
@@ -187,6 +195,7 @@ typedef union {
 
 /* -------- SSC_RFMR : (SSC Offset: 0x14) (R/W 32) Receive Frame Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
@@ -204,6 +213,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RFMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RFMR_OFFSET                     (0x14)                                        /**<  (SSC_RFMR) Receive Frame Mode Register  Offset */
@@ -254,6 +264,7 @@ typedef union {
 
 /* -------- SSC_TCMR : (SSC Offset: 0x18) (R/W 32) Transmit Clock Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CKS:2;                     /**< bit:   0..1  Transmit Clock Selection                 */
@@ -267,6 +278,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TCMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TCMR_OFFSET                     (0x18)                                        /**<  (SSC_TCMR) Transmit Clock Mode Register  Offset */
@@ -332,6 +344,7 @@ typedef union {
 
 /* -------- SSC_TFMR : (SSC Offset: 0x1c) (R/W 32) Transmit Frame Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATLEN:5;                  /**< bit:   0..4  Data Length                              */
@@ -349,6 +362,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TFMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TFMR_OFFSET                     (0x1C)                                        /**<  (SSC_TFMR) Transmit Frame Mode Register  Offset */
@@ -402,12 +416,14 @@ typedef union {
 
 /* -------- SSC_RHR : (SSC Offset: 0x20) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RDAT:32;                   /**< bit:  0..31  Receive Data                             */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RHR_OFFSET                      (0x20)                                        /**<  (SSC_RHR) Receive Holding Register  Offset */
@@ -421,12 +437,14 @@ typedef union {
 
 /* -------- SSC_THR : (SSC Offset: 0x24) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TDAT:32;                   /**< bit:  0..31  Transmit Data                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_THR_OFFSET                      (0x24)                                        /**<  (SSC_THR) Transmit Holding Register  Offset */
@@ -440,6 +458,7 @@ typedef union {
 
 /* -------- SSC_RSHR : (SSC Offset: 0x30) (R/ 32) Receive Sync. Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RSDAT:16;                  /**< bit:  0..15  Receive Synchronization Data             */
@@ -447,6 +466,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RSHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RSHR_OFFSET                     (0x30)                                        /**<  (SSC_RSHR) Receive Sync. Holding Register  Offset */
@@ -460,6 +480,7 @@ typedef union {
 
 /* -------- SSC_TSHR : (SSC Offset: 0x34) (R/W 32) Transmit Sync. Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TSDAT:16;                  /**< bit:  0..15  Transmit Synchronization Data            */
@@ -467,6 +488,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_TSHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_TSHR_OFFSET                     (0x34)                                        /**<  (SSC_TSHR) Transmit Sync. Holding Register  Offset */
@@ -480,6 +502,7 @@ typedef union {
 
 /* -------- SSC_RC0R : (SSC Offset: 0x38) (R/W 32) Receive Compare 0 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CP0:16;                    /**< bit:  0..15  Receive Compare Data 0                   */
@@ -487,6 +510,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RC0R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RC0R_OFFSET                     (0x38)                                        /**<  (SSC_RC0R) Receive Compare 0 Register  Offset */
@@ -500,6 +524,7 @@ typedef union {
 
 /* -------- SSC_RC1R : (SSC Offset: 0x3c) (R/W 32) Receive Compare 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CP1:16;                    /**< bit:  0..15  Receive Compare Data 1                   */
@@ -507,6 +532,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_RC1R_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_RC1R_OFFSET                     (0x3C)                                        /**<  (SSC_RC1R) Receive Compare 1 Register  Offset */
@@ -520,6 +546,7 @@ typedef union {
 
 /* -------- SSC_SR : (SSC Offset: 0x40) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready                           */
@@ -544,6 +571,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_SR_OFFSET                       (0x40)                                        /**<  (SSC_SR) Status Register  Offset */
@@ -587,6 +615,7 @@ typedef union {
 
 /* -------- SSC_IER : (SSC Offset: 0x44) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Enable          */
@@ -608,6 +637,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IER_OFFSET                      (0x44)                                        /**<  (SSC_IER) Interrupt Enable Register  Offset */
@@ -645,6 +675,7 @@ typedef union {
 
 /* -------- SSC_IDR : (SSC Offset: 0x48) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Disable         */
@@ -666,6 +697,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IDR_OFFSET                      (0x48)                                        /**<  (SSC_IDR) Interrupt Disable Register  Offset */
@@ -703,6 +735,7 @@ typedef union {
 
 /* -------- SSC_IMR : (SSC Offset: 0x4c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXRDY:1;                   /**< bit:      0  Transmit Ready Interrupt Mask            */
@@ -724,6 +757,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_IMR_OFFSET                      (0x4C)                                        /**<  (SSC_IMR) Interrupt Mask Register  Offset */
@@ -761,6 +795,7 @@ typedef union {
 
 /* -------- SSC_WPMR : (SSC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -769,6 +804,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_WPMR_OFFSET                     (0xE4)                                        /**<  (SSC_WPMR) Write Protection Mode Register  Offset */
@@ -787,6 +823,7 @@ typedef union {
 
 /* -------- SSC_WPSR : (SSC Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -796,6 +833,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SSC_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SSC_WPSR_OFFSET                     (0xE8)                                        /**<  (SSC_WPSR) Write Protection Status Register  Offset */
@@ -816,14 +854,14 @@ typedef union {
 typedef struct {  
   __O  uint32_t SSC_CR;         /**< (SSC Offset: 0x00) Control Register */
   __IO uint32_t SSC_CMR;        /**< (SSC Offset: 0x04) Clock Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __IO uint32_t SSC_RCMR;       /**< (SSC Offset: 0x10) Receive Clock Mode Register */
   __IO uint32_t SSC_RFMR;       /**< (SSC Offset: 0x14) Receive Frame Mode Register */
   __IO uint32_t SSC_TCMR;       /**< (SSC Offset: 0x18) Transmit Clock Mode Register */
   __IO uint32_t SSC_TFMR;       /**< (SSC Offset: 0x1C) Transmit Frame Mode Register */
   __I  uint32_t SSC_RHR;        /**< (SSC Offset: 0x20) Receive Holding Register */
   __O  uint32_t SSC_THR;        /**< (SSC Offset: 0x24) Transmit Holding Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __I  uint32_t SSC_RSHR;       /**< (SSC Offset: 0x30) Receive Sync. Holding Register */
   __IO uint32_t SSC_TSHR;       /**< (SSC Offset: 0x34) Transmit Sync. Holding Register */
   __IO uint32_t SSC_RC0R;       /**< (SSC Offset: 0x38) Receive Compare 0 Register */
@@ -832,7 +870,7 @@ typedef struct {
   __O  uint32_t SSC_IER;        /**< (SSC Offset: 0x44) Interrupt Enable Register */
   __O  uint32_t SSC_IDR;        /**< (SSC Offset: 0x48) Interrupt Disable Register */
   __I  uint32_t SSC_IMR;        /**< (SSC Offset: 0x4C) Interrupt Mask Register */
-  RoReg8  Reserved3[0x94];
+  __I  uint8_t                        Reserved3[148];
   __IO uint32_t SSC_WPMR;       /**< (SSC Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t SSC_WPSR;       /**< (SSC Offset: 0xE8) Write Protection Status Register */
 } Ssc;
@@ -842,14 +880,14 @@ typedef struct {
 typedef struct {  
   __O  SSC_CR_Type                    SSC_CR;         /**< Offset: 0x00 ( /W  32) Control Register */
   __IO SSC_CMR_Type                   SSC_CMR;        /**< Offset: 0x04 (R/W  32) Clock Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __IO SSC_RCMR_Type                  SSC_RCMR;       /**< Offset: 0x10 (R/W  32) Receive Clock Mode Register */
   __IO SSC_RFMR_Type                  SSC_RFMR;       /**< Offset: 0x14 (R/W  32) Receive Frame Mode Register */
   __IO SSC_TCMR_Type                  SSC_TCMR;       /**< Offset: 0x18 (R/W  32) Transmit Clock Mode Register */
   __IO SSC_TFMR_Type                  SSC_TFMR;       /**< Offset: 0x1C (R/W  32) Transmit Frame Mode Register */
   __I  SSC_RHR_Type                   SSC_RHR;        /**< Offset: 0x20 (R/   32) Receive Holding Register */
   __O  SSC_THR_Type                   SSC_THR;        /**< Offset: 0x24 ( /W  32) Transmit Holding Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __I  SSC_RSHR_Type                  SSC_RSHR;       /**< Offset: 0x30 (R/   32) Receive Sync. Holding Register */
   __IO SSC_TSHR_Type                  SSC_TSHR;       /**< Offset: 0x34 (R/W  32) Transmit Sync. Holding Register */
   __IO SSC_RC0R_Type                  SSC_RC0R;       /**< Offset: 0x38 (R/W  32) Receive Compare 0 Register */
@@ -858,7 +896,7 @@ typedef struct {
   __O  SSC_IER_Type                   SSC_IER;        /**< Offset: 0x44 ( /W  32) Interrupt Enable Register */
   __O  SSC_IDR_Type                   SSC_IDR;        /**< Offset: 0x48 ( /W  32) Interrupt Disable Register */
   __I  SSC_IMR_Type                   SSC_IMR;        /**< Offset: 0x4C (R/   32) Interrupt Mask Register */
-  __I  uint32_t                       Reserved3[37];
+  __I  uint8_t                        Reserved3[148];
   __IO SSC_WPMR_Type                  SSC_WPMR;       /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  SSC_WPSR_Type                  SSC_WPSR;       /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Ssc;

--- a/asf/sam/include/same70b/component/supc.h
+++ b/asf/sam/include/same70b/component/supc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for SUPC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SUPC_COMPONENT_H_
 #define _SAME70_SUPC_COMPONENT_H_
 #define _SAME70_SUPC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- SUPC_CR : (SUPC Offset: 0x00) (/W 32) Supply Controller Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -55,6 +58,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_CR_OFFSET                      (0x00)                                        /**<  (SUPC_CR) Supply Controller Control Register  Offset */
@@ -84,6 +88,7 @@ typedef union {
 
 /* -------- SUPC_SMMR : (SUPC Offset: 0x04) (R/W 32) Supply Controller Supply Monitor Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SMTH:4;                    /**< bit:   0..3  Supply Monitor Threshold                 */
@@ -96,6 +101,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_SMMR_OFFSET                    (0x04)                                        /**<  (SUPC_SMMR) Supply Controller Supply Monitor Mode Register  Offset */
@@ -136,6 +142,7 @@ typedef union {
 
 /* -------- SUPC_MR : (SUPC Offset: 0x08) (R/W 32) Supply Controller Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
@@ -151,6 +158,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_MR_OFFSET                      (0x08)                                        /**<  (SUPC_MR) Supply Controller Mode Register  Offset */
@@ -197,6 +205,7 @@ typedef union {
 
 /* -------- SUPC_WUMR : (SUPC Offset: 0x0c) (R/W 32) Supply Controller Wake-up Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -220,6 +229,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_WUMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_WUMR_OFFSET                    (0x0C)                                        /**<  (SUPC_WUMR) Supply Controller Wake-up Mode Register  Offset */
@@ -309,6 +319,7 @@ typedef union {
 
 /* -------- SUPC_WUIR : (SUPC Offset: 0x10) (R/W 32) Supply Controller Wake-up Inputs Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WKUPEN0:1;                 /**< bit:      0  Wake-up Input Enable 0 to 0              */
@@ -350,6 +361,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_WUIR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_WUIR_OFFSET                    (0x10)                                        /**<  (SUPC_WUIR) Supply Controller Wake-up Inputs Register  Offset */
@@ -562,6 +574,7 @@ typedef union {
 
 /* -------- SUPC_SR : (SUPC Offset: 0x14) (R/ 32) Supply Controller Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -601,6 +614,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } SUPC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define SUPC_SR_OFFSET                      (0x14)                                        /**<  (SUPC_SR) Supply Controller Status Register  Offset */

--- a/asf/sam/include/same70b/component/tc.h
+++ b/asf/sam/include/same70b/component/tc.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TC_COMPONENT_H_
 #define _SAME70_TC_COMPONENT_H_
 #define _SAME70_TC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -41,10 +43,11 @@
 #endif
 
 #define TC_6082                       /**< (TC) Module ID */
-#define REV_TC ZG                     /**< (TC) Module revision */
+#define REV_TC ZL                     /**< (TC) Module revision */
 
 /* -------- TC_CCR : (TC Offset: 0x00) (/W 32) Channel Control Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLKEN:1;                   /**< bit:      0  Counter Clock Enable Command             */
@@ -54,6 +57,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CCR_OFFSET                       (0x00)                                        /**<  (TC_CCR) Channel Control Register (channel = 0)  Offset */
@@ -73,25 +77,51 @@ typedef union {
 
 /* -------- TC_CMR : (TC Offset: 0x04) (R/W 32) Channel Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TCCLKS:3;                  /**< bit:   0..2  Clock Selection                          */
     uint32_t CLKI:1;                    /**< bit:      3  Clock Invert                             */
     uint32_t BURST:2;                   /**< bit:   4..5  Burst Signal Selection                   */
+    uint32_t :9;                        /**< bit:  6..14  Reserved */
+    uint32_t WAVE:1;                    /**< bit:     15  Waveform Mode                            */
+    uint32_t :16;                       /**< bit: 16..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CAPTURE mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
     uint32_t LDBSTOP:1;                 /**< bit:      6  Counter Clock Stopped with RB Loading    */
     uint32_t LDBDIS:1;                  /**< bit:      7  Counter Clock Disable with RB Loading    */
     uint32_t ETRGEDG:2;                 /**< bit:   8..9  External Trigger Edge Selection          */
     uint32_t ABETRG:1;                  /**< bit:     10  TIOAx or TIOBx External Trigger Selection */
     uint32_t :3;                        /**< bit: 11..13  Reserved */
     uint32_t CPCTRG:1;                  /**< bit:     14  RC Compare Trigger Enable                */
-    uint32_t WAVE:1;                    /**< bit:     15  Waveform Mode                            */
+    uint32_t :1;                        /**< bit:     15  Reserved */
     uint32_t LDRA:2;                    /**< bit: 16..17  RA Loading Edge Selection                */
     uint32_t LDRB:2;                    /**< bit: 18..19  RB Loading Edge Selection                */
     uint32_t SBSMPLR:3;                 /**< bit: 20..22  Loading Edge Subsampling Ratio           */
     uint32_t :9;                        /**< bit: 23..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } CAPTURE;                                /**< Structure used for CAPTURE mode access */
+  struct { // WAVEFORM mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t CPCSTOP:1;                 /**< bit:      6  Counter Clock Stopped with RC Compare    */
+    uint32_t CPCDIS:1;                  /**< bit:      7  Counter Clock Disable with RC Loading    */
+    uint32_t EEVTEDG:2;                 /**< bit:   8..9  External Event Edge Selection            */
+    uint32_t EEVT:2;                    /**< bit: 10..11  External Event Selection                 */
+    uint32_t ENETRG:1;                  /**< bit:     12  External Event Trigger Enable            */
+    uint32_t WAVSEL:2;                  /**< bit: 13..14  Waveform Selection                       */
+    uint32_t :1;                        /**< bit:     15  Reserved */
+    uint32_t ACPA:2;                    /**< bit: 16..17  RA Compare Effect on TIOAx               */
+    uint32_t ACPC:2;                    /**< bit: 18..19  RC Compare Effect on TIOAx               */
+    uint32_t AEEVT:2;                   /**< bit: 20..21  External Event Effect on TIOAx           */
+    uint32_t ASWTRG:2;                  /**< bit: 22..23  Software Trigger Effect on TIOAx         */
+    uint32_t BCPB:2;                    /**< bit: 24..25  RB Compare Effect on TIOBx               */
+    uint32_t BCPC:2;                    /**< bit: 26..27  RC Compare Effect on TIOBx               */
+    uint32_t BEEVT:2;                   /**< bit: 28..29  External Event Effect on TIOBx           */
+    uint32_t BSWTRG:2;                  /**< bit: 30..31  Software Trigger Effect on TIOBx         */
+  } WAVEFORM;                                /**< Structure used for WAVEFORM mode access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CMR_OFFSET                       (0x04)                                        /**<  (TC_CMR) Channel Mode Register (channel = 0)  Offset */
@@ -129,153 +159,212 @@ typedef union {
 #define TC_CMR_BURST_XC0                    (TC_CMR_BURST_XC0_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC0 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC1                    (TC_CMR_BURST_XC1_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC1 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC2                    (TC_CMR_BURST_XC2_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC2 is ANDed with the selected clock. Position  */
-#define TC_CMR_LDBSTOP_Pos                  6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
-#define TC_CMR_LDBSTOP_Msk                  (_U_(0x1) << TC_CMR_LDBSTOP_Pos)               /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
-#define TC_CMR_LDBSTOP                      TC_CMR_LDBSTOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBSTOP_Msk instead */
-#define TC_CMR_LDBDIS_Pos                   7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
-#define TC_CMR_LDBDIS_Msk                   (_U_(0x1) << TC_CMR_LDBDIS_Pos)                /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
-#define TC_CMR_LDBDIS                       TC_CMR_LDBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBDIS_Msk instead */
-#define TC_CMR_ETRGEDG_Pos                  8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
-#define TC_CMR_ETRGEDG_Msk                  (_U_(0x3) << TC_CMR_ETRGEDG_Pos)               /**< (TC_CMR) External Trigger Edge Selection Mask */
-#define TC_CMR_ETRGEDG(value)               (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
-#define   TC_CMR_ETRGEDG_NONE_Val           _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
-#define   TC_CMR_ETRGEDG_RISING_Val         _U_(0x1)                                       /**< (TC_CMR) Rising edge  */
-#define   TC_CMR_ETRGEDG_FALLING_Val        _U_(0x2)                                       /**< (TC_CMR) Falling edge  */
-#define   TC_CMR_ETRGEDG_EDGE_Val           _U_(0x3)                                       /**< (TC_CMR) Each edge  */
-#define TC_CMR_ETRGEDG_NONE                 (TC_CMR_ETRGEDG_NONE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) The clock is not gated by an external signal. Position  */
-#define TC_CMR_ETRGEDG_RISING               (TC_CMR_ETRGEDG_RISING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
-#define TC_CMR_ETRGEDG_FALLING              (TC_CMR_ETRGEDG_FALLING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
-#define TC_CMR_ETRGEDG_EDGE                 (TC_CMR_ETRGEDG_EDGE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
-#define TC_CMR_ABETRG_Pos                   10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
-#define TC_CMR_ABETRG_Msk                   (_U_(0x1) << TC_CMR_ABETRG_Pos)                /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
-#define TC_CMR_ABETRG                       TC_CMR_ABETRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_ABETRG_Msk instead */
-#define TC_CMR_CPCTRG_Pos                   14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
-#define TC_CMR_CPCTRG_Msk                   (_U_(0x1) << TC_CMR_CPCTRG_Pos)                /**< (TC_CMR) RC Compare Trigger Enable Mask */
-#define TC_CMR_CPCTRG                       TC_CMR_CPCTRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CPCTRG_Msk instead */
 #define TC_CMR_WAVE_Pos                     15                                             /**< (TC_CMR) Waveform Mode Position */
 #define TC_CMR_WAVE_Msk                     (_U_(0x1) << TC_CMR_WAVE_Pos)                  /**< (TC_CMR) Waveform Mode Mask */
 #define TC_CMR_WAVE                         TC_CMR_WAVE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVE_Msk instead */
-#define TC_CMR_LDRA_Pos                     16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
-#define TC_CMR_LDRA_Msk                     (_U_(0x3) << TC_CMR_LDRA_Pos)                  /**< (TC_CMR) RA Loading Edge Selection Mask */
-#define TC_CMR_LDRA(value)                  (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
-#define   TC_CMR_LDRA_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
-#define   TC_CMR_LDRA_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
-#define   TC_CMR_LDRA_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
-#define   TC_CMR_LDRA_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
-#define TC_CMR_LDRA_NONE                    (TC_CMR_LDRA_NONE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) None Position  */
-#define TC_CMR_LDRA_RISING                  (TC_CMR_LDRA_RISING_Val << TC_CMR_LDRA_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
-#define TC_CMR_LDRA_FALLING                 (TC_CMR_LDRA_FALLING_Val << TC_CMR_LDRA_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
-#define TC_CMR_LDRA_EDGE                    (TC_CMR_LDRA_EDGE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
-#define TC_CMR_LDRB_Pos                     18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
-#define TC_CMR_LDRB_Msk                     (_U_(0x3) << TC_CMR_LDRB_Pos)                  /**< (TC_CMR) RB Loading Edge Selection Mask */
-#define TC_CMR_LDRB(value)                  (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
-#define   TC_CMR_LDRB_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
-#define   TC_CMR_LDRB_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
-#define   TC_CMR_LDRB_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
-#define   TC_CMR_LDRB_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
-#define TC_CMR_LDRB_NONE                    (TC_CMR_LDRB_NONE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) None Position  */
-#define TC_CMR_LDRB_RISING                  (TC_CMR_LDRB_RISING_Val << TC_CMR_LDRB_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
-#define TC_CMR_LDRB_FALLING                 (TC_CMR_LDRB_FALLING_Val << TC_CMR_LDRB_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
-#define TC_CMR_LDRB_EDGE                    (TC_CMR_LDRB_EDGE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
-#define TC_CMR_SBSMPLR_Pos                  20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
-#define TC_CMR_SBSMPLR_Msk                  (_U_(0x7) << TC_CMR_SBSMPLR_Pos)               /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
-#define TC_CMR_SBSMPLR(value)               (TC_CMR_SBSMPLR_Msk & ((value) << TC_CMR_SBSMPLR_Pos))
-#define   TC_CMR_SBSMPLR_ONE_Val            _U_(0x0)                                       /**< (TC_CMR) Load a Capture Register each selected edge  */
-#define   TC_CMR_SBSMPLR_HALF_Val           _U_(0x1)                                       /**< (TC_CMR) Load a Capture Register every 2 selected edges  */
-#define   TC_CMR_SBSMPLR_FOURTH_Val         _U_(0x2)                                       /**< (TC_CMR) Load a Capture Register every 4 selected edges  */
-#define   TC_CMR_SBSMPLR_EIGHTH_Val         _U_(0x3)                                       /**< (TC_CMR) Load a Capture Register every 8 selected edges  */
-#define   TC_CMR_SBSMPLR_SIXTEENTH_Val      _U_(0x4)                                       /**< (TC_CMR) Load a Capture Register every 16 selected edges  */
-#define TC_CMR_SBSMPLR_ONE                  (TC_CMR_SBSMPLR_ONE_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
-#define TC_CMR_SBSMPLR_HALF                 (TC_CMR_SBSMPLR_HALF_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
-#define TC_CMR_SBSMPLR_FOURTH               (TC_CMR_SBSMPLR_FOURTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
-#define TC_CMR_SBSMPLR_EIGHTH               (TC_CMR_SBSMPLR_EIGHTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
-#define TC_CMR_SBSMPLR_SIXTEENTH            (TC_CMR_SBSMPLR_SIXTEENTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
-#define TC_CMR_CPCSTOP (0x1u << 6) /**< \brief (TC_CMR) Counter Clock Stopped with RC Compare */
-#define TC_CMR_CPCDIS (0x1u << 7) /**< \brief (TC_CMR) Counter Clock Disable with RC Compare */
-#define TC_CMR_EEVTEDG_Pos 8
-#define TC_CMR_EEVTEDG_Msk (0x3u << TC_CMR_EEVTEDG_Pos) /**< \brief (TC_CMR) External Event Edge Selection */
-#define TC_CMR_EEVTEDG(value) ((TC_CMR_EEVTEDG_Msk & ((value) << TC_CMR_EEVTEDG_Pos)))
-#define   TC_CMR_EEVTEDG_NONE (0x0u << 8) /**< \brief (TC_CMR) None */
-#define   TC_CMR_EEVTEDG_RISING (0x1u << 8) /**< \brief (TC_CMR) Rising edge */
-#define   TC_CMR_EEVTEDG_FALLING (0x2u << 8) /**< \brief (TC_CMR) Falling edge */
-#define   TC_CMR_EEVTEDG_EDGE (0x3u << 8) /**< \brief (TC_CMR) Each edge */
-#define TC_CMR_EEVT_Pos 10
-#define TC_CMR_EEVT_Msk (0x3u << TC_CMR_EEVT_Pos) /**< \brief (TC_CMR) External Event Selection */
-#define TC_CMR_EEVT(value) ((TC_CMR_EEVT_Msk & ((value) << TC_CMR_EEVT_Pos)))
-#define   TC_CMR_EEVT_TIOB (0x0u << 10) /**< \brief (TC_CMR) TIOB */
-#define   TC_CMR_EEVT_XC0 (0x1u << 10) /**< \brief (TC_CMR) XC0 */
-#define   TC_CMR_EEVT_XC1 (0x2u << 10) /**< \brief (TC_CMR) XC1 */
-#define   TC_CMR_EEVT_XC2 (0x3u << 10) /**< \brief (TC_CMR) XC2 */
-#define TC_CMR_ENETRG (0x1u << 12) /**< \brief (TC_CMR) External Event Trigger Enable */
-#define TC_CMR_WAVSEL_Pos 13
-#define TC_CMR_WAVSEL_Msk (0x3u << TC_CMR_WAVSEL_Pos) /**< \brief (TC_CMR) Waveform Selection */
-#define TC_CMR_WAVSEL(value) ((TC_CMR_WAVSEL_Msk & ((value) << TC_CMR_WAVSEL_Pos)))
-#define   TC_CMR_WAVSEL_UP (0x0u << 13) /**< \brief (TC_CMR) UP mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN (0x1u << 13) /**< \brief (TC_CMR) UPDOWN mode without automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UP_RC (0x2u << 13) /**< \brief (TC_CMR) UP mode with automatic trigger on RC Compare */
-#define   TC_CMR_WAVSEL_UPDOWN_RC (0x3u << 13) /**< \brief (TC_CMR) UPDOWN mode with automatic trigger on RC Compare */
-#define TC_CMR_ACPA_Pos 16
-#define TC_CMR_ACPA_Msk (0x3u << TC_CMR_ACPA_Pos) /**< \brief (TC_CMR) RA Compare Effect on TIOA */
-#define TC_CMR_ACPA(value) ((TC_CMR_ACPA_Msk & ((value) << TC_CMR_ACPA_Pos)))
-#define   TC_CMR_ACPA_NONE (0x0u << 16) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ACPA_SET (0x1u << 16) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ACPA_CLEAR (0x2u << 16) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ACPA_TOGGLE (0x3u << 16) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_ACPC_Pos 18
-#define TC_CMR_ACPC_Msk (0x3u << TC_CMR_ACPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOA */
-#define TC_CMR_ACPC(value) ((TC_CMR_ACPC_Msk & ((value) << TC_CMR_ACPC_Pos)))
-#define   TC_CMR_ACPC_NONE (0x0u << 18) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ACPC_SET (0x1u << 18) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ACPC_CLEAR (0x2u << 18) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ACPC_TOGGLE (0x3u << 18) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_AEEVT_Pos 20
-#define TC_CMR_AEEVT_Msk (0x3u << TC_CMR_AEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOA */
-#define TC_CMR_AEEVT(value) ((TC_CMR_AEEVT_Msk & ((value) << TC_CMR_AEEVT_Pos)))
-#define   TC_CMR_AEEVT_NONE (0x0u << 20) /**< \brief (TC_CMR) None */
-#define   TC_CMR_AEEVT_SET (0x1u << 20) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_AEEVT_CLEAR (0x2u << 20) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_AEEVT_TOGGLE (0x3u << 20) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_ASWTRG_Pos 22
-#define TC_CMR_ASWTRG_Msk (0x3u << TC_CMR_ASWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOA */
-#define TC_CMR_ASWTRG(value) ((TC_CMR_ASWTRG_Msk & ((value) << TC_CMR_ASWTRG_Pos)))
-#define   TC_CMR_ASWTRG_NONE (0x0u << 22) /**< \brief (TC_CMR) None */
-#define   TC_CMR_ASWTRG_SET (0x1u << 22) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_ASWTRG_CLEAR (0x2u << 22) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_ASWTRG_TOGGLE (0x3u << 22) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BCPB_Pos 24
-#define TC_CMR_BCPB_Msk (0x3u << TC_CMR_BCPB_Pos) /**< \brief (TC_CMR) RB Compare Effect on TIOB */
-#define TC_CMR_BCPB(value) ((TC_CMR_BCPB_Msk & ((value) << TC_CMR_BCPB_Pos)))
-#define   TC_CMR_BCPB_NONE (0x0u << 24) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BCPB_SET (0x1u << 24) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BCPB_CLEAR (0x2u << 24) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BCPB_TOGGLE (0x3u << 24) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BCPC_Pos 26
-#define TC_CMR_BCPC_Msk (0x3u << TC_CMR_BCPC_Pos) /**< \brief (TC_CMR) RC Compare Effect on TIOB */
-#define TC_CMR_BCPC(value) ((TC_CMR_BCPC_Msk & ((value) << TC_CMR_BCPC_Pos)))
-#define   TC_CMR_BCPC_NONE (0x0u << 26) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BCPC_SET (0x1u << 26) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BCPC_CLEAR (0x2u << 26) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BCPC_TOGGLE (0x3u << 26) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BEEVT_Pos 28
-#define TC_CMR_BEEVT_Msk (0x3u << TC_CMR_BEEVT_Pos) /**< \brief (TC_CMR) External Event Effect on TIOB */
-#define TC_CMR_BEEVT(value) ((TC_CMR_BEEVT_Msk & ((value) << TC_CMR_BEEVT_Pos)))
-#define   TC_CMR_BEEVT_NONE (0x0u << 28) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BEEVT_SET (0x1u << 28) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BEEVT_CLEAR (0x2u << 28) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BEEVT_TOGGLE (0x3u << 28) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_BSWTRG_Pos 30
-#define TC_CMR_BSWTRG_Msk (0x3u << TC_CMR_BSWTRG_Pos) /**< \brief (TC_CMR) Software Trigger Effect on TIOB */
-#define TC_CMR_BSWTRG(value) ((TC_CMR_BSWTRG_Msk & ((value) << TC_CMR_BSWTRG_Pos)))
-#define   TC_CMR_BSWTRG_NONE (0x0u << 30) /**< \brief (TC_CMR) None */
-#define   TC_CMR_BSWTRG_SET (0x1u << 30) /**< \brief (TC_CMR) Set */
-#define   TC_CMR_BSWTRG_CLEAR (0x2u << 30) /**< \brief (TC_CMR) Clear */
-#define   TC_CMR_BSWTRG_TOGGLE (0x3u << 30) /**< \brief (TC_CMR) Toggle */
-#define TC_CMR_MASK                         _U_(0x7FC7FF)                                  /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
-#define TC_CMR_Msk                          _U_(0x7FC7FF)                                  /**< (TC_CMR) Register Mask  */
+#define TC_CMR_MASK                         _U_(0x803F)                                    /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
+#define TC_CMR_Msk                          _U_(0x803F)                                    /**< (TC_CMR) Register Mask  */
+
+/* CAPTURE mode */
+#define TC_CMR_CAPTURE_LDBSTOP_Pos          6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_CAPTURE_LDBSTOP_Msk          (_U_(0x1) << TC_CMR_CAPTURE_LDBSTOP_Pos)       /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_CAPTURE_LDBSTOP              TC_CMR_CAPTURE_LDBSTOP_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_LDBSTOP_Msk instead */
+#define TC_CMR_CAPTURE_LDBDIS_Pos           7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_CAPTURE_LDBDIS_Msk           (_U_(0x1) << TC_CMR_CAPTURE_LDBDIS_Pos)        /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_CAPTURE_LDBDIS               TC_CMR_CAPTURE_LDBDIS_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_LDBDIS_Msk instead */
+#define TC_CMR_CAPTURE_ETRGEDG_Pos          8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_CAPTURE_ETRGEDG_Msk          (_U_(0x3) << TC_CMR_CAPTURE_ETRGEDG_Pos)       /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_CAPTURE_ETRGEDG(value)       (TC_CMR_CAPTURE_ETRGEDG_Msk & ((value) << TC_CMR_CAPTURE_ETRGEDG_Pos))
+#define   TC_CMR_CAPTURE_ETRGEDG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) CAPTURE The clock is not gated by an external signal.  */
+#define   TC_CMR_CAPTURE_ETRGEDG_RISING_Val _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge  */
+#define   TC_CMR_CAPTURE_ETRGEDG_FALLING_Val _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge  */
+#define   TC_CMR_CAPTURE_ETRGEDG_EDGE_Val   _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge  */
+#define TC_CMR_CAPTURE_ETRGEDG_NONE         (TC_CMR_CAPTURE_ETRGEDG_NONE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_RISING       (TC_CMR_CAPTURE_ETRGEDG_RISING_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_FALLING      (TC_CMR_CAPTURE_ETRGEDG_FALLING_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_CAPTURE_ETRGEDG_EDGE         (TC_CMR_CAPTURE_ETRGEDG_EDGE_Val << TC_CMR_CAPTURE_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
+#define TC_CMR_CAPTURE_ABETRG_Pos           10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_CAPTURE_ABETRG_Msk           (_U_(0x1) << TC_CMR_CAPTURE_ABETRG_Pos)        /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_CAPTURE_ABETRG               TC_CMR_CAPTURE_ABETRG_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_ABETRG_Msk instead */
+#define TC_CMR_CAPTURE_CPCTRG_Pos           14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CAPTURE_CPCTRG_Msk           (_U_(0x1) << TC_CMR_CAPTURE_CPCTRG_Pos)        /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CAPTURE_CPCTRG               TC_CMR_CAPTURE_CPCTRG_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CAPTURE_CPCTRG_Msk instead */
+#define TC_CMR_CAPTURE_LDRA_Pos             16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_CAPTURE_LDRA_Msk             (_U_(0x3) << TC_CMR_CAPTURE_LDRA_Pos)          /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_CAPTURE_LDRA(value)          (TC_CMR_CAPTURE_LDRA_Msk & ((value) << TC_CMR_CAPTURE_LDRA_Pos))
+#define   TC_CMR_CAPTURE_LDRA_NONE_Val      _U_(0x0)                                       /**< (TC_CMR) CAPTURE None  */
+#define   TC_CMR_CAPTURE_LDRA_RISING_Val    _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRA_FALLING_Val   _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRA_EDGE_Val      _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge of TIOAx  */
+#define TC_CMR_CAPTURE_LDRA_NONE            (TC_CMR_CAPTURE_LDRA_NONE_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_CAPTURE_LDRA_RISING          (TC_CMR_CAPTURE_LDRA_RISING_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRA_FALLING         (TC_CMR_CAPTURE_LDRA_FALLING_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRA_EDGE            (TC_CMR_CAPTURE_LDRA_EDGE_Val << TC_CMR_CAPTURE_LDRA_Pos)  /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_Pos             18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_CAPTURE_LDRB_Msk             (_U_(0x3) << TC_CMR_CAPTURE_LDRB_Pos)          /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_CAPTURE_LDRB(value)          (TC_CMR_CAPTURE_LDRB_Msk & ((value) << TC_CMR_CAPTURE_LDRB_Pos))
+#define   TC_CMR_CAPTURE_LDRB_NONE_Val      _U_(0x0)                                       /**< (TC_CMR) CAPTURE None  */
+#define   TC_CMR_CAPTURE_LDRB_RISING_Val    _U_(0x1)                                       /**< (TC_CMR) CAPTURE Rising edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRB_FALLING_Val   _U_(0x2)                                       /**< (TC_CMR) CAPTURE Falling edge of TIOAx  */
+#define   TC_CMR_CAPTURE_LDRB_EDGE_Val      _U_(0x3)                                       /**< (TC_CMR) CAPTURE Each edge of TIOAx  */
+#define TC_CMR_CAPTURE_LDRB_NONE            (TC_CMR_CAPTURE_LDRB_NONE_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_CAPTURE_LDRB_RISING          (TC_CMR_CAPTURE_LDRB_RISING_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_FALLING         (TC_CMR_CAPTURE_LDRB_FALLING_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_LDRB_EDGE            (TC_CMR_CAPTURE_LDRB_EDGE_Val << TC_CMR_CAPTURE_LDRB_Pos)  /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_Pos          20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_CAPTURE_SBSMPLR_Msk          (_U_(0x7) << TC_CMR_CAPTURE_SBSMPLR_Pos)       /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_CAPTURE_SBSMPLR(value)       (TC_CMR_CAPTURE_SBSMPLR_Msk & ((value) << TC_CMR_CAPTURE_SBSMPLR_Pos))
+#define   TC_CMR_CAPTURE_SBSMPLR_ONE_Val    _U_(0x0)                                       /**< (TC_CMR) CAPTURE Load a Capture Register each selected edge  */
+#define   TC_CMR_CAPTURE_SBSMPLR_HALF_Val   _U_(0x1)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 2 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_FOURTH_Val _U_(0x2)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 4 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_EIGHTH_Val _U_(0x3)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 8 selected edges  */
+#define   TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH_Val _U_(0x4)                                       /**< (TC_CMR) CAPTURE Load a Capture Register every 16 selected edges  */
+#define TC_CMR_CAPTURE_SBSMPLR_ONE          (TC_CMR_CAPTURE_SBSMPLR_ONE_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_HALF         (TC_CMR_CAPTURE_SBSMPLR_HALF_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_FOURTH       (TC_CMR_CAPTURE_SBSMPLR_FOURTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_EIGHTH       (TC_CMR_CAPTURE_SBSMPLR_EIGHTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
+#define TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH    (TC_CMR_CAPTURE_SBSMPLR_SIXTEENTH_Val << TC_CMR_CAPTURE_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
+#define TC_CMR_CAPTURE_MASK                 _U_(0x7F47C0)                                  /**< \deprecated (TC_CMR_CAPTURE) Register MASK  (Use TC_CMR_CAPTURE_Msk instead)  */
+#define TC_CMR_CAPTURE_Msk                  _U_(0x7F47C0)                                  /**< (TC_CMR_CAPTURE) Register Mask  */
+
+/* WAVEFORM mode */
+#define TC_CMR_WAVEFORM_CPCSTOP_Pos         6                                              /**< (TC_CMR) Counter Clock Stopped with RC Compare Position */
+#define TC_CMR_WAVEFORM_CPCSTOP_Msk         (_U_(0x1) << TC_CMR_WAVEFORM_CPCSTOP_Pos)      /**< (TC_CMR) Counter Clock Stopped with RC Compare Mask */
+#define TC_CMR_WAVEFORM_CPCSTOP             TC_CMR_WAVEFORM_CPCSTOP_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_CPCSTOP_Msk instead */
+#define TC_CMR_WAVEFORM_CPCDIS_Pos          7                                              /**< (TC_CMR) Counter Clock Disable with RC Loading Position */
+#define TC_CMR_WAVEFORM_CPCDIS_Msk          (_U_(0x1) << TC_CMR_WAVEFORM_CPCDIS_Pos)       /**< (TC_CMR) Counter Clock Disable with RC Loading Mask */
+#define TC_CMR_WAVEFORM_CPCDIS              TC_CMR_WAVEFORM_CPCDIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_CPCDIS_Msk instead */
+#define TC_CMR_WAVEFORM_EEVTEDG_Pos         8                                              /**< (TC_CMR) External Event Edge Selection Position */
+#define TC_CMR_WAVEFORM_EEVTEDG_Msk         (_U_(0x3) << TC_CMR_WAVEFORM_EEVTEDG_Pos)      /**< (TC_CMR) External Event Edge Selection Mask */
+#define TC_CMR_WAVEFORM_EEVTEDG(value)      (TC_CMR_WAVEFORM_EEVTEDG_Msk & ((value) << TC_CMR_WAVEFORM_EEVTEDG_Pos))
+#define   TC_CMR_WAVEFORM_EEVTEDG_NONE_Val  _U_(0x0)                                       /**< (TC_CMR) WAVEFORM None  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_RISING_Val _U_(0x1)                                       /**< (TC_CMR) WAVEFORM Rising edge  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_FALLING_Val _U_(0x2)                                       /**< (TC_CMR) WAVEFORM Falling edge  */
+#define   TC_CMR_WAVEFORM_EEVTEDG_EDGE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM Each edges  */
+#define TC_CMR_WAVEFORM_EEVTEDG_NONE        (TC_CMR_WAVEFORM_EEVTEDG_NONE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) None Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_RISING      (TC_CMR_WAVEFORM_EEVTEDG_RISING_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_FALLING     (TC_CMR_WAVEFORM_EEVTEDG_FALLING_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_WAVEFORM_EEVTEDG_EDGE        (TC_CMR_WAVEFORM_EEVTEDG_EDGE_Val << TC_CMR_WAVEFORM_EEVTEDG_Pos)  /**< (TC_CMR) Each edges Position  */
+#define TC_CMR_WAVEFORM_EEVT_Pos            10                                             /**< (TC_CMR) External Event Selection Position */
+#define TC_CMR_WAVEFORM_EEVT_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_EEVT_Pos)         /**< (TC_CMR) External Event Selection Mask */
+#define TC_CMR_WAVEFORM_EEVT(value)         (TC_CMR_WAVEFORM_EEVT_Msk & ((value) << TC_CMR_WAVEFORM_EEVT_Pos))
+#define   TC_CMR_WAVEFORM_EEVT_TIOB_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM TIOB  */
+#define   TC_CMR_WAVEFORM_EEVT_XC0_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM XC0  */
+#define   TC_CMR_WAVEFORM_EEVT_XC1_Val      _U_(0x2)                                       /**< (TC_CMR) WAVEFORM XC1  */
+#define   TC_CMR_WAVEFORM_EEVT_XC2_Val      _U_(0x3)                                       /**< (TC_CMR) WAVEFORM XC2  */
+#define TC_CMR_WAVEFORM_EEVT_TIOB           (TC_CMR_WAVEFORM_EEVT_TIOB_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) TIOB Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC0            (TC_CMR_WAVEFORM_EEVT_XC0_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC0 Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC1            (TC_CMR_WAVEFORM_EEVT_XC1_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC1 Position  */
+#define TC_CMR_WAVEFORM_EEVT_XC2            (TC_CMR_WAVEFORM_EEVT_XC2_Val << TC_CMR_WAVEFORM_EEVT_Pos)  /**< (TC_CMR) XC2 Position  */
+#define TC_CMR_WAVEFORM_ENETRG_Pos          12                                             /**< (TC_CMR) External Event Trigger Enable Position */
+#define TC_CMR_WAVEFORM_ENETRG_Msk          (_U_(0x1) << TC_CMR_WAVEFORM_ENETRG_Pos)       /**< (TC_CMR) External Event Trigger Enable Mask */
+#define TC_CMR_WAVEFORM_ENETRG              TC_CMR_WAVEFORM_ENETRG_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVEFORM_ENETRG_Msk instead */
+#define TC_CMR_WAVEFORM_WAVSEL_Pos          13                                             /**< (TC_CMR) Waveform Selection Position */
+#define TC_CMR_WAVEFORM_WAVSEL_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_WAVSEL_Pos)       /**< (TC_CMR) Waveform Selection Mask */
+#define TC_CMR_WAVEFORM_WAVSEL(value)       (TC_CMR_WAVEFORM_WAVSEL_Msk & ((value) << TC_CMR_WAVEFORM_WAVSEL_Pos))
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM UP mode without automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_Val _U_(0x1)                                       /**< (TC_CMR) WAVEFORM UPDOWN mode without automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UP_RC_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM UP mode with automatic trigger on RC Compare  */
+#define   TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM UPDOWN mode with automatic trigger on RC Compare  */
+#define TC_CMR_WAVEFORM_WAVSEL_UP           (TC_CMR_WAVEFORM_WAVSEL_UP_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UP mode without automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN       (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UPDOWN mode without automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UP_RC        (TC_CMR_WAVEFORM_WAVSEL_UP_RC_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UP mode with automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC    (TC_CMR_WAVEFORM_WAVSEL_UPDOWN_RC_Val << TC_CMR_WAVEFORM_WAVSEL_Pos)  /**< (TC_CMR) UPDOWN mode with automatic trigger on RC Compare Position  */
+#define TC_CMR_WAVEFORM_ACPA_Pos            16                                             /**< (TC_CMR) RA Compare Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ACPA_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_ACPA_Pos)         /**< (TC_CMR) RA Compare Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ACPA(value)         (TC_CMR_WAVEFORM_ACPA_Msk & ((value) << TC_CMR_WAVEFORM_ACPA_Pos))
+#define   TC_CMR_WAVEFORM_ACPA_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ACPA_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ACPA_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ACPA_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ACPA_NONE           (TC_CMR_WAVEFORM_ACPA_NONE_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ACPA_SET            (TC_CMR_WAVEFORM_ACPA_SET_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ACPA_CLEAR          (TC_CMR_WAVEFORM_ACPA_CLEAR_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ACPA_TOGGLE         (TC_CMR_WAVEFORM_ACPA_TOGGLE_Val << TC_CMR_WAVEFORM_ACPA_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_ACPC_Pos            18                                             /**< (TC_CMR) RC Compare Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ACPC_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_ACPC_Pos)         /**< (TC_CMR) RC Compare Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ACPC(value)         (TC_CMR_WAVEFORM_ACPC_Msk & ((value) << TC_CMR_WAVEFORM_ACPC_Pos))
+#define   TC_CMR_WAVEFORM_ACPC_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ACPC_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ACPC_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ACPC_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ACPC_NONE           (TC_CMR_WAVEFORM_ACPC_NONE_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ACPC_SET            (TC_CMR_WAVEFORM_ACPC_SET_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ACPC_CLEAR          (TC_CMR_WAVEFORM_ACPC_CLEAR_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ACPC_TOGGLE         (TC_CMR_WAVEFORM_ACPC_TOGGLE_Val << TC_CMR_WAVEFORM_ACPC_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_AEEVT_Pos           20                                             /**< (TC_CMR) External Event Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_AEEVT_Msk           (_U_(0x3) << TC_CMR_WAVEFORM_AEEVT_Pos)        /**< (TC_CMR) External Event Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_AEEVT(value)        (TC_CMR_WAVEFORM_AEEVT_Msk & ((value) << TC_CMR_WAVEFORM_AEEVT_Pos))
+#define   TC_CMR_WAVEFORM_AEEVT_NONE_Val    _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_AEEVT_SET_Val     _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_AEEVT_CLEAR_Val   _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_AEEVT_NONE          (TC_CMR_WAVEFORM_AEEVT_NONE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_AEEVT_SET           (TC_CMR_WAVEFORM_AEEVT_SET_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_AEEVT_CLEAR         (TC_CMR_WAVEFORM_AEEVT_CLEAR_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_AEEVT_TOGGLE        (TC_CMR_WAVEFORM_AEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_AEEVT_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_Pos          22                                             /**< (TC_CMR) Software Trigger Effect on TIOAx Position */
+#define TC_CMR_WAVEFORM_ASWTRG_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_ASWTRG_Pos)       /**< (TC_CMR) Software Trigger Effect on TIOAx Mask */
+#define TC_CMR_WAVEFORM_ASWTRG(value)       (TC_CMR_WAVEFORM_ASWTRG_Msk & ((value) << TC_CMR_WAVEFORM_ASWTRG_Pos))
+#define   TC_CMR_WAVEFORM_ASWTRG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_ASWTRG_SET_Val    _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_ASWTRG_NONE         (TC_CMR_WAVEFORM_ASWTRG_NONE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_SET          (TC_CMR_WAVEFORM_ASWTRG_SET_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_CLEAR        (TC_CMR_WAVEFORM_ASWTRG_CLEAR_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_ASWTRG_TOGGLE       (TC_CMR_WAVEFORM_ASWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_ASWTRG_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BCPB_Pos            24                                             /**< (TC_CMR) RB Compare Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BCPB_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_BCPB_Pos)         /**< (TC_CMR) RB Compare Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BCPB(value)         (TC_CMR_WAVEFORM_BCPB_Msk & ((value) << TC_CMR_WAVEFORM_BCPB_Pos))
+#define   TC_CMR_WAVEFORM_BCPB_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BCPB_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BCPB_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BCPB_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BCPB_NONE           (TC_CMR_WAVEFORM_BCPB_NONE_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BCPB_SET            (TC_CMR_WAVEFORM_BCPB_SET_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BCPB_CLEAR          (TC_CMR_WAVEFORM_BCPB_CLEAR_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BCPB_TOGGLE         (TC_CMR_WAVEFORM_BCPB_TOGGLE_Val << TC_CMR_WAVEFORM_BCPB_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BCPC_Pos            26                                             /**< (TC_CMR) RC Compare Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BCPC_Msk            (_U_(0x3) << TC_CMR_WAVEFORM_BCPC_Pos)         /**< (TC_CMR) RC Compare Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BCPC(value)         (TC_CMR_WAVEFORM_BCPC_Msk & ((value) << TC_CMR_WAVEFORM_BCPC_Pos))
+#define   TC_CMR_WAVEFORM_BCPC_NONE_Val     _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BCPC_SET_Val      _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BCPC_CLEAR_Val    _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BCPC_TOGGLE_Val   _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BCPC_NONE           (TC_CMR_WAVEFORM_BCPC_NONE_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BCPC_SET            (TC_CMR_WAVEFORM_BCPC_SET_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BCPC_CLEAR          (TC_CMR_WAVEFORM_BCPC_CLEAR_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BCPC_TOGGLE         (TC_CMR_WAVEFORM_BCPC_TOGGLE_Val << TC_CMR_WAVEFORM_BCPC_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BEEVT_Pos           28                                             /**< (TC_CMR) External Event Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BEEVT_Msk           (_U_(0x3) << TC_CMR_WAVEFORM_BEEVT_Pos)        /**< (TC_CMR) External Event Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BEEVT(value)        (TC_CMR_WAVEFORM_BEEVT_Msk & ((value) << TC_CMR_WAVEFORM_BEEVT_Pos))
+#define   TC_CMR_WAVEFORM_BEEVT_NONE_Val    _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BEEVT_SET_Val     _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BEEVT_CLEAR_Val   _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val  _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BEEVT_NONE          (TC_CMR_WAVEFORM_BEEVT_NONE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BEEVT_SET           (TC_CMR_WAVEFORM_BEEVT_SET_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BEEVT_CLEAR         (TC_CMR_WAVEFORM_BEEVT_CLEAR_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BEEVT_TOGGLE        (TC_CMR_WAVEFORM_BEEVT_TOGGLE_Val << TC_CMR_WAVEFORM_BEEVT_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_Pos          30                                             /**< (TC_CMR) Software Trigger Effect on TIOBx Position */
+#define TC_CMR_WAVEFORM_BSWTRG_Msk          (_U_(0x3) << TC_CMR_WAVEFORM_BSWTRG_Pos)       /**< (TC_CMR) Software Trigger Effect on TIOBx Mask */
+#define TC_CMR_WAVEFORM_BSWTRG(value)       (TC_CMR_WAVEFORM_BSWTRG_Msk & ((value) << TC_CMR_WAVEFORM_BSWTRG_Pos))
+#define   TC_CMR_WAVEFORM_BSWTRG_NONE_Val   _U_(0x0)                                       /**< (TC_CMR) WAVEFORM NONE  */
+#define   TC_CMR_WAVEFORM_BSWTRG_SET_Val    _U_(0x1)                                       /**< (TC_CMR) WAVEFORM SET  */
+#define   TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val  _U_(0x2)                                       /**< (TC_CMR) WAVEFORM CLEAR  */
+#define   TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val _U_(0x3)                                       /**< (TC_CMR) WAVEFORM TOGGLE  */
+#define TC_CMR_WAVEFORM_BSWTRG_NONE         (TC_CMR_WAVEFORM_BSWTRG_NONE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) NONE Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_SET          (TC_CMR_WAVEFORM_BSWTRG_SET_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) SET Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_CLEAR        (TC_CMR_WAVEFORM_BSWTRG_CLEAR_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) CLEAR Position  */
+#define TC_CMR_WAVEFORM_BSWTRG_TOGGLE       (TC_CMR_WAVEFORM_BSWTRG_TOGGLE_Val << TC_CMR_WAVEFORM_BSWTRG_Pos)  /**< (TC_CMR) TOGGLE Position  */
+#define TC_CMR_WAVEFORM_MASK                _U_(0xFFFF7FC0)                                /**< \deprecated (TC_CMR_WAVEFORM) Register MASK  (Use TC_CMR_WAVEFORM_Msk instead)  */
+#define TC_CMR_WAVEFORM_Msk                 _U_(0xFFFF7FC0)                                /**< (TC_CMR_WAVEFORM) Register Mask  */
 
 
 /* -------- TC_SMMR : (TC Offset: 0x08) (R/W 32) Stepper Motor Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t GCEN:1;                    /**< bit:      0  Gray Count Enable                        */
@@ -284,6 +373,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_SMMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SMMR_OFFSET                      (0x08)                                        /**<  (TC_SMMR) Stepper Motor Mode Register (channel = 0)  Offset */
@@ -300,12 +390,14 @@ typedef union {
 
 /* -------- TC_RAB : (TC Offset: 0x0c) (R/ 32) Register AB (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RAB:32;                    /**< bit:  0..31  Register A or Register B                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RAB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RAB_OFFSET                       (0x0C)                                        /**<  (TC_RAB) Register AB (channel = 0)  Offset */
@@ -319,12 +411,14 @@ typedef union {
 
 /* -------- TC_CV : (TC Offset: 0x10) (R/ 32) Counter Value (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CV:32;                     /**< bit:  0..31  Counter Value                            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_CV_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_CV_OFFSET                        (0x10)                                        /**<  (TC_CV) Counter Value (channel = 0)  Offset */
@@ -338,12 +432,14 @@ typedef union {
 
 /* -------- TC_RA : (TC Offset: 0x14) (R/W 32) Register A (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RA:32;                     /**< bit:  0..31  Register A                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RA_OFFSET                        (0x14)                                        /**<  (TC_RA) Register A (channel = 0)  Offset */
@@ -357,12 +453,14 @@ typedef union {
 
 /* -------- TC_RB : (TC Offset: 0x18) (R/W 32) Register B (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RB:32;                     /**< bit:  0..31  Register B                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RB_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RB_OFFSET                        (0x18)                                        /**<  (TC_RB) Register B (channel = 0)  Offset */
@@ -376,12 +474,14 @@ typedef union {
 
 /* -------- TC_RC : (TC Offset: 0x1c) (R/W 32) Register C (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RC:32;                     /**< bit:  0..31  Register C                               */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_RC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_RC_OFFSET                        (0x1C)                                        /**<  (TC_RC) Register C (channel = 0)  Offset */
@@ -395,6 +495,7 @@ typedef union {
 
 /* -------- TC_SR : (TC Offset: 0x20) (R/ 32) Status Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow Status (cleared on read) */
@@ -413,6 +514,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_SR_OFFSET                        (0x20)                                        /**<  (TC_SR) Status Register (channel = 0)  Offset */
@@ -456,6 +558,7 @@ typedef union {
 
 /* -------- TC_IER : (TC Offset: 0x24) (/W 32) Interrupt Enable Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -470,6 +573,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IER_OFFSET                       (0x24)                                        /**<  (TC_IER) Interrupt Enable Register (channel = 0)  Offset */
@@ -504,6 +608,7 @@ typedef union {
 
 /* -------- TC_IDR : (TC Offset: 0x28) (/W 32) Interrupt Disable Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -518,6 +623,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IDR_OFFSET                       (0x28)                                        /**<  (TC_IDR) Interrupt Disable Register (channel = 0)  Offset */
@@ -552,6 +658,7 @@ typedef union {
 
 /* -------- TC_IMR : (TC Offset: 0x2c) (R/ 32) Interrupt Mask Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COVFS:1;                   /**< bit:      0  Counter Overflow                         */
@@ -566,6 +673,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_IMR_OFFSET                       (0x2C)                                        /**<  (TC_IMR) Interrupt Mask Register (channel = 0)  Offset */
@@ -600,6 +708,7 @@ typedef union {
 
 /* -------- TC_EMR : (TC Offset: 0x30) (R/W 32) Extended Mode Register (channel = 0) -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TRIGSRCA:2;                /**< bit:   0..1  Trigger Source for Input A               */
@@ -611,6 +720,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_EMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_EMR_OFFSET                       (0x30)                                        /**<  (TC_EMR) Extended Mode Register (channel = 0)  Offset */
@@ -638,6 +748,7 @@ typedef union {
 
 /* -------- TC_BCR : (TC Offset: 0xc0) (/W 32) Block Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SYNC:1;                    /**< bit:      0  Synchro Command                          */
@@ -645,6 +756,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_BCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BCR_OFFSET                       (0xC0)                                        /**<  (TC_BCR) Block Control Register  Offset */
@@ -658,6 +770,7 @@ typedef union {
 
 /* -------- TC_BMR : (TC Offset: 0xc4) (R/W 32) Block Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TC0XC0S:2;                 /**< bit:   0..1  External Clock Signal 0 Selection        */
@@ -674,12 +787,15 @@ typedef union {
     uint32_t INVIDX:1;                  /**< bit:     15  Inverted Index                           */
     uint32_t SWAP:1;                    /**< bit:     16  Swap PHA and PHB                         */
     uint32_t IDXPHB:1;                  /**< bit:     17  Index Pin is PHB Pin                     */
-    uint32_t :2;                        /**< bit: 18..19  Reserved */
+    uint32_t AUTOC:1;                   /**< bit:     18  AutoCorrection of missing pulses         */
+    uint32_t :1;                        /**< bit:     19  Reserved */
     uint32_t MAXFILT:6;                 /**< bit: 20..25  Maximum Filter                           */
-    uint32_t :6;                        /**< bit: 26..31  Reserved */
+    uint32_t MAXCMP:4;                  /**< bit: 26..29  Maximum Consecutive Missing Pulses       */
+    uint32_t :2;                        /**< bit: 30..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_BMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_BMR_OFFSET                       (0xC4)                                        /**<  (TC_BMR) Block Mode Register  Offset */
@@ -741,24 +857,33 @@ typedef union {
 #define TC_BMR_IDXPHB_Pos                   17                                             /**< (TC_BMR) Index Pin is PHB Pin Position */
 #define TC_BMR_IDXPHB_Msk                   (_U_(0x1) << TC_BMR_IDXPHB_Pos)                /**< (TC_BMR) Index Pin is PHB Pin Mask */
 #define TC_BMR_IDXPHB                       TC_BMR_IDXPHB_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_IDXPHB_Msk instead */
+#define TC_BMR_AUTOC_Pos                    18                                             /**< (TC_BMR) AutoCorrection of missing pulses Position */
+#define TC_BMR_AUTOC_Msk                    (_U_(0x1) << TC_BMR_AUTOC_Pos)                 /**< (TC_BMR) AutoCorrection of missing pulses Mask */
+#define TC_BMR_AUTOC                        TC_BMR_AUTOC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_BMR_AUTOC_Msk instead */
 #define TC_BMR_MAXFILT_Pos                  20                                             /**< (TC_BMR) Maximum Filter Position */
 #define TC_BMR_MAXFILT_Msk                  (_U_(0x3F) << TC_BMR_MAXFILT_Pos)              /**< (TC_BMR) Maximum Filter Mask */
 #define TC_BMR_MAXFILT(value)               (TC_BMR_MAXFILT_Msk & ((value) << TC_BMR_MAXFILT_Pos))
-#define TC_BMR_MASK                         _U_(0x3F3FF3F)                                 /**< \deprecated (TC_BMR) Register MASK  (Use TC_BMR_Msk instead)  */
-#define TC_BMR_Msk                          _U_(0x3F3FF3F)                                 /**< (TC_BMR) Register Mask  */
+#define TC_BMR_MAXCMP_Pos                   26                                             /**< (TC_BMR) Maximum Consecutive Missing Pulses Position */
+#define TC_BMR_MAXCMP_Msk                   (_U_(0xF) << TC_BMR_MAXCMP_Pos)                /**< (TC_BMR) Maximum Consecutive Missing Pulses Mask */
+#define TC_BMR_MAXCMP(value)                (TC_BMR_MAXCMP_Msk & ((value) << TC_BMR_MAXCMP_Pos))
+#define TC_BMR_MASK                         _U_(0x3FF7FF3F)                                /**< \deprecated (TC_BMR) Register MASK  (Use TC_BMR_Msk instead)  */
+#define TC_BMR_Msk                          _U_(0x3FF7FF3F)                                /**< (TC_BMR) Register Mask  */
 
 
 /* -------- TC_QIER : (TC Offset: 0xc8) (/W 32) QDEC Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
     uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
     uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
-    uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIER_OFFSET                      (0xC8)                                        /**<  (TC_QIER) QDEC Interrupt Enable Register  Offset */
@@ -772,21 +897,27 @@ typedef union {
 #define TC_QIER_QERR_Pos                    2                                              /**< (TC_QIER) Quadrature Error Position */
 #define TC_QIER_QERR_Msk                    (_U_(0x1) << TC_QIER_QERR_Pos)                 /**< (TC_QIER) Quadrature Error Mask */
 #define TC_QIER_QERR                        TC_QIER_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_QERR_Msk instead */
-#define TC_QIER_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIER) Register MASK  (Use TC_QIER_Msk instead)  */
-#define TC_QIER_Msk                         _U_(0x07)                                      /**< (TC_QIER) Register Mask  */
+#define TC_QIER_MPE_Pos                     3                                              /**< (TC_QIER) Consecutive Missing Pulse Error Position */
+#define TC_QIER_MPE_Msk                     (_U_(0x1) << TC_QIER_MPE_Pos)                  /**< (TC_QIER) Consecutive Missing Pulse Error Mask */
+#define TC_QIER_MPE                         TC_QIER_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIER_MPE_Msk instead */
+#define TC_QIER_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIER) Register MASK  (Use TC_QIER_Msk instead)  */
+#define TC_QIER_Msk                         _U_(0x0F)                                      /**< (TC_QIER) Register Mask  */
 
 
 /* -------- TC_QIDR : (TC Offset: 0xcc) (/W 32) QDEC Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
     uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
     uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
-    uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIDR_OFFSET                      (0xCC)                                        /**<  (TC_QIDR) QDEC Interrupt Disable Register  Offset */
@@ -800,21 +931,27 @@ typedef union {
 #define TC_QIDR_QERR_Pos                    2                                              /**< (TC_QIDR) Quadrature Error Position */
 #define TC_QIDR_QERR_Msk                    (_U_(0x1) << TC_QIDR_QERR_Pos)                 /**< (TC_QIDR) Quadrature Error Mask */
 #define TC_QIDR_QERR                        TC_QIDR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_QERR_Msk instead */
-#define TC_QIDR_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIDR) Register MASK  (Use TC_QIDR_Msk instead)  */
-#define TC_QIDR_Msk                         _U_(0x07)                                      /**< (TC_QIDR) Register Mask  */
+#define TC_QIDR_MPE_Pos                     3                                              /**< (TC_QIDR) Consecutive Missing Pulse Error Position */
+#define TC_QIDR_MPE_Msk                     (_U_(0x1) << TC_QIDR_MPE_Pos)                  /**< (TC_QIDR) Consecutive Missing Pulse Error Mask */
+#define TC_QIDR_MPE                         TC_QIDR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIDR_MPE_Msk instead */
+#define TC_QIDR_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIDR) Register MASK  (Use TC_QIDR_Msk instead)  */
+#define TC_QIDR_Msk                         _U_(0x0F)                                      /**< (TC_QIDR) Register Mask  */
 
 
 /* -------- TC_QIMR : (TC Offset: 0xd0) (R/ 32) QDEC Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
     uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
     uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
-    uint32_t :29;                       /**< bit:  3..31  Reserved */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :28;                       /**< bit:  4..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QIMR_OFFSET                      (0xD0)                                        /**<  (TC_QIMR) QDEC Interrupt Mask Register  Offset */
@@ -828,23 +965,29 @@ typedef union {
 #define TC_QIMR_QERR_Pos                    2                                              /**< (TC_QIMR) Quadrature Error Position */
 #define TC_QIMR_QERR_Msk                    (_U_(0x1) << TC_QIMR_QERR_Pos)                 /**< (TC_QIMR) Quadrature Error Mask */
 #define TC_QIMR_QERR                        TC_QIMR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_QERR_Msk instead */
-#define TC_QIMR_MASK                        _U_(0x07)                                      /**< \deprecated (TC_QIMR) Register MASK  (Use TC_QIMR_Msk instead)  */
-#define TC_QIMR_Msk                         _U_(0x07)                                      /**< (TC_QIMR) Register Mask  */
+#define TC_QIMR_MPE_Pos                     3                                              /**< (TC_QIMR) Consecutive Missing Pulse Error Position */
+#define TC_QIMR_MPE_Msk                     (_U_(0x1) << TC_QIMR_MPE_Pos)                  /**< (TC_QIMR) Consecutive Missing Pulse Error Mask */
+#define TC_QIMR_MPE                         TC_QIMR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QIMR_MPE_Msk instead */
+#define TC_QIMR_MASK                        _U_(0x0F)                                      /**< \deprecated (TC_QIMR) Register MASK  (Use TC_QIMR_Msk instead)  */
+#define TC_QIMR_Msk                         _U_(0x0F)                                      /**< (TC_QIMR) Register Mask  */
 
 
 /* -------- TC_QISR : (TC Offset: 0xd4) (R/ 32) QDEC Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDX:1;                     /**< bit:      0  Index                                    */
     uint32_t DIRCHG:1;                  /**< bit:      1  Direction Change                         */
     uint32_t QERR:1;                    /**< bit:      2  Quadrature Error                         */
-    uint32_t :5;                        /**< bit:   3..7  Reserved */
+    uint32_t MPE:1;                     /**< bit:      3  Consecutive Missing Pulse Error          */
+    uint32_t :4;                        /**< bit:   4..7  Reserved */
     uint32_t DIR:1;                     /**< bit:      8  Direction                                */
     uint32_t :23;                       /**< bit:  9..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_QISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_QISR_OFFSET                      (0xD4)                                        /**<  (TC_QISR) QDEC Interrupt Status Register  Offset */
@@ -858,15 +1001,19 @@ typedef union {
 #define TC_QISR_QERR_Pos                    2                                              /**< (TC_QISR) Quadrature Error Position */
 #define TC_QISR_QERR_Msk                    (_U_(0x1) << TC_QISR_QERR_Pos)                 /**< (TC_QISR) Quadrature Error Mask */
 #define TC_QISR_QERR                        TC_QISR_QERR_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_QERR_Msk instead */
+#define TC_QISR_MPE_Pos                     3                                              /**< (TC_QISR) Consecutive Missing Pulse Error Position */
+#define TC_QISR_MPE_Msk                     (_U_(0x1) << TC_QISR_MPE_Pos)                  /**< (TC_QISR) Consecutive Missing Pulse Error Mask */
+#define TC_QISR_MPE                         TC_QISR_MPE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_MPE_Msk instead */
 #define TC_QISR_DIR_Pos                     8                                              /**< (TC_QISR) Direction Position */
 #define TC_QISR_DIR_Msk                     (_U_(0x1) << TC_QISR_DIR_Pos)                  /**< (TC_QISR) Direction Mask */
 #define TC_QISR_DIR                         TC_QISR_DIR_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_QISR_DIR_Msk instead */
-#define TC_QISR_MASK                        _U_(0x107)                                     /**< \deprecated (TC_QISR) Register MASK  (Use TC_QISR_Msk instead)  */
-#define TC_QISR_Msk                         _U_(0x107)                                     /**< (TC_QISR) Register Mask  */
+#define TC_QISR_MASK                        _U_(0x10F)                                     /**< \deprecated (TC_QISR) Register MASK  (Use TC_QISR_Msk instead)  */
+#define TC_QISR_Msk                         _U_(0x10F)                                     /**< (TC_QISR) Register Mask  */
 
 
 /* -------- TC_FMR : (TC Offset: 0xd8) (R/W 32) Fault Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENCF0:1;                   /**< bit:      0  Enable Compare Fault Channel 0           */
@@ -879,6 +1026,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } TC_FMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_FMR_OFFSET                       (0xD8)                                        /**<  (TC_FMR) Fault Mode Register  Offset */
@@ -898,6 +1046,7 @@ typedef union {
 
 /* -------- TC_WPMR : (TC Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -906,6 +1055,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TC_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TC_WPMR_OFFSET                      (0xE4)                                        /**<  (TC_WPMR) Write Protection Mode Register  Offset */
@@ -939,13 +1089,13 @@ typedef struct {
   __O  uint32_t TC_IDR;         /**< (TC_CHANNEL Offset: 0x28) Interrupt Disable Register (channel = 0) */
   __I  uint32_t TC_IMR;         /**< (TC_CHANNEL Offset: 0x2C) Interrupt Mask Register (channel = 0) */
   __IO uint32_t TC_EMR;         /**< (TC_CHANNEL Offset: 0x30) Extended Mode Register (channel = 0) */
-       RoReg8                         Reserved1[0x0C];
+  __I  uint8_t                        Reserved1[12];
 } TcChannel;
 
 #define TCCHANNEL_NUMBER 3
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel TC_CHANNEL[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
   __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
   __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
@@ -953,7 +1103,7 @@ typedef struct {
   __I  uint32_t TC_QIMR;        /**< (TC Offset: 0xD0) QDEC Interrupt Mask Register */
   __I  uint32_t TC_QISR;        /**< (TC Offset: 0xD4) QDEC Interrupt Status Register */
   __IO uint32_t TC_FMR;         /**< (TC Offset: 0xD8) Fault Mode Register */
-  RoReg8  Reserved1[0x8];
+  __I  uint8_t                        Reserved1[8];
   __IO uint32_t TC_WPMR;        /**< (TC Offset: 0xE4) Write Protection Mode Register */
 } Tc;
 
@@ -973,12 +1123,12 @@ typedef struct {
   __O  TC_IDR_Type                    TC_IDR;         /**< Offset: 0x28 ( /W  32) Interrupt Disable Register (channel = 0) */
   __I  TC_IMR_Type                    TC_IMR;         /**< Offset: 0x2C (R/   32) Interrupt Mask Register (channel = 0) */
   __IO TC_EMR_Type                    TC_EMR;         /**< Offset: 0x30 (R/W  32) Extended Mode Register (channel = 0) */
-       RoReg8                         Reserved1[0x0C];
+  __I  uint8_t                        Reserved1[12];
 } TcChannel;
 
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel                      TC_CHANNEL[3];  /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
   __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
   __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */
@@ -986,7 +1136,7 @@ typedef struct {
   __I  TC_QIMR_Type                   TC_QIMR;        /**< Offset: 0xD0 (R/   32) QDEC Interrupt Mask Register */
   __I  TC_QISR_Type                   TC_QISR;        /**< Offset: 0xD4 (R/   32) QDEC Interrupt Status Register */
   __IO TC_FMR_Type                    TC_FMR;         /**< Offset: 0xD8 (R/W  32) Fault Mode Register */
-  __I  uint32_t                       Reserved1[2];
+  __I  uint8_t                        Reserved1[8];
   __IO TC_WPMR_Type                   TC_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Tc;
 
@@ -997,4 +1147,7 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 /** @}  end of Timer Counter */
 
+#if !(defined(DO_NOT_USE_DEPRECATED_MACROS))
+#include "deprecated/tc.h"
+#endif /* DO_NOT_USE_DEPRECATED_MACROS */
 #endif /* _SAME70_TC_COMPONENT_H_ */

--- a/asf/sam/include/same70b/component/tc.h
+++ b/asf/sam/include/same70b/component/tc.h
@@ -1095,7 +1095,7 @@ typedef struct {
 #define TCCHANNEL_NUMBER 3
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel TcChannel[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel TC_CHANNEL[TCCHANNEL_NUMBER]; /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  uint32_t TC_BCR;         /**< (TC Offset: 0xC0) Block Control Register */
   __IO uint32_t TC_BMR;         /**< (TC Offset: 0xC4) Block Mode Register */
   __O  uint32_t TC_QIER;        /**< (TC Offset: 0xC8) QDEC Interrupt Enable Register */
@@ -1128,7 +1128,7 @@ typedef struct {
 
 /** \brief TC hardware registers */
 typedef struct {  
-       TcChannel                      TcChannel[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
+       TcChannel                      TC_CHANNEL[3];   /**< Offset: 0x00 Channel Control Register (channel = 0) */
   __O  TC_BCR_Type                    TC_BCR;         /**< Offset: 0xC0 ( /W  32) Block Control Register */
   __IO TC_BMR_Type                    TC_BMR;         /**< Offset: 0xC4 (R/W  32) Block Mode Register */
   __O  TC_QIER_Type                   TC_QIER;        /**< Offset: 0xC8 ( /W  32) QDEC Interrupt Enable Register */

--- a/asf/sam/include/same70b/component/trng.h
+++ b/asf/sam/include/same70b/component/trng.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TRNG
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TRNG_COMPONENT_H_
 #define _SAME70_TRNG_COMPONENT_H_
 #define _SAME70_TRNG_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- TRNG_CR : (TRNG Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ENABLE:1;                  /**< bit:      0  Enables the TRNG to Provide Random Values */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_CR_OFFSET                      (0x00)                                        /**<  (TRNG_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- TRNG_IER : (TRNG Offset: 0x10) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Enable              */
@@ -78,6 +83,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IER_OFFSET                     (0x10)                                        /**<  (TRNG_IER) Interrupt Enable Register  Offset */
@@ -91,6 +97,7 @@ typedef union {
 
 /* -------- TRNG_IDR : (TRNG Offset: 0x14) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Disable             */
@@ -98,6 +105,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IDR_OFFSET                     (0x14)                                        /**<  (TRNG_IDR) Interrupt Disable Register  Offset */
@@ -111,6 +119,7 @@ typedef union {
 
 /* -------- TRNG_IMR : (TRNG Offset: 0x18) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready Interrupt Mask                */
@@ -118,6 +127,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_IMR_OFFSET                     (0x18)                                        /**<  (TRNG_IMR) Interrupt Mask Register  Offset */
@@ -131,6 +141,7 @@ typedef union {
 
 /* -------- TRNG_ISR : (TRNG Offset: 0x1c) (R/ 32) Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATRDY:1;                  /**< bit:      0  Data Ready                               */
@@ -138,6 +149,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_ISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ISR_OFFSET                     (0x1C)                                        /**<  (TRNG_ISR) Interrupt Status Register  Offset */
@@ -151,12 +163,14 @@ typedef union {
 
 /* -------- TRNG_ODATA : (TRNG Offset: 0x50) (R/ 32) Output Data Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ODATA:32;                  /**< bit:  0..31  Output Data                              */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TRNG_ODATA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TRNG_ODATA_OFFSET                   (0x50)                                        /**<  (TRNG_ODATA) Output Data Register  Offset */
@@ -173,12 +187,12 @@ typedef union {
 /** \brief TRNG hardware registers */
 typedef struct {  
   __O  uint32_t TRNG_CR;        /**< (TRNG Offset: 0x00) Control Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __O  uint32_t TRNG_IER;       /**< (TRNG Offset: 0x10) Interrupt Enable Register */
   __O  uint32_t TRNG_IDR;       /**< (TRNG Offset: 0x14) Interrupt Disable Register */
   __I  uint32_t TRNG_IMR;       /**< (TRNG Offset: 0x18) Interrupt Mask Register */
   __I  uint32_t TRNG_ISR;       /**< (TRNG Offset: 0x1C) Interrupt Status Register */
-  RoReg8  Reserved2[0x30];
+  __I  uint8_t                        Reserved2[48];
   __I  uint32_t TRNG_ODATA;     /**< (TRNG Offset: 0x50) Output Data Register */
 } Trng;
 
@@ -186,12 +200,12 @@ typedef struct {
 /** \brief TRNG hardware registers */
 typedef struct {  
   __O  TRNG_CR_Type                   TRNG_CR;        /**< Offset: 0x00 ( /W  32) Control Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __O  TRNG_IER_Type                  TRNG_IER;       /**< Offset: 0x10 ( /W  32) Interrupt Enable Register */
   __O  TRNG_IDR_Type                  TRNG_IDR;       /**< Offset: 0x14 ( /W  32) Interrupt Disable Register */
   __I  TRNG_IMR_Type                  TRNG_IMR;       /**< Offset: 0x18 (R/   32) Interrupt Mask Register */
   __I  TRNG_ISR_Type                  TRNG_ISR;       /**< Offset: 0x1C (R/   32) Interrupt Status Register */
-  __I  uint32_t                       Reserved2[12];
+  __I  uint8_t                        Reserved2[48];
   __I  TRNG_ODATA_Type                TRNG_ODATA;     /**< Offset: 0x50 (R/   32) Output Data Register */
 } Trng;
 

--- a/asf/sam/include/same70b/component/twihs.h
+++ b/asf/sam/include/same70b/component/twihs.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for TWIHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TWIHS_COMPONENT_H_
 #define _SAME70_TWIHS_COMPONENT_H_
 #define _SAME70_TWIHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- TWIHS_CR : (TWIHS Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t START:1;                   /**< bit:      0  Send a START Condition                   */
@@ -76,6 +79,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_CR_OFFSET                     (0x00)                                        /**<  (TWIHS_CR) Control Register  Offset */
@@ -152,6 +156,7 @@ typedef union {
 
 /* -------- TWIHS_MMR : (TWIHS Offset: 0x04) (R/W 32) Master Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
@@ -164,6 +169,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_MMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_MMR_OFFSET                    (0x04)                                        /**<  (TWIHS_MMR) Master Mode Register  Offset */
@@ -191,6 +197,7 @@ typedef union {
 
 /* -------- TWIHS_SMR : (TWIHS Offset: 0x08) (R/W 32) Slave Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NACKEN:1;                  /**< bit:      0  Slave Receiver Data Phase NACK enable    */
@@ -211,6 +218,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SMR_OFFSET                    (0x08)                                        /**<  (TWIHS_SMR) Slave Mode Register  Offset */
@@ -250,6 +258,7 @@ typedef union {
 
 /* -------- TWIHS_IADR : (TWIHS Offset: 0x0c) (R/W 32) Internal Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IADR:24;                   /**< bit:  0..23  Internal Address                         */
@@ -257,6 +266,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IADR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IADR_OFFSET                   (0x0C)                                        /**<  (TWIHS_IADR) Internal Address Register  Offset */
@@ -270,6 +280,7 @@ typedef union {
 
 /* -------- TWIHS_CWGR : (TWIHS Offset: 0x10) (R/W 32) Clock Waveform Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CLDIV:8;                   /**< bit:   0..7  Clock Low Divider                        */
@@ -281,6 +292,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_CWGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_CWGR_OFFSET                   (0x10)                                        /**<  (TWIHS_CWGR) Clock Waveform Generator Register  Offset */
@@ -303,6 +315,7 @@ typedef union {
 
 /* -------- TWIHS_SR : (TWIHS Offset: 0x20) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed (cleared by writing TWIHS_THR) */
@@ -331,6 +344,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SR_OFFSET                     (0x20)                                        /**<  (TWIHS_SR) Status Register  Offset */
@@ -398,6 +412,7 @@ typedef union {
 
 /* -------- TWIHS_IER : (TWIHS Offset: 0x24) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Enable  */
@@ -423,6 +438,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IER_OFFSET                    (0x24)                                        /**<  (TWIHS_IER) Interrupt Enable Register  Offset */
@@ -481,6 +497,7 @@ typedef union {
 
 /* -------- TWIHS_IDR : (TWIHS Offset: 0x28) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Disable */
@@ -506,6 +523,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IDR_OFFSET                    (0x28)                                        /**<  (TWIHS_IDR) Interrupt Disable Register  Offset */
@@ -564,6 +582,7 @@ typedef union {
 
 /* -------- TWIHS_IMR : (TWIHS Offset: 0x2c) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCOMP:1;                  /**< bit:      0  Transmission Completed Interrupt Mask    */
@@ -589,6 +608,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_IMR_OFFSET                    (0x2C)                                        /**<  (TWIHS_IMR) Interrupt Mask Register  Offset */
@@ -647,6 +667,7 @@ typedef union {
 
 /* -------- TWIHS_RHR : (TWIHS Offset: 0x30) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXDATA:8;                  /**< bit:   0..7  Master or Slave Receive Holding Data     */
@@ -654,6 +675,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_RHR_OFFSET                    (0x30)                                        /**<  (TWIHS_RHR) Receive Holding Register  Offset */
@@ -667,6 +689,7 @@ typedef union {
 
 /* -------- TWIHS_THR : (TWIHS Offset: 0x34) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXDATA:8;                  /**< bit:   0..7  Master or Slave Transmit Holding Data    */
@@ -674,6 +697,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_THR_OFFSET                    (0x34)                                        /**<  (TWIHS_THR) Transmit Holding Register  Offset */
@@ -687,6 +711,7 @@ typedef union {
 
 /* -------- TWIHS_SMBTR : (TWIHS Offset: 0x38) (R/W 32) SMBus Timing Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PRESC:4;                   /**< bit:   0..3  SMBus Clock Prescaler                    */
@@ -697,6 +722,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SMBTR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SMBTR_OFFSET                  (0x38)                                        /**<  (TWIHS_SMBTR) SMBus Timing Register  Offset */
@@ -719,6 +745,7 @@ typedef union {
 
 /* -------- TWIHS_FILTR : (TWIHS Offset: 0x44) (R/W 32) Filter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FILT:1;                    /**< bit:      0  RX Digital Filter                        */
@@ -730,6 +757,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_FILTR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_FILTR_OFFSET                  (0x44)                                        /**<  (TWIHS_FILTR) Filter Register  Offset */
@@ -752,6 +780,7 @@ typedef union {
 
 /* -------- TWIHS_SWMR : (TWIHS Offset: 0x4c) (R/W 32) SleepWalking Matching Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SADR1:7;                   /**< bit:   0..6  Slave Address 1                          */
@@ -764,6 +793,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_SWMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_SWMR_OFFSET                   (0x4C)                                        /**<  (TWIHS_SWMR) SleepWalking Matching Register  Offset */
@@ -786,6 +816,7 @@ typedef union {
 
 /* -------- TWIHS_WPMR : (TWIHS Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -794,6 +825,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_WPMR_OFFSET                   (0xE4)                                        /**<  (TWIHS_WPMR) Write Protection Mode Register  Offset */
@@ -812,6 +844,7 @@ typedef union {
 
 /* -------- TWIHS_WPSR : (TWIHS Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -820,6 +853,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } TWIHS_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define TWIHS_WPSR_OFFSET                   (0xE8)                                        /**<  (TWIHS_WPSR) Write Protection Status Register  Offset */
@@ -843,7 +877,7 @@ typedef struct {
   __IO uint32_t TWIHS_SMR;      /**< (TWIHS Offset: 0x08) Slave Mode Register */
   __IO uint32_t TWIHS_IADR;     /**< (TWIHS Offset: 0x0C) Internal Address Register */
   __IO uint32_t TWIHS_CWGR;     /**< (TWIHS Offset: 0x10) Clock Waveform Generator Register */
-  RoReg8  Reserved1[0xC];
+  __I  uint8_t                        Reserved1[12];
   __I  uint32_t TWIHS_SR;       /**< (TWIHS Offset: 0x20) Status Register */
   __O  uint32_t TWIHS_IER;      /**< (TWIHS Offset: 0x24) Interrupt Enable Register */
   __O  uint32_t TWIHS_IDR;      /**< (TWIHS Offset: 0x28) Interrupt Disable Register */
@@ -851,11 +885,11 @@ typedef struct {
   __I  uint32_t TWIHS_RHR;      /**< (TWIHS Offset: 0x30) Receive Holding Register */
   __O  uint32_t TWIHS_THR;      /**< (TWIHS Offset: 0x34) Transmit Holding Register */
   __IO uint32_t TWIHS_SMBTR;    /**< (TWIHS Offset: 0x38) SMBus Timing Register */
-  RoReg8  Reserved2[0x8];
+  __I  uint8_t                        Reserved2[8];
   __IO uint32_t TWIHS_FILTR;    /**< (TWIHS Offset: 0x44) Filter Register */
-  RoReg8  Reserved3[0x4];
+  __I  uint8_t                        Reserved3[4];
   __IO uint32_t TWIHS_SWMR;     /**< (TWIHS Offset: 0x4C) SleepWalking Matching Register */
-  RoReg8  Reserved4[0x94];
+  __I  uint8_t                        Reserved4[148];
   __IO uint32_t TWIHS_WPMR;     /**< (TWIHS Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t TWIHS_WPSR;     /**< (TWIHS Offset: 0xE8) Write Protection Status Register */
 } Twihs;
@@ -868,7 +902,7 @@ typedef struct {
   __IO TWIHS_SMR_Type                 TWIHS_SMR;      /**< Offset: 0x08 (R/W  32) Slave Mode Register */
   __IO TWIHS_IADR_Type                TWIHS_IADR;     /**< Offset: 0x0C (R/W  32) Internal Address Register */
   __IO TWIHS_CWGR_Type                TWIHS_CWGR;     /**< Offset: 0x10 (R/W  32) Clock Waveform Generator Register */
-  __I  uint32_t                       Reserved1[3];
+  __I  uint8_t                        Reserved1[12];
   __I  TWIHS_SR_Type                  TWIHS_SR;       /**< Offset: 0x20 (R/   32) Status Register */
   __O  TWIHS_IER_Type                 TWIHS_IER;      /**< Offset: 0x24 ( /W  32) Interrupt Enable Register */
   __O  TWIHS_IDR_Type                 TWIHS_IDR;      /**< Offset: 0x28 ( /W  32) Interrupt Disable Register */
@@ -876,11 +910,11 @@ typedef struct {
   __I  TWIHS_RHR_Type                 TWIHS_RHR;      /**< Offset: 0x30 (R/   32) Receive Holding Register */
   __O  TWIHS_THR_Type                 TWIHS_THR;      /**< Offset: 0x34 ( /W  32) Transmit Holding Register */
   __IO TWIHS_SMBTR_Type               TWIHS_SMBTR;    /**< Offset: 0x38 (R/W  32) SMBus Timing Register */
-  __I  uint32_t                       Reserved2[2];
+  __I  uint8_t                        Reserved2[8];
   __IO TWIHS_FILTR_Type               TWIHS_FILTR;    /**< Offset: 0x44 (R/W  32) Filter Register */
-  __I  uint32_t                       Reserved3[1];
+  __I  uint8_t                        Reserved3[4];
   __IO TWIHS_SWMR_Type                TWIHS_SWMR;     /**< Offset: 0x4C (R/W  32) SleepWalking Matching Register */
-  __I  uint32_t                       Reserved4[37];
+  __I  uint8_t                        Reserved4[148];
   __IO TWIHS_WPMR_Type                TWIHS_WPMR;     /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  TWIHS_WPSR_Type                TWIHS_WPSR;     /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Twihs;

--- a/asf/sam/include/same70b/component/uart.h
+++ b/asf/sam/include/same70b/component/uart.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for UART
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART_COMPONENT_H_
 #define _SAME70_UART_COMPONENT_H_
 #define _SAME70_UART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- UART_CR : (UART Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -61,6 +64,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_CR_OFFSET                      (0x00)                                        /**<  (UART_CR) Control Register  Offset */
@@ -95,6 +99,7 @@ typedef union {
 
 /* -------- UART_MR : (UART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -108,6 +113,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_MR_OFFSET                      (0x04)                                        /**<  (UART_MR) Mode Register  Offset */
@@ -136,9 +142,9 @@ typedef union {
 #define UART_MR_BRSRCCK_Msk                 (_U_(0x1) << UART_MR_BRSRCCK_Pos)              /**< (UART_MR) Baud Rate Source Clock Mask */
 #define UART_MR_BRSRCCK                     UART_MR_BRSRCCK_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use UART_MR_BRSRCCK_Msk instead */
 #define   UART_MR_BRSRCCK_PERIPH_CLK_Val    _U_(0x0)                                       /**< (UART_MR) The baud rate is driven by the peripheral clock  */
-#define   UART_MR_BRSRCCK_PMC_PCK_Val       _U_(0x1)                                       /**< (UART_MR) The baud rate is driven by a PMC programmable clock PCK (see section Power Management Controller (PMC)).  */
+#define   UART_MR_BRSRCCK_PMC_PCK_Val       _U_(0x1)                                       /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)).  */
 #define UART_MR_BRSRCCK_PERIPH_CLK          (UART_MR_BRSRCCK_PERIPH_CLK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by the peripheral clock Position  */
-#define UART_MR_BRSRCCK_PMC_PCK             (UART_MR_BRSRCCK_PMC_PCK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by a PMC programmable clock PCK (see section Power Management Controller (PMC)). Position  */
+#define UART_MR_BRSRCCK_PMC_PCK             (UART_MR_BRSRCCK_PMC_PCK_Val << UART_MR_BRSRCCK_Pos)  /**< (UART_MR) The baud rate is driven by a PMC-programmable clock PCK (see section Power Management Controller (PMC)). Position  */
 #define UART_MR_CHMODE_Pos                  14                                             /**< (UART_MR) Channel Mode Position */
 #define UART_MR_CHMODE_Msk                  (_U_(0x3) << UART_MR_CHMODE_Pos)               /**< (UART_MR) Channel Mode Mask */
 #define UART_MR_CHMODE(value)               (UART_MR_CHMODE_Msk & ((value) << UART_MR_CHMODE_Pos))
@@ -156,6 +162,7 @@ typedef union {
 
 /* -------- UART_IER : (UART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Enable RXRDY Interrupt                   */
@@ -172,6 +179,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IER_OFFSET                     (0x08)                                        /**<  (UART_IER) Interrupt Enable Register  Offset */
@@ -203,6 +211,7 @@ typedef union {
 
 /* -------- UART_IDR : (UART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Disable RXRDY Interrupt                  */
@@ -219,6 +228,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IDR_OFFSET                     (0x0C)                                        /**<  (UART_IDR) Interrupt Disable Register  Offset */
@@ -250,6 +260,7 @@ typedef union {
 
 /* -------- UART_IMR : (UART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Mask RXRDY Interrupt                     */
@@ -266,6 +277,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_IMR_OFFSET                     (0x10)                                        /**<  (UART_IMR) Interrupt Mask Register  Offset */
@@ -297,6 +309,7 @@ typedef union {
 
 /* -------- UART_SR : (UART Offset: 0x14) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready                           */
@@ -313,6 +326,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_SR_OFFSET                      (0x14)                                        /**<  (UART_SR) Status Register  Offset */
@@ -344,6 +358,7 @@ typedef union {
 
 /* -------- UART_RHR : (UART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXCHR:8;                   /**< bit:   0..7  Received Character                       */
@@ -351,6 +366,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_RHR_OFFSET                     (0x18)                                        /**<  (UART_RHR) Receive Holding Register  Offset */
@@ -364,6 +380,7 @@ typedef union {
 
 /* -------- UART_THR : (UART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCHR:8;                   /**< bit:   0..7  Character to be Transmitted              */
@@ -371,6 +388,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_THR_OFFSET                     (0x1C)                                        /**<  (UART_THR) Transmit Holding Register  Offset */
@@ -384,6 +402,7 @@ typedef union {
 
 /* -------- UART_BRGR : (UART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CD:16;                     /**< bit:  0..15  Clock Divisor                            */
@@ -391,6 +410,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_BRGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_BRGR_OFFSET                    (0x20)                                        /**<  (UART_BRGR) Baud Rate Generator Register  Offset */
@@ -404,6 +424,7 @@ typedef union {
 
 /* -------- UART_CMPR : (UART Offset: 0x24) (R/W 32) Comparison Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t VAL1:8;                    /**< bit:   0..7  First Comparison Value for Received Character */
@@ -417,6 +438,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_CMPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_CMPR_OFFSET                    (0x24)                                        /**<  (UART_CMPR) Comparison Register  Offset */
@@ -443,6 +465,7 @@ typedef union {
 
 /* -------- UART_WPMR : (UART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -451,6 +474,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UART_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UART_WPMR_OFFSET                    (0xE4)                                        /**<  (UART_WPMR) Write Protection Mode Register  Offset */
@@ -481,7 +505,7 @@ typedef struct {
   __O  uint32_t UART_THR;       /**< (UART Offset: 0x1C) Transmit Holding Register */
   __IO uint32_t UART_BRGR;      /**< (UART Offset: 0x20) Baud Rate Generator Register */
   __IO uint32_t UART_CMPR;      /**< (UART Offset: 0x24) Comparison Register */
-  RoReg8  Reserved1[0xBC];
+  __I  uint8_t                        Reserved1[188];
   __IO uint32_t UART_WPMR;      /**< (UART Offset: 0xE4) Write Protection Mode Register */
 } Uart;
 
@@ -498,7 +522,7 @@ typedef struct {
   __O  UART_THR_Type                  UART_THR;       /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
   __IO UART_BRGR_Type                 UART_BRGR;      /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
   __IO UART_CMPR_Type                 UART_CMPR;      /**< Offset: 0x24 (R/W  32) Comparison Register */
-  __I  uint32_t                       Reserved1[47];
+  __I  uint8_t                        Reserved1[188];
   __IO UART_WPMR_Type                 UART_WPMR;      /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
 } Uart;
 

--- a/asf/sam/include/same70b/component/usart.h
+++ b/asf/sam/include/same70b/component/usart.h
@@ -274,9 +274,83 @@ typedef union {
 #define US_MR_CHRL_6_BIT                    (US_MR_CHRL_6_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 6 bits Position  */
 #define US_MR_CHRL_7_BIT                    (US_MR_CHRL_7_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 7 bits Position  */
 #define US_MR_CHRL_8_BIT                    (US_MR_CHRL_8_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 8 bits Position  */
+#define US_MR_SYNC_Pos                      8                                              /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_SYNC_Msk                      (_U_(0x1) << US_MR_SYNC_Pos)                   /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_SYNC                          US_MR_SYNC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SYNC_Msk instead */
+#define US_MR_PAR_Pos                       9                                              /**< (US_MR) Parity Type Position */
+#define US_MR_PAR_Msk                       (_U_(0x7) << US_MR_PAR_Pos)                    /**< (US_MR) Parity Type Mask */
+#define US_MR_PAR(value)                    (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos))
+#define   US_MR_PAR_EVEN_Val                _U_(0x0)                                       /**< (US_MR) Even parity  */
+#define   US_MR_PAR_ODD_Val                 _U_(0x1)                                       /**< (US_MR) Odd parity  */
+#define   US_MR_PAR_SPACE_Val               _U_(0x2)                                       /**< (US_MR) Parity forced to 0 (Space)  */
+#define   US_MR_PAR_MARK_Val                _U_(0x3)                                       /**< (US_MR) Parity forced to 1 (Mark)  */
+#define   US_MR_PAR_NO_Val                  _U_(0x4)                                       /**< (US_MR) No parity  */
+#define   US_MR_PAR_MULTIDROP_Val           _U_(0x6)                                       /**< (US_MR) Multidrop mode  */
+#define US_MR_PAR_EVEN                      (US_MR_PAR_EVEN_Val << US_MR_PAR_Pos)          /**< (US_MR) Even parity Position  */
+#define US_MR_PAR_ODD                       (US_MR_PAR_ODD_Val << US_MR_PAR_Pos)           /**< (US_MR) Odd parity Position  */
+#define US_MR_PAR_SPACE                     (US_MR_PAR_SPACE_Val << US_MR_PAR_Pos)         /**< (US_MR) Parity forced to 0 (Space) Position  */
+#define US_MR_PAR_MARK                      (US_MR_PAR_MARK_Val << US_MR_PAR_Pos)          /**< (US_MR) Parity forced to 1 (Mark) Position  */
+#define US_MR_PAR_NO                        (US_MR_PAR_NO_Val << US_MR_PAR_Pos)            /**< (US_MR) No parity Position  */
+#define US_MR_PAR_MULTIDROP                 (US_MR_PAR_MULTIDROP_Val << US_MR_PAR_Pos)     /**< (US_MR) Multidrop mode Position  */
+#define US_MR_NBSTOP_Pos                    12                                             /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_NBSTOP_Msk                    (_U_(0x3) << US_MR_NBSTOP_Pos)                 /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_NBSTOP(value)                 (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
+#define   US_MR_NBSTOP_1_BIT_Val            _U_(0x0)                                       /**< (US_MR) 1 stop bit  */
+#define   US_MR_NBSTOP_1_5_BIT_Val          _U_(0x1)                                       /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
+#define   US_MR_NBSTOP_2_BIT_Val            _U_(0x2)                                       /**< (US_MR) 2 stop bits  */
+#define US_MR_NBSTOP_1_BIT                  (US_MR_NBSTOP_1_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 1 stop bit Position  */
+#define US_MR_NBSTOP_1_5_BIT                (US_MR_NBSTOP_1_5_BIT_Val << US_MR_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
+#define US_MR_NBSTOP_2_BIT                  (US_MR_NBSTOP_2_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 2 stop bits Position  */
+#define US_MR_CHMODE_Pos                    14                                             /**< (US_MR) Channel Mode Position */
+#define US_MR_CHMODE_Msk                    (_U_(0x3) << US_MR_CHMODE_Pos)                 /**< (US_MR) Channel Mode Mask */
+#define US_MR_CHMODE(value)                 (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
+#define   US_MR_CHMODE_NORMAL_Val           _U_(0x0)                                       /**< (US_MR) Normal mode  */
+#define   US_MR_CHMODE_AUTOMATIC_Val        _U_(0x1)                                       /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin.  */
+#define   US_MR_CHMODE_LOCAL_LOOPBACK_Val   _U_(0x2)                                       /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input.  */
+#define   US_MR_CHMODE_REMOTE_LOOPBACK_Val  _U_(0x3)                                       /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin.  */
+#define US_MR_CHMODE_NORMAL                 (US_MR_CHMODE_NORMAL_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_CHMODE_AUTOMATIC              (US_MR_CHMODE_AUTOMATIC_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
+#define US_MR_CHMODE_LOCAL_LOOPBACK         (US_MR_CHMODE_LOCAL_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
+#define US_MR_CHMODE_REMOTE_LOOPBACK        (US_MR_CHMODE_REMOTE_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
+#define US_MR_MSBF_Pos                      16                                             /**< (US_MR) Bit Order Position */
+#define US_MR_MSBF_Msk                      (_U_(0x1) << US_MR_MSBF_Pos)                   /**< (US_MR) Bit Order Mask */
+#define US_MR_MSBF                          US_MR_MSBF_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MSBF_Msk instead */
+#define US_MR_MODE9_Pos                     17                                             /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_MODE9_Msk                     (_U_(0x1) << US_MR_MODE9_Pos)                  /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_MODE9                         US_MR_MODE9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODE9_Msk instead */
 #define US_MR_CLKO_Pos                      18                                             /**< (US_MR) Clock Output Select Position */
 #define US_MR_CLKO_Msk                      (_U_(0x1) << US_MR_CLKO_Pos)                   /**< (US_MR) Clock Output Select Mask */
 #define US_MR_CLKO                          US_MR_CLKO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_CLKO_Msk instead */
+#define US_MR_OVER_Pos                      19                                             /**< (US_MR) Oversampling Mode Position */
+#define US_MR_OVER_Msk                      (_U_(0x1) << US_MR_OVER_Pos)                   /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_OVER                          US_MR_OVER_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_OVER_Msk instead */
+#define US_MR_INACK_Pos                     20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_INACK_Msk                     (_U_(0x1) << US_MR_INACK_Pos)                  /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_INACK                         US_MR_INACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INACK_Msk instead */
+#define US_MR_DSNACK_Pos                    21                                             /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_DSNACK_Msk                    (_U_(0x1) << US_MR_DSNACK_Pos)                 /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_DSNACK                        US_MR_DSNACK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_DSNACK_Msk instead */
+#define US_MR_VAR_SYNC_Pos                  22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_VAR_SYNC_Msk                  (_U_(0x1) << US_MR_VAR_SYNC_Pos)               /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_VAR_SYNC                      US_MR_VAR_SYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_VAR_SYNC_Msk instead */
+#define US_MR_INVDATA_Pos                   23                                             /**< (US_MR) Inverted Data Position */
+#define US_MR_INVDATA_Msk                   (_U_(0x1) << US_MR_INVDATA_Pos)                /**< (US_MR) Inverted Data Mask */
+#define US_MR_INVDATA                       US_MR_INVDATA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INVDATA_Msk instead */
+#define US_MR_MAX_ITERATION_Pos             24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_MAX_ITERATION_Msk             (_U_(0x7) << US_MR_MAX_ITERATION_Pos)          /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_MAX_ITERATION(value)          (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
+#define US_MR_FILTER_Pos                    28                                             /**< (US_MR) Receive Line Filter Position */
+#define US_MR_FILTER_Msk                    (_U_(0x1) << US_MR_FILTER_Pos)                 /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_FILTER                        US_MR_FILTER_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_FILTER_Msk instead */
+#define US_MR_MAN_Pos                       29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_MAN_Msk                       (_U_(0x1) << US_MR_MAN_Pos)                    /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_MAN                           US_MR_MAN_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MAN_Msk instead */
+#define US_MR_MODSYNC_Pos                   30                                             /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_MODSYNC_Msk                   (_U_(0x1) << US_MR_MODSYNC_Pos)                /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_MODSYNC                       US_MR_MODSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODSYNC_Msk instead */
+#define US_MR_ONEBIT_Pos                    31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_ONEBIT_Msk                    (_U_(0x1) << US_MR_ONEBIT_Pos)                 /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_ONEBIT                        US_MR_ONEBIT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_ONEBIT_Msk instead */
 #define US_MR_MASK                          _U_(0x400FF)                                   /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
 #define US_MR_Msk                           _U_(0x400FF)                                   /**< (US_MR) Register Mask  */
 
@@ -457,12 +531,45 @@ typedef union {
 #define US_IER_TXRDY_Pos                    1                                              /**< (US_IER) TXRDY Interrupt Enable Position */
 #define US_IER_TXRDY_Msk                    (_U_(0x1) << US_IER_TXRDY_Pos)                 /**< (US_IER) TXRDY Interrupt Enable Mask */
 #define US_IER_TXRDY                        US_IER_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXRDY_Msk instead */
+#define US_IER_RXBRK_Pos                    2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_RXBRK_Msk                    (_U_(0x1) << US_IER_RXBRK_Pos)                 /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_RXBRK                        US_IER_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXBRK_Msk instead */
 #define US_IER_OVRE_Pos                     5                                              /**< (US_IER) Overrun Error Interrupt Enable Position */
 #define US_IER_OVRE_Msk                     (_U_(0x1) << US_IER_OVRE_Pos)                  /**< (US_IER) Overrun Error Interrupt Enable Mask */
 #define US_IER_OVRE                         US_IER_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_OVRE_Msk instead */
+#define US_IER_FRAME_Pos                    6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_FRAME_Msk                    (_U_(0x1) << US_IER_FRAME_Pos)                 /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_FRAME                        US_IER_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_FRAME_Msk instead */
+#define US_IER_PARE_Pos                     7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_PARE_Msk                     (_U_(0x1) << US_IER_PARE_Pos)                  /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_PARE                         US_IER_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_PARE_Msk instead */
+#define US_IER_TIMEOUT_Pos                  8                                              /**< (US_IER) Timeout Interrupt Enable Position */
+#define US_IER_TIMEOUT_Msk                  (_U_(0x1) << US_IER_TIMEOUT_Pos)               /**< (US_IER) Timeout Interrupt Enable Mask */
+#define US_IER_TIMEOUT                      US_IER_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TIMEOUT_Msk instead */
 #define US_IER_TXEMPTY_Pos                  9                                              /**< (US_IER) TXEMPTY Interrupt Enable Position */
 #define US_IER_TXEMPTY_Msk                  (_U_(0x1) << US_IER_TXEMPTY_Pos)               /**< (US_IER) TXEMPTY Interrupt Enable Mask */
 #define US_IER_TXEMPTY                      US_IER_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXEMPTY_Msk instead */
+#define US_IER_ITER_Pos                     10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_ITER_Msk                     (_U_(0x1) << US_IER_ITER_Pos)                  /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_ITER                         US_IER_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_ITER_Msk instead */
+#define US_IER_NACK_Pos                     13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_NACK_Msk                     (_U_(0x1) << US_IER_NACK_Pos)                  /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_NACK                         US_IER_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_NACK_Msk instead */
+#define US_IER_RIIC_Pos                     16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_RIIC_Msk                     (_U_(0x1) << US_IER_RIIC_Pos)                  /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_RIIC                         US_IER_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RIIC_Msk instead */
+#define US_IER_DSRIC_Pos                    17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_DSRIC_Msk                    (_U_(0x1) << US_IER_DSRIC_Pos)                 /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_DSRIC                        US_IER_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DSRIC_Msk instead */
+#define US_IER_DCDIC_Pos                    18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_DCDIC_Msk                    (_U_(0x1) << US_IER_DCDIC_Pos)                 /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_DCDIC                        US_IER_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DCDIC_Msk instead */
+#define US_IER_CTSIC_Pos                    19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_CTSIC_Msk                    (_U_(0x1) << US_IER_CTSIC_Pos)                 /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_CTSIC                        US_IER_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_CTSIC_Msk instead */
+#define US_IER_MANE_Pos                     24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_MANE_Msk                     (_U_(0x1) << US_IER_MANE_Pos)                  /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_MANE                         US_IER_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_MANE_Msk instead */
 #define US_IER_MASK                         _U_(0x223)                                     /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
 #define US_IER_Msk                          _U_(0x223)                                     /**< (US_IER) Register Mask  */
 
@@ -667,12 +774,30 @@ typedef union {
 #define US_IDR_TXRDY_Pos                    1                                              /**< (US_IDR) TXRDY Interrupt Disable Position */
 #define US_IDR_TXRDY_Msk                    (_U_(0x1) << US_IDR_TXRDY_Pos)                 /**< (US_IDR) TXRDY Interrupt Disable Mask */
 #define US_IDR_TXRDY                        US_IDR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXRDY_Msk instead */
+#define US_IDR_RXBRK_Pos                    2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_RXBRK_Msk                    (_U_(0x1) << US_IDR_RXBRK_Pos)                 /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_RXBRK                        US_IDR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXBRK_Msk instead */
 #define US_IDR_OVRE_Pos                     5                                              /**< (US_IDR) Overrun Error Interrupt Enable Position */
 #define US_IDR_OVRE_Msk                     (_U_(0x1) << US_IDR_OVRE_Pos)                  /**< (US_IDR) Overrun Error Interrupt Enable Mask */
 #define US_IDR_OVRE                         US_IDR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_OVRE_Msk instead */
+#define US_IDR_FRAME_Pos                    6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_FRAME_Msk                    (_U_(0x1) << US_IDR_FRAME_Pos)                 /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_FRAME                        US_IDR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_FRAME_Msk instead */
+#define US_IDR_PARE_Pos                     7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_PARE_Msk                     (_U_(0x1) << US_IDR_PARE_Pos)                  /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_PARE                         US_IDR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_PARE_Msk instead */
+#define US_IDR_TIMEOUT_Pos                  8                                              /**< (US_IDR) Timeout Interrupt Disable Position */
+#define US_IDR_TIMEOUT_Msk                  (_U_(0x1) << US_IDR_TIMEOUT_Pos)               /**< (US_IDR) Timeout Interrupt Disable Mask */
+#define US_IDR_TIMEOUT                      US_IDR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TIMEOUT_Msk instead */
 #define US_IDR_TXEMPTY_Pos                  9                                              /**< (US_IDR) TXEMPTY Interrupt Disable Position */
 #define US_IDR_TXEMPTY_Msk                  (_U_(0x1) << US_IDR_TXEMPTY_Pos)               /**< (US_IDR) TXEMPTY Interrupt Disable Mask */
 #define US_IDR_TXEMPTY                      US_IDR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXEMPTY_Msk instead */
+#define US_IDR_ITER_Pos                     10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_ITER_Msk                     (_U_(0x1) << US_IDR_ITER_Pos)                  /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_ITER                         US_IDR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_ITER_Msk instead */
+#define US_IDR_NACK_Pos                     13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_NACK_Msk                     (_U_(0x1) << US_IDR_NACK_Pos)                  /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_NACK                         US_IDR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_NACK_Msk instead */
 #define US_IDR_RIIC_Pos                     16                                             /**< (US_IDR) Ring Indicator Input Change Disable Position */
 #define US_IDR_RIIC_Msk                     (_U_(0x1) << US_IDR_RIIC_Pos)                  /**< (US_IDR) Ring Indicator Input Change Disable Mask */
 #define US_IDR_RIIC                         US_IDR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RIIC_Msk instead */
@@ -682,6 +807,12 @@ typedef union {
 #define US_IDR_DCDIC_Pos                    18                                             /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Position */
 #define US_IDR_DCDIC_Msk                    (_U_(0x1) << US_IDR_DCDIC_Pos)                 /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Mask */
 #define US_IDR_DCDIC                        US_IDR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DCDIC_Msk instead */
+#define US_IDR_CTSIC_Pos                    19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_CTSIC_Msk                    (_U_(0x1) << US_IDR_CTSIC_Pos)                 /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_CTSIC                        US_IDR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_CTSIC_Msk instead */
+#define US_IDR_MANE_Pos                     24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_MANE_Msk                     (_U_(0x1) << US_IDR_MANE_Pos)                  /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_MANE                         US_IDR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_MANE_Msk instead */
 #define US_IDR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
 #define US_IDR_Msk                          _U_(0x70223)                                   /**< (US_IDR) Register Mask  */
 
@@ -1094,12 +1225,30 @@ typedef union {
 #define US_CSR_TXRDY_Pos                    1                                              /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Position */
 #define US_CSR_TXRDY_Msk                    (_U_(0x1) << US_CSR_TXRDY_Pos)                 /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Mask */
 #define US_CSR_TXRDY                        US_CSR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXRDY_Msk instead */
+#define US_CSR_RXBRK_Pos                    2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_RXBRK_Msk                    (_U_(0x1) << US_CSR_RXBRK_Pos)                 /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_RXBRK                        US_CSR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXBRK_Msk instead */
 #define US_CSR_OVRE_Pos                     5                                              /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
 #define US_CSR_OVRE_Msk                     (_U_(0x1) << US_CSR_OVRE_Pos)                  /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
 #define US_CSR_OVRE                         US_CSR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_OVRE_Msk instead */
+#define US_CSR_FRAME_Pos                    6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_FRAME_Msk                    (_U_(0x1) << US_CSR_FRAME_Pos)                 /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_FRAME                        US_CSR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_FRAME_Msk instead */
+#define US_CSR_PARE_Pos                     7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_PARE_Msk                     (_U_(0x1) << US_CSR_PARE_Pos)                  /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_PARE                         US_CSR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_PARE_Msk instead */
+#define US_CSR_TIMEOUT_Pos                  8                                              /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_TIMEOUT_Msk                  (_U_(0x1) << US_CSR_TIMEOUT_Pos)               /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_TIMEOUT                      US_CSR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TIMEOUT_Msk instead */
 #define US_CSR_TXEMPTY_Pos                  9                                              /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Position */
 #define US_CSR_TXEMPTY_Msk                  (_U_(0x1) << US_CSR_TXEMPTY_Pos)               /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Mask */
 #define US_CSR_TXEMPTY                      US_CSR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXEMPTY_Msk instead */
+#define US_CSR_ITER_Pos                     10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_ITER_Msk                     (_U_(0x1) << US_CSR_ITER_Pos)                  /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_ITER                         US_CSR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_ITER_Msk instead */
+#define US_CSR_NACK_Pos                     13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_NACK_Msk                     (_U_(0x1) << US_CSR_NACK_Pos)                  /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_NACK                         US_CSR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_NACK_Msk instead */
 #define US_CSR_RIIC_Pos                     16                                             /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Position */
 #define US_CSR_RIIC_Msk                     (_U_(0x1) << US_CSR_RIIC_Pos)                  /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Mask */
 #define US_CSR_RIIC                         US_CSR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RIIC_Msk instead */
@@ -1109,6 +1258,24 @@ typedef union {
 #define US_CSR_DCDIC_Pos                    18                                             /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Position */
 #define US_CSR_DCDIC_Msk                    (_U_(0x1) << US_CSR_DCDIC_Pos)                 /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Mask */
 #define US_CSR_DCDIC                        US_CSR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCDIC_Msk instead */
+#define US_CSR_CTSIC_Pos                    19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_CTSIC_Msk                    (_U_(0x1) << US_CSR_CTSIC_Pos)                 /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_CTSIC                        US_CSR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTSIC_Msk instead */
+#define US_CSR_RI_Pos                       20                                             /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_RI_Msk                       (_U_(0x1) << US_CSR_RI_Pos)                    /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_RI                           US_CSR_RI_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RI_Msk instead */
+#define US_CSR_DSR_Pos                      21                                             /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_DSR_Msk                      (_U_(0x1) << US_CSR_DSR_Pos)                   /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_DSR                          US_CSR_DSR_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSR_Msk instead */
+#define US_CSR_DCD_Pos                      22                                             /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_DCD_Msk                      (_U_(0x1) << US_CSR_DCD_Pos)                   /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_DCD                          US_CSR_DCD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCD_Msk instead */
+#define US_CSR_CTS_Pos                      23                                             /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_CTS_Msk                      (_U_(0x1) << US_CSR_CTS_Pos)                   /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_CTS                          US_CSR_CTS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTS_Msk instead */
+#define US_CSR_MANERR_Pos                   24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_MANERR_Msk                   (_U_(0x1) << US_CSR_MANERR_Pos)                /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_MANERR                       US_CSR_MANERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_MANERR_Msk instead */
 #define US_CSR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
 #define US_CSR_Msk                          _U_(0x70223)                                   /**< (US_CSR) Register Mask  */
 
@@ -2062,6 +2229,8 @@ typedef struct {
 
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 /** @}  end of Universal Synchronous Asynchronous Receiver Transmitter */
+
+#define DO_NOT_USE_DEPRECATED_MACROS
 
 #if !(defined(DO_NOT_USE_DEPRECATED_MACROS))
 #include "deprecated/usart.h"

--- a/asf/sam/include/same70b/component/usart.h
+++ b/asf/sam/include/same70b/component/usart.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for USART
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USART_COMPONENT_H_
 #define _SAME70_USART_COMPONENT_H_
 #define _SAME70_USART_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- US_CR : (USART Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :2;                        /**< bit:   0..1  Reserved */
@@ -55,23 +58,38 @@ typedef union {
     uint32_t TXEN:1;                    /**< bit:      6  Transmitter Enable                       */
     uint32_t TXDIS:1;                   /**< bit:      7  Transmitter Disable                      */
     uint32_t RSTSTA:1;                  /**< bit:      8  Reset Status Bits                        */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :9;                        /**< bit:   0..8  Reserved */
     uint32_t STTBRK:1;                  /**< bit:      9  Start Break                              */
     uint32_t STPBRK:1;                  /**< bit:     10  Stop Break                               */
-    uint32_t STTTO:1;                   /**< bit:     11  Clear TIMEOUT Flag and Start Time-out After Next Character Received */
+    uint32_t STTTO:1;                   /**< bit:     11  Clear TIMEOUT Flag and Start Timeout After Next Character Received */
     uint32_t SENDA:1;                   /**< bit:     12  Send Address                             */
     uint32_t RSTIT:1;                   /**< bit:     13  Reset Iterations                         */
     uint32_t RSTNACK:1;                 /**< bit:     14  Reset Non Acknowledge                    */
-    uint32_t RETTO:1;                   /**< bit:     15  Start Time-out Immediately               */
+    uint32_t RETTO:1;                   /**< bit:     15  Start Timeout Immediately                */
     uint32_t DTREN:1;                   /**< bit:     16  Data Terminal Ready Enable               */
     uint32_t DTRDIS:1;                  /**< bit:     17  Data Terminal Ready Disable              */
-    uint32_t RTSEN:1;                   /**< bit:     18  Request to Send Pin Control              */
-    uint32_t RTSDIS:1;                  /**< bit:     19  Request to Send Pin Control              */
+    uint32_t RTSEN:1;                   /**< bit:     18  Request to Send Enable                   */
+    uint32_t RTSDIS:1;                  /**< bit:     19  Request to Send Disable                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // SPI mode
+    uint32_t :18;                       /**< bit:  0..17  Reserved */
+    uint32_t FCS:1;                     /**< bit:     18  Force SPI Chip Select                    */
+    uint32_t RCS:1;                     /**< bit:     19  Release SPI Chip Select                  */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :20;                       /**< bit:  0..19  Reserved */
     uint32_t LINABT:1;                  /**< bit:     20  Abort LIN Transmission                   */
     uint32_t LINWKUP:1;                 /**< bit:     21  Send LIN Wakeup Signal                   */
     uint32_t :10;                       /**< bit: 22..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } LIN;                                /**< Structure used for LIN mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_CR_OFFSET                        (0x00)                                        /**<  (US_CR) Control Register  Offset */
@@ -97,63 +115,88 @@ typedef union {
 #define US_CR_RSTSTA_Pos                    8                                              /**< (US_CR) Reset Status Bits Position */
 #define US_CR_RSTSTA_Msk                    (_U_(0x1) << US_CR_RSTSTA_Pos)                 /**< (US_CR) Reset Status Bits Mask */
 #define US_CR_RSTSTA                        US_CR_RSTSTA_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTSTA_Msk instead */
-#define US_CR_STTBRK_Pos                    9                                              /**< (US_CR) Start Break Position */
-#define US_CR_STTBRK_Msk                    (_U_(0x1) << US_CR_STTBRK_Pos)                 /**< (US_CR) Start Break Mask */
-#define US_CR_STTBRK                        US_CR_STTBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTBRK_Msk instead */
-#define US_CR_STPBRK_Pos                    10                                             /**< (US_CR) Stop Break Position */
-#define US_CR_STPBRK_Msk                    (_U_(0x1) << US_CR_STPBRK_Pos)                 /**< (US_CR) Stop Break Mask */
-#define US_CR_STPBRK                        US_CR_STPBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STPBRK_Msk instead */
-#define US_CR_STTTO_Pos                     11                                             /**< (US_CR) Clear TIMEOUT Flag and Start Time-out After Next Character Received Position */
-#define US_CR_STTTO_Msk                     (_U_(0x1) << US_CR_STTTO_Pos)                  /**< (US_CR) Clear TIMEOUT Flag and Start Time-out After Next Character Received Mask */
-#define US_CR_STTTO                         US_CR_STTTO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_STTTO_Msk instead */
-#define US_CR_SENDA_Pos                     12                                             /**< (US_CR) Send Address Position */
-#define US_CR_SENDA_Msk                     (_U_(0x1) << US_CR_SENDA_Pos)                  /**< (US_CR) Send Address Mask */
-#define US_CR_SENDA                         US_CR_SENDA_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SENDA_Msk instead */
-#define US_CR_RSTIT_Pos                     13                                             /**< (US_CR) Reset Iterations Position */
-#define US_CR_RSTIT_Msk                     (_U_(0x1) << US_CR_RSTIT_Pos)                  /**< (US_CR) Reset Iterations Mask */
-#define US_CR_RSTIT                         US_CR_RSTIT_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTIT_Msk instead */
-#define US_CR_RSTNACK_Pos                   14                                             /**< (US_CR) Reset Non Acknowledge Position */
-#define US_CR_RSTNACK_Msk                   (_U_(0x1) << US_CR_RSTNACK_Pos)                /**< (US_CR) Reset Non Acknowledge Mask */
-#define US_CR_RSTNACK                       US_CR_RSTNACK_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RSTNACK_Msk instead */
-#define US_CR_RETTO_Pos                     15                                             /**< (US_CR) Start Time-out Immediately Position */
-#define US_CR_RETTO_Msk                     (_U_(0x1) << US_CR_RETTO_Pos)                  /**< (US_CR) Start Time-out Immediately Mask */
-#define US_CR_RETTO                         US_CR_RETTO_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RETTO_Msk instead */
-#define US_CR_DTREN_Pos                     16                                             /**< (US_CR) Data Terminal Ready Enable Position */
-#define US_CR_DTREN_Msk                     (_U_(0x1) << US_CR_DTREN_Pos)                  /**< (US_CR) Data Terminal Ready Enable Mask */
-#define US_CR_DTREN                         US_CR_DTREN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTREN_Msk instead */
-#define US_CR_DTRDIS_Pos                    17                                             /**< (US_CR) Data Terminal Ready Disable Position */
-#define US_CR_DTRDIS_Msk                    (_U_(0x1) << US_CR_DTRDIS_Pos)                 /**< (US_CR) Data Terminal Ready Disable Mask */
-#define US_CR_DTRDIS                        US_CR_DTRDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_DTRDIS_Msk instead */
-#define US_CR_RTSEN_Pos                     18                                             /**< (US_CR) Request to Send Pin Control Position */
-#define US_CR_RTSEN_Msk                     (_U_(0x1) << US_CR_RTSEN_Pos)                  /**< (US_CR) Request to Send Pin Control Mask */
-#define US_CR_RTSEN                         US_CR_RTSEN_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSEN_Msk instead */
-#define US_CR_RTSDIS_Pos                    19                                             /**< (US_CR) Request to Send Pin Control Position */
-#define US_CR_RTSDIS_Msk                    (_U_(0x1) << US_CR_RTSDIS_Pos)                 /**< (US_CR) Request to Send Pin Control Mask */
-#define US_CR_RTSDIS                        US_CR_RTSDIS_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_RTSDIS_Msk instead */
-#define US_CR_LINABT_Pos                    20                                             /**< (US_CR) Abort LIN Transmission Position */
-#define US_CR_LINABT_Msk                    (_U_(0x1) << US_CR_LINABT_Pos)                 /**< (US_CR) Abort LIN Transmission Mask */
-#define US_CR_LINABT                        US_CR_LINABT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINABT_Msk instead */
-#define US_CR_LINWKUP_Pos                   21                                             /**< (US_CR) Send LIN Wakeup Signal Position */
-#define US_CR_LINWKUP_Msk                   (_U_(0x1) << US_CR_LINWKUP_Pos)                /**< (US_CR) Send LIN Wakeup Signal Mask */
-#define US_CR_LINWKUP                       US_CR_LINWKUP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LINWKUP_Msk instead */
-#define US_CR_MASK                          _U_(0x3FFFFC)                                  /**< \deprecated (US_CR) Register MASK  (Use US_CR_Msk instead)  */
-#define US_CR_Msk                           _U_(0x3FFFFC)                                  /**< (US_CR) Register Mask  */
+#define US_CR_MASK                          _U_(0x1FC)                                     /**< \deprecated (US_CR) Register MASK  (Use US_CR_Msk instead)  */
+#define US_CR_Msk                           _U_(0x1FC)                                     /**< (US_CR) Register Mask  */
+
+/* USART mode */
+#define US_CR_USART_STTBRK_Pos              9                                              /**< (US_CR) Start Break Position */
+#define US_CR_USART_STTBRK_Msk              (_U_(0x1) << US_CR_USART_STTBRK_Pos)           /**< (US_CR) Start Break Mask */
+#define US_CR_USART_STTBRK                  US_CR_USART_STTBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STTBRK_Msk instead */
+#define US_CR_USART_STPBRK_Pos              10                                             /**< (US_CR) Stop Break Position */
+#define US_CR_USART_STPBRK_Msk              (_U_(0x1) << US_CR_USART_STPBRK_Pos)           /**< (US_CR) Stop Break Mask */
+#define US_CR_USART_STPBRK                  US_CR_USART_STPBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STPBRK_Msk instead */
+#define US_CR_USART_STTTO_Pos               11                                             /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Position */
+#define US_CR_USART_STTTO_Msk               (_U_(0x1) << US_CR_USART_STTTO_Pos)            /**< (US_CR) Clear TIMEOUT Flag and Start Timeout After Next Character Received Mask */
+#define US_CR_USART_STTTO                   US_CR_USART_STTTO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_STTTO_Msk instead */
+#define US_CR_USART_SENDA_Pos               12                                             /**< (US_CR) Send Address Position */
+#define US_CR_USART_SENDA_Msk               (_U_(0x1) << US_CR_USART_SENDA_Pos)            /**< (US_CR) Send Address Mask */
+#define US_CR_USART_SENDA                   US_CR_USART_SENDA_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_SENDA_Msk instead */
+#define US_CR_USART_RSTIT_Pos               13                                             /**< (US_CR) Reset Iterations Position */
+#define US_CR_USART_RSTIT_Msk               (_U_(0x1) << US_CR_USART_RSTIT_Pos)            /**< (US_CR) Reset Iterations Mask */
+#define US_CR_USART_RSTIT                   US_CR_USART_RSTIT_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RSTIT_Msk instead */
+#define US_CR_USART_RSTNACK_Pos             14                                             /**< (US_CR) Reset Non Acknowledge Position */
+#define US_CR_USART_RSTNACK_Msk             (_U_(0x1) << US_CR_USART_RSTNACK_Pos)          /**< (US_CR) Reset Non Acknowledge Mask */
+#define US_CR_USART_RSTNACK                 US_CR_USART_RSTNACK_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RSTNACK_Msk instead */
+#define US_CR_USART_RETTO_Pos               15                                             /**< (US_CR) Start Timeout Immediately Position */
+#define US_CR_USART_RETTO_Msk               (_U_(0x1) << US_CR_USART_RETTO_Pos)            /**< (US_CR) Start Timeout Immediately Mask */
+#define US_CR_USART_RETTO                   US_CR_USART_RETTO_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RETTO_Msk instead */
+#define US_CR_USART_DTREN_Pos               16                                             /**< (US_CR) Data Terminal Ready Enable Position */
+#define US_CR_USART_DTREN_Msk               (_U_(0x1) << US_CR_USART_DTREN_Pos)            /**< (US_CR) Data Terminal Ready Enable Mask */
+#define US_CR_USART_DTREN                   US_CR_USART_DTREN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_DTREN_Msk instead */
+#define US_CR_USART_DTRDIS_Pos              17                                             /**< (US_CR) Data Terminal Ready Disable Position */
+#define US_CR_USART_DTRDIS_Msk              (_U_(0x1) << US_CR_USART_DTRDIS_Pos)           /**< (US_CR) Data Terminal Ready Disable Mask */
+#define US_CR_USART_DTRDIS                  US_CR_USART_DTRDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_DTRDIS_Msk instead */
+#define US_CR_USART_RTSEN_Pos               18                                             /**< (US_CR) Request to Send Enable Position */
+#define US_CR_USART_RTSEN_Msk               (_U_(0x1) << US_CR_USART_RTSEN_Pos)            /**< (US_CR) Request to Send Enable Mask */
+#define US_CR_USART_RTSEN                   US_CR_USART_RTSEN_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RTSEN_Msk instead */
+#define US_CR_USART_RTSDIS_Pos              19                                             /**< (US_CR) Request to Send Disable Position */
+#define US_CR_USART_RTSDIS_Msk              (_U_(0x1) << US_CR_USART_RTSDIS_Pos)           /**< (US_CR) Request to Send Disable Mask */
+#define US_CR_USART_RTSDIS                  US_CR_USART_RTSDIS_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_USART_RTSDIS_Msk instead */
+#define US_CR_USART_MASK                    _U_(0xFFE00)                                   /**< \deprecated (US_CR_USART) Register MASK  (Use US_CR_USART_Msk instead)  */
+#define US_CR_USART_Msk                     _U_(0xFFE00)                                   /**< (US_CR_USART) Register Mask  */
+
+/* SPI mode */
+#define US_CR_SPI_FCS_Pos                   18                                             /**< (US_CR) Force SPI Chip Select Position */
+#define US_CR_SPI_FCS_Msk                   (_U_(0x1) << US_CR_SPI_FCS_Pos)                /**< (US_CR) Force SPI Chip Select Mask */
+#define US_CR_SPI_FCS                       US_CR_SPI_FCS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SPI_FCS_Msk instead */
+#define US_CR_SPI_RCS_Pos                   19                                             /**< (US_CR) Release SPI Chip Select Position */
+#define US_CR_SPI_RCS_Msk                   (_U_(0x1) << US_CR_SPI_RCS_Pos)                /**< (US_CR) Release SPI Chip Select Mask */
+#define US_CR_SPI_RCS                       US_CR_SPI_RCS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_SPI_RCS_Msk instead */
+#define US_CR_SPI_MASK                      _U_(0xC0000)                                   /**< \deprecated (US_CR_SPI) Register MASK  (Use US_CR_SPI_Msk instead)  */
+#define US_CR_SPI_Msk                       _U_(0xC0000)                                   /**< (US_CR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_CR_LIN_LINABT_Pos                20                                             /**< (US_CR) Abort LIN Transmission Position */
+#define US_CR_LIN_LINABT_Msk                (_U_(0x1) << US_CR_LIN_LINABT_Pos)             /**< (US_CR) Abort LIN Transmission Mask */
+#define US_CR_LIN_LINABT                    US_CR_LIN_LINABT_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LIN_LINABT_Msk instead */
+#define US_CR_LIN_LINWKUP_Pos               21                                             /**< (US_CR) Send LIN Wakeup Signal Position */
+#define US_CR_LIN_LINWKUP_Msk               (_U_(0x1) << US_CR_LIN_LINWKUP_Pos)            /**< (US_CR) Send LIN Wakeup Signal Mask */
+#define US_CR_LIN_LINWKUP                   US_CR_LIN_LINWKUP_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CR_LIN_LINWKUP_Msk instead */
+#define US_CR_LIN_MASK                      _U_(0x300000)                                  /**< \deprecated (US_CR_LIN) Register MASK  (Use US_CR_LIN_Msk instead)  */
+#define US_CR_LIN_Msk                       _U_(0x300000)                                  /**< (US_CR_LIN) Register Mask  */
 
 
 /* -------- US_MR : (USART Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t USART_MODE:4;              /**< bit:   0..3  USART Mode of Operation                  */
     uint32_t USCLKS:2;                  /**< bit:   4..5  Clock Selection                          */
     uint32_t CHRL:2;                    /**< bit:   6..7  Character Length                         */
+    uint32_t :10;                       /**< bit:  8..17  Reserved */
+    uint32_t CLKO:1;                    /**< bit:     18  Clock Output Select                      */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
     uint32_t SYNC:1;                    /**< bit:      8  Synchronous Mode Select                  */
     uint32_t PAR:3;                     /**< bit:  9..11  Parity Type                              */
     uint32_t NBSTOP:2;                  /**< bit: 12..13  Number of Stop Bits                      */
     uint32_t CHMODE:2;                  /**< bit: 14..15  Channel Mode                             */
     uint32_t MSBF:1;                    /**< bit:     16  Bit Order                                */
     uint32_t MODE9:1;                   /**< bit:     17  9-bit Character Length                   */
-    uint32_t CLKO:1;                    /**< bit:     18  Clock Output Select                      */
+    uint32_t :1;                        /**< bit:     18  Reserved */
     uint32_t OVER:1;                    /**< bit:     19  Oversampling Mode                        */
     uint32_t INACK:1;                   /**< bit:     20  Inhibit Non Acknowledge                  */
     uint32_t DSNACK:1;                  /**< bit:     21  Disable Successive NACK                  */
@@ -165,9 +208,19 @@ typedef union {
     uint32_t MAN:1;                     /**< bit:     29  Manchester Encoder/Decoder Enable        */
     uint32_t MODSYNC:1;                 /**< bit:     30  Manchester Synchronization Mode          */
     uint32_t ONEBIT:1;                  /**< bit:     31  Start Frame Delimiter Selector           */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // SPI mode
+    uint32_t :8;                        /**< bit:   0..7  Reserved */
+    uint32_t CPHA:1;                    /**< bit:      8  SPI Clock Phase                          */
+    uint32_t :7;                        /**< bit:  9..15  Reserved */
+    uint32_t CPOL:1;                    /**< bit:     16  SPI Clock Polarity                       */
+    uint32_t :3;                        /**< bit: 17..19  Reserved */
+    uint32_t WRDBT:1;                   /**< bit:     20  Wait Read Data Before Transfer           */
+    uint32_t :11;                       /**< bit: 21..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MR_OFFSET                        (0x04)                                        /**<  (US_MR) Mode Register  Offset */
@@ -177,37 +230,37 @@ typedef union {
 #define US_MR_USART_MODE(value)             (US_MR_USART_MODE_Msk & ((value) << US_MR_USART_MODE_Pos))
 #define   US_MR_USART_MODE_NORMAL_Val       _U_(0x0)                                       /**< (US_MR) Normal mode  */
 #define   US_MR_USART_MODE_RS485_Val        _U_(0x1)                                       /**< (US_MR) RS485  */
-#define   US_MR_USART_MODE_HW_HANDSHAKING_Val _U_(0x2)                                       /**< (US_MR) Hardware Handshaking  */
+#define   US_MR_USART_MODE_HW_HANDSHAKING_Val _U_(0x2)                                       /**< (US_MR) Hardware handshaking  */
 #define   US_MR_USART_MODE_MODEM_Val        _U_(0x3)                                       /**< (US_MR) Modem  */
 #define   US_MR_USART_MODE_IS07816_T_0_Val  _U_(0x4)                                       /**< (US_MR) IS07816 Protocol: T = 0  */
 #define   US_MR_USART_MODE_IS07816_T_1_Val  _U_(0x6)                                       /**< (US_MR) IS07816 Protocol: T = 1  */
 #define   US_MR_USART_MODE_IRDA_Val         _U_(0x8)                                       /**< (US_MR) IrDA  */
 #define   US_MR_USART_MODE_LON_Val          _U_(0x9)                                       /**< (US_MR) LON  */
-#define   US_MR_USART_MODE_LIN_MASTER_Val   _U_(0xA)                                       /**< (US_MR) LIN master  */
-#define   US_MR_USART_MODE_LIN_SLAVE_Val    _U_(0xB)                                       /**< (US_MR) LIN slave  */
-#define   US_MR_USART_MODE_SPI_MASTER_Val   _U_(0xE)                                       /**< (US_MR) SPI master  */
-#define   US_MR_USART_MODE_SPI_SLAVE_Val    _U_(0xF)                                       /**< (US_MR) SPI Slave  */
+#define   US_MR_USART_MODE_LIN_MASTER_Val   _U_(0xA)                                       /**< (US_MR) LIN Master mode  */
+#define   US_MR_USART_MODE_LIN_SLAVE_Val    _U_(0xB)                                       /**< (US_MR) LIN Slave mode  */
+#define   US_MR_USART_MODE_SPI_MASTER_Val   _U_(0xE)                                       /**< (US_MR) SPI Master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2)  */
+#define   US_MR_USART_MODE_SPI_SLAVE_Val    _U_(0xF)                                       /**< (US_MR) SPI Slave mode  */
 #define US_MR_USART_MODE_NORMAL             (US_MR_USART_MODE_NORMAL_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Normal mode Position  */
 #define US_MR_USART_MODE_RS485              (US_MR_USART_MODE_RS485_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) RS485 Position  */
-#define US_MR_USART_MODE_HW_HANDSHAKING     (US_MR_USART_MODE_HW_HANDSHAKING_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Hardware Handshaking Position  */
+#define US_MR_USART_MODE_HW_HANDSHAKING     (US_MR_USART_MODE_HW_HANDSHAKING_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Hardware handshaking Position  */
 #define US_MR_USART_MODE_MODEM              (US_MR_USART_MODE_MODEM_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) Modem Position  */
 #define US_MR_USART_MODE_IS07816_T_0        (US_MR_USART_MODE_IS07816_T_0_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 0 Position  */
 #define US_MR_USART_MODE_IS07816_T_1        (US_MR_USART_MODE_IS07816_T_1_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IS07816 Protocol: T = 1 Position  */
 #define US_MR_USART_MODE_IRDA               (US_MR_USART_MODE_IRDA_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) IrDA Position  */
 #define US_MR_USART_MODE_LON                (US_MR_USART_MODE_LON_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LON Position  */
-#define US_MR_USART_MODE_LIN_MASTER         (US_MR_USART_MODE_LIN_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN master Position  */
-#define US_MR_USART_MODE_LIN_SLAVE          (US_MR_USART_MODE_LIN_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN slave Position  */
-#define US_MR_USART_MODE_SPI_MASTER         (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI master Position  */
-#define US_MR_USART_MODE_SPI_SLAVE          (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Slave Position  */
+#define US_MR_USART_MODE_LIN_MASTER         (US_MR_USART_MODE_LIN_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN Master mode Position  */
+#define US_MR_USART_MODE_LIN_SLAVE          (US_MR_USART_MODE_LIN_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) LIN Slave mode Position  */
+#define US_MR_USART_MODE_SPI_MASTER         (US_MR_USART_MODE_SPI_MASTER_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Master mode (CLKO must be written to 1 and USCLKS = 0, 1 or 2) Position  */
+#define US_MR_USART_MODE_SPI_SLAVE          (US_MR_USART_MODE_SPI_SLAVE_Val << US_MR_USART_MODE_Pos)  /**< (US_MR) SPI Slave mode Position  */
 #define US_MR_USCLKS_Pos                    4                                              /**< (US_MR) Clock Selection Position */
 #define US_MR_USCLKS_Msk                    (_U_(0x3) << US_MR_USCLKS_Pos)                 /**< (US_MR) Clock Selection Mask */
 #define US_MR_USCLKS(value)                 (US_MR_USCLKS_Msk & ((value) << US_MR_USCLKS_Pos))
 #define   US_MR_USCLKS_MCK_Val              _U_(0x0)                                       /**< (US_MR) Peripheral clock is selected  */
-#define   US_MR_USCLKS_DIV_Val              _U_(0x1)                                       /**< (US_MR) Peripheral clock divided (DIV=DIV=8) is selected  */
+#define   US_MR_USCLKS_DIV_Val              _U_(0x1)                                       /**< (US_MR) Peripheral clock divided (DIV = 8) is selected  */
 #define   US_MR_USCLKS_PCK_Val              _U_(0x2)                                       /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1.  */
 #define   US_MR_USCLKS_SCK_Val              _U_(0x3)                                       /**< (US_MR) Serial clock (SCK) is selected  */
 #define US_MR_USCLKS_MCK                    (US_MR_USCLKS_MCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock is selected Position  */
-#define US_MR_USCLKS_DIV                    (US_MR_USCLKS_DIV_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock divided (DIV=DIV=8) is selected Position  */
+#define US_MR_USCLKS_DIV                    (US_MR_USCLKS_DIV_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Peripheral clock divided (DIV = 8) is selected Position  */
 #define US_MR_USCLKS_PCK                    (US_MR_USCLKS_PCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) PMC programmable clock (PCK) is selected. If the SCK pin is driven (CLKO = 1), the CD field must be greater than 1. Position  */
 #define US_MR_USCLKS_SCK                    (US_MR_USCLKS_SCK_Val << US_MR_USCLKS_Pos)     /**< (US_MR) Serial clock (SCK) is selected Position  */
 #define US_MR_CHRL_Pos                      6                                              /**< (US_MR) Character Length Position */
@@ -221,100 +274,121 @@ typedef union {
 #define US_MR_CHRL_6_BIT                    (US_MR_CHRL_6_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 6 bits Position  */
 #define US_MR_CHRL_7_BIT                    (US_MR_CHRL_7_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 7 bits Position  */
 #define US_MR_CHRL_8_BIT                    (US_MR_CHRL_8_BIT_Val << US_MR_CHRL_Pos)       /**< (US_MR) Character length is 8 bits Position  */
-#define US_MR_SYNC_Pos                      8                                              /**< (US_MR) Synchronous Mode Select Position */
-#define US_MR_SYNC_Msk                      (_U_(0x1) << US_MR_SYNC_Pos)                   /**< (US_MR) Synchronous Mode Select Mask */
-#define US_MR_SYNC                          US_MR_SYNC_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SYNC_Msk instead */
-#define US_MR_PAR_Pos                       9                                              /**< (US_MR) Parity Type Position */
-#define US_MR_PAR_Msk                       (_U_(0x7) << US_MR_PAR_Pos)                    /**< (US_MR) Parity Type Mask */
-#define US_MR_PAR(value)                    (US_MR_PAR_Msk & ((value) << US_MR_PAR_Pos)) 
-#define   US_MR_PAR_EVEN_Val                _U_(0x0)                                       /**< (US_MR) Even parity  */
-#define   US_MR_PAR_ODD_Val                 _U_(0x1)                                       /**< (US_MR) Odd parity  */
-#define   US_MR_PAR_SPACE_Val               _U_(0x2)                                       /**< (US_MR) Parity forced to 0 (Space)  */
-#define   US_MR_PAR_MARK_Val                _U_(0x3)                                       /**< (US_MR) Parity forced to 1 (Mark)  */
-#define   US_MR_PAR_NO_Val                  _U_(0x4)                                       /**< (US_MR) No parity  */
-#define   US_MR_PAR_MULTIDROP_Val           _U_(0x6)                                       /**< (US_MR) Multidrop mode  */
-#define US_MR_PAR_EVEN                      (US_MR_PAR_EVEN_Val << US_MR_PAR_Pos)          /**< (US_MR) Even parity Position  */
-#define US_MR_PAR_ODD                       (US_MR_PAR_ODD_Val << US_MR_PAR_Pos)           /**< (US_MR) Odd parity Position  */
-#define US_MR_PAR_SPACE                     (US_MR_PAR_SPACE_Val << US_MR_PAR_Pos)         /**< (US_MR) Parity forced to 0 (Space) Position  */
-#define US_MR_PAR_MARK                      (US_MR_PAR_MARK_Val << US_MR_PAR_Pos)          /**< (US_MR) Parity forced to 1 (Mark) Position  */
-#define US_MR_PAR_NO                        (US_MR_PAR_NO_Val << US_MR_PAR_Pos)            /**< (US_MR) No parity Position  */
-#define US_MR_PAR_MULTIDROP                 (US_MR_PAR_MULTIDROP_Val << US_MR_PAR_Pos)     /**< (US_MR) Multidrop mode Position  */
-#define US_MR_NBSTOP_Pos                    12                                             /**< (US_MR) Number of Stop Bits Position */
-#define US_MR_NBSTOP_Msk                    (_U_(0x3) << US_MR_NBSTOP_Pos)                 /**< (US_MR) Number of Stop Bits Mask */
-#define US_MR_NBSTOP(value)                 (US_MR_NBSTOP_Msk & ((value) << US_MR_NBSTOP_Pos))
-#define   US_MR_NBSTOP_1_BIT_Val            _U_(0x0)                                       /**< (US_MR) 1 stop bit  */
-#define   US_MR_NBSTOP_1_5_BIT_Val          _U_(0x1)                                       /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
-#define   US_MR_NBSTOP_2_BIT_Val            _U_(0x2)                                       /**< (US_MR) 2 stop bits  */
-#define US_MR_NBSTOP_1_BIT                  (US_MR_NBSTOP_1_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 1 stop bit Position  */
-#define US_MR_NBSTOP_1_5_BIT                (US_MR_NBSTOP_1_5_BIT_Val << US_MR_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
-#define US_MR_NBSTOP_2_BIT                  (US_MR_NBSTOP_2_BIT_Val << US_MR_NBSTOP_Pos)   /**< (US_MR) 2 stop bits Position  */
-#define US_MR_CHMODE_Pos                    14                                             /**< (US_MR) Channel Mode Position */
-#define US_MR_CHMODE_Msk                    (_U_(0x3) << US_MR_CHMODE_Pos)                 /**< (US_MR) Channel Mode Mask */
-#define US_MR_CHMODE(value)                 (US_MR_CHMODE_Msk & ((value) << US_MR_CHMODE_Pos))
-#define   US_MR_CHMODE_NORMAL_Val           _U_(0x0)                                       /**< (US_MR) Normal mode  */
-#define   US_MR_CHMODE_AUTOMATIC_Val        _U_(0x1)                                       /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin.  */
-#define   US_MR_CHMODE_LOCAL_LOOPBACK_Val   _U_(0x2)                                       /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input.  */
-#define   US_MR_CHMODE_REMOTE_LOOPBACK_Val  _U_(0x3)                                       /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin.  */
-#define US_MR_CHMODE_NORMAL                 (US_MR_CHMODE_NORMAL_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
-#define US_MR_CHMODE_AUTOMATIC              (US_MR_CHMODE_AUTOMATIC_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
-#define US_MR_CHMODE_LOCAL_LOOPBACK         (US_MR_CHMODE_LOCAL_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
-#define US_MR_CHMODE_REMOTE_LOOPBACK        (US_MR_CHMODE_REMOTE_LOOPBACK_Val << US_MR_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
-#define US_MR_MSBF_Pos                      16                                             /**< (US_MR) Bit Order Position */
-#define US_MR_MSBF_Msk                      (_U_(0x1) << US_MR_MSBF_Pos)                   /**< (US_MR) Bit Order Mask */
-#define US_MR_MSBF                          US_MR_MSBF_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MSBF_Msk instead */
-#define US_MR_MODE9_Pos                     17                                             /**< (US_MR) 9-bit Character Length Position */
-#define US_MR_MODE9_Msk                     (_U_(0x1) << US_MR_MODE9_Pos)                  /**< (US_MR) 9-bit Character Length Mask */
-#define US_MR_MODE9                         US_MR_MODE9_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODE9_Msk instead */
 #define US_MR_CLKO_Pos                      18                                             /**< (US_MR) Clock Output Select Position */
 #define US_MR_CLKO_Msk                      (_U_(0x1) << US_MR_CLKO_Pos)                   /**< (US_MR) Clock Output Select Mask */
 #define US_MR_CLKO                          US_MR_CLKO_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_CLKO_Msk instead */
-#define US_MR_OVER_Pos                      19                                             /**< (US_MR) Oversampling Mode Position */
-#define US_MR_OVER_Msk                      (_U_(0x1) << US_MR_OVER_Pos)                   /**< (US_MR) Oversampling Mode Mask */
-#define US_MR_OVER                          US_MR_OVER_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_OVER_Msk instead */
-#define US_MR_INACK_Pos                     20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
-#define US_MR_INACK_Msk                     (_U_(0x1) << US_MR_INACK_Pos)                  /**< (US_MR) Inhibit Non Acknowledge Mask */
-#define US_MR_INACK                         US_MR_INACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INACK_Msk instead */
-#define US_MR_DSNACK_Pos                    21                                             /**< (US_MR) Disable Successive NACK Position */
-#define US_MR_DSNACK_Msk                    (_U_(0x1) << US_MR_DSNACK_Pos)                 /**< (US_MR) Disable Successive NACK Mask */
-#define US_MR_DSNACK                        US_MR_DSNACK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_DSNACK_Msk instead */
-#define US_MR_VAR_SYNC_Pos                  22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
-#define US_MR_VAR_SYNC_Msk                  (_U_(0x1) << US_MR_VAR_SYNC_Pos)               /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
-#define US_MR_VAR_SYNC                      US_MR_VAR_SYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_VAR_SYNC_Msk instead */
-#define US_MR_INVDATA_Pos                   23                                             /**< (US_MR) Inverted Data Position */
-#define US_MR_INVDATA_Msk                   (_U_(0x1) << US_MR_INVDATA_Pos)                /**< (US_MR) Inverted Data Mask */
-#define US_MR_INVDATA                       US_MR_INVDATA_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_INVDATA_Msk instead */
-#define US_MR_MAX_ITERATION_Pos             24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
-#define US_MR_MAX_ITERATION_Msk             (_U_(0x7) << US_MR_MAX_ITERATION_Pos)          /**< (US_MR) Maximum Number of Automatic Iteration Mask */
-#define US_MR_MAX_ITERATION(value)          (US_MR_MAX_ITERATION_Msk & ((value) << US_MR_MAX_ITERATION_Pos))
-#define US_MR_FILTER_Pos                    28                                             /**< (US_MR) Receive Line Filter Position */
-#define US_MR_FILTER_Msk                    (_U_(0x1) << US_MR_FILTER_Pos)                 /**< (US_MR) Receive Line Filter Mask */
-#define US_MR_FILTER                        US_MR_FILTER_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_FILTER_Msk instead */
-#define US_MR_MAN_Pos                       29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
-#define US_MR_MAN_Msk                       (_U_(0x1) << US_MR_MAN_Pos)                    /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
-#define US_MR_MAN                           US_MR_MAN_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MAN_Msk instead */
-#define US_MR_MODSYNC_Pos                   30                                             /**< (US_MR) Manchester Synchronization Mode Position */
-#define US_MR_MODSYNC_Msk                   (_U_(0x1) << US_MR_MODSYNC_Pos)                /**< (US_MR) Manchester Synchronization Mode Mask */
-#define US_MR_MODSYNC                       US_MR_MODSYNC_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_MODSYNC_Msk instead */
-#define US_MR_ONEBIT_Pos                    31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
-#define US_MR_ONEBIT_Msk                    (_U_(0x1) << US_MR_ONEBIT_Pos)                 /**< (US_MR) Start Frame Delimiter Selector Mask */
-#define US_MR_ONEBIT                        US_MR_ONEBIT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_ONEBIT_Msk instead */
-#define US_MR_MASK                          _U_(0xF7FFFFFF)                                /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
-#define US_MR_Msk                           _U_(0xF7FFFFFF)                                /**< (US_MR) Register Mask  */
+#define US_MR_MASK                          _U_(0x400FF)                                   /**< \deprecated (US_MR) Register MASK  (Use US_MR_Msk instead)  */
+#define US_MR_Msk                           _U_(0x400FF)                                   /**< (US_MR) Register Mask  */
+
+/* USART mode */
+#define US_MR_USART_SYNC_Pos                8                                              /**< (US_MR) Synchronous Mode Select Position */
+#define US_MR_USART_SYNC_Msk                (_U_(0x1) << US_MR_USART_SYNC_Pos)             /**< (US_MR) Synchronous Mode Select Mask */
+#define US_MR_USART_SYNC                    US_MR_USART_SYNC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_SYNC_Msk instead */
+#define US_MR_USART_PAR_Pos                 9                                              /**< (US_MR) Parity Type Position */
+#define US_MR_USART_PAR_Msk                 (_U_(0x7) << US_MR_USART_PAR_Pos)              /**< (US_MR) Parity Type Mask */
+#define US_MR_USART_PAR(value)              (US_MR_USART_PAR_Msk & ((value) << US_MR_USART_PAR_Pos))
+#define   US_MR_USART_PAR_EVEN_Val          _U_(0x0)                                       /**< (US_MR) USART Even parity  */
+#define   US_MR_USART_PAR_ODD_Val           _U_(0x1)                                       /**< (US_MR) USART Odd parity  */
+#define   US_MR_USART_PAR_SPACE_Val         _U_(0x2)                                       /**< (US_MR) USART Parity forced to 0 (Space)  */
+#define   US_MR_USART_PAR_MARK_Val          _U_(0x3)                                       /**< (US_MR) USART Parity forced to 1 (Mark)  */
+#define   US_MR_USART_PAR_NO_Val            _U_(0x4)                                       /**< (US_MR) USART No parity  */
+#define   US_MR_USART_PAR_MULTIDROP_Val     _U_(0x6)                                       /**< (US_MR) USART Multidrop mode  */
+#define US_MR_USART_PAR_EVEN                (US_MR_USART_PAR_EVEN_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Even parity Position  */
+#define US_MR_USART_PAR_ODD                 (US_MR_USART_PAR_ODD_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Odd parity Position  */
+#define US_MR_USART_PAR_SPACE               (US_MR_USART_PAR_SPACE_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Parity forced to 0 (Space) Position  */
+#define US_MR_USART_PAR_MARK                (US_MR_USART_PAR_MARK_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Parity forced to 1 (Mark) Position  */
+#define US_MR_USART_PAR_NO                  (US_MR_USART_PAR_NO_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) No parity Position  */
+#define US_MR_USART_PAR_MULTIDROP           (US_MR_USART_PAR_MULTIDROP_Val << US_MR_USART_PAR_Pos)  /**< (US_MR) Multidrop mode Position  */
+#define US_MR_USART_NBSTOP_Pos              12                                             /**< (US_MR) Number of Stop Bits Position */
+#define US_MR_USART_NBSTOP_Msk              (_U_(0x3) << US_MR_USART_NBSTOP_Pos)           /**< (US_MR) Number of Stop Bits Mask */
+#define US_MR_USART_NBSTOP(value)           (US_MR_USART_NBSTOP_Msk & ((value) << US_MR_USART_NBSTOP_Pos))
+#define   US_MR_USART_NBSTOP_1_BIT_Val      _U_(0x0)                                       /**< (US_MR) USART 1 stop bit  */
+#define   US_MR_USART_NBSTOP_1_5_BIT_Val    _U_(0x1)                                       /**< (US_MR) USART 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1)  */
+#define   US_MR_USART_NBSTOP_2_BIT_Val      _U_(0x2)                                       /**< (US_MR) USART 2 stop bits  */
+#define US_MR_USART_NBSTOP_1_BIT            (US_MR_USART_NBSTOP_1_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 1 stop bit Position  */
+#define US_MR_USART_NBSTOP_1_5_BIT          (US_MR_USART_NBSTOP_1_5_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 1.5 stop bit (SYNC = 0) or reserved (SYNC = 1) Position  */
+#define US_MR_USART_NBSTOP_2_BIT            (US_MR_USART_NBSTOP_2_BIT_Val << US_MR_USART_NBSTOP_Pos)  /**< (US_MR) 2 stop bits Position  */
+#define US_MR_USART_CHMODE_Pos              14                                             /**< (US_MR) Channel Mode Position */
+#define US_MR_USART_CHMODE_Msk              (_U_(0x3) << US_MR_USART_CHMODE_Pos)           /**< (US_MR) Channel Mode Mask */
+#define US_MR_USART_CHMODE(value)           (US_MR_USART_CHMODE_Msk & ((value) << US_MR_USART_CHMODE_Pos))
+#define   US_MR_USART_CHMODE_NORMAL_Val     _U_(0x0)                                       /**< (US_MR) USART Normal mode  */
+#define   US_MR_USART_CHMODE_AUTOMATIC_Val  _U_(0x1)                                       /**< (US_MR) USART Automatic Echo. Receiver input is connected to the TXD pin.  */
+#define   US_MR_USART_CHMODE_LOCAL_LOOPBACK_Val _U_(0x2)                                       /**< (US_MR) USART Local Loopback. Transmitter output is connected to the Receiver Input.  */
+#define   US_MR_USART_CHMODE_REMOTE_LOOPBACK_Val _U_(0x3)                                       /**< (US_MR) USART Remote Loopback. RXD pin is internally connected to the TXD pin.  */
+#define US_MR_USART_CHMODE_NORMAL           (US_MR_USART_CHMODE_NORMAL_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Normal mode Position  */
+#define US_MR_USART_CHMODE_AUTOMATIC        (US_MR_USART_CHMODE_AUTOMATIC_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Automatic Echo. Receiver input is connected to the TXD pin. Position  */
+#define US_MR_USART_CHMODE_LOCAL_LOOPBACK   (US_MR_USART_CHMODE_LOCAL_LOOPBACK_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Local Loopback. Transmitter output is connected to the Receiver Input. Position  */
+#define US_MR_USART_CHMODE_REMOTE_LOOPBACK  (US_MR_USART_CHMODE_REMOTE_LOOPBACK_Val << US_MR_USART_CHMODE_Pos)  /**< (US_MR) Remote Loopback. RXD pin is internally connected to the TXD pin. Position  */
+#define US_MR_USART_MSBF_Pos                16                                             /**< (US_MR) Bit Order Position */
+#define US_MR_USART_MSBF_Msk                (_U_(0x1) << US_MR_USART_MSBF_Pos)             /**< (US_MR) Bit Order Mask */
+#define US_MR_USART_MSBF                    US_MR_USART_MSBF_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MSBF_Msk instead */
+#define US_MR_USART_MODE9_Pos               17                                             /**< (US_MR) 9-bit Character Length Position */
+#define US_MR_USART_MODE9_Msk               (_U_(0x1) << US_MR_USART_MODE9_Pos)            /**< (US_MR) 9-bit Character Length Mask */
+#define US_MR_USART_MODE9                   US_MR_USART_MODE9_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MODE9_Msk instead */
+#define US_MR_USART_OVER_Pos                19                                             /**< (US_MR) Oversampling Mode Position */
+#define US_MR_USART_OVER_Msk                (_U_(0x1) << US_MR_USART_OVER_Pos)             /**< (US_MR) Oversampling Mode Mask */
+#define US_MR_USART_OVER                    US_MR_USART_OVER_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_OVER_Msk instead */
+#define US_MR_USART_INACK_Pos               20                                             /**< (US_MR) Inhibit Non Acknowledge Position */
+#define US_MR_USART_INACK_Msk               (_U_(0x1) << US_MR_USART_INACK_Pos)            /**< (US_MR) Inhibit Non Acknowledge Mask */
+#define US_MR_USART_INACK                   US_MR_USART_INACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_INACK_Msk instead */
+#define US_MR_USART_DSNACK_Pos              21                                             /**< (US_MR) Disable Successive NACK Position */
+#define US_MR_USART_DSNACK_Msk              (_U_(0x1) << US_MR_USART_DSNACK_Pos)           /**< (US_MR) Disable Successive NACK Mask */
+#define US_MR_USART_DSNACK                  US_MR_USART_DSNACK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_DSNACK_Msk instead */
+#define US_MR_USART_VAR_SYNC_Pos            22                                             /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Position */
+#define US_MR_USART_VAR_SYNC_Msk            (_U_(0x1) << US_MR_USART_VAR_SYNC_Pos)         /**< (US_MR) Variable Synchronization of Command/Data Sync Start Frame Delimiter Mask */
+#define US_MR_USART_VAR_SYNC                US_MR_USART_VAR_SYNC_Msk                       /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_VAR_SYNC_Msk instead */
+#define US_MR_USART_INVDATA_Pos             23                                             /**< (US_MR) Inverted Data Position */
+#define US_MR_USART_INVDATA_Msk             (_U_(0x1) << US_MR_USART_INVDATA_Pos)          /**< (US_MR) Inverted Data Mask */
+#define US_MR_USART_INVDATA                 US_MR_USART_INVDATA_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_INVDATA_Msk instead */
+#define US_MR_USART_MAX_ITERATION_Pos       24                                             /**< (US_MR) Maximum Number of Automatic Iteration Position */
+#define US_MR_USART_MAX_ITERATION_Msk       (_U_(0x7) << US_MR_USART_MAX_ITERATION_Pos)    /**< (US_MR) Maximum Number of Automatic Iteration Mask */
+#define US_MR_USART_MAX_ITERATION(value)    (US_MR_USART_MAX_ITERATION_Msk & ((value) << US_MR_USART_MAX_ITERATION_Pos))
+#define US_MR_USART_FILTER_Pos              28                                             /**< (US_MR) Receive Line Filter Position */
+#define US_MR_USART_FILTER_Msk              (_U_(0x1) << US_MR_USART_FILTER_Pos)           /**< (US_MR) Receive Line Filter Mask */
+#define US_MR_USART_FILTER                  US_MR_USART_FILTER_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_FILTER_Msk instead */
+#define US_MR_USART_MAN_Pos                 29                                             /**< (US_MR) Manchester Encoder/Decoder Enable Position */
+#define US_MR_USART_MAN_Msk                 (_U_(0x1) << US_MR_USART_MAN_Pos)              /**< (US_MR) Manchester Encoder/Decoder Enable Mask */
+#define US_MR_USART_MAN                     US_MR_USART_MAN_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MAN_Msk instead */
+#define US_MR_USART_MODSYNC_Pos             30                                             /**< (US_MR) Manchester Synchronization Mode Position */
+#define US_MR_USART_MODSYNC_Msk             (_U_(0x1) << US_MR_USART_MODSYNC_Pos)          /**< (US_MR) Manchester Synchronization Mode Mask */
+#define US_MR_USART_MODSYNC                 US_MR_USART_MODSYNC_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_MODSYNC_Msk instead */
+#define US_MR_USART_ONEBIT_Pos              31                                             /**< (US_MR) Start Frame Delimiter Selector Position */
+#define US_MR_USART_ONEBIT_Msk              (_U_(0x1) << US_MR_USART_ONEBIT_Pos)           /**< (US_MR) Start Frame Delimiter Selector Mask */
+#define US_MR_USART_ONEBIT                  US_MR_USART_ONEBIT_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_USART_ONEBIT_Msk instead */
+#define US_MR_USART_MASK                    _U_(0xF7FBFF00)                                /**< \deprecated (US_MR_USART) Register MASK  (Use US_MR_USART_Msk instead)  */
+#define US_MR_USART_Msk                     _U_(0xF7FBFF00)                                /**< (US_MR_USART) Register Mask  */
+
+/* SPI mode */
+#define US_MR_SPI_CPHA_Pos                  8                                              /**< (US_MR) SPI Clock Phase Position */
+#define US_MR_SPI_CPHA_Msk                  (_U_(0x1) << US_MR_SPI_CPHA_Pos)               /**< (US_MR) SPI Clock Phase Mask */
+#define US_MR_SPI_CPHA                      US_MR_SPI_CPHA_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_CPHA_Msk instead */
+#define US_MR_SPI_CPOL_Pos                  16                                             /**< (US_MR) SPI Clock Polarity Position */
+#define US_MR_SPI_CPOL_Msk                  (_U_(0x1) << US_MR_SPI_CPOL_Pos)               /**< (US_MR) SPI Clock Polarity Mask */
+#define US_MR_SPI_CPOL                      US_MR_SPI_CPOL_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_CPOL_Msk instead */
+#define US_MR_SPI_WRDBT_Pos                 20                                             /**< (US_MR) Wait Read Data Before Transfer Position */
+#define US_MR_SPI_WRDBT_Msk                 (_U_(0x1) << US_MR_SPI_WRDBT_Pos)              /**< (US_MR) Wait Read Data Before Transfer Mask */
+#define US_MR_SPI_WRDBT                     US_MR_SPI_WRDBT_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MR_SPI_WRDBT_Msk instead */
+#define US_MR_SPI_MASK                      _U_(0x110100)                                  /**< \deprecated (US_MR_SPI) Register MASK  (Use US_MR_SPI_Msk instead)  */
+#define US_MR_SPI_Msk                       _U_(0x110100)                                  /**< (US_MR_SPI) Register Mask  */
 
 
 /* -------- US_IER : (USART Offset: 0x08) (/W 32) Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Enable                   */
     uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Enable                   */
-    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Enable          */
-    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
-    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Enable           */
-    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Enable            */
-    uint32_t TIMEOUT:1;                 /**< bit:      8  Time-out Interrupt Enable                */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
     uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Enable                 */
+    uint32_t :22;                       /**< bit: 10..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Enable          */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
     uint32_t ITER:1;                    /**< bit:     10  Max number of Repetitions Reached Interrupt Enable */
     uint32_t :2;                        /**< bit: 11..12  Reserved */
     uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Enable         */
@@ -326,9 +400,53 @@ typedef union {
     uint32_t :4;                        /**< bit: 20..23  Reserved */
     uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Enable        */
     uint32_t :7;                        /**< bit: 25..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Enable           */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Enable            */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Enable                 */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Enable */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Enable */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Enable  */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Enable           */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Enable */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Enable   */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Enable      */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Enable */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Enable */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Enable */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Enable   */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Enable           */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Enable   */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Enable           */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Enable */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Enable      */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Enable */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  Underrun Error Interrupt Enable          */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IER_OFFSET                       (0x08)                                        /**<  (US_IER) Interrupt Enable Register  Offset */
@@ -339,76 +457,206 @@ typedef union {
 #define US_IER_TXRDY_Pos                    1                                              /**< (US_IER) TXRDY Interrupt Enable Position */
 #define US_IER_TXRDY_Msk                    (_U_(0x1) << US_IER_TXRDY_Pos)                 /**< (US_IER) TXRDY Interrupt Enable Mask */
 #define US_IER_TXRDY                        US_IER_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXRDY_Msk instead */
-#define US_IER_RXBRK_Pos                    2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
-#define US_IER_RXBRK_Msk                    (_U_(0x1) << US_IER_RXBRK_Pos)                 /**< (US_IER) Receiver Break Interrupt Enable Mask */
-#define US_IER_RXBRK                        US_IER_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RXBRK_Msk instead */
 #define US_IER_OVRE_Pos                     5                                              /**< (US_IER) Overrun Error Interrupt Enable Position */
 #define US_IER_OVRE_Msk                     (_U_(0x1) << US_IER_OVRE_Pos)                  /**< (US_IER) Overrun Error Interrupt Enable Mask */
 #define US_IER_OVRE                         US_IER_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_OVRE_Msk instead */
-#define US_IER_FRAME_Pos                    6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
-#define US_IER_FRAME_Msk                    (_U_(0x1) << US_IER_FRAME_Pos)                 /**< (US_IER) Framing Error Interrupt Enable Mask */
-#define US_IER_FRAME                        US_IER_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_FRAME_Msk instead */
-#define US_IER_PARE_Pos                     7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
-#define US_IER_PARE_Msk                     (_U_(0x1) << US_IER_PARE_Pos)                  /**< (US_IER) Parity Error Interrupt Enable Mask */
-#define US_IER_PARE                         US_IER_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_PARE_Msk instead */
-#define US_IER_TIMEOUT_Pos                  8                                              /**< (US_IER) Time-out Interrupt Enable Position */
-#define US_IER_TIMEOUT_Msk                  (_U_(0x1) << US_IER_TIMEOUT_Pos)               /**< (US_IER) Time-out Interrupt Enable Mask */
-#define US_IER_TIMEOUT                      US_IER_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TIMEOUT_Msk instead */
 #define US_IER_TXEMPTY_Pos                  9                                              /**< (US_IER) TXEMPTY Interrupt Enable Position */
 #define US_IER_TXEMPTY_Msk                  (_U_(0x1) << US_IER_TXEMPTY_Pos)               /**< (US_IER) TXEMPTY Interrupt Enable Mask */
 #define US_IER_TXEMPTY                      US_IER_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_TXEMPTY_Msk instead */
-#define US_IER_ITER_Pos                     10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
-#define US_IER_ITER_Msk                     (_U_(0x1) << US_IER_ITER_Pos)                  /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
-#define US_IER_ITER                         US_IER_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_ITER_Msk instead */
-#define US_IER_NACK_Pos                     13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
-#define US_IER_NACK_Msk                     (_U_(0x1) << US_IER_NACK_Pos)                  /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
-#define US_IER_NACK                         US_IER_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_NACK_Msk instead */
-#define US_IER_RIIC_Pos                     16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
-#define US_IER_RIIC_Msk                     (_U_(0x1) << US_IER_RIIC_Pos)                  /**< (US_IER) Ring Indicator Input Change Enable Mask */
-#define US_IER_RIIC                         US_IER_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_RIIC_Msk instead */
-#define US_IER_DSRIC_Pos                    17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
-#define US_IER_DSRIC_Msk                    (_U_(0x1) << US_IER_DSRIC_Pos)                 /**< (US_IER) Data Set Ready Input Change Enable Mask */
-#define US_IER_DSRIC                        US_IER_DSRIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DSRIC_Msk instead */
-#define US_IER_DCDIC_Pos                    18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
-#define US_IER_DCDIC_Msk                    (_U_(0x1) << US_IER_DCDIC_Pos)                 /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
-#define US_IER_DCDIC                        US_IER_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_DCDIC_Msk instead */
-#define US_IER_CTSIC_Pos                    19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
-#define US_IER_CTSIC_Msk                    (_U_(0x1) << US_IER_CTSIC_Pos)                 /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
-#define US_IER_CTSIC                        US_IER_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_CTSIC_Msk instead */
-#define US_IER_MANE_Pos                     24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
-#define US_IER_MANE_Msk                     (_U_(0x1) << US_IER_MANE_Pos)                  /**< (US_IER) Manchester Error Interrupt Enable Mask */
-#define US_IER_MANE                         US_IER_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_MANE_Msk instead */
-#define US_IER_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
-#define US_IER_Msk                          _U_(0x10F27E7)                                 /**< (US_IER) Register Mask  */
+#define US_IER_MASK                         _U_(0x223)                                     /**< \deprecated (US_IER) Register MASK  (Use US_IER_Msk instead)  */
+#define US_IER_Msk                          _U_(0x223)                                     /**< (US_IER) Register Mask  */
+
+/* USART mode */
+#define US_IER_USART_RXBRK_Pos              2                                              /**< (US_IER) Receiver Break Interrupt Enable Position */
+#define US_IER_USART_RXBRK_Msk              (_U_(0x1) << US_IER_USART_RXBRK_Pos)           /**< (US_IER) Receiver Break Interrupt Enable Mask */
+#define US_IER_USART_RXBRK                  US_IER_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_RXBRK_Msk instead */
+#define US_IER_USART_ITER_Pos               10                                             /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Position */
+#define US_IER_USART_ITER_Msk               (_U_(0x1) << US_IER_USART_ITER_Pos)            /**< (US_IER) Max number of Repetitions Reached Interrupt Enable Mask */
+#define US_IER_USART_ITER                   US_IER_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_ITER_Msk instead */
+#define US_IER_USART_NACK_Pos               13                                             /**< (US_IER) Non Acknowledge Interrupt Enable Position */
+#define US_IER_USART_NACK_Msk               (_U_(0x1) << US_IER_USART_NACK_Pos)            /**< (US_IER) Non Acknowledge Interrupt Enable Mask */
+#define US_IER_USART_NACK                   US_IER_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_NACK_Msk instead */
+#define US_IER_USART_RIIC_Pos               16                                             /**< (US_IER) Ring Indicator Input Change Enable Position */
+#define US_IER_USART_RIIC_Msk               (_U_(0x1) << US_IER_USART_RIIC_Pos)            /**< (US_IER) Ring Indicator Input Change Enable Mask */
+#define US_IER_USART_RIIC                   US_IER_USART_RIIC_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_RIIC_Msk instead */
+#define US_IER_USART_DSRIC_Pos              17                                             /**< (US_IER) Data Set Ready Input Change Enable Position */
+#define US_IER_USART_DSRIC_Msk              (_U_(0x1) << US_IER_USART_DSRIC_Pos)           /**< (US_IER) Data Set Ready Input Change Enable Mask */
+#define US_IER_USART_DSRIC                  US_IER_USART_DSRIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_DSRIC_Msk instead */
+#define US_IER_USART_DCDIC_Pos              18                                             /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Position */
+#define US_IER_USART_DCDIC_Msk              (_U_(0x1) << US_IER_USART_DCDIC_Pos)           /**< (US_IER) Data Carrier Detect Input Change Interrupt Enable Mask */
+#define US_IER_USART_DCDIC                  US_IER_USART_DCDIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_DCDIC_Msk instead */
+#define US_IER_USART_CTSIC_Pos              19                                             /**< (US_IER) Clear to Send Input Change Interrupt Enable Position */
+#define US_IER_USART_CTSIC_Msk              (_U_(0x1) << US_IER_USART_CTSIC_Pos)           /**< (US_IER) Clear to Send Input Change Interrupt Enable Mask */
+#define US_IER_USART_CTSIC                  US_IER_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_CTSIC_Msk instead */
+#define US_IER_USART_MANE_Pos               24                                             /**< (US_IER) Manchester Error Interrupt Enable Position */
+#define US_IER_USART_MANE_Msk               (_U_(0x1) << US_IER_USART_MANE_Pos)            /**< (US_IER) Manchester Error Interrupt Enable Mask */
+#define US_IER_USART_MANE                   US_IER_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_MANE_Msk instead */
+#define US_IER_USART_MASK                   _U_(0x10F2404)                                 /**< \deprecated (US_IER_USART) Register MASK  (Use US_IER_USART_Msk instead)  */
+#define US_IER_USART_Msk                    _U_(0x10F2404)                                 /**< (US_IER_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IER_USART_LIN_FRAME_Pos          6                                              /**< (US_IER) Framing Error Interrupt Enable Position */
+#define US_IER_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IER_USART_LIN_FRAME_Pos)       /**< (US_IER) Framing Error Interrupt Enable Mask */
+#define US_IER_USART_LIN_FRAME              US_IER_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_FRAME_Msk instead */
+#define US_IER_USART_LIN_PARE_Pos           7                                              /**< (US_IER) Parity Error Interrupt Enable Position */
+#define US_IER_USART_LIN_PARE_Msk           (_U_(0x1) << US_IER_USART_LIN_PARE_Pos)        /**< (US_IER) Parity Error Interrupt Enable Mask */
+#define US_IER_USART_LIN_PARE               US_IER_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_PARE_Msk instead */
+#define US_IER_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IER) Timeout Interrupt Enable Position */
+#define US_IER_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IER_USART_LIN_TIMEOUT_Pos)     /**< (US_IER) Timeout Interrupt Enable Mask */
+#define US_IER_USART_LIN_TIMEOUT            US_IER_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_USART_LIN_TIMEOUT_Msk instead */
+#define US_IER_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IER_USART_LIN) Register MASK  (Use US_IER_USART_LIN_Msk instead)  */
+#define US_IER_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IER_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IER_SPI_NSSE_Pos                 19                                             /**< (US_IER) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IER_SPI_NSSE_Msk                 (_U_(0x1) << US_IER_SPI_NSSE_Pos)              /**< (US_IER) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IER_SPI_NSSE                     US_IER_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_SPI_NSSE_Msk instead */
+#define US_IER_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IER_SPI) Register MASK  (Use US_IER_SPI_Msk instead)  */
+#define US_IER_SPI_Msk                      _U_(0x80000)                                   /**< (US_IER_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IER_LIN_LINBK_Pos                13                                             /**< (US_IER) LIN Break Sent or LIN Break Received Interrupt Enable Position */
+#define US_IER_LIN_LINBK_Msk                (_U_(0x1) << US_IER_LIN_LINBK_Pos)             /**< (US_IER) LIN Break Sent or LIN Break Received Interrupt Enable Mask */
+#define US_IER_LIN_LINBK                    US_IER_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINBK_Msk instead */
+#define US_IER_LIN_LINID_Pos                14                                             /**< (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable Position */
+#define US_IER_LIN_LINID_Msk                (_U_(0x1) << US_IER_LIN_LINID_Pos)             /**< (US_IER) LIN Identifier Sent or LIN Identifier Received Interrupt Enable Mask */
+#define US_IER_LIN_LINID                    US_IER_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINID_Msk instead */
+#define US_IER_LIN_LINTC_Pos                15                                             /**< (US_IER) LIN Transfer Completed Interrupt Enable Position */
+#define US_IER_LIN_LINTC_Msk                (_U_(0x1) << US_IER_LIN_LINTC_Pos)             /**< (US_IER) LIN Transfer Completed Interrupt Enable Mask */
+#define US_IER_LIN_LINTC                    US_IER_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINTC_Msk instead */
+#define US_IER_LIN_LINBE_Pos                25                                             /**< (US_IER) LIN Bus Error Interrupt Enable Position */
+#define US_IER_LIN_LINBE_Msk                (_U_(0x1) << US_IER_LIN_LINBE_Pos)             /**< (US_IER) LIN Bus Error Interrupt Enable Mask */
+#define US_IER_LIN_LINBE                    US_IER_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINBE_Msk instead */
+#define US_IER_LIN_LINISFE_Pos              26                                             /**< (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable Position */
+#define US_IER_LIN_LINISFE_Msk              (_U_(0x1) << US_IER_LIN_LINISFE_Pos)           /**< (US_IER) LIN Inconsistent Synch Field Error Interrupt Enable Mask */
+#define US_IER_LIN_LINISFE                  US_IER_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINISFE_Msk instead */
+#define US_IER_LIN_LINIPE_Pos               27                                             /**< (US_IER) LIN Identifier Parity Interrupt Enable Position */
+#define US_IER_LIN_LINIPE_Msk               (_U_(0x1) << US_IER_LIN_LINIPE_Pos)            /**< (US_IER) LIN Identifier Parity Interrupt Enable Mask */
+#define US_IER_LIN_LINIPE                   US_IER_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINIPE_Msk instead */
+#define US_IER_LIN_LINCE_Pos                28                                             /**< (US_IER) LIN Checksum Error Interrupt Enable Position */
+#define US_IER_LIN_LINCE_Msk                (_U_(0x1) << US_IER_LIN_LINCE_Pos)             /**< (US_IER) LIN Checksum Error Interrupt Enable Mask */
+#define US_IER_LIN_LINCE                    US_IER_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINCE_Msk instead */
+#define US_IER_LIN_LINSNRE_Pos              29                                             /**< (US_IER) LIN Slave Not Responding Error Interrupt Enable Position */
+#define US_IER_LIN_LINSNRE_Msk              (_U_(0x1) << US_IER_LIN_LINSNRE_Pos)           /**< (US_IER) LIN Slave Not Responding Error Interrupt Enable Mask */
+#define US_IER_LIN_LINSNRE                  US_IER_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINSNRE_Msk instead */
+#define US_IER_LIN_LINSTE_Pos               30                                             /**< (US_IER) LIN Synch Tolerance Error Interrupt Enable Position */
+#define US_IER_LIN_LINSTE_Msk               (_U_(0x1) << US_IER_LIN_LINSTE_Pos)            /**< (US_IER) LIN Synch Tolerance Error Interrupt Enable Mask */
+#define US_IER_LIN_LINSTE                   US_IER_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINSTE_Msk instead */
+#define US_IER_LIN_LINHTE_Pos               31                                             /**< (US_IER) LIN Header Timeout Error Interrupt Enable Position */
+#define US_IER_LIN_LINHTE_Msk               (_U_(0x1) << US_IER_LIN_LINHTE_Pos)            /**< (US_IER) LIN Header Timeout Error Interrupt Enable Mask */
+#define US_IER_LIN_LINHTE                   US_IER_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LIN_LINHTE_Msk instead */
+#define US_IER_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IER_LIN) Register MASK  (Use US_IER_LIN_Msk instead)  */
+#define US_IER_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IER_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IER_LON_LSFE_Pos                 6                                              /**< (US_IER) LON Short Frame Error Interrupt Enable Position */
+#define US_IER_LON_LSFE_Msk                 (_U_(0x1) << US_IER_LON_LSFE_Pos)              /**< (US_IER) LON Short Frame Error Interrupt Enable Mask */
+#define US_IER_LON_LSFE                     US_IER_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LSFE_Msk instead */
+#define US_IER_LON_LCRCE_Pos                7                                              /**< (US_IER) LON CRC Error Interrupt Enable Position */
+#define US_IER_LON_LCRCE_Msk                (_U_(0x1) << US_IER_LON_LCRCE_Pos)             /**< (US_IER) LON CRC Error Interrupt Enable Mask */
+#define US_IER_LON_LCRCE                    US_IER_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LCRCE_Msk instead */
+#define US_IER_LON_LTXD_Pos                 24                                             /**< (US_IER) LON Transmission Done Interrupt Enable Position */
+#define US_IER_LON_LTXD_Msk                 (_U_(0x1) << US_IER_LON_LTXD_Pos)              /**< (US_IER) LON Transmission Done Interrupt Enable Mask */
+#define US_IER_LON_LTXD                     US_IER_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LTXD_Msk instead */
+#define US_IER_LON_LCOL_Pos                 25                                             /**< (US_IER) LON Collision Interrupt Enable Position */
+#define US_IER_LON_LCOL_Msk                 (_U_(0x1) << US_IER_LON_LCOL_Pos)              /**< (US_IER) LON Collision Interrupt Enable Mask */
+#define US_IER_LON_LCOL                     US_IER_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LCOL_Msk instead */
+#define US_IER_LON_LFET_Pos                 26                                             /**< (US_IER) LON Frame Early Termination Interrupt Enable Position */
+#define US_IER_LON_LFET_Msk                 (_U_(0x1) << US_IER_LON_LFET_Pos)              /**< (US_IER) LON Frame Early Termination Interrupt Enable Mask */
+#define US_IER_LON_LFET                     US_IER_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LFET_Msk instead */
+#define US_IER_LON_LRXD_Pos                 27                                             /**< (US_IER) LON Reception Done Interrupt Enable Position */
+#define US_IER_LON_LRXD_Msk                 (_U_(0x1) << US_IER_LON_LRXD_Pos)              /**< (US_IER) LON Reception Done Interrupt Enable Mask */
+#define US_IER_LON_LRXD                     US_IER_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LRXD_Msk instead */
+#define US_IER_LON_LBLOVFE_Pos              28                                             /**< (US_IER) LON Backlog Overflow Error Interrupt Enable Position */
+#define US_IER_LON_LBLOVFE_Msk              (_U_(0x1) << US_IER_LON_LBLOVFE_Pos)           /**< (US_IER) LON Backlog Overflow Error Interrupt Enable Mask */
+#define US_IER_LON_LBLOVFE                  US_IER_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_LBLOVFE_Msk instead */
+#define US_IER_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IER_LON) Register MASK  (Use US_IER_LON_Msk instead)  */
+#define US_IER_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IER_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IER_LON_SPI_UNRE_Pos             10                                             /**< (US_IER) Underrun Error Interrupt Enable Position */
+#define US_IER_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IER_LON_SPI_UNRE_Pos)          /**< (US_IER) Underrun Error Interrupt Enable Mask */
+#define US_IER_LON_SPI_UNRE                 US_IER_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IER_LON_SPI_UNRE_Msk instead */
+#define US_IER_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IER_LON_SPI) Register MASK  (Use US_IER_LON_SPI_Msk instead)  */
+#define US_IER_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IER_LON_SPI) Register Mask  */
 
 
 /* -------- US_IDR : (USART Offset: 0x0c) (/W 32) Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Disable                  */
     uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Disable                  */
-    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Disable         */
-    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Enable           */
-    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Disable          */
-    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Disable           */
-    uint32_t TIMEOUT:1;                 /**< bit:      8  Time-out Interrupt Disable               */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
     uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Disable                */
-    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Disable */
-    uint32_t :2;                        /**< bit: 11..12  Reserved */
-    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Disable        */
-    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
     uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Disable      */
     uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Disable      */
     uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Disable */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Disable         */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Disable */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Disable        */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
     uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Disable */
     uint32_t :4;                        /**< bit: 20..23  Reserved */
     uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Disable       */
     uint32_t :7;                        /**< bit: 25..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Disable          */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Disable           */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Disable                */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Disable */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Disable */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Disable */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Disable          */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Disable */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Disable  */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Disable     */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Disable */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Disable */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Disable */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Disable  */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Disable          */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Disable  */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Disable          */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Disable */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Disable     */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Disable */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error Interrupt Disable     */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDR_OFFSET                       (0x0C)                                        /**<  (US_IDR) Interrupt Disable Register  Offset */
@@ -419,30 +667,12 @@ typedef union {
 #define US_IDR_TXRDY_Pos                    1                                              /**< (US_IDR) TXRDY Interrupt Disable Position */
 #define US_IDR_TXRDY_Msk                    (_U_(0x1) << US_IDR_TXRDY_Pos)                 /**< (US_IDR) TXRDY Interrupt Disable Mask */
 #define US_IDR_TXRDY                        US_IDR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXRDY_Msk instead */
-#define US_IDR_RXBRK_Pos                    2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
-#define US_IDR_RXBRK_Msk                    (_U_(0x1) << US_IDR_RXBRK_Pos)                 /**< (US_IDR) Receiver Break Interrupt Disable Mask */
-#define US_IDR_RXBRK                        US_IDR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RXBRK_Msk instead */
 #define US_IDR_OVRE_Pos                     5                                              /**< (US_IDR) Overrun Error Interrupt Enable Position */
 #define US_IDR_OVRE_Msk                     (_U_(0x1) << US_IDR_OVRE_Pos)                  /**< (US_IDR) Overrun Error Interrupt Enable Mask */
 #define US_IDR_OVRE                         US_IDR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_OVRE_Msk instead */
-#define US_IDR_FRAME_Pos                    6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
-#define US_IDR_FRAME_Msk                    (_U_(0x1) << US_IDR_FRAME_Pos)                 /**< (US_IDR) Framing Error Interrupt Disable Mask */
-#define US_IDR_FRAME                        US_IDR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_FRAME_Msk instead */
-#define US_IDR_PARE_Pos                     7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
-#define US_IDR_PARE_Msk                     (_U_(0x1) << US_IDR_PARE_Pos)                  /**< (US_IDR) Parity Error Interrupt Disable Mask */
-#define US_IDR_PARE                         US_IDR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_PARE_Msk instead */
-#define US_IDR_TIMEOUT_Pos                  8                                              /**< (US_IDR) Time-out Interrupt Disable Position */
-#define US_IDR_TIMEOUT_Msk                  (_U_(0x1) << US_IDR_TIMEOUT_Pos)               /**< (US_IDR) Time-out Interrupt Disable Mask */
-#define US_IDR_TIMEOUT                      US_IDR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TIMEOUT_Msk instead */
 #define US_IDR_TXEMPTY_Pos                  9                                              /**< (US_IDR) TXEMPTY Interrupt Disable Position */
 #define US_IDR_TXEMPTY_Msk                  (_U_(0x1) << US_IDR_TXEMPTY_Pos)               /**< (US_IDR) TXEMPTY Interrupt Disable Mask */
 #define US_IDR_TXEMPTY                      US_IDR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_TXEMPTY_Msk instead */
-#define US_IDR_ITER_Pos                     10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
-#define US_IDR_ITER_Msk                     (_U_(0x1) << US_IDR_ITER_Pos)                  /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
-#define US_IDR_ITER                         US_IDR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_ITER_Msk instead */
-#define US_IDR_NACK_Pos                     13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
-#define US_IDR_NACK_Msk                     (_U_(0x1) << US_IDR_NACK_Pos)                  /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
-#define US_IDR_NACK                         US_IDR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_NACK_Msk instead */
 #define US_IDR_RIIC_Pos                     16                                             /**< (US_IDR) Ring Indicator Input Change Disable Position */
 #define US_IDR_RIIC_Msk                     (_U_(0x1) << US_IDR_RIIC_Pos)                  /**< (US_IDR) Ring Indicator Input Change Disable Mask */
 #define US_IDR_RIIC                         US_IDR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_RIIC_Msk instead */
@@ -452,43 +682,191 @@ typedef union {
 #define US_IDR_DCDIC_Pos                    18                                             /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Position */
 #define US_IDR_DCDIC_Msk                    (_U_(0x1) << US_IDR_DCDIC_Pos)                 /**< (US_IDR) Data Carrier Detect Input Change Interrupt Disable Mask */
 #define US_IDR_DCDIC                        US_IDR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_DCDIC_Msk instead */
-#define US_IDR_CTSIC_Pos                    19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
-#define US_IDR_CTSIC_Msk                    (_U_(0x1) << US_IDR_CTSIC_Pos)                 /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
-#define US_IDR_CTSIC                        US_IDR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_CTSIC_Msk instead */
-#define US_IDR_MANE_Pos                     24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
-#define US_IDR_MANE_Msk                     (_U_(0x1) << US_IDR_MANE_Pos)                  /**< (US_IDR) Manchester Error Interrupt Disable Mask */
-#define US_IDR_MANE                         US_IDR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_MANE_Msk instead */
-#define US_IDR_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
-#define US_IDR_Msk                          _U_(0x10F27E7)                                 /**< (US_IDR) Register Mask  */
+#define US_IDR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IDR) Register MASK  (Use US_IDR_Msk instead)  */
+#define US_IDR_Msk                          _U_(0x70223)                                   /**< (US_IDR) Register Mask  */
+
+/* USART mode */
+#define US_IDR_USART_RXBRK_Pos              2                                              /**< (US_IDR) Receiver Break Interrupt Disable Position */
+#define US_IDR_USART_RXBRK_Msk              (_U_(0x1) << US_IDR_USART_RXBRK_Pos)           /**< (US_IDR) Receiver Break Interrupt Disable Mask */
+#define US_IDR_USART_RXBRK                  US_IDR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_RXBRK_Msk instead */
+#define US_IDR_USART_ITER_Pos               10                                             /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Position */
+#define US_IDR_USART_ITER_Msk               (_U_(0x1) << US_IDR_USART_ITER_Pos)            /**< (US_IDR) Max Number of Repetitions Reached Interrupt Disable Mask */
+#define US_IDR_USART_ITER                   US_IDR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_ITER_Msk instead */
+#define US_IDR_USART_NACK_Pos               13                                             /**< (US_IDR) Non Acknowledge Interrupt Disable Position */
+#define US_IDR_USART_NACK_Msk               (_U_(0x1) << US_IDR_USART_NACK_Pos)            /**< (US_IDR) Non Acknowledge Interrupt Disable Mask */
+#define US_IDR_USART_NACK                   US_IDR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_NACK_Msk instead */
+#define US_IDR_USART_CTSIC_Pos              19                                             /**< (US_IDR) Clear to Send Input Change Interrupt Disable Position */
+#define US_IDR_USART_CTSIC_Msk              (_U_(0x1) << US_IDR_USART_CTSIC_Pos)           /**< (US_IDR) Clear to Send Input Change Interrupt Disable Mask */
+#define US_IDR_USART_CTSIC                  US_IDR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_CTSIC_Msk instead */
+#define US_IDR_USART_MANE_Pos               24                                             /**< (US_IDR) Manchester Error Interrupt Disable Position */
+#define US_IDR_USART_MANE_Msk               (_U_(0x1) << US_IDR_USART_MANE_Pos)            /**< (US_IDR) Manchester Error Interrupt Disable Mask */
+#define US_IDR_USART_MANE                   US_IDR_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_MANE_Msk instead */
+#define US_IDR_USART_MASK                   _U_(0x1082404)                                 /**< \deprecated (US_IDR_USART) Register MASK  (Use US_IDR_USART_Msk instead)  */
+#define US_IDR_USART_Msk                    _U_(0x1082404)                                 /**< (US_IDR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IDR_USART_LIN_FRAME_Pos          6                                              /**< (US_IDR) Framing Error Interrupt Disable Position */
+#define US_IDR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IDR_USART_LIN_FRAME_Pos)       /**< (US_IDR) Framing Error Interrupt Disable Mask */
+#define US_IDR_USART_LIN_FRAME              US_IDR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_FRAME_Msk instead */
+#define US_IDR_USART_LIN_PARE_Pos           7                                              /**< (US_IDR) Parity Error Interrupt Disable Position */
+#define US_IDR_USART_LIN_PARE_Msk           (_U_(0x1) << US_IDR_USART_LIN_PARE_Pos)        /**< (US_IDR) Parity Error Interrupt Disable Mask */
+#define US_IDR_USART_LIN_PARE               US_IDR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_PARE_Msk instead */
+#define US_IDR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IDR) Timeout Interrupt Disable Position */
+#define US_IDR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IDR_USART_LIN_TIMEOUT_Pos)     /**< (US_IDR) Timeout Interrupt Disable Mask */
+#define US_IDR_USART_LIN_TIMEOUT            US_IDR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_USART_LIN_TIMEOUT_Msk instead */
+#define US_IDR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IDR_USART_LIN) Register MASK  (Use US_IDR_USART_LIN_Msk instead)  */
+#define US_IDR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IDR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IDR_SPI_NSSE_Pos                 19                                             /**< (US_IDR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IDR_SPI_NSSE_Msk                 (_U_(0x1) << US_IDR_SPI_NSSE_Pos)              /**< (US_IDR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IDR_SPI_NSSE                     US_IDR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_SPI_NSSE_Msk instead */
+#define US_IDR_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IDR_SPI) Register MASK  (Use US_IDR_SPI_Msk instead)  */
+#define US_IDR_SPI_Msk                      _U_(0x80000)                                   /**< (US_IDR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IDR_LIN_LINBK_Pos                13                                             /**< (US_IDR) LIN Break Sent or LIN Break Received Interrupt Disable Position */
+#define US_IDR_LIN_LINBK_Msk                (_U_(0x1) << US_IDR_LIN_LINBK_Pos)             /**< (US_IDR) LIN Break Sent or LIN Break Received Interrupt Disable Mask */
+#define US_IDR_LIN_LINBK                    US_IDR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINBK_Msk instead */
+#define US_IDR_LIN_LINID_Pos                14                                             /**< (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable Position */
+#define US_IDR_LIN_LINID_Msk                (_U_(0x1) << US_IDR_LIN_LINID_Pos)             /**< (US_IDR) LIN Identifier Sent or LIN Identifier Received Interrupt Disable Mask */
+#define US_IDR_LIN_LINID                    US_IDR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINID_Msk instead */
+#define US_IDR_LIN_LINTC_Pos                15                                             /**< (US_IDR) LIN Transfer Completed Interrupt Disable Position */
+#define US_IDR_LIN_LINTC_Msk                (_U_(0x1) << US_IDR_LIN_LINTC_Pos)             /**< (US_IDR) LIN Transfer Completed Interrupt Disable Mask */
+#define US_IDR_LIN_LINTC                    US_IDR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINTC_Msk instead */
+#define US_IDR_LIN_LINBE_Pos                25                                             /**< (US_IDR) LIN Bus Error Interrupt Disable Position */
+#define US_IDR_LIN_LINBE_Msk                (_U_(0x1) << US_IDR_LIN_LINBE_Pos)             /**< (US_IDR) LIN Bus Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINBE                    US_IDR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINBE_Msk instead */
+#define US_IDR_LIN_LINISFE_Pos              26                                             /**< (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable Position */
+#define US_IDR_LIN_LINISFE_Msk              (_U_(0x1) << US_IDR_LIN_LINISFE_Pos)           /**< (US_IDR) LIN Inconsistent Synch Field Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINISFE                  US_IDR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINISFE_Msk instead */
+#define US_IDR_LIN_LINIPE_Pos               27                                             /**< (US_IDR) LIN Identifier Parity Interrupt Disable Position */
+#define US_IDR_LIN_LINIPE_Msk               (_U_(0x1) << US_IDR_LIN_LINIPE_Pos)            /**< (US_IDR) LIN Identifier Parity Interrupt Disable Mask */
+#define US_IDR_LIN_LINIPE                   US_IDR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINIPE_Msk instead */
+#define US_IDR_LIN_LINCE_Pos                28                                             /**< (US_IDR) LIN Checksum Error Interrupt Disable Position */
+#define US_IDR_LIN_LINCE_Msk                (_U_(0x1) << US_IDR_LIN_LINCE_Pos)             /**< (US_IDR) LIN Checksum Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINCE                    US_IDR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINCE_Msk instead */
+#define US_IDR_LIN_LINSNRE_Pos              29                                             /**< (US_IDR) LIN Slave Not Responding Error Interrupt Disable Position */
+#define US_IDR_LIN_LINSNRE_Msk              (_U_(0x1) << US_IDR_LIN_LINSNRE_Pos)           /**< (US_IDR) LIN Slave Not Responding Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINSNRE                  US_IDR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINSNRE_Msk instead */
+#define US_IDR_LIN_LINSTE_Pos               30                                             /**< (US_IDR) LIN Synch Tolerance Error Interrupt Disable Position */
+#define US_IDR_LIN_LINSTE_Msk               (_U_(0x1) << US_IDR_LIN_LINSTE_Pos)            /**< (US_IDR) LIN Synch Tolerance Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINSTE                   US_IDR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINSTE_Msk instead */
+#define US_IDR_LIN_LINHTE_Pos               31                                             /**< (US_IDR) LIN Header Timeout Error Interrupt Disable Position */
+#define US_IDR_LIN_LINHTE_Msk               (_U_(0x1) << US_IDR_LIN_LINHTE_Pos)            /**< (US_IDR) LIN Header Timeout Error Interrupt Disable Mask */
+#define US_IDR_LIN_LINHTE                   US_IDR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LIN_LINHTE_Msk instead */
+#define US_IDR_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IDR_LIN) Register MASK  (Use US_IDR_LIN_Msk instead)  */
+#define US_IDR_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IDR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IDR_LON_LSFE_Pos                 6                                              /**< (US_IDR) LON Short Frame Error Interrupt Disable Position */
+#define US_IDR_LON_LSFE_Msk                 (_U_(0x1) << US_IDR_LON_LSFE_Pos)              /**< (US_IDR) LON Short Frame Error Interrupt Disable Mask */
+#define US_IDR_LON_LSFE                     US_IDR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LSFE_Msk instead */
+#define US_IDR_LON_LCRCE_Pos                7                                              /**< (US_IDR) LON CRC Error Interrupt Disable Position */
+#define US_IDR_LON_LCRCE_Msk                (_U_(0x1) << US_IDR_LON_LCRCE_Pos)             /**< (US_IDR) LON CRC Error Interrupt Disable Mask */
+#define US_IDR_LON_LCRCE                    US_IDR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LCRCE_Msk instead */
+#define US_IDR_LON_LTXD_Pos                 24                                             /**< (US_IDR) LON Transmission Done Interrupt Disable Position */
+#define US_IDR_LON_LTXD_Msk                 (_U_(0x1) << US_IDR_LON_LTXD_Pos)              /**< (US_IDR) LON Transmission Done Interrupt Disable Mask */
+#define US_IDR_LON_LTXD                     US_IDR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LTXD_Msk instead */
+#define US_IDR_LON_LCOL_Pos                 25                                             /**< (US_IDR) LON Collision Interrupt Disable Position */
+#define US_IDR_LON_LCOL_Msk                 (_U_(0x1) << US_IDR_LON_LCOL_Pos)              /**< (US_IDR) LON Collision Interrupt Disable Mask */
+#define US_IDR_LON_LCOL                     US_IDR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LCOL_Msk instead */
+#define US_IDR_LON_LFET_Pos                 26                                             /**< (US_IDR) LON Frame Early Termination Interrupt Disable Position */
+#define US_IDR_LON_LFET_Msk                 (_U_(0x1) << US_IDR_LON_LFET_Pos)              /**< (US_IDR) LON Frame Early Termination Interrupt Disable Mask */
+#define US_IDR_LON_LFET                     US_IDR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LFET_Msk instead */
+#define US_IDR_LON_LRXD_Pos                 27                                             /**< (US_IDR) LON Reception Done Interrupt Disable Position */
+#define US_IDR_LON_LRXD_Msk                 (_U_(0x1) << US_IDR_LON_LRXD_Pos)              /**< (US_IDR) LON Reception Done Interrupt Disable Mask */
+#define US_IDR_LON_LRXD                     US_IDR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LRXD_Msk instead */
+#define US_IDR_LON_LBLOVFE_Pos              28                                             /**< (US_IDR) LON Backlog Overflow Error Interrupt Disable Position */
+#define US_IDR_LON_LBLOVFE_Msk              (_U_(0x1) << US_IDR_LON_LBLOVFE_Pos)           /**< (US_IDR) LON Backlog Overflow Error Interrupt Disable Mask */
+#define US_IDR_LON_LBLOVFE                  US_IDR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_LBLOVFE_Msk instead */
+#define US_IDR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IDR_LON) Register MASK  (Use US_IDR_LON_Msk instead)  */
+#define US_IDR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IDR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IDR_LON_SPI_UNRE_Pos             10                                             /**< (US_IDR) SPI Underrun Error Interrupt Disable Position */
+#define US_IDR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IDR_LON_SPI_UNRE_Pos)          /**< (US_IDR) SPI Underrun Error Interrupt Disable Mask */
+#define US_IDR_LON_SPI_UNRE                 US_IDR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IDR_LON_SPI_UNRE_Msk instead */
+#define US_IDR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IDR_LON_SPI) Register MASK  (Use US_IDR_LON_SPI_Msk instead)  */
+#define US_IDR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IDR_LON_SPI) Register Mask  */
 
 
 /* -------- US_IMR : (USART Offset: 0x10) (R/ 32) Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  RXRDY Interrupt Mask                     */
     uint32_t TXRDY:1;                   /**< bit:      1  TXRDY Interrupt Mask                     */
-    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Mask            */
-    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVRE:1;                    /**< bit:      5  Overrun Error Interrupt Mask             */
-    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Mask             */
-    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Mask              */
-    uint32_t TIMEOUT:1;                 /**< bit:      8  Time-out Interrupt Mask                  */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
     uint32_t TXEMPTY:1;                 /**< bit:      9  TXEMPTY Interrupt Mask                   */
-    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Mask */
-    uint32_t :2;                        /**< bit: 11..12  Reserved */
-    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Mask           */
-    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
     uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Mask         */
     uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Mask         */
     uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Interrupt Mask */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Receiver Break Interrupt Mask            */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached Interrupt Mask */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt Mask           */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
     uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Interrupt Mask */
     uint32_t :4;                        /**< bit: 20..23  Reserved */
     uint32_t MANE:1;                    /**< bit:     24  Manchester Error Interrupt Mask          */
     uint32_t :7;                        /**< bit: 25..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error Interrupt Mask             */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error Interrupt Mask              */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Timeout Interrupt Mask                   */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received Interrupt Mask */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received Interrupt Mask */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed Interrupt Mask    */
+    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error Interrupt Mask             */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error Interrupt Mask */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Interrupt Mask     */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error Interrupt Mask        */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Mask */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error Interrupt Mask */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error Interrupt Mask  */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error Interrupt Mask     */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error Interrupt Mask             */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission Done Interrupt Mask     */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Interrupt Mask             */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination Interrupt Mask */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception Done Interrupt Mask        */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error Interrupt Mask */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error Interrupt Mask        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IMR_OFFSET                       (0x10)                                        /**<  (US_IMR) Interrupt Mask Register  Offset */
@@ -499,30 +877,12 @@ typedef union {
 #define US_IMR_TXRDY_Pos                    1                                              /**< (US_IMR) TXRDY Interrupt Mask Position */
 #define US_IMR_TXRDY_Msk                    (_U_(0x1) << US_IMR_TXRDY_Pos)                 /**< (US_IMR) TXRDY Interrupt Mask Mask */
 #define US_IMR_TXRDY                        US_IMR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXRDY_Msk instead */
-#define US_IMR_RXBRK_Pos                    2                                              /**< (US_IMR) Receiver Break Interrupt Mask Position */
-#define US_IMR_RXBRK_Msk                    (_U_(0x1) << US_IMR_RXBRK_Pos)                 /**< (US_IMR) Receiver Break Interrupt Mask Mask */
-#define US_IMR_RXBRK                        US_IMR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RXBRK_Msk instead */
 #define US_IMR_OVRE_Pos                     5                                              /**< (US_IMR) Overrun Error Interrupt Mask Position */
 #define US_IMR_OVRE_Msk                     (_U_(0x1) << US_IMR_OVRE_Pos)                  /**< (US_IMR) Overrun Error Interrupt Mask Mask */
 #define US_IMR_OVRE                         US_IMR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_OVRE_Msk instead */
-#define US_IMR_FRAME_Pos                    6                                              /**< (US_IMR) Framing Error Interrupt Mask Position */
-#define US_IMR_FRAME_Msk                    (_U_(0x1) << US_IMR_FRAME_Pos)                 /**< (US_IMR) Framing Error Interrupt Mask Mask */
-#define US_IMR_FRAME                        US_IMR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_FRAME_Msk instead */
-#define US_IMR_PARE_Pos                     7                                              /**< (US_IMR) Parity Error Interrupt Mask Position */
-#define US_IMR_PARE_Msk                     (_U_(0x1) << US_IMR_PARE_Pos)                  /**< (US_IMR) Parity Error Interrupt Mask Mask */
-#define US_IMR_PARE                         US_IMR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_PARE_Msk instead */
-#define US_IMR_TIMEOUT_Pos                  8                                              /**< (US_IMR) Time-out Interrupt Mask Position */
-#define US_IMR_TIMEOUT_Msk                  (_U_(0x1) << US_IMR_TIMEOUT_Pos)               /**< (US_IMR) Time-out Interrupt Mask Mask */
-#define US_IMR_TIMEOUT                      US_IMR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TIMEOUT_Msk instead */
 #define US_IMR_TXEMPTY_Pos                  9                                              /**< (US_IMR) TXEMPTY Interrupt Mask Position */
 #define US_IMR_TXEMPTY_Msk                  (_U_(0x1) << US_IMR_TXEMPTY_Pos)               /**< (US_IMR) TXEMPTY Interrupt Mask Mask */
 #define US_IMR_TXEMPTY                      US_IMR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_TXEMPTY_Msk instead */
-#define US_IMR_ITER_Pos                     10                                             /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Position */
-#define US_IMR_ITER_Msk                     (_U_(0x1) << US_IMR_ITER_Pos)                  /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Mask */
-#define US_IMR_ITER                         US_IMR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_ITER_Msk instead */
-#define US_IMR_NACK_Pos                     13                                             /**< (US_IMR) Non Acknowledge Interrupt Mask Position */
-#define US_IMR_NACK_Msk                     (_U_(0x1) << US_IMR_NACK_Pos)                  /**< (US_IMR) Non Acknowledge Interrupt Mask Mask */
-#define US_IMR_NACK                         US_IMR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_NACK_Msk instead */
 #define US_IMR_RIIC_Pos                     16                                             /**< (US_IMR) Ring Indicator Input Change Mask Position */
 #define US_IMR_RIIC_Msk                     (_U_(0x1) << US_IMR_RIIC_Pos)                  /**< (US_IMR) Ring Indicator Input Change Mask Mask */
 #define US_IMR_RIIC                         US_IMR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_RIIC_Msk instead */
@@ -532,36 +892,140 @@ typedef union {
 #define US_IMR_DCDIC_Pos                    18                                             /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Position */
 #define US_IMR_DCDIC_Msk                    (_U_(0x1) << US_IMR_DCDIC_Pos)                 /**< (US_IMR) Data Carrier Detect Input Change Interrupt Mask Mask */
 #define US_IMR_DCDIC                        US_IMR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_DCDIC_Msk instead */
-#define US_IMR_CTSIC_Pos                    19                                             /**< (US_IMR) Clear to Send Input Change Interrupt Mask Position */
-#define US_IMR_CTSIC_Msk                    (_U_(0x1) << US_IMR_CTSIC_Pos)                 /**< (US_IMR) Clear to Send Input Change Interrupt Mask Mask */
-#define US_IMR_CTSIC                        US_IMR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_CTSIC_Msk instead */
-#define US_IMR_MANE_Pos                     24                                             /**< (US_IMR) Manchester Error Interrupt Mask Position */
-#define US_IMR_MANE_Msk                     (_U_(0x1) << US_IMR_MANE_Pos)                  /**< (US_IMR) Manchester Error Interrupt Mask Mask */
-#define US_IMR_MANE                         US_IMR_MANE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_MANE_Msk instead */
-#define US_IMR_MASK                         _U_(0x10F27E7)                                 /**< \deprecated (US_IMR) Register MASK  (Use US_IMR_Msk instead)  */
-#define US_IMR_Msk                          _U_(0x10F27E7)                                 /**< (US_IMR) Register Mask  */
+#define US_IMR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_IMR) Register MASK  (Use US_IMR_Msk instead)  */
+#define US_IMR_Msk                          _U_(0x70223)                                   /**< (US_IMR) Register Mask  */
+
+/* USART mode */
+#define US_IMR_USART_RXBRK_Pos              2                                              /**< (US_IMR) Receiver Break Interrupt Mask Position */
+#define US_IMR_USART_RXBRK_Msk              (_U_(0x1) << US_IMR_USART_RXBRK_Pos)           /**< (US_IMR) Receiver Break Interrupt Mask Mask */
+#define US_IMR_USART_RXBRK                  US_IMR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_RXBRK_Msk instead */
+#define US_IMR_USART_ITER_Pos               10                                             /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Position */
+#define US_IMR_USART_ITER_Msk               (_U_(0x1) << US_IMR_USART_ITER_Pos)            /**< (US_IMR) Max Number of Repetitions Reached Interrupt Mask Mask */
+#define US_IMR_USART_ITER                   US_IMR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_ITER_Msk instead */
+#define US_IMR_USART_NACK_Pos               13                                             /**< (US_IMR) Non Acknowledge Interrupt Mask Position */
+#define US_IMR_USART_NACK_Msk               (_U_(0x1) << US_IMR_USART_NACK_Pos)            /**< (US_IMR) Non Acknowledge Interrupt Mask Mask */
+#define US_IMR_USART_NACK                   US_IMR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_NACK_Msk instead */
+#define US_IMR_USART_CTSIC_Pos              19                                             /**< (US_IMR) Clear to Send Input Change Interrupt Mask Position */
+#define US_IMR_USART_CTSIC_Msk              (_U_(0x1) << US_IMR_USART_CTSIC_Pos)           /**< (US_IMR) Clear to Send Input Change Interrupt Mask Mask */
+#define US_IMR_USART_CTSIC                  US_IMR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_CTSIC_Msk instead */
+#define US_IMR_USART_MANE_Pos               24                                             /**< (US_IMR) Manchester Error Interrupt Mask Position */
+#define US_IMR_USART_MANE_Msk               (_U_(0x1) << US_IMR_USART_MANE_Pos)            /**< (US_IMR) Manchester Error Interrupt Mask Mask */
+#define US_IMR_USART_MANE                   US_IMR_USART_MANE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_MANE_Msk instead */
+#define US_IMR_USART_MASK                   _U_(0x1082404)                                 /**< \deprecated (US_IMR_USART) Register MASK  (Use US_IMR_USART_Msk instead)  */
+#define US_IMR_USART_Msk                    _U_(0x1082404)                                 /**< (US_IMR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_IMR_USART_LIN_FRAME_Pos          6                                              /**< (US_IMR) Framing Error Interrupt Mask Position */
+#define US_IMR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_IMR_USART_LIN_FRAME_Pos)       /**< (US_IMR) Framing Error Interrupt Mask Mask */
+#define US_IMR_USART_LIN_FRAME              US_IMR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_FRAME_Msk instead */
+#define US_IMR_USART_LIN_PARE_Pos           7                                              /**< (US_IMR) Parity Error Interrupt Mask Position */
+#define US_IMR_USART_LIN_PARE_Msk           (_U_(0x1) << US_IMR_USART_LIN_PARE_Pos)        /**< (US_IMR) Parity Error Interrupt Mask Mask */
+#define US_IMR_USART_LIN_PARE               US_IMR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_PARE_Msk instead */
+#define US_IMR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_IMR) Timeout Interrupt Mask Position */
+#define US_IMR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_IMR_USART_LIN_TIMEOUT_Pos)     /**< (US_IMR) Timeout Interrupt Mask Mask */
+#define US_IMR_USART_LIN_TIMEOUT            US_IMR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_USART_LIN_TIMEOUT_Msk instead */
+#define US_IMR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_IMR_USART_LIN) Register MASK  (Use US_IMR_USART_LIN_Msk instead)  */
+#define US_IMR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_IMR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_IMR_SPI_NSSE_Pos                 19                                             /**< (US_IMR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_IMR_SPI_NSSE_Msk                 (_U_(0x1) << US_IMR_SPI_NSSE_Pos)              /**< (US_IMR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_IMR_SPI_NSSE                     US_IMR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_SPI_NSSE_Msk instead */
+#define US_IMR_SPI_MASK                     _U_(0x80000)                                   /**< \deprecated (US_IMR_SPI) Register MASK  (Use US_IMR_SPI_Msk instead)  */
+#define US_IMR_SPI_Msk                      _U_(0x80000)                                   /**< (US_IMR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_IMR_LIN_LINBK_Pos                13                                             /**< (US_IMR) LIN Break Sent or LIN Break Received Interrupt Mask Position */
+#define US_IMR_LIN_LINBK_Msk                (_U_(0x1) << US_IMR_LIN_LINBK_Pos)             /**< (US_IMR) LIN Break Sent or LIN Break Received Interrupt Mask Mask */
+#define US_IMR_LIN_LINBK                    US_IMR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINBK_Msk instead */
+#define US_IMR_LIN_LINID_Pos                14                                             /**< (US_IMR) LIN Identifier Sent or LIN Identifier Received Interrupt Mask Position */
+#define US_IMR_LIN_LINID_Msk                (_U_(0x1) << US_IMR_LIN_LINID_Pos)             /**< (US_IMR) LIN Identifier Sent or LIN Identifier Received Interrupt Mask Mask */
+#define US_IMR_LIN_LINID                    US_IMR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINID_Msk instead */
+#define US_IMR_LIN_LINTC_Pos                15                                             /**< (US_IMR) LIN Transfer Completed Interrupt Mask Position */
+#define US_IMR_LIN_LINTC_Msk                (_U_(0x1) << US_IMR_LIN_LINTC_Pos)             /**< (US_IMR) LIN Transfer Completed Interrupt Mask Mask */
+#define US_IMR_LIN_LINTC                    US_IMR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINTC_Msk instead */
+#define US_IMR_LIN_LINBE_Pos                25                                             /**< (US_IMR) LIN Bus Error Interrupt Mask Position */
+#define US_IMR_LIN_LINBE_Msk                (_U_(0x1) << US_IMR_LIN_LINBE_Pos)             /**< (US_IMR) LIN Bus Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINBE                    US_IMR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINBE_Msk instead */
+#define US_IMR_LIN_LINISFE_Pos              26                                             /**< (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask Position */
+#define US_IMR_LIN_LINISFE_Msk              (_U_(0x1) << US_IMR_LIN_LINISFE_Pos)           /**< (US_IMR) LIN Inconsistent Synch Field Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINISFE                  US_IMR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINISFE_Msk instead */
+#define US_IMR_LIN_LINIPE_Pos               27                                             /**< (US_IMR) LIN Identifier Parity Interrupt Mask Position */
+#define US_IMR_LIN_LINIPE_Msk               (_U_(0x1) << US_IMR_LIN_LINIPE_Pos)            /**< (US_IMR) LIN Identifier Parity Interrupt Mask Mask */
+#define US_IMR_LIN_LINIPE                   US_IMR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINIPE_Msk instead */
+#define US_IMR_LIN_LINCE_Pos                28                                             /**< (US_IMR) LIN Checksum Error Interrupt Mask Position */
+#define US_IMR_LIN_LINCE_Msk                (_U_(0x1) << US_IMR_LIN_LINCE_Pos)             /**< (US_IMR) LIN Checksum Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINCE                    US_IMR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINCE_Msk instead */
+#define US_IMR_LIN_LINSNRE_Pos              29                                             /**< (US_IMR) LIN Slave Not Responding Error Interrupt Mask Position */
+#define US_IMR_LIN_LINSNRE_Msk              (_U_(0x1) << US_IMR_LIN_LINSNRE_Pos)           /**< (US_IMR) LIN Slave Not Responding Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINSNRE                  US_IMR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINSNRE_Msk instead */
+#define US_IMR_LIN_LINSTE_Pos               30                                             /**< (US_IMR) LIN Synch Tolerance Error Interrupt Mask Position */
+#define US_IMR_LIN_LINSTE_Msk               (_U_(0x1) << US_IMR_LIN_LINSTE_Pos)            /**< (US_IMR) LIN Synch Tolerance Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINSTE                   US_IMR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINSTE_Msk instead */
+#define US_IMR_LIN_LINHTE_Pos               31                                             /**< (US_IMR) LIN Header Timeout Error Interrupt Mask Position */
+#define US_IMR_LIN_LINHTE_Msk               (_U_(0x1) << US_IMR_LIN_LINHTE_Pos)            /**< (US_IMR) LIN Header Timeout Error Interrupt Mask Mask */
+#define US_IMR_LIN_LINHTE                   US_IMR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LIN_LINHTE_Msk instead */
+#define US_IMR_LIN_MASK                     _U_(0xFE00E000)                                /**< \deprecated (US_IMR_LIN) Register MASK  (Use US_IMR_LIN_Msk instead)  */
+#define US_IMR_LIN_Msk                      _U_(0xFE00E000)                                /**< (US_IMR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_IMR_LON_LSFE_Pos                 6                                              /**< (US_IMR) LON Short Frame Error Interrupt Mask Position */
+#define US_IMR_LON_LSFE_Msk                 (_U_(0x1) << US_IMR_LON_LSFE_Pos)              /**< (US_IMR) LON Short Frame Error Interrupt Mask Mask */
+#define US_IMR_LON_LSFE                     US_IMR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LSFE_Msk instead */
+#define US_IMR_LON_LCRCE_Pos                7                                              /**< (US_IMR) LON CRC Error Interrupt Mask Position */
+#define US_IMR_LON_LCRCE_Msk                (_U_(0x1) << US_IMR_LON_LCRCE_Pos)             /**< (US_IMR) LON CRC Error Interrupt Mask Mask */
+#define US_IMR_LON_LCRCE                    US_IMR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LCRCE_Msk instead */
+#define US_IMR_LON_LTXD_Pos                 24                                             /**< (US_IMR) LON Transmission Done Interrupt Mask Position */
+#define US_IMR_LON_LTXD_Msk                 (_U_(0x1) << US_IMR_LON_LTXD_Pos)              /**< (US_IMR) LON Transmission Done Interrupt Mask Mask */
+#define US_IMR_LON_LTXD                     US_IMR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LTXD_Msk instead */
+#define US_IMR_LON_LCOL_Pos                 25                                             /**< (US_IMR) LON Collision Interrupt Mask Position */
+#define US_IMR_LON_LCOL_Msk                 (_U_(0x1) << US_IMR_LON_LCOL_Pos)              /**< (US_IMR) LON Collision Interrupt Mask Mask */
+#define US_IMR_LON_LCOL                     US_IMR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LCOL_Msk instead */
+#define US_IMR_LON_LFET_Pos                 26                                             /**< (US_IMR) LON Frame Early Termination Interrupt Mask Position */
+#define US_IMR_LON_LFET_Msk                 (_U_(0x1) << US_IMR_LON_LFET_Pos)              /**< (US_IMR) LON Frame Early Termination Interrupt Mask Mask */
+#define US_IMR_LON_LFET                     US_IMR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LFET_Msk instead */
+#define US_IMR_LON_LRXD_Pos                 27                                             /**< (US_IMR) LON Reception Done Interrupt Mask Position */
+#define US_IMR_LON_LRXD_Msk                 (_U_(0x1) << US_IMR_LON_LRXD_Pos)              /**< (US_IMR) LON Reception Done Interrupt Mask Mask */
+#define US_IMR_LON_LRXD                     US_IMR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LRXD_Msk instead */
+#define US_IMR_LON_LBLOVFE_Pos              28                                             /**< (US_IMR) LON Backlog Overflow Error Interrupt Mask Position */
+#define US_IMR_LON_LBLOVFE_Msk              (_U_(0x1) << US_IMR_LON_LBLOVFE_Pos)           /**< (US_IMR) LON Backlog Overflow Error Interrupt Mask Mask */
+#define US_IMR_LON_LBLOVFE                  US_IMR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_LBLOVFE_Msk instead */
+#define US_IMR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_IMR_LON) Register MASK  (Use US_IMR_LON_Msk instead)  */
+#define US_IMR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_IMR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_IMR_LON_SPI_UNRE_Pos             10                                             /**< (US_IMR) SPI Underrun Error Interrupt Mask Position */
+#define US_IMR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_IMR_LON_SPI_UNRE_Pos)          /**< (US_IMR) SPI Underrun Error Interrupt Mask Mask */
+#define US_IMR_LON_SPI_UNRE                 US_IMR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_IMR_LON_SPI_UNRE_Msk instead */
+#define US_IMR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_IMR_LON_SPI) Register MASK  (Use US_IMR_LON_SPI_Msk instead)  */
+#define US_IMR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_IMR_LON_SPI) Register Mask  */
 
 
 /* -------- US_CSR : (USART Offset: 0x14) (R/ 32) Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXRDY:1;                   /**< bit:      0  Receiver Ready (cleared by reading US_RHR) */
     uint32_t TXRDY:1;                   /**< bit:      1  Transmitter Ready (cleared by writing US_THR) */
-    uint32_t RXBRK:1;                   /**< bit:      2  Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) */
-    uint32_t :2;                        /**< bit:   3..4  Reserved */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVRE:1;                    /**< bit:      5  Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) */
-    uint32_t FRAME:1;                   /**< bit:      6  Framing Error (cleared by writing a one to bit US_CR.RSTSTA) */
-    uint32_t PARE:1;                    /**< bit:      7  Parity Error (cleared by writing a one to bit US_CR.RSTSTA) */
-    uint32_t TIMEOUT:1;                 /**< bit:      8  Receiver Time-out (cleared by writing a one to bit US_CR.STTTO) */
+    uint32_t :3;                        /**< bit:   6..8  Reserved */
     uint32_t TXEMPTY:1;                 /**< bit:      9  Transmitter Empty (cleared by writing US_THR) */
-    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) */
-    uint32_t :2;                        /**< bit: 11..12  Reserved */
-    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) */
-    uint32_t :2;                        /**< bit: 14..15  Reserved */
+    uint32_t :6;                        /**< bit: 10..15  Reserved */
     uint32_t RIIC:1;                    /**< bit:     16  Ring Indicator Input Change Flag (cleared on read) */
     uint32_t DSRIC:1;                   /**< bit:     17  Data Set Ready Input Change Flag (cleared on read) */
     uint32_t DCDIC:1;                   /**< bit:     18  Data Carrier Detect Input Change Flag (cleared on read) */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // USART mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXBRK:1;                   /**< bit:      2  Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t :7;                        /**< bit:   3..9  Reserved */
+    uint32_t ITER:1;                    /**< bit:     10  Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) */
+    uint32_t :2;                        /**< bit: 11..12  Reserved */
+    uint32_t NACK:1;                    /**< bit:     13  Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) */
+    uint32_t :5;                        /**< bit: 14..18  Reserved */
     uint32_t CTSIC:1;                   /**< bit:     19  Clear to Send Input Change Flag (cleared on read) */
     uint32_t RI:1;                      /**< bit:     20  Image of RI Input                        */
     uint32_t DSR:1;                     /**< bit:     21  Image of DSR Input                       */
@@ -569,9 +1033,57 @@ typedef union {
     uint32_t CTS:1;                     /**< bit:     23  Image of CTS Input                       */
     uint32_t MANERR:1;                  /**< bit:     24  Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) */
     uint32_t :7;                        /**< bit: 25..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // USART_LIN mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t FRAME:1;                   /**< bit:      6  Framing Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t PARE:1;                    /**< bit:      7  Parity Error (cleared by writing a one to bit US_CR.RSTSTA) */
+    uint32_t TIMEOUT:1;                 /**< bit:      8  Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) */
+    uint32_t :23;                       /**< bit:  9..31  Reserved */
+  } USART_LIN;                                /**< Structure used for USART_LIN mode access */
+  struct { // SPI mode
+    uint32_t :19;                       /**< bit:  0..18  Reserved */
+    uint32_t NSSE:1;                    /**< bit:     19  NSS Line (Driving CTS Pin) Rising or Falling Edge Event */
+    uint32_t :3;                        /**< bit: 20..22  Reserved */
+    uint32_t NSS:1;                     /**< bit:     23  Image of NSS Line                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } SPI;                                /**< Structure used for SPI mode access */
+  struct { // LIN mode
+    uint32_t :13;                       /**< bit:  0..12  Reserved */
+    uint32_t LINBK:1;                   /**< bit:     13  LIN Break Sent or LIN Break Received     */
+    uint32_t LINID:1;                   /**< bit:     14  LIN Identifier Sent or LIN Identifier Received */
+    uint32_t LINTC:1;                   /**< bit:     15  LIN Transfer Completed                   */
+    uint32_t :7;                        /**< bit: 16..22  Reserved */
+    uint32_t LINBLS:1;                  /**< bit:     23  LIN Bus Line Status                      */
+    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t LINBE:1;                   /**< bit:     25  LIN Bus Error                            */
+    uint32_t LINISFE:1;                 /**< bit:     26  LIN Inconsistent Synch Field Error       */
+    uint32_t LINIPE:1;                  /**< bit:     27  LIN Identifier Parity Error              */
+    uint32_t LINCE:1;                   /**< bit:     28  LIN Checksum Error                       */
+    uint32_t LINSNRE:1;                 /**< bit:     29  LIN Slave Not Responding Error Interrupt Mask */
+    uint32_t LINSTE:1;                  /**< bit:     30  LIN Synch Tolerance Error                */
+    uint32_t LINHTE:1;                  /**< bit:     31  LIN Header Timeout Error                 */
+  } LIN;                                /**< Structure used for LIN mode access */
+  struct { // LON mode
+    uint32_t :6;                        /**< bit:   0..5  Reserved */
+    uint32_t LSFE:1;                    /**< bit:      6  LON Short Frame Error                    */
+    uint32_t LCRCE:1;                   /**< bit:      7  LON CRC Error                            */
+    uint32_t :16;                       /**< bit:  8..23  Reserved */
+    uint32_t LTXD:1;                    /**< bit:     24  LON Transmission End Flag                */
+    uint32_t LCOL:1;                    /**< bit:     25  LON Collision Detected Flag              */
+    uint32_t LFET:1;                    /**< bit:     26  LON Frame Early Termination              */
+    uint32_t LRXD:1;                    /**< bit:     27  LON Reception End Flag                   */
+    uint32_t LBLOVFE:1;                 /**< bit:     28  LON Backlog Overflow Error               */
+    uint32_t :3;                        /**< bit: 29..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
+  struct { // LON_SPI mode
+    uint32_t :10;                       /**< bit:   0..9  Reserved */
+    uint32_t UNRE:1;                    /**< bit:     10  SPI Underrun Error                       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } LON_SPI;                                /**< Structure used for LON_SPI mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_CSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_CSR_OFFSET                       (0x14)                                        /**<  (US_CSR) Channel Status Register  Offset */
@@ -582,30 +1094,12 @@ typedef union {
 #define US_CSR_TXRDY_Pos                    1                                              /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Position */
 #define US_CSR_TXRDY_Msk                    (_U_(0x1) << US_CSR_TXRDY_Pos)                 /**< (US_CSR) Transmitter Ready (cleared by writing US_THR) Mask */
 #define US_CSR_TXRDY                        US_CSR_TXRDY_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXRDY_Msk instead */
-#define US_CSR_RXBRK_Pos                    2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
-#define US_CSR_RXBRK_Msk                    (_U_(0x1) << US_CSR_RXBRK_Pos)                 /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
-#define US_CSR_RXBRK                        US_CSR_RXBRK_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RXBRK_Msk instead */
 #define US_CSR_OVRE_Pos                     5                                              /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
 #define US_CSR_OVRE_Msk                     (_U_(0x1) << US_CSR_OVRE_Pos)                  /**< (US_CSR) Overrun Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
 #define US_CSR_OVRE                         US_CSR_OVRE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_OVRE_Msk instead */
-#define US_CSR_FRAME_Pos                    6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
-#define US_CSR_FRAME_Msk                    (_U_(0x1) << US_CSR_FRAME_Pos)                 /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
-#define US_CSR_FRAME                        US_CSR_FRAME_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_FRAME_Msk instead */
-#define US_CSR_PARE_Pos                     7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
-#define US_CSR_PARE_Msk                     (_U_(0x1) << US_CSR_PARE_Pos)                  /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
-#define US_CSR_PARE                         US_CSR_PARE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_PARE_Msk instead */
-#define US_CSR_TIMEOUT_Pos                  8                                              /**< (US_CSR) Receiver Time-out (cleared by writing a one to bit US_CR.STTTO) Position */
-#define US_CSR_TIMEOUT_Msk                  (_U_(0x1) << US_CSR_TIMEOUT_Pos)               /**< (US_CSR) Receiver Time-out (cleared by writing a one to bit US_CR.STTTO) Mask */
-#define US_CSR_TIMEOUT                      US_CSR_TIMEOUT_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TIMEOUT_Msk instead */
 #define US_CSR_TXEMPTY_Pos                  9                                              /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Position */
 #define US_CSR_TXEMPTY_Msk                  (_U_(0x1) << US_CSR_TXEMPTY_Pos)               /**< (US_CSR) Transmitter Empty (cleared by writing US_THR) Mask */
 #define US_CSR_TXEMPTY                      US_CSR_TXEMPTY_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_TXEMPTY_Msk instead */
-#define US_CSR_ITER_Pos                     10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
-#define US_CSR_ITER_Msk                     (_U_(0x1) << US_CSR_ITER_Pos)                  /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
-#define US_CSR_ITER                         US_CSR_ITER_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_ITER_Msk instead */
-#define US_CSR_NACK_Pos                     13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
-#define US_CSR_NACK_Msk                     (_U_(0x1) << US_CSR_NACK_Pos)                  /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
-#define US_CSR_NACK                         US_CSR_NACK_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_NACK_Msk instead */
 #define US_CSR_RIIC_Pos                     16                                             /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Position */
 #define US_CSR_RIIC_Msk                     (_U_(0x1) << US_CSR_RIIC_Pos)                  /**< (US_CSR) Ring Indicator Input Change Flag (cleared on read) Mask */
 #define US_CSR_RIIC                         US_CSR_RIIC_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RIIC_Msk instead */
@@ -615,30 +1109,136 @@ typedef union {
 #define US_CSR_DCDIC_Pos                    18                                             /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Position */
 #define US_CSR_DCDIC_Msk                    (_U_(0x1) << US_CSR_DCDIC_Pos)                 /**< (US_CSR) Data Carrier Detect Input Change Flag (cleared on read) Mask */
 #define US_CSR_DCDIC                        US_CSR_DCDIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCDIC_Msk instead */
-#define US_CSR_CTSIC_Pos                    19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
-#define US_CSR_CTSIC_Msk                    (_U_(0x1) << US_CSR_CTSIC_Pos)                 /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
-#define US_CSR_CTSIC                        US_CSR_CTSIC_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTSIC_Msk instead */
-#define US_CSR_RI_Pos                       20                                             /**< (US_CSR) Image of RI Input Position */
-#define US_CSR_RI_Msk                       (_U_(0x1) << US_CSR_RI_Pos)                    /**< (US_CSR) Image of RI Input Mask */
-#define US_CSR_RI                           US_CSR_RI_Msk                                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_RI_Msk instead */
-#define US_CSR_DSR_Pos                      21                                             /**< (US_CSR) Image of DSR Input Position */
-#define US_CSR_DSR_Msk                      (_U_(0x1) << US_CSR_DSR_Pos)                   /**< (US_CSR) Image of DSR Input Mask */
-#define US_CSR_DSR                          US_CSR_DSR_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DSR_Msk instead */
-#define US_CSR_DCD_Pos                      22                                             /**< (US_CSR) Image of DCD Input Position */
-#define US_CSR_DCD_Msk                      (_U_(0x1) << US_CSR_DCD_Pos)                   /**< (US_CSR) Image of DCD Input Mask */
-#define US_CSR_DCD                          US_CSR_DCD_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_DCD_Msk instead */
-#define US_CSR_CTS_Pos                      23                                             /**< (US_CSR) Image of CTS Input Position */
-#define US_CSR_CTS_Msk                      (_U_(0x1) << US_CSR_CTS_Pos)                   /**< (US_CSR) Image of CTS Input Mask */
-#define US_CSR_CTS                          US_CSR_CTS_Msk                                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_CTS_Msk instead */
-#define US_CSR_MANERR_Pos                   24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
-#define US_CSR_MANERR_Msk                   (_U_(0x1) << US_CSR_MANERR_Pos)                /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
-#define US_CSR_MANERR                       US_CSR_MANERR_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_MANERR_Msk instead */
-#define US_CSR_MASK                         _U_(0x1FF27E7)                                 /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
-#define US_CSR_Msk                          _U_(0x1FF27E7)                                 /**< (US_CSR) Register Mask  */
+#define US_CSR_MASK                         _U_(0x70223)                                   /**< \deprecated (US_CSR) Register MASK  (Use US_CSR_Msk instead)  */
+#define US_CSR_Msk                          _U_(0x70223)                                   /**< (US_CSR) Register Mask  */
+
+/* USART mode */
+#define US_CSR_USART_RXBRK_Pos              2                                              /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_RXBRK_Msk              (_U_(0x1) << US_CSR_USART_RXBRK_Pos)           /**< (US_CSR) Break Received/End of Break (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_RXBRK                  US_CSR_USART_RXBRK_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_RXBRK_Msk instead */
+#define US_CSR_USART_ITER_Pos               10                                             /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Position */
+#define US_CSR_USART_ITER_Msk               (_U_(0x1) << US_CSR_USART_ITER_Pos)            /**< (US_CSR) Max Number of Repetitions Reached (cleared by writing a one to bit US_CR.RSTIT) Mask */
+#define US_CSR_USART_ITER                   US_CSR_USART_ITER_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_ITER_Msk instead */
+#define US_CSR_USART_NACK_Pos               13                                             /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Position */
+#define US_CSR_USART_NACK_Msk               (_U_(0x1) << US_CSR_USART_NACK_Pos)            /**< (US_CSR) Non Acknowledge Interrupt (cleared by writing a one to bit US_CR.RSTNACK) Mask */
+#define US_CSR_USART_NACK                   US_CSR_USART_NACK_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_NACK_Msk instead */
+#define US_CSR_USART_CTSIC_Pos              19                                             /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Position */
+#define US_CSR_USART_CTSIC_Msk              (_U_(0x1) << US_CSR_USART_CTSIC_Pos)           /**< (US_CSR) Clear to Send Input Change Flag (cleared on read) Mask */
+#define US_CSR_USART_CTSIC                  US_CSR_USART_CTSIC_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_CTSIC_Msk instead */
+#define US_CSR_USART_RI_Pos                 20                                             /**< (US_CSR) Image of RI Input Position */
+#define US_CSR_USART_RI_Msk                 (_U_(0x1) << US_CSR_USART_RI_Pos)              /**< (US_CSR) Image of RI Input Mask */
+#define US_CSR_USART_RI                     US_CSR_USART_RI_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_RI_Msk instead */
+#define US_CSR_USART_DSR_Pos                21                                             /**< (US_CSR) Image of DSR Input Position */
+#define US_CSR_USART_DSR_Msk                (_U_(0x1) << US_CSR_USART_DSR_Pos)             /**< (US_CSR) Image of DSR Input Mask */
+#define US_CSR_USART_DSR                    US_CSR_USART_DSR_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_DSR_Msk instead */
+#define US_CSR_USART_DCD_Pos                22                                             /**< (US_CSR) Image of DCD Input Position */
+#define US_CSR_USART_DCD_Msk                (_U_(0x1) << US_CSR_USART_DCD_Pos)             /**< (US_CSR) Image of DCD Input Mask */
+#define US_CSR_USART_DCD                    US_CSR_USART_DCD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_DCD_Msk instead */
+#define US_CSR_USART_CTS_Pos                23                                             /**< (US_CSR) Image of CTS Input Position */
+#define US_CSR_USART_CTS_Msk                (_U_(0x1) << US_CSR_USART_CTS_Pos)             /**< (US_CSR) Image of CTS Input Mask */
+#define US_CSR_USART_CTS                    US_CSR_USART_CTS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_CTS_Msk instead */
+#define US_CSR_USART_MANERR_Pos             24                                             /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_MANERR_Msk             (_U_(0x1) << US_CSR_USART_MANERR_Pos)          /**< (US_CSR) Manchester Error (cleared by writing a one to the bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_MANERR                 US_CSR_USART_MANERR_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_MANERR_Msk instead */
+#define US_CSR_USART_MASK                   _U_(0x1F82404)                                 /**< \deprecated (US_CSR_USART) Register MASK  (Use US_CSR_USART_Msk instead)  */
+#define US_CSR_USART_Msk                    _U_(0x1F82404)                                 /**< (US_CSR_USART) Register Mask  */
+
+/* USART_LIN mode */
+#define US_CSR_USART_LIN_FRAME_Pos          6                                              /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_LIN_FRAME_Msk          (_U_(0x1) << US_CSR_USART_LIN_FRAME_Pos)       /**< (US_CSR) Framing Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_LIN_FRAME              US_CSR_USART_LIN_FRAME_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_FRAME_Msk instead */
+#define US_CSR_USART_LIN_PARE_Pos           7                                              /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Position */
+#define US_CSR_USART_LIN_PARE_Msk           (_U_(0x1) << US_CSR_USART_LIN_PARE_Pos)        /**< (US_CSR) Parity Error (cleared by writing a one to bit US_CR.RSTSTA) Mask */
+#define US_CSR_USART_LIN_PARE               US_CSR_USART_LIN_PARE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_PARE_Msk instead */
+#define US_CSR_USART_LIN_TIMEOUT_Pos        8                                              /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Position */
+#define US_CSR_USART_LIN_TIMEOUT_Msk        (_U_(0x1) << US_CSR_USART_LIN_TIMEOUT_Pos)     /**< (US_CSR) Receiver Timeout (cleared by writing a one to bit US_CR.STTTO) Mask */
+#define US_CSR_USART_LIN_TIMEOUT            US_CSR_USART_LIN_TIMEOUT_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_USART_LIN_TIMEOUT_Msk instead */
+#define US_CSR_USART_LIN_MASK               _U_(0x1C0)                                     /**< \deprecated (US_CSR_USART_LIN) Register MASK  (Use US_CSR_USART_LIN_Msk instead)  */
+#define US_CSR_USART_LIN_Msk                _U_(0x1C0)                                     /**< (US_CSR_USART_LIN) Register Mask  */
+
+/* SPI mode */
+#define US_CSR_SPI_NSSE_Pos                 19                                             /**< (US_CSR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Position */
+#define US_CSR_SPI_NSSE_Msk                 (_U_(0x1) << US_CSR_SPI_NSSE_Pos)              /**< (US_CSR) NSS Line (Driving CTS Pin) Rising or Falling Edge Event Mask */
+#define US_CSR_SPI_NSSE                     US_CSR_SPI_NSSE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_SPI_NSSE_Msk instead */
+#define US_CSR_SPI_NSS_Pos                  23                                             /**< (US_CSR) Image of NSS Line Position */
+#define US_CSR_SPI_NSS_Msk                  (_U_(0x1) << US_CSR_SPI_NSS_Pos)               /**< (US_CSR) Image of NSS Line Mask */
+#define US_CSR_SPI_NSS                      US_CSR_SPI_NSS_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_SPI_NSS_Msk instead */
+#define US_CSR_SPI_MASK                     _U_(0x880000)                                  /**< \deprecated (US_CSR_SPI) Register MASK  (Use US_CSR_SPI_Msk instead)  */
+#define US_CSR_SPI_Msk                      _U_(0x880000)                                  /**< (US_CSR_SPI) Register Mask  */
+
+/* LIN mode */
+#define US_CSR_LIN_LINBK_Pos                13                                             /**< (US_CSR) LIN Break Sent or LIN Break Received Position */
+#define US_CSR_LIN_LINBK_Msk                (_U_(0x1) << US_CSR_LIN_LINBK_Pos)             /**< (US_CSR) LIN Break Sent or LIN Break Received Mask */
+#define US_CSR_LIN_LINBK                    US_CSR_LIN_LINBK_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBK_Msk instead */
+#define US_CSR_LIN_LINID_Pos                14                                             /**< (US_CSR) LIN Identifier Sent or LIN Identifier Received Position */
+#define US_CSR_LIN_LINID_Msk                (_U_(0x1) << US_CSR_LIN_LINID_Pos)             /**< (US_CSR) LIN Identifier Sent or LIN Identifier Received Mask */
+#define US_CSR_LIN_LINID                    US_CSR_LIN_LINID_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINID_Msk instead */
+#define US_CSR_LIN_LINTC_Pos                15                                             /**< (US_CSR) LIN Transfer Completed Position */
+#define US_CSR_LIN_LINTC_Msk                (_U_(0x1) << US_CSR_LIN_LINTC_Pos)             /**< (US_CSR) LIN Transfer Completed Mask */
+#define US_CSR_LIN_LINTC                    US_CSR_LIN_LINTC_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINTC_Msk instead */
+#define US_CSR_LIN_LINBLS_Pos               23                                             /**< (US_CSR) LIN Bus Line Status Position */
+#define US_CSR_LIN_LINBLS_Msk               (_U_(0x1) << US_CSR_LIN_LINBLS_Pos)            /**< (US_CSR) LIN Bus Line Status Mask */
+#define US_CSR_LIN_LINBLS                   US_CSR_LIN_LINBLS_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBLS_Msk instead */
+#define US_CSR_LIN_LINBE_Pos                25                                             /**< (US_CSR) LIN Bus Error Position */
+#define US_CSR_LIN_LINBE_Msk                (_U_(0x1) << US_CSR_LIN_LINBE_Pos)             /**< (US_CSR) LIN Bus Error Mask */
+#define US_CSR_LIN_LINBE                    US_CSR_LIN_LINBE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINBE_Msk instead */
+#define US_CSR_LIN_LINISFE_Pos              26                                             /**< (US_CSR) LIN Inconsistent Synch Field Error Position */
+#define US_CSR_LIN_LINISFE_Msk              (_U_(0x1) << US_CSR_LIN_LINISFE_Pos)           /**< (US_CSR) LIN Inconsistent Synch Field Error Mask */
+#define US_CSR_LIN_LINISFE                  US_CSR_LIN_LINISFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINISFE_Msk instead */
+#define US_CSR_LIN_LINIPE_Pos               27                                             /**< (US_CSR) LIN Identifier Parity Error Position */
+#define US_CSR_LIN_LINIPE_Msk               (_U_(0x1) << US_CSR_LIN_LINIPE_Pos)            /**< (US_CSR) LIN Identifier Parity Error Mask */
+#define US_CSR_LIN_LINIPE                   US_CSR_LIN_LINIPE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINIPE_Msk instead */
+#define US_CSR_LIN_LINCE_Pos                28                                             /**< (US_CSR) LIN Checksum Error Position */
+#define US_CSR_LIN_LINCE_Msk                (_U_(0x1) << US_CSR_LIN_LINCE_Pos)             /**< (US_CSR) LIN Checksum Error Mask */
+#define US_CSR_LIN_LINCE                    US_CSR_LIN_LINCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINCE_Msk instead */
+#define US_CSR_LIN_LINSNRE_Pos              29                                             /**< (US_CSR) LIN Slave Not Responding Error Interrupt Mask Position */
+#define US_CSR_LIN_LINSNRE_Msk              (_U_(0x1) << US_CSR_LIN_LINSNRE_Pos)           /**< (US_CSR) LIN Slave Not Responding Error Interrupt Mask Mask */
+#define US_CSR_LIN_LINSNRE                  US_CSR_LIN_LINSNRE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINSNRE_Msk instead */
+#define US_CSR_LIN_LINSTE_Pos               30                                             /**< (US_CSR) LIN Synch Tolerance Error Position */
+#define US_CSR_LIN_LINSTE_Msk               (_U_(0x1) << US_CSR_LIN_LINSTE_Pos)            /**< (US_CSR) LIN Synch Tolerance Error Mask */
+#define US_CSR_LIN_LINSTE                   US_CSR_LIN_LINSTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINSTE_Msk instead */
+#define US_CSR_LIN_LINHTE_Pos               31                                             /**< (US_CSR) LIN Header Timeout Error Position */
+#define US_CSR_LIN_LINHTE_Msk               (_U_(0x1) << US_CSR_LIN_LINHTE_Pos)            /**< (US_CSR) LIN Header Timeout Error Mask */
+#define US_CSR_LIN_LINHTE                   US_CSR_LIN_LINHTE_Msk                          /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LIN_LINHTE_Msk instead */
+#define US_CSR_LIN_MASK                     _U_(0xFE80E000)                                /**< \deprecated (US_CSR_LIN) Register MASK  (Use US_CSR_LIN_Msk instead)  */
+#define US_CSR_LIN_Msk                      _U_(0xFE80E000)                                /**< (US_CSR_LIN) Register Mask  */
+
+/* LON mode */
+#define US_CSR_LON_LSFE_Pos                 6                                              /**< (US_CSR) LON Short Frame Error Position */
+#define US_CSR_LON_LSFE_Msk                 (_U_(0x1) << US_CSR_LON_LSFE_Pos)              /**< (US_CSR) LON Short Frame Error Mask */
+#define US_CSR_LON_LSFE                     US_CSR_LON_LSFE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LSFE_Msk instead */
+#define US_CSR_LON_LCRCE_Pos                7                                              /**< (US_CSR) LON CRC Error Position */
+#define US_CSR_LON_LCRCE_Msk                (_U_(0x1) << US_CSR_LON_LCRCE_Pos)             /**< (US_CSR) LON CRC Error Mask */
+#define US_CSR_LON_LCRCE                    US_CSR_LON_LCRCE_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LCRCE_Msk instead */
+#define US_CSR_LON_LTXD_Pos                 24                                             /**< (US_CSR) LON Transmission End Flag Position */
+#define US_CSR_LON_LTXD_Msk                 (_U_(0x1) << US_CSR_LON_LTXD_Pos)              /**< (US_CSR) LON Transmission End Flag Mask */
+#define US_CSR_LON_LTXD                     US_CSR_LON_LTXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LTXD_Msk instead */
+#define US_CSR_LON_LCOL_Pos                 25                                             /**< (US_CSR) LON Collision Detected Flag Position */
+#define US_CSR_LON_LCOL_Msk                 (_U_(0x1) << US_CSR_LON_LCOL_Pos)              /**< (US_CSR) LON Collision Detected Flag Mask */
+#define US_CSR_LON_LCOL                     US_CSR_LON_LCOL_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LCOL_Msk instead */
+#define US_CSR_LON_LFET_Pos                 26                                             /**< (US_CSR) LON Frame Early Termination Position */
+#define US_CSR_LON_LFET_Msk                 (_U_(0x1) << US_CSR_LON_LFET_Pos)              /**< (US_CSR) LON Frame Early Termination Mask */
+#define US_CSR_LON_LFET                     US_CSR_LON_LFET_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LFET_Msk instead */
+#define US_CSR_LON_LRXD_Pos                 27                                             /**< (US_CSR) LON Reception End Flag Position */
+#define US_CSR_LON_LRXD_Msk                 (_U_(0x1) << US_CSR_LON_LRXD_Pos)              /**< (US_CSR) LON Reception End Flag Mask */
+#define US_CSR_LON_LRXD                     US_CSR_LON_LRXD_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LRXD_Msk instead */
+#define US_CSR_LON_LBLOVFE_Pos              28                                             /**< (US_CSR) LON Backlog Overflow Error Position */
+#define US_CSR_LON_LBLOVFE_Msk              (_U_(0x1) << US_CSR_LON_LBLOVFE_Pos)           /**< (US_CSR) LON Backlog Overflow Error Mask */
+#define US_CSR_LON_LBLOVFE                  US_CSR_LON_LBLOVFE_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_LBLOVFE_Msk instead */
+#define US_CSR_LON_MASK                     _U_(0x1F0000C0)                                /**< \deprecated (US_CSR_LON) Register MASK  (Use US_CSR_LON_Msk instead)  */
+#define US_CSR_LON_Msk                      _U_(0x1F0000C0)                                /**< (US_CSR_LON) Register Mask  */
+
+/* LON_SPI mode */
+#define US_CSR_LON_SPI_UNRE_Pos             10                                             /**< (US_CSR) SPI Underrun Error Position */
+#define US_CSR_LON_SPI_UNRE_Msk             (_U_(0x1) << US_CSR_LON_SPI_UNRE_Pos)          /**< (US_CSR) SPI Underrun Error Mask */
+#define US_CSR_LON_SPI_UNRE                 US_CSR_LON_SPI_UNRE_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_CSR_LON_SPI_UNRE_Msk instead */
+#define US_CSR_LON_SPI_MASK                 _U_(0x400)                                     /**< \deprecated (US_CSR_LON_SPI) Register MASK  (Use US_CSR_LON_SPI_Msk instead)  */
+#define US_CSR_LON_SPI_Msk                  _U_(0x400)                                     /**< (US_CSR_LON_SPI) Register Mask  */
 
 
 /* -------- US_RHR : (USART Offset: 0x18) (R/ 32) Receive Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXCHR:9;                   /**< bit:   0..8  Received Character                       */
@@ -648,6 +1248,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_RHR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_RHR_OFFSET                       (0x18)                                        /**<  (US_RHR) Receive Holding Register  Offset */
@@ -664,6 +1265,7 @@ typedef union {
 
 /* -------- US_THR : (USART Offset: 0x1c) (/W 32) Transmit Holding Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXCHR:9;                   /**< bit:   0..8  Character to be Transmitted              */
@@ -673,6 +1275,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_THR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_THR_OFFSET                       (0x1C)                                        /**<  (US_THR) Transmit Holding Register  Offset */
@@ -689,6 +1292,7 @@ typedef union {
 
 /* -------- US_BRGR : (USART Offset: 0x20) (R/W 32) Baud Rate Generator Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CD:16;                     /**< bit:  0..15  Clock Divider                            */
@@ -697,6 +1301,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_BRGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_BRGR_OFFSET                      (0x20)                                        /**<  (US_BRGR) Baud Rate Generator Register  Offset */
@@ -711,21 +1316,23 @@ typedef union {
 #define US_BRGR_Msk                         _U_(0x7FFFF)                                   /**< (US_BRGR) Register Mask  */
 
 
-/* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Time-out Register -------- */
+/* -------- US_RTOR : (USART Offset: 0x24) (R/W 32) Receiver Timeout Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
-    uint32_t TO:17;                     /**< bit:  0..16  Time-out Value                           */
+    uint32_t TO:17;                     /**< bit:  0..16  Timeout Value                            */
     uint32_t :15;                       /**< bit: 17..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_RTOR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define US_RTOR_OFFSET                      (0x24)                                        /**<  (US_RTOR) Receiver Time-out Register  Offset */
+#define US_RTOR_OFFSET                      (0x24)                                        /**<  (US_RTOR) Receiver Timeout Register  Offset */
 
-#define US_RTOR_TO_Pos                      0                                              /**< (US_RTOR) Time-out Value Position */
-#define US_RTOR_TO_Msk                      (_U_(0x1FFFF) << US_RTOR_TO_Pos)               /**< (US_RTOR) Time-out Value Mask */
+#define US_RTOR_TO_Pos                      0                                              /**< (US_RTOR) Timeout Value Position */
+#define US_RTOR_TO_Msk                      (_U_(0x1FFFF) << US_RTOR_TO_Pos)               /**< (US_RTOR) Timeout Value Mask */
 #define US_RTOR_TO(value)                   (US_RTOR_TO_Msk & ((value) << US_RTOR_TO_Pos))
 #define US_RTOR_MASK                        _U_(0x1FFFF)                                   /**< \deprecated (US_RTOR) Register MASK  (Use US_RTOR_Msk instead)  */
 #define US_RTOR_Msk                         _U_(0x1FFFF)                                   /**< (US_RTOR) Register Mask  */
@@ -733,46 +1340,81 @@ typedef union {
 
 /* -------- US_TTGR : (USART Offset: 0x28) (R/W 32) Transmitter Timeguard Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
-  struct {
+  struct { // USART mode
     uint32_t TG:8;                      /**< bit:   0..7  Timeguard Value                          */
     uint32_t :24;                       /**< bit:  8..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // LON mode
+    uint32_t PCYCLE:24;                 /**< bit:  0..23  LON PCYCLE Length                        */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_TTGR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_TTGR_OFFSET                      (0x28)                                        /**<  (US_TTGR) Transmitter Timeguard Register  Offset */
 
-#define US_TTGR_TG_Pos                      0                                              /**< (US_TTGR) Timeguard Value Position */
-#define US_TTGR_TG_Msk                      (_U_(0xFF) << US_TTGR_TG_Pos)                  /**< (US_TTGR) Timeguard Value Mask */
-#define US_TTGR_TG(value)                   (US_TTGR_TG_Msk & ((value) << US_TTGR_TG_Pos))
-#define US_TTGR_MASK                        _U_(0xFF)                                      /**< \deprecated (US_TTGR) Register MASK  (Use US_TTGR_Msk instead)  */
-#define US_TTGR_Msk                         _U_(0xFF)                                      /**< (US_TTGR) Register Mask  */
+#define US_TTGR_MASK                        _U_(0x00)                                      /**< \deprecated (US_TTGR) Register MASK  (Use US_TTGR_Msk instead)  */
+#define US_TTGR_Msk                         _U_(0x00)                                      /**< (US_TTGR) Register Mask  */
+
+/* USART mode */
+#define US_TTGR_USART_TG_Pos                0                                              /**< (US_TTGR) Timeguard Value Position */
+#define US_TTGR_USART_TG_Msk                (_U_(0xFF) << US_TTGR_USART_TG_Pos)            /**< (US_TTGR) Timeguard Value Mask */
+#define US_TTGR_USART_TG(value)             (US_TTGR_USART_TG_Msk & ((value) << US_TTGR_USART_TG_Pos))
+#define US_TTGR_USART_MASK                  _U_(0xFF)                                      /**< \deprecated (US_TTGR_USART) Register MASK  (Use US_TTGR_USART_Msk instead)  */
+#define US_TTGR_USART_Msk                   _U_(0xFF)                                      /**< (US_TTGR_USART) Register Mask  */
+
+/* LON mode */
+#define US_TTGR_LON_PCYCLE_Pos              0                                              /**< (US_TTGR) LON PCYCLE Length Position */
+#define US_TTGR_LON_PCYCLE_Msk              (_U_(0xFFFFFF) << US_TTGR_LON_PCYCLE_Pos)      /**< (US_TTGR) LON PCYCLE Length Mask */
+#define US_TTGR_LON_PCYCLE(value)           (US_TTGR_LON_PCYCLE_Msk & ((value) << US_TTGR_LON_PCYCLE_Pos))
+#define US_TTGR_LON_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (US_TTGR_LON) Register MASK  (Use US_TTGR_LON_Msk instead)  */
+#define US_TTGR_LON_Msk                     _U_(0xFFFFFF)                                  /**< (US_TTGR_LON) Register Mask  */
 
 
 /* -------- US_FIDI : (USART Offset: 0x40) (R/W 32) FI DI Ratio Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
-  struct {
+  struct { // USART mode
     uint32_t FI_DI_RATIO:16;            /**< bit:  0..15  FI Over DI Ratio Value                   */
     uint32_t :16;                       /**< bit: 16..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } USART;                                /**< Structure used for USART mode access */
+  struct { // LON mode
+    uint32_t BETA2:24;                  /**< bit:  0..23  LON BETA2 Length                         */
+    uint32_t :8;                        /**< bit: 24..31  Reserved */
+  } LON;                                /**< Structure used for LON mode access */
   uint32_t reg;                         /**< Type used for register access */
 } US_FIDI_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_FIDI_OFFSET                      (0x40)                                        /**<  (US_FIDI) FI DI Ratio Register  Offset */
 
-#define US_FIDI_FI_DI_RATIO_Pos             0                                              /**< (US_FIDI) FI Over DI Ratio Value Position */
-#define US_FIDI_FI_DI_RATIO_Msk             (_U_(0xFFFF) << US_FIDI_FI_DI_RATIO_Pos)       /**< (US_FIDI) FI Over DI Ratio Value Mask */
-#define US_FIDI_FI_DI_RATIO(value)          (US_FIDI_FI_DI_RATIO_Msk & ((value) << US_FIDI_FI_DI_RATIO_Pos))
-#define US_FIDI_MASK                        _U_(0xFFFF)                                    /**< \deprecated (US_FIDI) Register MASK  (Use US_FIDI_Msk instead)  */
-#define US_FIDI_Msk                         _U_(0xFFFF)                                    /**< (US_FIDI) Register Mask  */
+#define US_FIDI_MASK                        _U_(0x00)                                      /**< \deprecated (US_FIDI) Register MASK  (Use US_FIDI_Msk instead)  */
+#define US_FIDI_Msk                         _U_(0x00)                                      /**< (US_FIDI) Register Mask  */
+
+/* USART mode */
+#define US_FIDI_USART_FI_DI_RATIO_Pos       0                                              /**< (US_FIDI) FI Over DI Ratio Value Position */
+#define US_FIDI_USART_FI_DI_RATIO_Msk       (_U_(0xFFFF) << US_FIDI_USART_FI_DI_RATIO_Pos)  /**< (US_FIDI) FI Over DI Ratio Value Mask */
+#define US_FIDI_USART_FI_DI_RATIO(value)    (US_FIDI_USART_FI_DI_RATIO_Msk & ((value) << US_FIDI_USART_FI_DI_RATIO_Pos))
+#define US_FIDI_USART_MASK                  _U_(0xFFFF)                                    /**< \deprecated (US_FIDI_USART) Register MASK  (Use US_FIDI_USART_Msk instead)  */
+#define US_FIDI_USART_Msk                   _U_(0xFFFF)                                    /**< (US_FIDI_USART) Register Mask  */
+
+/* LON mode */
+#define US_FIDI_LON_BETA2_Pos               0                                              /**< (US_FIDI) LON BETA2 Length Position */
+#define US_FIDI_LON_BETA2_Msk               (_U_(0xFFFFFF) << US_FIDI_LON_BETA2_Pos)       /**< (US_FIDI) LON BETA2 Length Mask */
+#define US_FIDI_LON_BETA2(value)            (US_FIDI_LON_BETA2_Msk & ((value) << US_FIDI_LON_BETA2_Pos))
+#define US_FIDI_LON_MASK                    _U_(0xFFFFFF)                                  /**< \deprecated (US_FIDI_LON) Register MASK  (Use US_FIDI_LON_Msk instead)  */
+#define US_FIDI_LON_Msk                     _U_(0xFFFFFF)                                  /**< (US_FIDI_LON) Register Mask  */
 
 
 /* -------- US_NER : (USART Offset: 0x44) (R/ 32) Number of Errors Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NB_ERRORS:8;               /**< bit:   0..7  Number of Errors                         */
@@ -780,6 +1422,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_NER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_NER_OFFSET                       (0x44)                                        /**<  (US_NER) Number of Errors Register  Offset */
@@ -793,6 +1436,7 @@ typedef union {
 
 /* -------- US_IF : (USART Offset: 0x4c) (R/W 32) IrDA Filter Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IRDA_FILTER:8;             /**< bit:   0..7  IrDA Filter                              */
@@ -800,6 +1444,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IF_OFFSET                        (0x4C)                                        /**<  (US_IF) IrDA Filter Register  Offset */
@@ -813,6 +1458,7 @@ typedef union {
 
 /* -------- US_MAN : (USART Offset: 0x50) (R/W 32) Manchester Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TX_PL:4;                   /**< bit:   0..3  Transmitter Preamble Length              */
@@ -828,10 +1474,11 @@ typedef union {
     uint32_t RX_MPOL:1;                 /**< bit:     28  Receiver Manchester Polarity             */
     uint32_t ONE:1;                     /**< bit:     29  Must Be Set to 1                         */
     uint32_t DRIFT:1;                   /**< bit:     30  Drift Compensation                       */
-    uint32_t RXIDLEV:1;                 /**< bit:     31                                           */
+    uint32_t RXIDLEV:1;                 /**< bit:     31  Receiver Idle Value                      */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_MAN_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_MAN_OFFSET                       (0x50)                                        /**<  (US_MAN) Manchester Configuration Register  Offset */
@@ -876,8 +1523,8 @@ typedef union {
 #define US_MAN_DRIFT_Pos                    30                                             /**< (US_MAN) Drift Compensation Position */
 #define US_MAN_DRIFT_Msk                    (_U_(0x1) << US_MAN_DRIFT_Pos)                 /**< (US_MAN) Drift Compensation Mask */
 #define US_MAN_DRIFT                        US_MAN_DRIFT_Msk                               /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_DRIFT_Msk instead */
-#define US_MAN_RXIDLEV_Pos                  31                                             /**< (US_MAN)  Position */
-#define US_MAN_RXIDLEV_Msk                  (_U_(0x1) << US_MAN_RXIDLEV_Pos)               /**< (US_MAN)  Mask */
+#define US_MAN_RXIDLEV_Pos                  31                                             /**< (US_MAN) Receiver Idle Value Position */
+#define US_MAN_RXIDLEV_Msk                  (_U_(0x1) << US_MAN_RXIDLEV_Pos)               /**< (US_MAN) Receiver Idle Value Mask */
 #define US_MAN_RXIDLEV                      US_MAN_RXIDLEV_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use US_MAN_RXIDLEV_Msk instead */
 #define US_MAN_MASK                         _U_(0xF30F130F)                                /**< \deprecated (US_MAN) Register MASK  (Use US_MAN_Msk instead)  */
 #define US_MAN_Msk                          _U_(0xF30F130F)                                /**< (US_MAN) Register Mask  */
@@ -885,6 +1532,7 @@ typedef union {
 
 /* -------- US_LINMR : (USART Offset: 0x54) (R/W 32) LIN Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NACT:2;                    /**< bit:   0..1  LIN Node Action                          */
@@ -901,6 +1549,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINMR_OFFSET                     (0x54)                                        /**<  (US_LINMR) LIN Mode Register  Offset */
@@ -947,6 +1596,7 @@ typedef union {
 
 /* -------- US_LINIR : (USART Offset: 0x58) (R/W 32) LIN Identifier Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDCHR:8;                   /**< bit:   0..7  Identifier Character                     */
@@ -954,6 +1604,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINIR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINIR_OFFSET                     (0x58)                                        /**<  (US_LINIR) LIN Identifier Register  Offset */
@@ -967,6 +1618,7 @@ typedef union {
 
 /* -------- US_LINBRR : (USART Offset: 0x5c) (R/ 32) LIN Baud Rate Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LINCD:16;                  /**< bit:  0..15  Clock Divider after Synchronization      */
@@ -975,6 +1627,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LINBRR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LINBRR_OFFSET                    (0x5C)                                        /**<  (US_LINBRR) LIN Baud Rate Register  Offset */
@@ -991,6 +1644,7 @@ typedef union {
 
 /* -------- US_LONMR : (USART Offset: 0x60) (R/W 32) LON Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t COMMT:1;                   /**< bit:      0  LON comm_type Parameter Value            */
@@ -1005,6 +1659,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONMR_OFFSET                     (0x60)                                        /**<  (US_LONMR) LON Mode Register  Offset */
@@ -1036,6 +1691,7 @@ typedef union {
 
 /* -------- US_LONPR : (USART Offset: 0x64) (R/W 32) LON Preamble Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONPL:14;                  /**< bit:  0..13  LON Preamble Length                      */
@@ -1043,6 +1699,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONPR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONPR_OFFSET                     (0x64)                                        /**<  (US_LONPR) LON Preamble Register  Offset */
@@ -1056,6 +1713,7 @@ typedef union {
 
 /* -------- US_LONDL : (USART Offset: 0x68) (R/W 32) LON Data Length Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONDL:8;                   /**< bit:   0..7  LON Data Length                          */
@@ -1063,6 +1721,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONDL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONDL_OFFSET                     (0x68)                                        /**<  (US_LONDL) LON Data Length Register  Offset */
@@ -1076,6 +1735,7 @@ typedef union {
 
 /* -------- US_LONL2HDR : (USART Offset: 0x6c) (R/W 32) LON L2HDR Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BLI:6;                     /**< bit:   0..5  LON Backlog Increment                    */
@@ -1085,6 +1745,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONL2HDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONL2HDR_OFFSET                  (0x6C)                                        /**<  (US_LONL2HDR) LON L2HDR Register  Offset */
@@ -1104,6 +1765,7 @@ typedef union {
 
 /* -------- US_LONBL : (USART Offset: 0x70) (R/ 32) LON Backlog Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t LONBL:6;                   /**< bit:   0..5  LON Node Backlog Value                   */
@@ -1111,6 +1773,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONBL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONBL_OFFSET                     (0x70)                                        /**<  (US_LONBL) LON Backlog Register  Offset */
@@ -1124,6 +1787,7 @@ typedef union {
 
 /* -------- US_LONB1TX : (USART Offset: 0x74) (R/W 32) LON Beta1 Tx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BETA1TX:24;                /**< bit:  0..23  LON Beta1 Length after Transmission      */
@@ -1131,6 +1795,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONB1TX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONB1TX_OFFSET                   (0x74)                                        /**<  (US_LONB1TX) LON Beta1 Tx Register  Offset */
@@ -1144,6 +1809,7 @@ typedef union {
 
 /* -------- US_LONB1RX : (USART Offset: 0x78) (R/W 32) LON Beta1 Rx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BETA1RX:24;                /**< bit:  0..23  LON Beta1 Length after Reception         */
@@ -1151,6 +1817,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONB1RX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONB1RX_OFFSET                   (0x78)                                        /**<  (US_LONB1RX) LON Beta1 Rx Register  Offset */
@@ -1164,6 +1831,7 @@ typedef union {
 
 /* -------- US_LONPRIO : (USART Offset: 0x7c) (R/W 32) LON Priority Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PSNB:7;                    /**< bit:   0..6  LON Priority Slot Number                 */
@@ -1173,6 +1841,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_LONPRIO_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_LONPRIO_OFFSET                   (0x7C)                                        /**<  (US_LONPRIO) LON Priority Register  Offset */
@@ -1189,6 +1858,7 @@ typedef union {
 
 /* -------- US_IDTTX : (USART Offset: 0x80) (R/W 32) LON IDT Tx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDTTX:24;                  /**< bit:  0..23  LON Indeterminate Time after Transmission (comm_type = 1 mode only) */
@@ -1196,6 +1866,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDTTX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDTTX_OFFSET                     (0x80)                                        /**<  (US_IDTTX) LON IDT Tx Register  Offset */
@@ -1209,6 +1880,7 @@ typedef union {
 
 /* -------- US_IDTRX : (USART Offset: 0x84) (R/W 32) LON IDT Rx Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IDTRX:24;                  /**< bit:  0..23  LON Indeterminate Time after Reception (comm_type = 1 mode only) */
@@ -1216,6 +1888,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_IDTRX_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_IDTRX_OFFSET                     (0x84)                                        /**<  (US_IDTRX) LON IDT Rx Register  Offset */
@@ -1229,6 +1902,7 @@ typedef union {
 
 /* -------- US_ICDIFF : (USART Offset: 0x88) (R/W 32) IC DIFF Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ICDIFF:4;                  /**< bit:   0..3  IC Differentiator Number                 */
@@ -1236,6 +1910,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_ICDIFF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_ICDIFF_OFFSET                    (0x88)                                        /**<  (US_ICDIFF) IC DIFF Register  Offset */
@@ -1249,6 +1924,7 @@ typedef union {
 
 /* -------- US_WPMR : (USART Offset: 0xe4) (R/W 32) Write Protection Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPEN:1;                    /**< bit:      0  Write Protection Enable                  */
@@ -1257,6 +1933,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_WPMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPMR_OFFSET                      (0xE4)                                        /**<  (US_WPMR) Write Protection Mode Register  Offset */
@@ -1275,6 +1952,7 @@ typedef union {
 
 /* -------- US_WPSR : (USART Offset: 0xe8) (R/ 32) Write Protection Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WPVS:1;                    /**< bit:      0  Write Protection Violation Status        */
@@ -1284,6 +1962,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } US_WPSR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define US_WPSR_OFFSET                      (0xE8)                                        /**<  (US_WPSR) Write Protection Status Register  Offset */
@@ -1311,12 +1990,12 @@ typedef struct {
   __I  uint32_t US_RHR;         /**< (USART Offset: 0x18) Receive Holding Register */
   __O  uint32_t US_THR;         /**< (USART Offset: 0x1C) Transmit Holding Register */
   __IO uint32_t US_BRGR;        /**< (USART Offset: 0x20) Baud Rate Generator Register */
-  __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Time-out Register */
+  __IO uint32_t US_RTOR;        /**< (USART Offset: 0x24) Receiver Timeout Register */
   __IO uint32_t US_TTGR;        /**< (USART Offset: 0x28) Transmitter Timeguard Register */
-  RoReg8  Reserved1[0x14];
+  __I  uint8_t                        Reserved1[20];
   __IO uint32_t US_FIDI;        /**< (USART Offset: 0x40) FI DI Ratio Register */
   __I  uint32_t US_NER;         /**< (USART Offset: 0x44) Number of Errors Register */
-  RoReg8  Reserved2[0x4];
+  __I  uint8_t                        Reserved2[4];
   __IO uint32_t US_IF;          /**< (USART Offset: 0x4C) IrDA Filter Register */
   __IO uint32_t US_MAN;         /**< (USART Offset: 0x50) Manchester Configuration Register */
   __IO uint32_t US_LINMR;       /**< (USART Offset: 0x54) LIN Mode Register */
@@ -1333,7 +2012,7 @@ typedef struct {
   __IO uint32_t US_IDTTX;       /**< (USART Offset: 0x80) LON IDT Tx Register */
   __IO uint32_t US_IDTRX;       /**< (USART Offset: 0x84) LON IDT Rx Register */
   __IO uint32_t US_ICDIFF;      /**< (USART Offset: 0x88) IC DIFF Register */
-  RoReg8  Reserved3[0x58];
+  __I  uint8_t                        Reserved3[88];
   __IO uint32_t US_WPMR;        /**< (USART Offset: 0xE4) Write Protection Mode Register */
   __I  uint32_t US_WPSR;        /**< (USART Offset: 0xE8) Write Protection Status Register */
 } Usart;
@@ -1350,12 +2029,12 @@ typedef struct {
   __I  US_RHR_Type                    US_RHR;         /**< Offset: 0x18 (R/   32) Receive Holding Register */
   __O  US_THR_Type                    US_THR;         /**< Offset: 0x1C ( /W  32) Transmit Holding Register */
   __IO US_BRGR_Type                   US_BRGR;        /**< Offset: 0x20 (R/W  32) Baud Rate Generator Register */
-  __IO US_RTOR_Type                   US_RTOR;        /**< Offset: 0x24 (R/W  32) Receiver Time-out Register */
+  __IO US_RTOR_Type                   US_RTOR;        /**< Offset: 0x24 (R/W  32) Receiver Timeout Register */
   __IO US_TTGR_Type                   US_TTGR;        /**< Offset: 0x28 (R/W  32) Transmitter Timeguard Register */
-  __I  uint32_t                       Reserved1[5];
+  __I  uint8_t                        Reserved1[20];
   __IO US_FIDI_Type                   US_FIDI;        /**< Offset: 0x40 (R/W  32) FI DI Ratio Register */
   __I  US_NER_Type                    US_NER;         /**< Offset: 0x44 (R/   32) Number of Errors Register */
-  __I  uint32_t                       Reserved2[1];
+  __I  uint8_t                        Reserved2[4];
   __IO US_IF_Type                     US_IF;          /**< Offset: 0x4C (R/W  32) IrDA Filter Register */
   __IO US_MAN_Type                    US_MAN;         /**< Offset: 0x50 (R/W  32) Manchester Configuration Register */
   __IO US_LINMR_Type                  US_LINMR;       /**< Offset: 0x54 (R/W  32) LIN Mode Register */
@@ -1372,7 +2051,7 @@ typedef struct {
   __IO US_IDTTX_Type                  US_IDTTX;       /**< Offset: 0x80 (R/W  32) LON IDT Tx Register */
   __IO US_IDTRX_Type                  US_IDTRX;       /**< Offset: 0x84 (R/W  32) LON IDT Rx Register */
   __IO US_ICDIFF_Type                 US_ICDIFF;      /**< Offset: 0x88 (R/W  32) IC DIFF Register */
-  __I  uint32_t                       Reserved3[22];
+  __I  uint8_t                        Reserved3[88];
   __IO US_WPMR_Type                   US_WPMR;        /**< Offset: 0xE4 (R/W  32) Write Protection Mode Register */
   __I  US_WPSR_Type                   US_WPSR;        /**< Offset: 0xE8 (R/   32) Write Protection Status Register */
 } Usart;
@@ -1384,4 +2063,7 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 /** @}  end of Universal Synchronous Asynchronous Receiver Transmitter */
 
+#if !(defined(DO_NOT_USE_DEPRECATED_MACROS))
+#include "deprecated/usart.h"
+#endif /* DO_NOT_USE_DEPRECATED_MACROS */
 #endif /* _SAME70_USART_COMPONENT_H_ */

--- a/asf/sam/include/same70b/component/usbhs.h
+++ b/asf/sam/include/same70b/component/usbhs.h
@@ -4399,7 +4399,7 @@ typedef struct {
   __I  uint8_t                        Reserved7[8];
   __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Interrupt Disable Register */
   __I  uint8_t                        Reserved8[200];
-       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+       UsbhsDevdma USBHS_DEVDMA[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
   __I  uint8_t                        Reserved9[128];
   __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
   __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
@@ -4483,7 +4483,7 @@ typedef struct {
   __I  uint8_t                        Reserved7[8];
   __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Interrupt Disable Register */
   __I  uint8_t                        Reserved8[200];
-       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+       UsbhsDevdma                    USBHS_DEVDMA[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
   __I  uint8_t                        Reserved9[128];
   __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
   __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */

--- a/asf/sam/include/same70b/component/usbhs.h
+++ b/asf/sam/include/same70b/component/usbhs.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for USBHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USBHS_COMPONENT_H_
 #define _SAME70_USBHS_COMPONENT_H_
 #define _SAME70_USBHS_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -43,17 +45,19 @@
 #define USBHS_11292                      /**< (USBHS) Module ID */
 #define REV_USBHS G                      /**< (USBHS) Module revision */
 
-/* -------- USBHS_DEVDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Device DMA Channel Next Descriptor Address Register (n = 1) -------- */
+/* -------- USBHS_DEVDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Device DMA Channel Next Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMANXTDSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_DEVDMANXTDSC) Device DMA Channel Next Descriptor Address Register (n = 1)  Offset */
+#define USBHS_DEVDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_DEVDMANXTDSC) Device DMA Channel Next Descriptor Address Register  Offset */
 
 #define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Position */
 #define USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_DEVDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_DEVDMANXTDSC) Next Descriptor Address Mask */
@@ -62,17 +66,19 @@ typedef union {
 #define USBHS_DEVDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMANXTDSC) Register Mask  */
 
 
-/* -------- USBHS_DEVDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Device DMA Channel Address Register (n = 1) -------- */
+/* -------- USBHS_DEVDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Device DMA Channel Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMAADDRESS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_DEVDMAADDRESS) Device DMA Channel Address Register (n = 1)  Offset */
+#define USBHS_DEVDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_DEVDMAADDRESS) Device DMA Channel Address Register  Offset */
 
 #define USBHS_DEVDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_DEVDMAADDRESS) Buffer Address Position */
 #define USBHS_DEVDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_DEVDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_DEVDMAADDRESS) Buffer Address Mask */
@@ -81,8 +87,9 @@ typedef union {
 #define USBHS_DEVDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_DEVDMAADDRESS) Register Mask  */
 
 
-/* -------- USBHS_DEVDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Device DMA Channel Control Register (n = 1) -------- */
+/* -------- USBHS_DEVDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Device DMA Channel Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
@@ -98,9 +105,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMACONTROL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_DEVDMACONTROL) Device DMA Channel Control Register (n = 1)  Offset */
+#define USBHS_DEVDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_DEVDMACONTROL) Device DMA Channel Control Register  Offset */
 
 #define USBHS_DEVDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_DEVDMACONTROL) Channel Enable Command Position */
 #define USBHS_DEVDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_DEVDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_DEVDMACONTROL) Channel Enable Command Mask */
@@ -133,8 +141,9 @@ typedef union {
 #define USBHS_DEVDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_DEVDMACONTROL) Register Mask  */
 
 
-/* -------- USBHS_DEVDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Device DMA Channel Status Register (n = 1) -------- */
+/* -------- USBHS_DEVDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Device DMA Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
@@ -148,9 +157,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVDMASTATUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_DEVDMASTATUS) Device DMA Channel Status Register (n = 1)  Offset */
+#define USBHS_DEVDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_DEVDMASTATUS) Device DMA Channel Status Register  Offset */
 
 #define USBHS_DEVDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_DEVDMASTATUS) Channel Enable Status Position */
 #define USBHS_DEVDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_DEVDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_DEVDMASTATUS) Channel Enable Status Mask */
@@ -174,17 +184,19 @@ typedef union {
 #define USBHS_DEVDMASTATUS_Msk              _U_(0xFFFF0073)                                /**< (USBHS_DEVDMASTATUS) Register Mask  */
 
 
-/* -------- USBHS_HSTDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Host DMA Channel Next Descriptor Address Register (n = 1) -------- */
+/* -------- USBHS_HSTDMANXTDSC : (USBHS Offset: 0x00) (R/W 32) Host DMA Channel Next Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NXT_DSC_ADD:32;            /**< bit:  0..31  Next Descriptor Address                  */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMANXTDSC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_HSTDMANXTDSC) Host DMA Channel Next Descriptor Address Register (n = 1)  Offset */
+#define USBHS_HSTDMANXTDSC_OFFSET           (0x00)                                        /**<  (USBHS_HSTDMANXTDSC) Host DMA Channel Next Descriptor Address Register  Offset */
 
 #define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos  0                                              /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Position */
 #define USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Msk  (_U_(0xFFFFFFFF) << USBHS_HSTDMANXTDSC_NXT_DSC_ADD_Pos)  /**< (USBHS_HSTDMANXTDSC) Next Descriptor Address Mask */
@@ -193,17 +205,19 @@ typedef union {
 #define USBHS_HSTDMANXTDSC_Msk              _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMANXTDSC) Register Mask  */
 
 
-/* -------- USBHS_HSTDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Host DMA Channel Address Register (n = 1) -------- */
+/* -------- USBHS_HSTDMAADDRESS : (USBHS Offset: 0x04) (R/W 32) Host DMA Channel Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BUFF_ADD:32;               /**< bit:  0..31  Buffer Address                           */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMAADDRESS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_HSTDMAADDRESS) Host DMA Channel Address Register (n = 1)  Offset */
+#define USBHS_HSTDMAADDRESS_OFFSET          (0x04)                                        /**<  (USBHS_HSTDMAADDRESS) Host DMA Channel Address Register  Offset */
 
 #define USBHS_HSTDMAADDRESS_BUFF_ADD_Pos    0                                              /**< (USBHS_HSTDMAADDRESS) Buffer Address Position */
 #define USBHS_HSTDMAADDRESS_BUFF_ADD_Msk    (_U_(0xFFFFFFFF) << USBHS_HSTDMAADDRESS_BUFF_ADD_Pos)  /**< (USBHS_HSTDMAADDRESS) Buffer Address Mask */
@@ -212,8 +226,9 @@ typedef union {
 #define USBHS_HSTDMAADDRESS_Msk             _U_(0xFFFFFFFF)                                /**< (USBHS_HSTDMAADDRESS) Register Mask  */
 
 
-/* -------- USBHS_HSTDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Host DMA Channel Control Register (n = 1) -------- */
+/* -------- USBHS_HSTDMACONTROL : (USBHS Offset: 0x08) (R/W 32) Host DMA Channel Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Command                   */
@@ -229,9 +244,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMACONTROL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_HSTDMACONTROL) Host DMA Channel Control Register (n = 1)  Offset */
+#define USBHS_HSTDMACONTROL_OFFSET          (0x08)                                        /**<  (USBHS_HSTDMACONTROL) Host DMA Channel Control Register  Offset */
 
 #define USBHS_HSTDMACONTROL_CHANN_ENB_Pos   0                                              /**< (USBHS_HSTDMACONTROL) Channel Enable Command Position */
 #define USBHS_HSTDMACONTROL_CHANN_ENB_Msk   (_U_(0x1) << USBHS_HSTDMACONTROL_CHANN_ENB_Pos)  /**< (USBHS_HSTDMACONTROL) Channel Enable Command Mask */
@@ -264,8 +280,9 @@ typedef union {
 #define USBHS_HSTDMACONTROL_Msk             _U_(0xFFFF00FF)                                /**< (USBHS_HSTDMACONTROL) Register Mask  */
 
 
-/* -------- USBHS_HSTDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Host DMA Channel Status Register (n = 1) -------- */
+/* -------- USBHS_HSTDMASTATUS : (USBHS Offset: 0x0c) (R/W 32) Host DMA Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CHANN_ENB:1;               /**< bit:      0  Channel Enable Status                    */
@@ -279,9 +296,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTDMASTATUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_HSTDMASTATUS) Host DMA Channel Status Register (n = 1)  Offset */
+#define USBHS_HSTDMASTATUS_OFFSET           (0x0C)                                        /**<  (USBHS_HSTDMASTATUS) Host DMA Channel Status Register  Offset */
 
 #define USBHS_HSTDMASTATUS_CHANN_ENB_Pos    0                                              /**< (USBHS_HSTDMASTATUS) Channel Enable Status Position */
 #define USBHS_HSTDMASTATUS_CHANN_ENB_Msk    (_U_(0x1) << USBHS_HSTDMASTATUS_CHANN_ENB_Pos)  /**< (USBHS_HSTDMASTATUS) Channel Enable Status Mask */
@@ -307,6 +325,7 @@ typedef union {
 
 /* -------- USBHS_DEVCTRL : (USBHS Offset: 0x00) (R/W 32) Device General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UADD:7;                    /**< bit:   0..6  USB Address                              */
@@ -321,8 +340,14 @@ typedef union {
     uint32_t OPMODE2:1;                 /**< bit:     16  Specific Operational mode                */
     uint32_t :15;                       /**< bit: 17..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :16;                       /**< bit:  0..15  Reserved */
+    uint32_t OPMODE:1;                  /**< bit:     16  Specific Operational mode                */
+    uint32_t :15;                       /**< bit: 17..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVCTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVCTRL_OFFSET                (0x00)                                        /**<  (USBHS_DEVCTRL) Device General Control Register  Offset */
@@ -344,8 +369,12 @@ typedef union {
 #define USBHS_DEVCTRL_SPDCONF(value)        (USBHS_DEVCTRL_SPDCONF_Msk & ((value) << USBHS_DEVCTRL_SPDCONF_Pos))
 #define   USBHS_DEVCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable.  */
 #define   USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_DEVCTRL) Forced high speed.  */
+#define   USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability.  */
 #define USBHS_DEVCTRL_SPDCONF_NORMAL        (USBHS_DEVCTRL_SPDCONF_NORMAL_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the host is high-speed-capable. Position  */
 #define USBHS_DEVCTRL_SPDCONF_LOW_POWER     (USBHS_DEVCTRL_SPDCONF_LOW_POWER_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_HIGH_SPEED    (USBHS_DEVCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) Forced high speed. Position  */
+#define USBHS_DEVCTRL_SPDCONF_FORCED_FS     (USBHS_DEVCTRL_SPDCONF_FORCED_FS_Val << USBHS_DEVCTRL_SPDCONF_Pos)  /**< (USBHS_DEVCTRL) The peripheral remains in Full-speed mode whatever the host speed capability. Position  */
 #define USBHS_DEVCTRL_LS_Pos                12                                             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Position */
 #define USBHS_DEVCTRL_LS_Msk                (_U_(0x1) << USBHS_DEVCTRL_LS_Pos)             /**< (USBHS_DEVCTRL) Low-Speed Mode Force Mask */
 #define USBHS_DEVCTRL_LS                    USBHS_DEVCTRL_LS_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVCTRL_LS_Msk instead */
@@ -364,9 +393,13 @@ typedef union {
 #define USBHS_DEVCTRL_MASK                  _U_(0x1FFFF)                                   /**< \deprecated (USBHS_DEVCTRL) Register MASK  (Use USBHS_DEVCTRL_Msk instead)  */
 #define USBHS_DEVCTRL_Msk                   _U_(0x1FFFF)                                   /**< (USBHS_DEVCTRL) Register Mask  */
 
+#define USBHS_DEVCTRL_OPMODE_Pos            16                                             /**< (USBHS_DEVCTRL Position) Specific Operational mode */
+#define USBHS_DEVCTRL_OPMODE_Msk            (_U_(0x1) << USBHS_DEVCTRL_OPMODE_Pos)         /**< (USBHS_DEVCTRL Mask) OPMODE */
+#define USBHS_DEVCTRL_OPMODE(value)         (USBHS_DEVCTRL_OPMODE_Msk & ((value) << USBHS_DEVCTRL_OPMODE_Pos))  
 
 /* -------- USBHS_DEVISR : (USBHS Offset: 0x04) (R/ 32) Device Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSP:1;                    /**< bit:      0  Suspend Interrupt                        */
@@ -387,9 +420,7 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt                     */
     uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt                     */
     uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt                     */
-    uint32_t PEP_10:1;                  /**< bit:     22  Endpoint 10 Interrupt                    */
-    uint32_t PEP_11:1;                  /**< bit:     23  Endpoint 11 Interrupt                    */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt                  */
     uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt                  */
     uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt                  */
@@ -400,12 +431,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
-    uint32_t PEP_:12;                   /**< bit: 12..23  Endpoint x Interrupt                     */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt                     */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt                  */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVISR_OFFSET                 (0x04)                                        /**<  (USBHS_DEVISR) Device Global Interrupt Status Register  Offset */
@@ -461,12 +493,6 @@ typedef union {
 #define USBHS_DEVISR_PEP_9_Pos              21                                             /**< (USBHS_DEVISR) Endpoint 9 Interrupt Position */
 #define USBHS_DEVISR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVISR_PEP_9_Pos)           /**< (USBHS_DEVISR) Endpoint 9 Interrupt Mask */
 #define USBHS_DEVISR_PEP_9                  USBHS_DEVISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_9_Msk instead */
-#define USBHS_DEVISR_PEP_10_Pos             22                                             /**< (USBHS_DEVISR) Endpoint 10 Interrupt Position */
-#define USBHS_DEVISR_PEP_10_Msk             (_U_(0x1) << USBHS_DEVISR_PEP_10_Pos)          /**< (USBHS_DEVISR) Endpoint 10 Interrupt Mask */
-#define USBHS_DEVISR_PEP_10                 USBHS_DEVISR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_10_Msk instead */
-#define USBHS_DEVISR_PEP_11_Pos             23                                             /**< (USBHS_DEVISR) Endpoint 11 Interrupt Position */
-#define USBHS_DEVISR_PEP_11_Msk             (_U_(0x1) << USBHS_DEVISR_PEP_11_Pos)          /**< (USBHS_DEVISR) Endpoint 11 Interrupt Mask */
-#define USBHS_DEVISR_PEP_11                 USBHS_DEVISR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_PEP_11_Msk instead */
 #define USBHS_DEVISR_DMA_1_Pos              25                                             /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Position */
 #define USBHS_DEVISR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_1_Pos)           /**< (USBHS_DEVISR) DMA Channel 1 Interrupt Mask */
 #define USBHS_DEVISR_DMA_1                  USBHS_DEVISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_1_Msk instead */
@@ -488,11 +514,11 @@ typedef union {
 #define USBHS_DEVISR_DMA_7_Pos              31                                             /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Position */
 #define USBHS_DEVISR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVISR_DMA_7_Pos)           /**< (USBHS_DEVISR) DMA Channel 7 Interrupt Mask */
 #define USBHS_DEVISR_DMA_7                  USBHS_DEVISR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVISR_DMA_7_Msk instead */
-#define USBHS_DEVISR_MASK                   _U_(0xFEFFF07F)                                /**< \deprecated (USBHS_DEVISR) Register MASK  (Use USBHS_DEVISR_Msk instead)  */
-#define USBHS_DEVISR_Msk                    _U_(0xFEFFF07F)                                /**< (USBHS_DEVISR) Register Mask  */
+#define USBHS_DEVISR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVISR) Register MASK  (Use USBHS_DEVISR_Msk instead)  */
+#define USBHS_DEVISR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVISR) Register Mask  */
 
 #define USBHS_DEVISR_PEP__Pos               12                                             /**< (USBHS_DEVISR Position) Endpoint x Interrupt */
-#define USBHS_DEVISR_PEP__Msk               (_U_(0xFFF) << USBHS_DEVISR_PEP__Pos)          /**< (USBHS_DEVISR Mask) PEP_ */
+#define USBHS_DEVISR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVISR_PEP__Pos)          /**< (USBHS_DEVISR Mask) PEP_ */
 #define USBHS_DEVISR_PEP_(value)            (USBHS_DEVISR_PEP__Msk & ((value) << USBHS_DEVISR_PEP__Pos))  
 #define USBHS_DEVISR_DMA__Pos               25                                             /**< (USBHS_DEVISR Position) DMA Channel 7 Interrupt */
 #define USBHS_DEVISR_DMA__Msk               (_U_(0x7F) << USBHS_DEVISR_DMA__Pos)           /**< (USBHS_DEVISR Mask) DMA_ */
@@ -500,6 +526,7 @@ typedef union {
 
 /* -------- USBHS_DEVICR : (USBHS Offset: 0x08) (/W 32) Device Global Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPC:1;                   /**< bit:      0  Suspend Interrupt Clear                  */
@@ -513,6 +540,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVICR_OFFSET                 (0x08)                                        /**<  (USBHS_DEVICR) Device Global Interrupt Clear Register  Offset */
@@ -544,6 +572,7 @@ typedef union {
 
 /* -------- USBHS_DEVIFR : (USBHS Offset: 0x0c) (/W 32) Device Global Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPS:1;                   /**< bit:      0  Suspend Interrupt Set                    */
@@ -568,6 +597,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIFR_OFFSET                 (0x0C)                                        /**<  (USBHS_DEVIFR) Device Global Interrupt Set Register  Offset */
@@ -623,6 +653,7 @@ typedef union {
 
 /* -------- USBHS_DEVIMR : (USBHS Offset: 0x10) (R/ 32) Device Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPE:1;                   /**< bit:      0  Suspend Interrupt Mask                   */
@@ -643,9 +674,7 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Mask                */
     uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Mask                */
     uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Mask                */
-    uint32_t PEP_10:1;                  /**< bit:     22  Endpoint 10 Interrupt Mask               */
-    uint32_t PEP_11:1;                  /**< bit:     23  Endpoint 11 Interrupt Mask               */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Mask             */
     uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Mask             */
     uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Mask             */
@@ -656,12 +685,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
-    uint32_t PEP_:12;                   /**< bit: 12..23  Endpoint x Interrupt Mask                */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Mask                */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Mask             */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIMR_OFFSET                 (0x10)                                        /**<  (USBHS_DEVIMR) Device Global Interrupt Mask Register  Offset */
@@ -717,12 +747,6 @@ typedef union {
 #define USBHS_DEVIMR_PEP_9_Pos              21                                             /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Position */
 #define USBHS_DEVIMR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIMR_PEP_9_Pos)           /**< (USBHS_DEVIMR) Endpoint 9 Interrupt Mask Mask */
 #define USBHS_DEVIMR_PEP_9                  USBHS_DEVIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_9_Msk instead */
-#define USBHS_DEVIMR_PEP_10_Pos             22                                             /**< (USBHS_DEVIMR) Endpoint 10 Interrupt Mask Position */
-#define USBHS_DEVIMR_PEP_10_Msk             (_U_(0x1) << USBHS_DEVIMR_PEP_10_Pos)          /**< (USBHS_DEVIMR) Endpoint 10 Interrupt Mask Mask */
-#define USBHS_DEVIMR_PEP_10                 USBHS_DEVIMR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_10_Msk instead */
-#define USBHS_DEVIMR_PEP_11_Pos             23                                             /**< (USBHS_DEVIMR) Endpoint 11 Interrupt Mask Position */
-#define USBHS_DEVIMR_PEP_11_Msk             (_U_(0x1) << USBHS_DEVIMR_PEP_11_Pos)          /**< (USBHS_DEVIMR) Endpoint 11 Interrupt Mask Mask */
-#define USBHS_DEVIMR_PEP_11                 USBHS_DEVIMR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_PEP_11_Msk instead */
 #define USBHS_DEVIMR_DMA_1_Pos              25                                             /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Position */
 #define USBHS_DEVIMR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_1_Pos)           /**< (USBHS_DEVIMR) DMA Channel 1 Interrupt Mask Mask */
 #define USBHS_DEVIMR_DMA_1                  USBHS_DEVIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_1_Msk instead */
@@ -744,11 +768,11 @@ typedef union {
 #define USBHS_DEVIMR_DMA_7_Pos              31                                             /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Position */
 #define USBHS_DEVIMR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIMR_DMA_7_Pos)           /**< (USBHS_DEVIMR) DMA Channel 7 Interrupt Mask Mask */
 #define USBHS_DEVIMR_DMA_7                  USBHS_DEVIMR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIMR_DMA_7_Msk instead */
-#define USBHS_DEVIMR_MASK                   _U_(0xFEFFF07F)                                /**< \deprecated (USBHS_DEVIMR) Register MASK  (Use USBHS_DEVIMR_Msk instead)  */
-#define USBHS_DEVIMR_Msk                    _U_(0xFEFFF07F)                                /**< (USBHS_DEVIMR) Register Mask  */
+#define USBHS_DEVIMR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIMR) Register MASK  (Use USBHS_DEVIMR_Msk instead)  */
+#define USBHS_DEVIMR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIMR) Register Mask  */
 
 #define USBHS_DEVIMR_PEP__Pos               12                                             /**< (USBHS_DEVIMR Position) Endpoint x Interrupt Mask */
-#define USBHS_DEVIMR_PEP__Msk               (_U_(0xFFF) << USBHS_DEVIMR_PEP__Pos)          /**< (USBHS_DEVIMR Mask) PEP_ */
+#define USBHS_DEVIMR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIMR_PEP__Pos)          /**< (USBHS_DEVIMR Mask) PEP_ */
 #define USBHS_DEVIMR_PEP_(value)            (USBHS_DEVIMR_PEP__Msk & ((value) << USBHS_DEVIMR_PEP__Pos))  
 #define USBHS_DEVIMR_DMA__Pos               25                                             /**< (USBHS_DEVIMR Position) DMA Channel 7 Interrupt Mask */
 #define USBHS_DEVIMR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIMR_DMA__Pos)           /**< (USBHS_DEVIMR Mask) DMA_ */
@@ -756,6 +780,7 @@ typedef union {
 
 /* -------- USBHS_DEVIDR : (USBHS Offset: 0x14) (/W 32) Device Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPEC:1;                  /**< bit:      0  Suspend Interrupt Disable                */
@@ -776,9 +801,7 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Disable             */
     uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Disable             */
     uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Disable             */
-    uint32_t PEP_10:1;                  /**< bit:     22  Endpoint 10 Interrupt Disable            */
-    uint32_t PEP_11:1;                  /**< bit:     23  Endpoint 11 Interrupt Disable            */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Disable          */
     uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Disable          */
     uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Disable          */
@@ -789,12 +812,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
-    uint32_t PEP_:12;                   /**< bit: 12..23  Endpoint x Interrupt Disable             */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Disable             */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Disable          */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIDR_OFFSET                 (0x14)                                        /**<  (USBHS_DEVIDR) Device Global Interrupt Disable Register  Offset */
@@ -850,12 +874,6 @@ typedef union {
 #define USBHS_DEVIDR_PEP_9_Pos              21                                             /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Position */
 #define USBHS_DEVIDR_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIDR_PEP_9_Pos)           /**< (USBHS_DEVIDR) Endpoint 9 Interrupt Disable Mask */
 #define USBHS_DEVIDR_PEP_9                  USBHS_DEVIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_9_Msk instead */
-#define USBHS_DEVIDR_PEP_10_Pos             22                                             /**< (USBHS_DEVIDR) Endpoint 10 Interrupt Disable Position */
-#define USBHS_DEVIDR_PEP_10_Msk             (_U_(0x1) << USBHS_DEVIDR_PEP_10_Pos)          /**< (USBHS_DEVIDR) Endpoint 10 Interrupt Disable Mask */
-#define USBHS_DEVIDR_PEP_10                 USBHS_DEVIDR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_10_Msk instead */
-#define USBHS_DEVIDR_PEP_11_Pos             23                                             /**< (USBHS_DEVIDR) Endpoint 11 Interrupt Disable Position */
-#define USBHS_DEVIDR_PEP_11_Msk             (_U_(0x1) << USBHS_DEVIDR_PEP_11_Pos)          /**< (USBHS_DEVIDR) Endpoint 11 Interrupt Disable Mask */
-#define USBHS_DEVIDR_PEP_11                 USBHS_DEVIDR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_PEP_11_Msk instead */
 #define USBHS_DEVIDR_DMA_1_Pos              25                                             /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Position */
 #define USBHS_DEVIDR_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_1_Pos)           /**< (USBHS_DEVIDR) DMA Channel 1 Interrupt Disable Mask */
 #define USBHS_DEVIDR_DMA_1                  USBHS_DEVIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_1_Msk instead */
@@ -877,11 +895,11 @@ typedef union {
 #define USBHS_DEVIDR_DMA_7_Pos              31                                             /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Position */
 #define USBHS_DEVIDR_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIDR_DMA_7_Pos)           /**< (USBHS_DEVIDR) DMA Channel 7 Interrupt Disable Mask */
 #define USBHS_DEVIDR_DMA_7                  USBHS_DEVIDR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIDR_DMA_7_Msk instead */
-#define USBHS_DEVIDR_MASK                   _U_(0xFEFFF07F)                                /**< \deprecated (USBHS_DEVIDR) Register MASK  (Use USBHS_DEVIDR_Msk instead)  */
-#define USBHS_DEVIDR_Msk                    _U_(0xFEFFF07F)                                /**< (USBHS_DEVIDR) Register Mask  */
+#define USBHS_DEVIDR_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIDR) Register MASK  (Use USBHS_DEVIDR_Msk instead)  */
+#define USBHS_DEVIDR_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIDR) Register Mask  */
 
 #define USBHS_DEVIDR_PEP__Pos               12                                             /**< (USBHS_DEVIDR Position) Endpoint x Interrupt Disable */
-#define USBHS_DEVIDR_PEP__Msk               (_U_(0xFFF) << USBHS_DEVIDR_PEP__Pos)          /**< (USBHS_DEVIDR Mask) PEP_ */
+#define USBHS_DEVIDR_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIDR_PEP__Pos)          /**< (USBHS_DEVIDR Mask) PEP_ */
 #define USBHS_DEVIDR_PEP_(value)            (USBHS_DEVIDR_PEP__Msk & ((value) << USBHS_DEVIDR_PEP__Pos))  
 #define USBHS_DEVIDR_DMA__Pos               25                                             /**< (USBHS_DEVIDR Position) DMA Channel 7 Interrupt Disable */
 #define USBHS_DEVIDR_DMA__Msk               (_U_(0x7F) << USBHS_DEVIDR_DMA__Pos)           /**< (USBHS_DEVIDR Mask) DMA_ */
@@ -889,6 +907,7 @@ typedef union {
 
 /* -------- USBHS_DEVIER : (USBHS Offset: 0x18) (/W 32) Device Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUSPES:1;                  /**< bit:      0  Suspend Interrupt Enable                 */
@@ -909,9 +928,7 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     19  Endpoint 7 Interrupt Enable              */
     uint32_t PEP_8:1;                   /**< bit:     20  Endpoint 8 Interrupt Enable              */
     uint32_t PEP_9:1;                   /**< bit:     21  Endpoint 9 Interrupt Enable              */
-    uint32_t PEP_10:1;                  /**< bit:     22  Endpoint 10 Interrupt Enable             */
-    uint32_t PEP_11:1;                  /**< bit:     23  Endpoint 11 Interrupt Enable             */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
     uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
     uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
@@ -922,12 +939,13 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :12;                       /**< bit:  0..11  Reserved */
-    uint32_t PEP_:12;                   /**< bit: 12..23  Endpoint x Interrupt Enable              */
-    uint32_t :1;                        /**< bit:     24  Reserved */
+    uint32_t PEP_:10;                   /**< bit: 12..21  Endpoint x Interrupt Enable              */
+    uint32_t :3;                        /**< bit: 22..24  Reserved */
     uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVIER_OFFSET                 (0x18)                                        /**<  (USBHS_DEVIER) Device Global Interrupt Enable Register  Offset */
@@ -983,12 +1001,6 @@ typedef union {
 #define USBHS_DEVIER_PEP_9_Pos              21                                             /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Position */
 #define USBHS_DEVIER_PEP_9_Msk              (_U_(0x1) << USBHS_DEVIER_PEP_9_Pos)           /**< (USBHS_DEVIER) Endpoint 9 Interrupt Enable Mask */
 #define USBHS_DEVIER_PEP_9                  USBHS_DEVIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_9_Msk instead */
-#define USBHS_DEVIER_PEP_10_Pos             22                                             /**< (USBHS_DEVIER) Endpoint 10 Interrupt Enable Position */
-#define USBHS_DEVIER_PEP_10_Msk             (_U_(0x1) << USBHS_DEVIER_PEP_10_Pos)          /**< (USBHS_DEVIER) Endpoint 10 Interrupt Enable Mask */
-#define USBHS_DEVIER_PEP_10                 USBHS_DEVIER_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_10_Msk instead */
-#define USBHS_DEVIER_PEP_11_Pos             23                                             /**< (USBHS_DEVIER) Endpoint 11 Interrupt Enable Position */
-#define USBHS_DEVIER_PEP_11_Msk             (_U_(0x1) << USBHS_DEVIER_PEP_11_Pos)          /**< (USBHS_DEVIER) Endpoint 11 Interrupt Enable Mask */
-#define USBHS_DEVIER_PEP_11                 USBHS_DEVIER_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_PEP_11_Msk instead */
 #define USBHS_DEVIER_DMA_1_Pos              25                                             /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Position */
 #define USBHS_DEVIER_DMA_1_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_1_Pos)           /**< (USBHS_DEVIER) DMA Channel 1 Interrupt Enable Mask */
 #define USBHS_DEVIER_DMA_1                  USBHS_DEVIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_1_Msk instead */
@@ -1010,11 +1022,11 @@ typedef union {
 #define USBHS_DEVIER_DMA_7_Pos              31                                             /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Position */
 #define USBHS_DEVIER_DMA_7_Msk              (_U_(0x1) << USBHS_DEVIER_DMA_7_Pos)           /**< (USBHS_DEVIER) DMA Channel 7 Interrupt Enable Mask */
 #define USBHS_DEVIER_DMA_7                  USBHS_DEVIER_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVIER_DMA_7_Msk instead */
-#define USBHS_DEVIER_MASK                   _U_(0xFEFFF07F)                                /**< \deprecated (USBHS_DEVIER) Register MASK  (Use USBHS_DEVIER_Msk instead)  */
-#define USBHS_DEVIER_Msk                    _U_(0xFEFFF07F)                                /**< (USBHS_DEVIER) Register Mask  */
+#define USBHS_DEVIER_MASK                   _U_(0xFE3FF07F)                                /**< \deprecated (USBHS_DEVIER) Register MASK  (Use USBHS_DEVIER_Msk instead)  */
+#define USBHS_DEVIER_Msk                    _U_(0xFE3FF07F)                                /**< (USBHS_DEVIER) Register Mask  */
 
 #define USBHS_DEVIER_PEP__Pos               12                                             /**< (USBHS_DEVIER Position) Endpoint x Interrupt Enable */
-#define USBHS_DEVIER_PEP__Msk               (_U_(0xFFF) << USBHS_DEVIER_PEP__Pos)          /**< (USBHS_DEVIER Mask) PEP_ */
+#define USBHS_DEVIER_PEP__Msk               (_U_(0x3FF) << USBHS_DEVIER_PEP__Pos)          /**< (USBHS_DEVIER Mask) PEP_ */
 #define USBHS_DEVIER_PEP_(value)            (USBHS_DEVIER_PEP__Msk & ((value) << USBHS_DEVIER_PEP__Pos))  
 #define USBHS_DEVIER_DMA__Pos               25                                             /**< (USBHS_DEVIER Position) DMA Channel 7 Interrupt Enable */
 #define USBHS_DEVIER_DMA__Msk               (_U_(0x7F) << USBHS_DEVIER_DMA__Pos)           /**< (USBHS_DEVIER Mask) DMA_ */
@@ -1022,6 +1034,7 @@ typedef union {
 
 /* -------- USBHS_DEVEPT : (USBHS Offset: 0x1c) (R/W 32) Device Endpoint Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EPEN0:1;                   /**< bit:      0  Endpoint 0 Enable                        */
@@ -1055,6 +1068,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPT_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVEPT_OFFSET                 (0x1C)                                        /**<  (USBHS_DEVEPT) Device Endpoint Register  Offset */
@@ -1131,6 +1145,7 @@ typedef union {
 
 /* -------- USBHS_DEVFNUM : (USBHS Offset: 0x20) (R/ 32) Device Frame Number Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
@@ -1141,6 +1156,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVFNUM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_DEVFNUM_OFFSET                (0x20)                                        /**<  (USBHS_DEVFNUM) Device Frame Number Register  Offset */
@@ -1158,8 +1174,9 @@ typedef union {
 #define USBHS_DEVFNUM_Msk                   _U_(0xBFFF)                                    /**< (USBHS_DEVFNUM) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTCFG : (USBHS Offset: 0x100) (R/W 32) Device Endpoint Configuration Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTCFG : (USBHS Offset: 0x100) (R/W 32) Device Endpoint Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -1176,9 +1193,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTCFG_OFFSET              (0x100)                                       /**<  (USBHS_DEVEPTCFG) Device Endpoint Configuration Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTCFG_OFFSET              (0x100)                                       /**<  (USBHS_DEVEPTCFG) Device Endpoint Configuration Register  Offset */
 
 #define USBHS_DEVEPTCFG_ALLOC_Pos           1                                              /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Position */
 #define USBHS_DEVEPTCFG_ALLOC_Msk           (_U_(0x1) << USBHS_DEVEPTCFG_ALLOC_Pos)        /**< (USBHS_DEVEPTCFG) Endpoint Memory Allocate Mask */
@@ -1247,34 +1265,78 @@ typedef union {
 #define USBHS_DEVEPTCFG_Msk                 _U_(0x7B7E)                                    /**< (USBHS_DEVEPTCFG) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTISR : (USBHS Offset: 0x130) (R/ 32) Device Endpoint Status Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTISR : (USBHS Offset: 0x130) (R/ 32) Device Endpoint Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINI:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
     uint32_t RXOUTI:1;                  /**< bit:      1  Received OUT Data Interrupt              */
-    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
-    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
-    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
-    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKET:1;             /**< bit:      7  Short Packet Interrupt                   */
     uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
     uint32_t :2;                        /**< bit: 10..11  Reserved */
     uint32_t NBUSYBK:2;                 /**< bit: 12..13  Number of Busy Banks                     */
     uint32_t CURRBK:2;                  /**< bit: 14..15  Current Bank                             */
     uint32_t RWALL:1;                   /**< bit:     16  Read/Write Allowed                       */
-    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :1;                        /**< bit:     17  Reserved */
     uint32_t CFGOK:1;                   /**< bit:     18  Configuration OK Status                  */
     uint32_t :1;                        /**< bit:     19  Reserved */
     uint32_t BYCT:11;                   /**< bit: 20..30  Byte Count                               */
     uint32_t :1;                        /**< bit:     31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t HBISOINERRI:1;             /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt */
+    uint32_t HBISOFLUSHI:1;             /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRI:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :3;                        /**< bit:   7..9  Reserved */
+    uint32_t ERRORTRANS:1;              /**< bit:     10  High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPI:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTI:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINI:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDI:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t CTRLDIR:1;                 /**< bit:     17  Control Direction                        */
+    uint32_t :14;                       /**< bit: 18..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTISR_OFFSET              (0x130)                                       /**<  (USBHS_DEVEPTISR) Device Endpoint Status Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTISR_OFFSET              (0x130)                                       /**<  (USBHS_DEVEPTISR) Device Endpoint Interrupt Status Register  Offset */
 
 #define USBHS_DEVEPTISR_TXINI_Pos           0                                              /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Position */
 #define USBHS_DEVEPTISR_TXINI_Msk           (_U_(0x1) << USBHS_DEVEPTISR_TXINI_Pos)        /**< (USBHS_DEVEPTISR) Transmitted IN Data Interrupt Mask */
@@ -1282,21 +1344,9 @@ typedef union {
 #define USBHS_DEVEPTISR_RXOUTI_Pos          1                                              /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Position */
 #define USBHS_DEVEPTISR_RXOUTI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_RXOUTI_Pos)       /**< (USBHS_DEVEPTISR) Received OUT Data Interrupt Mask */
 #define USBHS_DEVEPTISR_RXOUTI              USBHS_DEVEPTISR_RXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXOUTI_Msk instead */
-#define USBHS_DEVEPTISR_RXSTPI_Pos          2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
-#define USBHS_DEVEPTISR_RXSTPI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_RXSTPI_Pos)       /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
-#define USBHS_DEVEPTISR_RXSTPI              USBHS_DEVEPTISR_RXSTPI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RXSTPI_Msk instead */
-#define USBHS_DEVEPTISR_NAKOUTI_Pos         3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
-#define USBHS_DEVEPTISR_NAKOUTI_Msk         (_U_(0x1) << USBHS_DEVEPTISR_NAKOUTI_Pos)      /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
-#define USBHS_DEVEPTISR_NAKOUTI             USBHS_DEVEPTISR_NAKOUTI_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKOUTI_Msk instead */
-#define USBHS_DEVEPTISR_NAKINI_Pos          4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
-#define USBHS_DEVEPTISR_NAKINI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_NAKINI_Pos)       /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
-#define USBHS_DEVEPTISR_NAKINI              USBHS_DEVEPTISR_NAKINI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_NAKINI_Msk instead */
 #define USBHS_DEVEPTISR_OVERFI_Pos          5                                              /**< (USBHS_DEVEPTISR) Overflow Interrupt Position */
 #define USBHS_DEVEPTISR_OVERFI_Msk          (_U_(0x1) << USBHS_DEVEPTISR_OVERFI_Pos)       /**< (USBHS_DEVEPTISR) Overflow Interrupt Mask */
 #define USBHS_DEVEPTISR_OVERFI              USBHS_DEVEPTISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_OVERFI_Msk instead */
-#define USBHS_DEVEPTISR_STALLEDI_Pos        6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
-#define USBHS_DEVEPTISR_STALLEDI_Msk        (_U_(0x1) << USBHS_DEVEPTISR_STALLEDI_Pos)     /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
-#define USBHS_DEVEPTISR_STALLEDI            USBHS_DEVEPTISR_STALLEDI_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_STALLEDI_Msk instead */
 #define USBHS_DEVEPTISR_SHORTPACKET_Pos     7                                              /**< (USBHS_DEVEPTISR) Short Packet Interrupt Position */
 #define USBHS_DEVEPTISR_SHORTPACKET_Msk     (_U_(0x1) << USBHS_DEVEPTISR_SHORTPACKET_Pos)  /**< (USBHS_DEVEPTISR) Short Packet Interrupt Mask */
 #define USBHS_DEVEPTISR_SHORTPACKET         USBHS_DEVEPTISR_SHORTPACKET_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_SHORTPACKET_Msk instead */
@@ -1334,38 +1384,147 @@ typedef union {
 #define USBHS_DEVEPTISR_RWALL_Pos           16                                             /**< (USBHS_DEVEPTISR) Read/Write Allowed Position */
 #define USBHS_DEVEPTISR_RWALL_Msk           (_U_(0x1) << USBHS_DEVEPTISR_RWALL_Pos)        /**< (USBHS_DEVEPTISR) Read/Write Allowed Mask */
 #define USBHS_DEVEPTISR_RWALL               USBHS_DEVEPTISR_RWALL_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_RWALL_Msk instead */
-#define USBHS_DEVEPTISR_CTRLDIR_Pos         17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
-#define USBHS_DEVEPTISR_CTRLDIR_Msk         (_U_(0x1) << USBHS_DEVEPTISR_CTRLDIR_Pos)      /**< (USBHS_DEVEPTISR) Control Direction Mask */
-#define USBHS_DEVEPTISR_CTRLDIR             USBHS_DEVEPTISR_CTRLDIR_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRLDIR_Msk instead */
 #define USBHS_DEVEPTISR_CFGOK_Pos           18                                             /**< (USBHS_DEVEPTISR) Configuration OK Status Position */
 #define USBHS_DEVEPTISR_CFGOK_Msk           (_U_(0x1) << USBHS_DEVEPTISR_CFGOK_Pos)        /**< (USBHS_DEVEPTISR) Configuration OK Status Mask */
 #define USBHS_DEVEPTISR_CFGOK               USBHS_DEVEPTISR_CFGOK_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CFGOK_Msk instead */
 #define USBHS_DEVEPTISR_BYCT_Pos            20                                             /**< (USBHS_DEVEPTISR) Byte Count Position */
 #define USBHS_DEVEPTISR_BYCT_Msk            (_U_(0x7FF) << USBHS_DEVEPTISR_BYCT_Pos)       /**< (USBHS_DEVEPTISR) Byte Count Mask */
 #define USBHS_DEVEPTISR_BYCT(value)         (USBHS_DEVEPTISR_BYCT_Msk & ((value) << USBHS_DEVEPTISR_BYCT_Pos))
-#define USBHS_DEVEPTISR_MASK                _U_(0x7FF7F3FF)                                /**< \deprecated (USBHS_DEVEPTISR) Register MASK  (Use USBHS_DEVEPTISR_Msk instead)  */
-#define USBHS_DEVEPTISR_Msk                 _U_(0x7FF7F3FF)                                /**< (USBHS_DEVEPTISR) Register Mask  */
+#define USBHS_DEVEPTISR_MASK                _U_(0x7FF5F3A3)                                /**< \deprecated (USBHS_DEVEPTISR) Register MASK  (Use USBHS_DEVEPTISR_Msk instead)  */
+#define USBHS_DEVEPTISR_Msk                 _U_(0x7FF5F3A3)                                /**< (USBHS_DEVEPTISR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI_Pos     2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_CTRL_RXSTPI_Pos)  /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_RXSTPI         USBHS_DEVEPTISR_CTRL_RXSTPI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI_Pos    3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk    (_U_(0x1) << USBHS_DEVEPTISR_CTRL_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_NAKOUTI        USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_NAKINI_Pos     4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_NAKINI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_CTRL_NAKINI_Pos)  /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_NAKINI         USBHS_DEVEPTISR_CTRL_NAKINI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI_Pos   6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_CTRL_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_CTRL_STALLEDI       USBHS_DEVEPTISR_CTRL_STALLEDI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR_Pos    17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk    (_U_(0x1) << USBHS_DEVEPTISR_CTRL_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_CTRL_CTRLDIR        USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_CTRL_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_CTRL_MASK           _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_CTRL) Register MASK  (Use USBHS_DEVEPTISR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTISR_CTRL_Msk            _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTISR_ISO_UNDERFI_Pos     2                                              /**< (USBHS_DEVEPTISR) Underflow Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_UNDERFI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_ISO_UNDERFI_Pos)  /**< (USBHS_DEVEPTISR) Underflow Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_UNDERFI         USBHS_DEVEPTISR_ISO_UNDERFI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_UNDERFI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI_Pos 3                                              /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Underflow Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk (_U_(0x1) << USBHS_DEVEPTISR_ISO_HBISOINERRI_Pos)  /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Underflow Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_HBISOINERRI     USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_HBISOINERRI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Pos 4                                              /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Flush Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk (_U_(0x1) << USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Pos)  /**< (USBHS_DEVEPTISR) High Bandwidth Isochronous IN Flush Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_HBISOFLUSHI     USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_HBISOFLUSHI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_CRCERRI_Pos     6                                              /**< (USBHS_DEVEPTISR) CRC Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_CRCERRI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_ISO_CRCERRI_Pos)  /**< (USBHS_DEVEPTISR) CRC Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_CRCERRI         USBHS_DEVEPTISR_ISO_CRCERRI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_CRCERRI_Msk instead */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS_Pos  10                                             /**< (USBHS_DEVEPTISR) High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt Position */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk  (_U_(0x1) << USBHS_DEVEPTISR_ISO_ERRORTRANS_Pos)  /**< (USBHS_DEVEPTISR) High-bandwidth Isochronous OUT Endpoint Transaction Error Interrupt Mask */
+#define USBHS_DEVEPTISR_ISO_ERRORTRANS      USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_ISO_ERRORTRANS_Msk instead */
+#define USBHS_DEVEPTISR_ISO_MASK            _U_(0x45C)                                     /**< \deprecated (USBHS_DEVEPTISR_ISO) Register MASK  (Use USBHS_DEVEPTISR_ISO_Msk instead)  */
+#define USBHS_DEVEPTISR_ISO_Msk             _U_(0x45C)                                     /**< (USBHS_DEVEPTISR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTISR_BLK_RXSTPI_Pos      2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_RXSTPI_Msk      (_U_(0x1) << USBHS_DEVEPTISR_BLK_RXSTPI_Pos)   /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_RXSTPI          USBHS_DEVEPTISR_BLK_RXSTPI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI_Pos     3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI_Msk     (_U_(0x1) << USBHS_DEVEPTISR_BLK_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_NAKOUTI         USBHS_DEVEPTISR_BLK_NAKOUTI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_NAKINI_Pos      4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_NAKINI_Msk      (_U_(0x1) << USBHS_DEVEPTISR_BLK_NAKINI_Pos)   /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_NAKINI          USBHS_DEVEPTISR_BLK_NAKINI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_STALLEDI_Pos    6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_BLK_STALLEDI_Msk    (_U_(0x1) << USBHS_DEVEPTISR_BLK_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_BLK_STALLEDI        USBHS_DEVEPTISR_BLK_STALLEDI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR_Pos     17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR_Msk     (_U_(0x1) << USBHS_DEVEPTISR_BLK_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_BLK_CTRLDIR         USBHS_DEVEPTISR_BLK_CTRLDIR_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_BLK_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_BLK_MASK            _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_BLK) Register MASK  (Use USBHS_DEVEPTISR_BLK_Msk instead)  */
+#define USBHS_DEVEPTISR_BLK_Msk             _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI_Pos   2                                              /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_RXSTPI_Pos)  /**< (USBHS_DEVEPTISR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_RXSTPI       USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_RXSTPI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI_Pos  3                                              /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk  (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_NAKOUTI_Pos)  /**< (USBHS_DEVEPTISR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_NAKOUTI      USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_NAKOUTI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI_Pos   4                                              /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI_Msk   (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_NAKINI_Pos)  /**< (USBHS_DEVEPTISR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_NAKINI       USBHS_DEVEPTISR_INTRPT_NAKINI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_NAKINI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI_Pos 6                                              /**< (USBHS_DEVEPTISR) STALLed Interrupt Position */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_STALLEDI_Pos)  /**< (USBHS_DEVEPTISR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTISR_INTRPT_STALLEDI     USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_STALLEDI_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR_Pos  17                                             /**< (USBHS_DEVEPTISR) Control Direction Position */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk  (_U_(0x1) << USBHS_DEVEPTISR_INTRPT_CTRLDIR_Pos)  /**< (USBHS_DEVEPTISR) Control Direction Mask */
+#define USBHS_DEVEPTISR_INTRPT_CTRLDIR      USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTISR_INTRPT_CTRLDIR_Msk instead */
+#define USBHS_DEVEPTISR_INTRPT_MASK         _U_(0x2005C)                                   /**< \deprecated (USBHS_DEVEPTISR_INTRPT) Register MASK  (Use USBHS_DEVEPTISR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTISR_INTRPT_Msk          _U_(0x2005C)                                   /**< (USBHS_DEVEPTISR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTICR : (USBHS Offset: 0x160) (/W 32) Device Endpoint Clear Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTICR : (USBHS Offset: 0x160) (/W 32) Device Endpoint Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINIC:1;                  /**< bit:      0  Transmitted IN Data Interrupt Clear      */
     uint32_t RXOUTIC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
-    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
-    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
-    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
-    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETC:1;            /**< bit:      7  Short Packet Interrupt Clear             */
     uint32_t :24;                       /**< bit:  8..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t HBISOINERRIC:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Clear */
+    uint32_t HBISOFLUSHIC:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Clear */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRIC:1;                /**< bit:      6  CRC Error Interrupt Clear                */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTIC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINIC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTICR_OFFSET              (0x160)                                       /**<  (USBHS_DEVEPTICR) Device Endpoint Clear Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTICR_OFFSET              (0x160)                                       /**<  (USBHS_DEVEPTICR) Device Endpoint Interrupt Clear Register  Offset */
 
 #define USBHS_DEVEPTICR_TXINIC_Pos          0                                              /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Position */
 #define USBHS_DEVEPTICR_TXINIC_Msk          (_U_(0x1) << USBHS_DEVEPTICR_TXINIC_Pos)       /**< (USBHS_DEVEPTICR) Transmitted IN Data Interrupt Clear Mask */
@@ -1373,49 +1532,137 @@ typedef union {
 #define USBHS_DEVEPTICR_RXOUTIC_Pos         1                                              /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Position */
 #define USBHS_DEVEPTICR_RXOUTIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_RXOUTIC_Pos)      /**< (USBHS_DEVEPTICR) Received OUT Data Interrupt Clear Mask */
 #define USBHS_DEVEPTICR_RXOUTIC             USBHS_DEVEPTICR_RXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXOUTIC_Msk instead */
-#define USBHS_DEVEPTICR_RXSTPIC_Pos         2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
-#define USBHS_DEVEPTICR_RXSTPIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_RXSTPIC_Pos)      /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
-#define USBHS_DEVEPTICR_RXSTPIC             USBHS_DEVEPTICR_RXSTPIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_RXSTPIC_Msk instead */
-#define USBHS_DEVEPTICR_NAKOUTIC_Pos        3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
-#define USBHS_DEVEPTICR_NAKOUTIC_Msk        (_U_(0x1) << USBHS_DEVEPTICR_NAKOUTIC_Pos)     /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
-#define USBHS_DEVEPTICR_NAKOUTIC            USBHS_DEVEPTICR_NAKOUTIC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKOUTIC_Msk instead */
-#define USBHS_DEVEPTICR_NAKINIC_Pos         4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
-#define USBHS_DEVEPTICR_NAKINIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_NAKINIC_Pos)      /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
-#define USBHS_DEVEPTICR_NAKINIC             USBHS_DEVEPTICR_NAKINIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_NAKINIC_Msk instead */
 #define USBHS_DEVEPTICR_OVERFIC_Pos         5                                              /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Position */
 #define USBHS_DEVEPTICR_OVERFIC_Msk         (_U_(0x1) << USBHS_DEVEPTICR_OVERFIC_Pos)      /**< (USBHS_DEVEPTICR) Overflow Interrupt Clear Mask */
 #define USBHS_DEVEPTICR_OVERFIC             USBHS_DEVEPTICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_OVERFIC_Msk instead */
-#define USBHS_DEVEPTICR_STALLEDIC_Pos       6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
-#define USBHS_DEVEPTICR_STALLEDIC_Msk       (_U_(0x1) << USBHS_DEVEPTICR_STALLEDIC_Pos)    /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
-#define USBHS_DEVEPTICR_STALLEDIC           USBHS_DEVEPTICR_STALLEDIC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_STALLEDIC_Msk instead */
 #define USBHS_DEVEPTICR_SHORTPACKETC_Pos    7                                              /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Position */
 #define USBHS_DEVEPTICR_SHORTPACKETC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_SHORTPACKETC_Pos)  /**< (USBHS_DEVEPTICR) Short Packet Interrupt Clear Mask */
 #define USBHS_DEVEPTICR_SHORTPACKETC        USBHS_DEVEPTICR_SHORTPACKETC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_SHORTPACKETC_Msk instead */
-#define USBHS_DEVEPTICR_MASK                _U_(0xFF)                                      /**< \deprecated (USBHS_DEVEPTICR) Register MASK  (Use USBHS_DEVEPTICR_Msk instead)  */
-#define USBHS_DEVEPTICR_Msk                 _U_(0xFF)                                      /**< (USBHS_DEVEPTICR) Register Mask  */
+#define USBHS_DEVEPTICR_MASK                _U_(0xA3)                                      /**< \deprecated (USBHS_DEVEPTICR) Register MASK  (Use USBHS_DEVEPTICR_Msk instead)  */
+#define USBHS_DEVEPTICR_Msk                 _U_(0xA3)                                      /**< (USBHS_DEVEPTICR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC_Pos    2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_CTRL_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_RXSTPIC        USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC_Pos   3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk   (_U_(0x1) << USBHS_DEVEPTICR_CTRL_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_NAKOUTIC       USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC_Pos    4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_CTRL_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_NAKINIC        USBHS_DEVEPTICR_CTRL_NAKINIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC_Pos  6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_CTRL_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_CTRL_STALLEDIC      USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_CTRL_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_CTRL_MASK           _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_CTRL) Register MASK  (Use USBHS_DEVEPTICR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTICR_CTRL_Msk            _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC_Pos    2                                              /**< (USBHS_DEVEPTICR) Underflow Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_ISO_UNDERFIC_Pos)  /**< (USBHS_DEVEPTICR) Underflow Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_UNDERFIC        USBHS_DEVEPTICR_ISO_UNDERFIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_UNDERFIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC_Pos 3                                              /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_ISO_HBISOINERRIC_Pos)  /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_HBISOINERRIC    USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_HBISOINERRIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Pos 4                                              /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Flush Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Pos)  /**< (USBHS_DEVEPTICR) High Bandwidth Isochronous IN Flush Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_HBISOFLUSHIC    USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_HBISOFLUSHIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC_Pos    6                                              /**< (USBHS_DEVEPTICR) CRC Error Interrupt Clear Position */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_ISO_CRCERRIC_Pos)  /**< (USBHS_DEVEPTICR) CRC Error Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_ISO_CRCERRIC        USBHS_DEVEPTICR_ISO_CRCERRIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_ISO_CRCERRIC_Msk instead */
+#define USBHS_DEVEPTICR_ISO_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_ISO) Register MASK  (Use USBHS_DEVEPTICR_ISO_Msk instead)  */
+#define USBHS_DEVEPTICR_ISO_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC_Pos     2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC_Msk     (_U_(0x1) << USBHS_DEVEPTICR_BLK_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_RXSTPIC         USBHS_DEVEPTICR_BLK_RXSTPIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC_Pos    3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk    (_U_(0x1) << USBHS_DEVEPTICR_BLK_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_NAKOUTIC        USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_NAKINIC_Pos     4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_NAKINIC_Msk     (_U_(0x1) << USBHS_DEVEPTICR_BLK_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_NAKINIC         USBHS_DEVEPTICR_BLK_NAKINIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC_Pos   6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC_Msk   (_U_(0x1) << USBHS_DEVEPTICR_BLK_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_BLK_STALLEDIC       USBHS_DEVEPTICR_BLK_STALLEDIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_BLK_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_BLK_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_BLK) Register MASK  (Use USBHS_DEVEPTICR_BLK_Msk instead)  */
+#define USBHS_DEVEPTICR_BLK_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC_Pos  2                                              /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_RXSTPIC_Pos)  /**< (USBHS_DEVEPTICR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_RXSTPIC      USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_RXSTPIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Pos 3                                              /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_NAKOUTIC     USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_NAKOUTIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC_Pos  4                                              /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk  (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_NAKINIC_Pos)  /**< (USBHS_DEVEPTICR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_NAKINIC      USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_NAKINIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC_Pos 6                                              /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk (_U_(0x1) << USBHS_DEVEPTICR_INTRPT_STALLEDIC_Pos)  /**< (USBHS_DEVEPTICR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTICR_INTRPT_STALLEDIC    USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTICR_INTRPT_STALLEDIC_Msk instead */
+#define USBHS_DEVEPTICR_INTRPT_MASK         _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTICR_INTRPT) Register MASK  (Use USBHS_DEVEPTICR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTICR_INTRPT_Msk          _U_(0x5C)                                      /**< (USBHS_DEVEPTICR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTIFR : (USBHS Offset: 0x190) (/W 32) Device Endpoint Set Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTIFR : (USBHS Offset: 0x190) (/W 32) Device Endpoint Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINIS:1;                  /**< bit:      0  Transmitted IN Data Interrupt Set        */
     uint32_t RXOUTIS:1;                 /**< bit:      1  Received OUT Data Interrupt Set          */
-    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
-    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
-    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
-    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETS:1;            /**< bit:      7  Short Packet Interrupt Set               */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Interrupt Set       */
     uint32_t :19;                       /**< bit: 13..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t HBISOINERRIS:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Set */
+    uint32_t HBISOFLUSHIS:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Set */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRIS:1;                /**< bit:      6  CRC Error Interrupt Set                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPIS:1;                 /**< bit:      2  Received SETUP Interrupt Set             */
+    uint32_t NAKOUTIS:1;                /**< bit:      3  NAKed OUT Interrupt Set                  */
+    uint32_t NAKINIS:1;                 /**< bit:      4  NAKed IN Interrupt Set                   */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDIS:1;               /**< bit:      6  STALLed Interrupt Set                    */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTIFR_OFFSET              (0x190)                                       /**<  (USBHS_DEVEPTIFR) Device Endpoint Set Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTIFR_OFFSET              (0x190)                                       /**<  (USBHS_DEVEPTIFR) Device Endpoint Interrupt Set Register  Offset */
 
 #define USBHS_DEVEPTIFR_TXINIS_Pos          0                                              /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Position */
 #define USBHS_DEVEPTIFR_TXINIS_Msk          (_U_(0x1) << USBHS_DEVEPTIFR_TXINIS_Pos)       /**< (USBHS_DEVEPTIFR) Transmitted IN Data Interrupt Set Mask */
@@ -1423,42 +1670,93 @@ typedef union {
 #define USBHS_DEVEPTIFR_RXOUTIS_Pos         1                                              /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Position */
 #define USBHS_DEVEPTIFR_RXOUTIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_RXOUTIS_Pos)      /**< (USBHS_DEVEPTIFR) Received OUT Data Interrupt Set Mask */
 #define USBHS_DEVEPTIFR_RXOUTIS             USBHS_DEVEPTIFR_RXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXOUTIS_Msk instead */
-#define USBHS_DEVEPTIFR_RXSTPIS_Pos         2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
-#define USBHS_DEVEPTIFR_RXSTPIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_RXSTPIS_Pos)      /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
-#define USBHS_DEVEPTIFR_RXSTPIS             USBHS_DEVEPTIFR_RXSTPIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_RXSTPIS_Msk instead */
-#define USBHS_DEVEPTIFR_NAKOUTIS_Pos        3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
-#define USBHS_DEVEPTIFR_NAKOUTIS_Msk        (_U_(0x1) << USBHS_DEVEPTIFR_NAKOUTIS_Pos)     /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
-#define USBHS_DEVEPTIFR_NAKOUTIS            USBHS_DEVEPTIFR_NAKOUTIS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKOUTIS_Msk instead */
-#define USBHS_DEVEPTIFR_NAKINIS_Pos         4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
-#define USBHS_DEVEPTIFR_NAKINIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_NAKINIS_Pos)      /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
-#define USBHS_DEVEPTIFR_NAKINIS             USBHS_DEVEPTIFR_NAKINIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NAKINIS_Msk instead */
 #define USBHS_DEVEPTIFR_OVERFIS_Pos         5                                              /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Position */
 #define USBHS_DEVEPTIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_DEVEPTIFR_OVERFIS_Pos)      /**< (USBHS_DEVEPTIFR) Overflow Interrupt Set Mask */
 #define USBHS_DEVEPTIFR_OVERFIS             USBHS_DEVEPTIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_OVERFIS_Msk instead */
-#define USBHS_DEVEPTIFR_STALLEDIS_Pos       6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
-#define USBHS_DEVEPTIFR_STALLEDIS_Msk       (_U_(0x1) << USBHS_DEVEPTIFR_STALLEDIS_Pos)    /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
-#define USBHS_DEVEPTIFR_STALLEDIS           USBHS_DEVEPTIFR_STALLEDIS_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_STALLEDIS_Msk instead */
 #define USBHS_DEVEPTIFR_SHORTPACKETS_Pos    7                                              /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Position */
 #define USBHS_DEVEPTIFR_SHORTPACKETS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_SHORTPACKETS_Pos)  /**< (USBHS_DEVEPTIFR) Short Packet Interrupt Set Mask */
 #define USBHS_DEVEPTIFR_SHORTPACKETS        USBHS_DEVEPTIFR_SHORTPACKETS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_SHORTPACKETS_Msk instead */
 #define USBHS_DEVEPTIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Position */
 #define USBHS_DEVEPTIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_DEVEPTIFR_NBUSYBKS_Pos)     /**< (USBHS_DEVEPTIFR) Number of Busy Banks Interrupt Set Mask */
 #define USBHS_DEVEPTIFR_NBUSYBKS            USBHS_DEVEPTIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_NBUSYBKS_Msk instead */
-#define USBHS_DEVEPTIFR_MASK                _U_(0x10FF)                                    /**< \deprecated (USBHS_DEVEPTIFR) Register MASK  (Use USBHS_DEVEPTIFR_Msk instead)  */
-#define USBHS_DEVEPTIFR_Msk                 _U_(0x10FF)                                    /**< (USBHS_DEVEPTIFR) Register Mask  */
+#define USBHS_DEVEPTIFR_MASK                _U_(0x10A3)                                    /**< \deprecated (USBHS_DEVEPTIFR) Register MASK  (Use USBHS_DEVEPTIFR_Msk instead)  */
+#define USBHS_DEVEPTIFR_Msk                 _U_(0x10A3)                                    /**< (USBHS_DEVEPTIFR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS_Pos    2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_RXSTPIS        USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Pos   3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk   (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_NAKOUTIS       USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS_Pos    4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_NAKINIS        USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS_Pos  6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_CTRL_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_CTRL_STALLEDIS      USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_CTRL_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_CTRL_MASK           _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_CTRL) Register MASK  (Use USBHS_DEVEPTIFR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIFR_CTRL_Msk            _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS_Pos    2                                              /**< (USBHS_DEVEPTIFR) Underflow Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_ISO_UNDERFIS_Pos)  /**< (USBHS_DEVEPTIFR) Underflow Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_UNDERFIS        USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_UNDERFIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Pos 3                                              /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Underflow Error Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Pos)  /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Underflow Error Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_HBISOINERRIS    USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_HBISOINERRIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Pos 4                                              /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Flush Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Pos)  /**< (USBHS_DEVEPTIFR) High Bandwidth Isochronous IN Flush Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS    USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_HBISOFLUSHIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS_Pos    6                                              /**< (USBHS_DEVEPTIFR) CRC Error Interrupt Set Position */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_ISO_CRCERRIS_Pos)  /**< (USBHS_DEVEPTIFR) CRC Error Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_ISO_CRCERRIS        USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_ISO_CRCERRIS_Msk instead */
+#define USBHS_DEVEPTIFR_ISO_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_ISO) Register MASK  (Use USBHS_DEVEPTIFR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIFR_ISO_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS_Pos     2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk     (_U_(0x1) << USBHS_DEVEPTIFR_BLK_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_RXSTPIS         USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS_Pos    3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk    (_U_(0x1) << USBHS_DEVEPTIFR_BLK_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_NAKOUTIS        USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS_Pos     4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS_Msk     (_U_(0x1) << USBHS_DEVEPTIFR_BLK_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_NAKINIS         USBHS_DEVEPTIFR_BLK_NAKINIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS_Pos   6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk   (_U_(0x1) << USBHS_DEVEPTIFR_BLK_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_BLK_STALLEDIS       USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_BLK_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_BLK_MASK            _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_BLK) Register MASK  (Use USBHS_DEVEPTIFR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIFR_BLK_Msk             _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Pos  2                                              /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Pos)  /**< (USBHS_DEVEPTIFR) Received SETUP Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_RXSTPIS      USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_RXSTPIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Pos 3                                              /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed OUT Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_NAKOUTIS     USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_NAKOUTIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS_Pos  4                                              /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk  (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_NAKINIS_Pos)  /**< (USBHS_DEVEPTIFR) NAKed IN Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_NAKINIS      USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_NAKINIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Pos 6                                              /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Position */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk (_U_(0x1) << USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Pos)  /**< (USBHS_DEVEPTIFR) STALLed Interrupt Set Mask */
+#define USBHS_DEVEPTIFR_INTRPT_STALLEDIS    USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIFR_INTRPT_STALLEDIS_Msk instead */
+#define USBHS_DEVEPTIFR_INTRPT_MASK         _U_(0x5C)                                      /**< \deprecated (USBHS_DEVEPTIFR_INTRPT) Register MASK  (Use USBHS_DEVEPTIFR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIFR_INTRPT_Msk          _U_(0x5C)                                      /**< (USBHS_DEVEPTIFR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTIMR : (USBHS Offset: 0x1c0) (R/ 32) Device Endpoint Mask Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTIMR : (USBHS Offset: 0x1c0) (R/ 32) Device Endpoint Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINE:1;                   /**< bit:      0  Transmitted IN Data Interrupt            */
     uint32_t RXOUTE:1;                  /**< bit:      1  Received OUT Data Interrupt              */
-    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
-    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
-    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFE:1;                  /**< bit:      5  Overflow Interrupt                       */
-    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETE:1;            /**< bit:      7  Short Packet Interrupt                   */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt           */
@@ -1466,16 +1764,68 @@ typedef union {
     uint32_t FIFOCON:1;                 /**< bit:     14  FIFO Control                             */
     uint32_t :1;                        /**< bit:     15  Reserved */
     uint32_t EPDISHDMA:1;               /**< bit:     16  Endpoint Interrupts Disable HDMA Request */
-    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     17  Reserved */
     uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
     uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
     uint32_t :12;                       /**< bit: 20..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFE:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t HBISOINERRE:1;             /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt */
+    uint32_t HBISOFLUSHE:1;             /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRE:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDATAE:1;                  /**< bit:      8  MData Interrupt                          */
+    uint32_t DATAXE:1;                  /**< bit:      9  DataX Interrupt                          */
+    uint32_t ERRORTRANSE:1;             /**< bit:     10  Transaction Error Interrupt              */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPE:1;                  /**< bit:      2  Received SETUP Interrupt                 */
+    uint32_t NAKOUTE:1;                 /**< bit:      3  NAKed OUT Interrupt                      */
+    uint32_t NAKINE:1;                  /**< bit:      4  NAKed IN Interrupt                       */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDE:1;                /**< bit:      6  STALLed Interrupt                        */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDIS:1;                 /**< bit:     17  NYET Token Disable                       */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQ:1;                 /**< bit:     19  STALL Request                            */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTIMR_OFFSET              (0x1C0)                                       /**<  (USBHS_DEVEPTIMR) Device Endpoint Mask Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTIMR_OFFSET              (0x1C0)                                       /**<  (USBHS_DEVEPTIMR) Device Endpoint Interrupt Mask Register  Offset */
 
 #define USBHS_DEVEPTIMR_TXINE_Pos           0                                              /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Position */
 #define USBHS_DEVEPTIMR_TXINE_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_TXINE_Pos)        /**< (USBHS_DEVEPTIMR) Transmitted IN Data Interrupt Mask */
@@ -1483,21 +1833,9 @@ typedef union {
 #define USBHS_DEVEPTIMR_RXOUTE_Pos          1                                              /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Position */
 #define USBHS_DEVEPTIMR_RXOUTE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_RXOUTE_Pos)       /**< (USBHS_DEVEPTIMR) Received OUT Data Interrupt Mask */
 #define USBHS_DEVEPTIMR_RXOUTE              USBHS_DEVEPTIMR_RXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXOUTE_Msk instead */
-#define USBHS_DEVEPTIMR_RXSTPE_Pos          2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
-#define USBHS_DEVEPTIMR_RXSTPE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_RXSTPE_Pos)       /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
-#define USBHS_DEVEPTIMR_RXSTPE              USBHS_DEVEPTIMR_RXSTPE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RXSTPE_Msk instead */
-#define USBHS_DEVEPTIMR_NAKOUTE_Pos         3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
-#define USBHS_DEVEPTIMR_NAKOUTE_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_NAKOUTE_Pos)      /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
-#define USBHS_DEVEPTIMR_NAKOUTE             USBHS_DEVEPTIMR_NAKOUTE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKOUTE_Msk instead */
-#define USBHS_DEVEPTIMR_NAKINE_Pos          4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
-#define USBHS_DEVEPTIMR_NAKINE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_NAKINE_Pos)       /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
-#define USBHS_DEVEPTIMR_NAKINE              USBHS_DEVEPTIMR_NAKINE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NAKINE_Msk instead */
 #define USBHS_DEVEPTIMR_OVERFE_Pos          5                                              /**< (USBHS_DEVEPTIMR) Overflow Interrupt Position */
 #define USBHS_DEVEPTIMR_OVERFE_Msk          (_U_(0x1) << USBHS_DEVEPTIMR_OVERFE_Pos)       /**< (USBHS_DEVEPTIMR) Overflow Interrupt Mask */
 #define USBHS_DEVEPTIMR_OVERFE              USBHS_DEVEPTIMR_OVERFE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_OVERFE_Msk instead */
-#define USBHS_DEVEPTIMR_STALLEDE_Pos        6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
-#define USBHS_DEVEPTIMR_STALLEDE_Msk        (_U_(0x1) << USBHS_DEVEPTIMR_STALLEDE_Pos)     /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
-#define USBHS_DEVEPTIMR_STALLEDE            USBHS_DEVEPTIMR_STALLEDE_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLEDE_Msk instead */
 #define USBHS_DEVEPTIMR_SHORTPACKETE_Pos    7                                              /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Position */
 #define USBHS_DEVEPTIMR_SHORTPACKETE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_SHORTPACKETE_Pos)  /**< (USBHS_DEVEPTIMR) Short Packet Interrupt Mask */
 #define USBHS_DEVEPTIMR_SHORTPACKETE        USBHS_DEVEPTIMR_SHORTPACKETE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_SHORTPACKETE_Msk instead */
@@ -1513,30 +1851,114 @@ typedef union {
 #define USBHS_DEVEPTIMR_EPDISHDMA_Pos       16                                             /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Position */
 #define USBHS_DEVEPTIMR_EPDISHDMA_Msk       (_U_(0x1) << USBHS_DEVEPTIMR_EPDISHDMA_Pos)    /**< (USBHS_DEVEPTIMR) Endpoint Interrupts Disable HDMA Request Mask */
 #define USBHS_DEVEPTIMR_EPDISHDMA           USBHS_DEVEPTIMR_EPDISHDMA_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_EPDISHDMA_Msk instead */
-#define USBHS_DEVEPTIMR_NYETDIS_Pos         17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
-#define USBHS_DEVEPTIMR_NYETDIS_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_NYETDIS_Pos)      /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
-#define USBHS_DEVEPTIMR_NYETDIS             USBHS_DEVEPTIMR_NYETDIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_NYETDIS_Msk instead */
 #define USBHS_DEVEPTIMR_RSTDT_Pos           18                                             /**< (USBHS_DEVEPTIMR) Reset Data Toggle Position */
 #define USBHS_DEVEPTIMR_RSTDT_Msk           (_U_(0x1) << USBHS_DEVEPTIMR_RSTDT_Pos)        /**< (USBHS_DEVEPTIMR) Reset Data Toggle Mask */
 #define USBHS_DEVEPTIMR_RSTDT               USBHS_DEVEPTIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_RSTDT_Msk instead */
-#define USBHS_DEVEPTIMR_STALLRQ_Pos         19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
-#define USBHS_DEVEPTIMR_STALLRQ_Msk         (_U_(0x1) << USBHS_DEVEPTIMR_STALLRQ_Pos)      /**< (USBHS_DEVEPTIMR) STALL Request Mask */
-#define USBHS_DEVEPTIMR_STALLRQ             USBHS_DEVEPTIMR_STALLRQ_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_STALLRQ_Msk instead */
-#define USBHS_DEVEPTIMR_MASK                _U_(0xF70FF)                                   /**< \deprecated (USBHS_DEVEPTIMR) Register MASK  (Use USBHS_DEVEPTIMR_Msk instead)  */
-#define USBHS_DEVEPTIMR_Msk                 _U_(0xF70FF)                                   /**< (USBHS_DEVEPTIMR) Register Mask  */
+#define USBHS_DEVEPTIMR_MASK                _U_(0x570A3)                                   /**< \deprecated (USBHS_DEVEPTIMR) Register MASK  (Use USBHS_DEVEPTIMR_Msk instead)  */
+#define USBHS_DEVEPTIMR_Msk                 _U_(0x570A3)                                   /**< (USBHS_DEVEPTIMR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE_Pos     2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_RXSTPE_Pos)  /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_RXSTPE         USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE_Pos    3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_NAKOUTE        USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE_Pos     4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NAKINE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_NAKINE         USBHS_DEVEPTIMR_CTRL_NAKINE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE_Pos   6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_CTRL_STALLEDE       USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS_Pos    17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_CTRL_NYETDIS        USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ_Pos    19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_CTRL_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_CTRL_STALLRQ        USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_CTRL_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_CTRL) Register MASK  (Use USBHS_DEVEPTIMR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIMR_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE_Pos     2                                              /**< (USBHS_DEVEPTIMR) Underflow Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_ISO_UNDERFE_Pos)  /**< (USBHS_DEVEPTIMR) Underflow Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_UNDERFE         USBHS_DEVEPTIMR_ISO_UNDERFE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_UNDERFE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE_Pos 3                                              /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Underflow Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_HBISOINERRE_Pos)  /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Underflow Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_HBISOINERRE     USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_HBISOINERRE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Pos 4                                              /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Flush Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Pos)  /**< (USBHS_DEVEPTIMR) High Bandwidth Isochronous IN Flush Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_HBISOFLUSHE     USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_HBISOFLUSHE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE_Pos     6                                              /**< (USBHS_DEVEPTIMR) CRC Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_ISO_CRCERRE_Pos)  /**< (USBHS_DEVEPTIMR) CRC Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_CRCERRE         USBHS_DEVEPTIMR_ISO_CRCERRE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_CRCERRE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_MDATAE_Pos      8                                              /**< (USBHS_DEVEPTIMR) MData Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_MDATAE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_ISO_MDATAE_Pos)   /**< (USBHS_DEVEPTIMR) MData Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_MDATAE          USBHS_DEVEPTIMR_ISO_MDATAE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_MDATAE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_DATAXE_Pos      9                                              /**< (USBHS_DEVEPTIMR) DataX Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_DATAXE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_ISO_DATAXE_Pos)   /**< (USBHS_DEVEPTIMR) DataX Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_DATAXE          USBHS_DEVEPTIMR_ISO_DATAXE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_DATAXE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Pos 10                                             /**< (USBHS_DEVEPTIMR) Transaction Error Interrupt Position */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Pos)  /**< (USBHS_DEVEPTIMR) Transaction Error Interrupt Mask */
+#define USBHS_DEVEPTIMR_ISO_ERRORTRANSE     USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_ISO_ERRORTRANSE_Msk instead */
+#define USBHS_DEVEPTIMR_ISO_MASK            _U_(0x75C)                                     /**< \deprecated (USBHS_DEVEPTIMR_ISO) Register MASK  (Use USBHS_DEVEPTIMR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIMR_ISO_Msk             _U_(0x75C)                                     /**< (USBHS_DEVEPTIMR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE_Pos      2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_BLK_RXSTPE_Pos)   /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_RXSTPE          USBHS_DEVEPTIMR_BLK_RXSTPE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE_Pos     3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_NAKOUTE         USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NAKINE_Pos      4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_NAKINE_Msk      (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NAKINE_Pos)   /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_NAKINE          USBHS_DEVEPTIMR_BLK_NAKINE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE_Pos    6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE_Msk    (_U_(0x1) << USBHS_DEVEPTIMR_BLK_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_BLK_STALLEDE        USBHS_DEVEPTIMR_BLK_STALLEDE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS_Pos     17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_BLK_NYETDIS         USBHS_DEVEPTIMR_BLK_NYETDIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ_Pos     19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ_Msk     (_U_(0x1) << USBHS_DEVEPTIMR_BLK_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_BLK_STALLRQ         USBHS_DEVEPTIMR_BLK_STALLRQ_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_BLK_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_BLK) Register MASK  (Use USBHS_DEVEPTIMR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIMR_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE_Pos   2                                              /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_RXSTPE_Pos)  /**< (USBHS_DEVEPTIMR) Received SETUP Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_RXSTPE       USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_RXSTPE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Pos  3                                              /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed OUT Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NAKOUTE      USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NAKOUTE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE_Pos   4                                              /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk   (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NAKINE_Pos)  /**< (USBHS_DEVEPTIMR) NAKed IN Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NAKINE       USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NAKINE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE_Pos 6                                              /**< (USBHS_DEVEPTIMR) STALLed Interrupt Position */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_STALLEDE_Pos)  /**< (USBHS_DEVEPTIMR) STALLed Interrupt Mask */
+#define USBHS_DEVEPTIMR_INTRPT_STALLEDE     USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_STALLEDE_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS_Pos  17                                             /**< (USBHS_DEVEPTIMR) NYET Token Disable Position */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_NYETDIS_Pos)  /**< (USBHS_DEVEPTIMR) NYET Token Disable Mask */
+#define USBHS_DEVEPTIMR_INTRPT_NYETDIS      USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_NYETDIS_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ_Pos  19                                             /**< (USBHS_DEVEPTIMR) STALL Request Position */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk  (_U_(0x1) << USBHS_DEVEPTIMR_INTRPT_STALLRQ_Pos)  /**< (USBHS_DEVEPTIMR) STALL Request Mask */
+#define USBHS_DEVEPTIMR_INTRPT_STALLRQ      USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIMR_INTRPT_STALLRQ_Msk instead */
+#define USBHS_DEVEPTIMR_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIMR_INTRPT) Register MASK  (Use USBHS_DEVEPTIMR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIMR_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIMR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTIER : (USBHS Offset: 0x1f0) (/W 32) Device Endpoint Enable Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTIER : (USBHS Offset: 0x1f0) (/W 32) Device Endpoint Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINES:1;                  /**< bit:      0  Transmitted IN Data Interrupt Enable     */
     uint32_t RXOUTES:1;                 /**< bit:      1  Received OUT Data Interrupt Enable       */
-    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
-    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
-    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFES:1;                 /**< bit:      5  Overflow Interrupt Enable                */
-    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETES:1;           /**< bit:      7  Short Packet Interrupt Enable            */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Interrupt Enable    */
@@ -1544,16 +1966,68 @@ typedef union {
     uint32_t FIFOCONS:1;                /**< bit:     14  FIFO Control                             */
     uint32_t :1;                        /**< bit:     15  Reserved */
     uint32_t EPDISHDMAS:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Enable */
-    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     17  Reserved */
     uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
+    uint32_t :13;                       /**< bit: 19..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
     uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
     uint32_t :12;                       /**< bit: 20..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFES:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t HBISOINERRES:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Enable */
+    uint32_t HBISOFLUSHES:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Enable */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t CRCERRES:1;                /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :1;                        /**< bit:      7  Reserved */
+    uint32_t MDATAES:1;                 /**< bit:      8  MData Interrupt Enable                   */
+    uint32_t DATAXES:1;                 /**< bit:      9  DataX Interrupt Enable                   */
+    uint32_t ERRORTRANSES:1;            /**< bit:     10  Transaction Error Interrupt Enable       */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPES:1;                 /**< bit:      2  Received SETUP Interrupt Enable          */
+    uint32_t NAKOUTES:1;                /**< bit:      3  NAKed OUT Interrupt Enable               */
+    uint32_t NAKINES:1;                 /**< bit:      4  NAKed IN Interrupt Enable                */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDES:1;               /**< bit:      6  STALLed Interrupt Enable                 */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISS:1;                /**< bit:     17  NYET Token Disable Enable                */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQS:1;                /**< bit:     19  STALL Request Enable                     */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTIER_OFFSET              (0x1F0)                                       /**<  (USBHS_DEVEPTIER) Device Endpoint Enable Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTIER_OFFSET              (0x1F0)                                       /**<  (USBHS_DEVEPTIER) Device Endpoint Interrupt Enable Register  Offset */
 
 #define USBHS_DEVEPTIER_TXINES_Pos          0                                              /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Position */
 #define USBHS_DEVEPTIER_TXINES_Msk          (_U_(0x1) << USBHS_DEVEPTIER_TXINES_Pos)       /**< (USBHS_DEVEPTIER) Transmitted IN Data Interrupt Enable Mask */
@@ -1561,21 +2035,9 @@ typedef union {
 #define USBHS_DEVEPTIER_RXOUTES_Pos         1                                              /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Position */
 #define USBHS_DEVEPTIER_RXOUTES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_RXOUTES_Pos)      /**< (USBHS_DEVEPTIER) Received OUT Data Interrupt Enable Mask */
 #define USBHS_DEVEPTIER_RXOUTES             USBHS_DEVEPTIER_RXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXOUTES_Msk instead */
-#define USBHS_DEVEPTIER_RXSTPES_Pos         2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
-#define USBHS_DEVEPTIER_RXSTPES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_RXSTPES_Pos)      /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
-#define USBHS_DEVEPTIER_RXSTPES             USBHS_DEVEPTIER_RXSTPES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RXSTPES_Msk instead */
-#define USBHS_DEVEPTIER_NAKOUTES_Pos        3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
-#define USBHS_DEVEPTIER_NAKOUTES_Msk        (_U_(0x1) << USBHS_DEVEPTIER_NAKOUTES_Pos)     /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
-#define USBHS_DEVEPTIER_NAKOUTES            USBHS_DEVEPTIER_NAKOUTES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKOUTES_Msk instead */
-#define USBHS_DEVEPTIER_NAKINES_Pos         4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
-#define USBHS_DEVEPTIER_NAKINES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_NAKINES_Pos)      /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
-#define USBHS_DEVEPTIER_NAKINES             USBHS_DEVEPTIER_NAKINES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NAKINES_Msk instead */
 #define USBHS_DEVEPTIER_OVERFES_Pos         5                                              /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Position */
 #define USBHS_DEVEPTIER_OVERFES_Msk         (_U_(0x1) << USBHS_DEVEPTIER_OVERFES_Pos)      /**< (USBHS_DEVEPTIER) Overflow Interrupt Enable Mask */
 #define USBHS_DEVEPTIER_OVERFES             USBHS_DEVEPTIER_OVERFES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_OVERFES_Msk instead */
-#define USBHS_DEVEPTIER_STALLEDES_Pos       6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
-#define USBHS_DEVEPTIER_STALLEDES_Msk       (_U_(0x1) << USBHS_DEVEPTIER_STALLEDES_Pos)    /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
-#define USBHS_DEVEPTIER_STALLEDES           USBHS_DEVEPTIER_STALLEDES_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLEDES_Msk instead */
 #define USBHS_DEVEPTIER_SHORTPACKETES_Pos   7                                              /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Position */
 #define USBHS_DEVEPTIER_SHORTPACKETES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_SHORTPACKETES_Pos)  /**< (USBHS_DEVEPTIER) Short Packet Interrupt Enable Mask */
 #define USBHS_DEVEPTIER_SHORTPACKETES       USBHS_DEVEPTIER_SHORTPACKETES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_SHORTPACKETES_Msk instead */
@@ -1591,30 +2053,114 @@ typedef union {
 #define USBHS_DEVEPTIER_EPDISHDMAS_Pos      16                                             /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Position */
 #define USBHS_DEVEPTIER_EPDISHDMAS_Msk      (_U_(0x1) << USBHS_DEVEPTIER_EPDISHDMAS_Pos)   /**< (USBHS_DEVEPTIER) Endpoint Interrupts Disable HDMA Request Enable Mask */
 #define USBHS_DEVEPTIER_EPDISHDMAS          USBHS_DEVEPTIER_EPDISHDMAS_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_EPDISHDMAS_Msk instead */
-#define USBHS_DEVEPTIER_NYETDISS_Pos        17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
-#define USBHS_DEVEPTIER_NYETDISS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_NYETDISS_Pos)     /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
-#define USBHS_DEVEPTIER_NYETDISS            USBHS_DEVEPTIER_NYETDISS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_NYETDISS_Msk instead */
 #define USBHS_DEVEPTIER_RSTDTS_Pos          18                                             /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Position */
 #define USBHS_DEVEPTIER_RSTDTS_Msk          (_U_(0x1) << USBHS_DEVEPTIER_RSTDTS_Pos)       /**< (USBHS_DEVEPTIER) Reset Data Toggle Enable Mask */
 #define USBHS_DEVEPTIER_RSTDTS              USBHS_DEVEPTIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_RSTDTS_Msk instead */
-#define USBHS_DEVEPTIER_STALLRQS_Pos        19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
-#define USBHS_DEVEPTIER_STALLRQS_Msk        (_U_(0x1) << USBHS_DEVEPTIER_STALLRQS_Pos)     /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
-#define USBHS_DEVEPTIER_STALLRQS            USBHS_DEVEPTIER_STALLRQS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_STALLRQS_Msk instead */
-#define USBHS_DEVEPTIER_MASK                _U_(0xF70FF)                                   /**< \deprecated (USBHS_DEVEPTIER) Register MASK  (Use USBHS_DEVEPTIER_Msk instead)  */
-#define USBHS_DEVEPTIER_Msk                 _U_(0xF70FF)                                   /**< (USBHS_DEVEPTIER) Register Mask  */
+#define USBHS_DEVEPTIER_MASK                _U_(0x570A3)                                   /**< \deprecated (USBHS_DEVEPTIER) Register MASK  (Use USBHS_DEVEPTIER_Msk instead)  */
+#define USBHS_DEVEPTIER_Msk                 _U_(0x570A3)                                   /**< (USBHS_DEVEPTIER) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES_Pos    2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_CTRL_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_RXSTPES        USBHS_DEVEPTIER_CTRL_RXSTPES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES_Pos   3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NAKOUTES       USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NAKINES_Pos    4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NAKINES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NAKINES        USBHS_DEVEPTIER_CTRL_NAKINES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES_Pos  6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_CTRL_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_STALLEDES      USBHS_DEVEPTIER_CTRL_STALLEDES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS_Pos   17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_NYETDISS       USBHS_DEVEPTIER_CTRL_NYETDISS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS_Pos   19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS_Msk   (_U_(0x1) << USBHS_DEVEPTIER_CTRL_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_CTRL_STALLRQS       USBHS_DEVEPTIER_CTRL_STALLRQS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_CTRL_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_CTRL) Register MASK  (Use USBHS_DEVEPTIER_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIER_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIER_ISO_UNDERFES_Pos    2                                              /**< (USBHS_DEVEPTIER) Underflow Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_UNDERFES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_ISO_UNDERFES_Pos)  /**< (USBHS_DEVEPTIER) Underflow Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_UNDERFES        USBHS_DEVEPTIER_ISO_UNDERFES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_UNDERFES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES_Pos 3                                              /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Underflow Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_HBISOINERRES_Pos)  /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Underflow Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_HBISOINERRES    USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_HBISOINERRES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Pos 4                                              /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Flush Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Pos)  /**< (USBHS_DEVEPTIER) High Bandwidth Isochronous IN Flush Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_HBISOFLUSHES    USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_HBISOFLUSHES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_CRCERRES_Pos    6                                              /**< (USBHS_DEVEPTIER) CRC Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_CRCERRES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_ISO_CRCERRES_Pos)  /**< (USBHS_DEVEPTIER) CRC Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_CRCERRES        USBHS_DEVEPTIER_ISO_CRCERRES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_CRCERRES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_MDATAES_Pos     8                                              /**< (USBHS_DEVEPTIER) MData Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_MDATAES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_ISO_MDATAES_Pos)  /**< (USBHS_DEVEPTIER) MData Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_MDATAES         USBHS_DEVEPTIER_ISO_MDATAES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_MDATAES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_DATAXES_Pos     9                                              /**< (USBHS_DEVEPTIER) DataX Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_DATAXES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_ISO_DATAXES_Pos)  /**< (USBHS_DEVEPTIER) DataX Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_DATAXES         USBHS_DEVEPTIER_ISO_DATAXES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_DATAXES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES_Pos 10                                             /**< (USBHS_DEVEPTIER) Transaction Error Interrupt Enable Position */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk (_U_(0x1) << USBHS_DEVEPTIER_ISO_ERRORTRANSES_Pos)  /**< (USBHS_DEVEPTIER) Transaction Error Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_ISO_ERRORTRANSES    USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_ISO_ERRORTRANSES_Msk instead */
+#define USBHS_DEVEPTIER_ISO_MASK            _U_(0x75C)                                     /**< \deprecated (USBHS_DEVEPTIER_ISO) Register MASK  (Use USBHS_DEVEPTIER_ISO_Msk instead)  */
+#define USBHS_DEVEPTIER_ISO_Msk             _U_(0x75C)                                     /**< (USBHS_DEVEPTIER_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIER_BLK_RXSTPES_Pos     2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_RXSTPES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_BLK_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_RXSTPES         USBHS_DEVEPTIER_BLK_RXSTPES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES_Pos    3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NAKOUTES        USBHS_DEVEPTIER_BLK_NAKOUTES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NAKINES_Pos     4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_NAKINES_Msk     (_U_(0x1) << USBHS_DEVEPTIER_BLK_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NAKINES         USBHS_DEVEPTIER_BLK_NAKINES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_STALLEDES_Pos   6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_BLK_STALLEDES_Msk   (_U_(0x1) << USBHS_DEVEPTIER_BLK_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_BLK_STALLEDES       USBHS_DEVEPTIER_BLK_STALLEDES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_BLK_NYETDISS_Pos    17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_BLK_NYETDISS_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_BLK_NYETDISS        USBHS_DEVEPTIER_BLK_NYETDISS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_BLK_STALLRQS_Pos    19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_BLK_STALLRQS_Msk    (_U_(0x1) << USBHS_DEVEPTIER_BLK_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_BLK_STALLRQS        USBHS_DEVEPTIER_BLK_STALLRQS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_BLK_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_BLK) Register MASK  (Use USBHS_DEVEPTIER_BLK_Msk instead)  */
+#define USBHS_DEVEPTIER_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES_Pos  2                                              /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_RXSTPES_Pos)  /**< (USBHS_DEVEPTIER) Received SETUP Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_RXSTPES      USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_RXSTPES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES_Pos 3                                              /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NAKOUTES_Pos)  /**< (USBHS_DEVEPTIER) NAKed OUT Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NAKOUTES     USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NAKOUTES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES_Pos  4                                              /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES_Msk  (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NAKINES_Pos)  /**< (USBHS_DEVEPTIER) NAKed IN Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NAKINES      USBHS_DEVEPTIER_INTRPT_NAKINES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NAKINES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES_Pos 6                                              /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_STALLEDES_Pos)  /**< (USBHS_DEVEPTIER) STALLed Interrupt Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_STALLEDES    USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_STALLEDES_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS_Pos 17                                             /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_NYETDISS_Pos)  /**< (USBHS_DEVEPTIER) NYET Token Disable Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_NYETDISS     USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_NYETDISS_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS_Pos 19                                             /**< (USBHS_DEVEPTIER) STALL Request Enable Position */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk (_U_(0x1) << USBHS_DEVEPTIER_INTRPT_STALLRQS_Pos)  /**< (USBHS_DEVEPTIER) STALL Request Enable Mask */
+#define USBHS_DEVEPTIER_INTRPT_STALLRQS     USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIER_INTRPT_STALLRQS_Msk instead */
+#define USBHS_DEVEPTIER_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIER_INTRPT) Register MASK  (Use USBHS_DEVEPTIER_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIER_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIER_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_DEVEPTIDR : (USBHS Offset: 0x220) (/W 32) Device Endpoint Disable Register (n = 0) 0 -------- */
+/* -------- USBHS_DEVEPTIDR : (USBHS Offset: 0x220) (/W 32) Device Endpoint Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TXINEC:1;                  /**< bit:      0  Transmitted IN Interrupt Clear           */
     uint32_t RXOUTEC:1;                 /**< bit:      1  Received OUT Data Interrupt Clear        */
-    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
-    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
-    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :3;                        /**< bit:   2..4  Reserved */
     uint32_t OVERFEC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
-    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETEC:1;           /**< bit:      7  Shortpacket Interrupt Clear              */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Interrupt Clear     */
@@ -1622,16 +2168,64 @@ typedef union {
     uint32_t FIFOCONC:1;                /**< bit:     14  FIFO Control Clear                       */
     uint32_t :1;                        /**< bit:     15  Reserved */
     uint32_t EPDISHDMAC:1;              /**< bit:     16  Endpoint Interrupts Disable HDMA Request Clear */
+    uint32_t :15;                       /**< bit: 17..31  Reserved */
+  } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
     uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
     uint32_t :1;                        /**< bit:     18  Reserved */
     uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
     uint32_t :12;                       /**< bit: 20..31  Reserved */
-  } bit;                                /**< Structure used for bit  access */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFEC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t HBISOINERREC:1;            /**< bit:      3  High Bandwidth Isochronous IN Underflow Error Interrupt Clear */
+    uint32_t HBISOFLUSHEC:1;            /**< bit:      4  High Bandwidth Isochronous IN Flush Interrupt Clear */
+    uint32_t :3;                        /**< bit:   5..7  Reserved */
+    uint32_t MDATAEC:1;                 /**< bit:      8  MData Interrupt Clear                    */
+    uint32_t DATAXEC:1;                 /**< bit:      9  DataX Interrupt Clear                    */
+    uint32_t ERRORTRANSEC:1;            /**< bit:     10  Transaction Error Interrupt Clear        */
+    uint32_t :21;                       /**< bit: 11..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t RXSTPEC:1;                 /**< bit:      2  Received SETUP Interrupt Clear           */
+    uint32_t NAKOUTEC:1;                /**< bit:      3  NAKed OUT Interrupt Clear                */
+    uint32_t NAKINEC:1;                 /**< bit:      4  NAKed IN Interrupt Clear                 */
+    uint32_t :1;                        /**< bit:      5  Reserved */
+    uint32_t STALLEDEC:1;               /**< bit:      6  STALLed Interrupt Clear                  */
+    uint32_t :10;                       /**< bit:  7..16  Reserved */
+    uint32_t NYETDISC:1;                /**< bit:     17  NYET Token Disable Clear                 */
+    uint32_t :1;                        /**< bit:     18  Reserved */
+    uint32_t STALLRQC:1;                /**< bit:     19  STALL Request Clear                      */
+    uint32_t :12;                       /**< bit: 20..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_DEVEPTIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_DEVEPTIDR_OFFSET              (0x220)                                       /**<  (USBHS_DEVEPTIDR) Device Endpoint Disable Register (n = 0) 0  Offset */
+#define USBHS_DEVEPTIDR_OFFSET              (0x220)                                       /**<  (USBHS_DEVEPTIDR) Device Endpoint Interrupt Disable Register  Offset */
 
 #define USBHS_DEVEPTIDR_TXINEC_Pos          0                                              /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Position */
 #define USBHS_DEVEPTIDR_TXINEC_Msk          (_U_(0x1) << USBHS_DEVEPTIDR_TXINEC_Pos)       /**< (USBHS_DEVEPTIDR) Transmitted IN Interrupt Clear Mask */
@@ -1639,21 +2233,9 @@ typedef union {
 #define USBHS_DEVEPTIDR_RXOUTEC_Pos         1                                              /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Position */
 #define USBHS_DEVEPTIDR_RXOUTEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_RXOUTEC_Pos)      /**< (USBHS_DEVEPTIDR) Received OUT Data Interrupt Clear Mask */
 #define USBHS_DEVEPTIDR_RXOUTEC             USBHS_DEVEPTIDR_RXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXOUTEC_Msk instead */
-#define USBHS_DEVEPTIDR_RXSTPEC_Pos         2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
-#define USBHS_DEVEPTIDR_RXSTPEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_RXSTPEC_Pos)      /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
-#define USBHS_DEVEPTIDR_RXSTPEC             USBHS_DEVEPTIDR_RXSTPEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_RXSTPEC_Msk instead */
-#define USBHS_DEVEPTIDR_NAKOUTEC_Pos        3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
-#define USBHS_DEVEPTIDR_NAKOUTEC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_NAKOUTEC_Pos)     /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
-#define USBHS_DEVEPTIDR_NAKOUTEC            USBHS_DEVEPTIDR_NAKOUTEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKOUTEC_Msk instead */
-#define USBHS_DEVEPTIDR_NAKINEC_Pos         4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
-#define USBHS_DEVEPTIDR_NAKINEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_NAKINEC_Pos)      /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
-#define USBHS_DEVEPTIDR_NAKINEC             USBHS_DEVEPTIDR_NAKINEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NAKINEC_Msk instead */
 #define USBHS_DEVEPTIDR_OVERFEC_Pos         5                                              /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Position */
 #define USBHS_DEVEPTIDR_OVERFEC_Msk         (_U_(0x1) << USBHS_DEVEPTIDR_OVERFEC_Pos)      /**< (USBHS_DEVEPTIDR) Overflow Interrupt Clear Mask */
 #define USBHS_DEVEPTIDR_OVERFEC             USBHS_DEVEPTIDR_OVERFEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_OVERFEC_Msk instead */
-#define USBHS_DEVEPTIDR_STALLEDEC_Pos       6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
-#define USBHS_DEVEPTIDR_STALLEDEC_Msk       (_U_(0x1) << USBHS_DEVEPTIDR_STALLEDEC_Pos)    /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
-#define USBHS_DEVEPTIDR_STALLEDEC           USBHS_DEVEPTIDR_STALLEDEC_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLEDEC_Msk instead */
 #define USBHS_DEVEPTIDR_SHORTPACKETEC_Pos   7                                              /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Position */
 #define USBHS_DEVEPTIDR_SHORTPACKETEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_SHORTPACKETEC_Pos)  /**< (USBHS_DEVEPTIDR) Shortpacket Interrupt Clear Mask */
 #define USBHS_DEVEPTIDR_SHORTPACKETEC       USBHS_DEVEPTIDR_SHORTPACKETEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_SHORTPACKETEC_Msk instead */
@@ -1666,18 +2248,101 @@ typedef union {
 #define USBHS_DEVEPTIDR_EPDISHDMAC_Pos      16                                             /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Position */
 #define USBHS_DEVEPTIDR_EPDISHDMAC_Msk      (_U_(0x1) << USBHS_DEVEPTIDR_EPDISHDMAC_Pos)   /**< (USBHS_DEVEPTIDR) Endpoint Interrupts Disable HDMA Request Clear Mask */
 #define USBHS_DEVEPTIDR_EPDISHDMAC          USBHS_DEVEPTIDR_EPDISHDMAC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_EPDISHDMAC_Msk instead */
-#define USBHS_DEVEPTIDR_NYETDISC_Pos        17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
-#define USBHS_DEVEPTIDR_NYETDISC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_NYETDISC_Pos)     /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
-#define USBHS_DEVEPTIDR_NYETDISC            USBHS_DEVEPTIDR_NYETDISC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_NYETDISC_Msk instead */
-#define USBHS_DEVEPTIDR_STALLRQC_Pos        19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
-#define USBHS_DEVEPTIDR_STALLRQC_Msk        (_U_(0x1) << USBHS_DEVEPTIDR_STALLRQC_Pos)     /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
-#define USBHS_DEVEPTIDR_STALLRQC            USBHS_DEVEPTIDR_STALLRQC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_STALLRQC_Msk instead */
-#define USBHS_DEVEPTIDR_MASK                _U_(0xB50FF)                                   /**< \deprecated (USBHS_DEVEPTIDR) Register MASK  (Use USBHS_DEVEPTIDR_Msk instead)  */
-#define USBHS_DEVEPTIDR_Msk                 _U_(0xB50FF)                                   /**< (USBHS_DEVEPTIDR) Register Mask  */
+#define USBHS_DEVEPTIDR_MASK                _U_(0x150A3)                                   /**< \deprecated (USBHS_DEVEPTIDR) Register MASK  (Use USBHS_DEVEPTIDR_Msk instead)  */
+#define USBHS_DEVEPTIDR_Msk                 _U_(0x150A3)                                   /**< (USBHS_DEVEPTIDR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC_Pos    2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_RXSTPEC        USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Pos   3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NAKOUTEC       USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC_Pos    4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NAKINEC        USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC_Pos  6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_STALLEDEC      USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC_Pos   17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_NYETDISC       USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC_Pos   19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_CTRL_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_CTRL_STALLRQC       USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_CTRL_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_CTRL_MASK           _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_CTRL) Register MASK  (Use USBHS_DEVEPTIDR_CTRL_Msk instead)  */
+#define USBHS_DEVEPTIDR_CTRL_Msk            _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC_Pos    2                                              /**< (USBHS_DEVEPTIDR) Underflow Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_ISO_UNDERFEC_Pos)  /**< (USBHS_DEVEPTIDR) Underflow Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_UNDERFEC        USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_UNDERFEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC_Pos 3                                              /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_HBISOINERREC_Pos)  /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Underflow Error Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_HBISOINERREC    USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_HBISOINERREC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Pos 4                                              /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Flush Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Pos)  /**< (USBHS_DEVEPTIDR) High Bandwidth Isochronous IN Flush Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC    USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_HBISOFLUSHEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC_Pos     8                                              /**< (USBHS_DEVEPTIDR) MData Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_ISO_MDATAEC_Pos)  /**< (USBHS_DEVEPTIDR) MData Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_MDATAEC         USBHS_DEVEPTIDR_ISO_MDATAEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_MDATAEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC_Pos     9                                              /**< (USBHS_DEVEPTIDR) DataX Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_ISO_DATAXEC_Pos)  /**< (USBHS_DEVEPTIDR) DataX Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_DATAXEC         USBHS_DEVEPTIDR_ISO_DATAXEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_DATAXEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Pos 10                                             /**< (USBHS_DEVEPTIDR) Transaction Error Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Pos)  /**< (USBHS_DEVEPTIDR) Transaction Error Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_ISO_ERRORTRANSEC    USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_ISO_ERRORTRANSEC_Msk instead */
+#define USBHS_DEVEPTIDR_ISO_MASK            _U_(0x71C)                                     /**< \deprecated (USBHS_DEVEPTIDR_ISO) Register MASK  (Use USBHS_DEVEPTIDR_ISO_Msk instead)  */
+#define USBHS_DEVEPTIDR_ISO_Msk             _U_(0x71C)                                     /**< (USBHS_DEVEPTIDR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC_Pos     2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_BLK_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_RXSTPEC         USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC_Pos    3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NAKOUTEC        USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC_Pos     4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC_Msk     (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NAKINEC         USBHS_DEVEPTIDR_BLK_NAKINEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC_Pos   6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk   (_U_(0x1) << USBHS_DEVEPTIDR_BLK_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_STALLEDEC       USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC_Pos    17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_NYETDISC        USBHS_DEVEPTIDR_BLK_NYETDISC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC_Pos    19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC_Msk    (_U_(0x1) << USBHS_DEVEPTIDR_BLK_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_BLK_STALLRQC        USBHS_DEVEPTIDR_BLK_STALLRQC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_BLK_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_BLK_MASK            _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_BLK) Register MASK  (Use USBHS_DEVEPTIDR_BLK_Msk instead)  */
+#define USBHS_DEVEPTIDR_BLK_Msk             _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Pos  2                                              /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Pos)  /**< (USBHS_DEVEPTIDR) Received SETUP Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_RXSTPEC      USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_RXSTPEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Pos 3                                              /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed OUT Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NAKOUTEC     USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NAKOUTEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC_Pos  4                                              /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk  (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NAKINEC_Pos)  /**< (USBHS_DEVEPTIDR) NAKed IN Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NAKINEC      USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NAKINEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Pos 6                                              /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Pos)  /**< (USBHS_DEVEPTIDR) STALLed Interrupt Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_STALLEDEC    USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_STALLEDEC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC_Pos 17                                             /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_NYETDISC_Pos)  /**< (USBHS_DEVEPTIDR) NYET Token Disable Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_NYETDISC     USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_NYETDISC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC_Pos 19                                             /**< (USBHS_DEVEPTIDR) STALL Request Clear Position */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk (_U_(0x1) << USBHS_DEVEPTIDR_INTRPT_STALLRQC_Pos)  /**< (USBHS_DEVEPTIDR) STALL Request Clear Mask */
+#define USBHS_DEVEPTIDR_INTRPT_STALLRQC     USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_DEVEPTIDR_INTRPT_STALLRQC_Msk instead */
+#define USBHS_DEVEPTIDR_INTRPT_MASK         _U_(0xA005C)                                   /**< \deprecated (USBHS_DEVEPTIDR_INTRPT) Register MASK  (Use USBHS_DEVEPTIDR_INTRPT_Msk instead)  */
+#define USBHS_DEVEPTIDR_INTRPT_Msk          _U_(0xA005C)                                   /**< (USBHS_DEVEPTIDR_INTRPT) Register Mask  */
 
 
 /* -------- USBHS_HSTCTRL : (USBHS Offset: 0x400) (R/W 32) Host General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
@@ -1690,6 +2355,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTCTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTCTRL_OFFSET                (0x400)                                       /**<  (USBHS_HSTCTRL) Host General Control Register  Offset */
@@ -1708,14 +2374,19 @@ typedef union {
 #define USBHS_HSTCTRL_SPDCONF(value)        (USBHS_HSTCTRL_SPDCONF_Msk & ((value) << USBHS_HSTCTRL_SPDCONF_Pos))
 #define   USBHS_HSTCTRL_SPDCONF_NORMAL_Val  _U_(0x0)                                       /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable.  */
 #define   USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val _U_(0x1)                                       /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed.  */
+#define   USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val _U_(0x2)                                       /**< (USBHS_HSTCTRL) Forced high speed.  */
+#define   USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val _U_(0x3)                                       /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability.  */
 #define USBHS_HSTCTRL_SPDCONF_NORMAL        (USBHS_HSTCTRL_SPDCONF_NORMAL_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host starts in Full-speed mode and performs a high-speed reset to switch to High-speed mode if the downstream peripheral is high-speed capable. Position  */
 #define USBHS_HSTCTRL_SPDCONF_LOW_POWER     (USBHS_HSTCTRL_SPDCONF_LOW_POWER_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) For a better consumption, if high speed is not needed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_HIGH_SPEED    (USBHS_HSTCTRL_SPDCONF_HIGH_SPEED_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) Forced high speed. Position  */
+#define USBHS_HSTCTRL_SPDCONF_FORCED_FS     (USBHS_HSTCTRL_SPDCONF_FORCED_FS_Val << USBHS_HSTCTRL_SPDCONF_Pos)  /**< (USBHS_HSTCTRL) The host remains in Full-speed mode whatever the peripheral speed capability. Position  */
 #define USBHS_HSTCTRL_MASK                  _U_(0x3700)                                    /**< \deprecated (USBHS_HSTCTRL) Register MASK  (Use USBHS_HSTCTRL_Msk instead)  */
 #define USBHS_HSTCTRL_Msk                   _U_(0x3700)                                    /**< (USBHS_HSTCTRL) Register Mask  */
 
 
 /* -------- USBHS_HSTISR : (USBHS Offset: 0x404) (R/ 32) Host Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNI:1;                  /**< bit:      0  Device Connection Interrupt              */
@@ -1736,25 +2407,24 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt                         */
     uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt                         */
     uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt                         */
-    uint32_t PEP_10:1;                  /**< bit:     18  Pipe 10 Interrupt                        */
-    uint32_t PEP_11:1;                  /**< bit:     19  Pipe 11 Interrupt                        */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt                  */
-    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt                  */
-    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt                  */
-    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt                  */
-    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt                  */
-    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt                  */
-    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt                  */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt                  */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt                  */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt                  */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt                  */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt                  */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt                  */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PEP_:12;                   /**< bit:  8..19  Pipe x Interrupt                         */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt                  */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt                         */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt                  */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTISR_OFFSET                 (0x404)                                       /**<  (USBHS_HSTISR) Host Global Interrupt Status Register  Offset */
@@ -1810,45 +2480,40 @@ typedef union {
 #define USBHS_HSTISR_PEP_9_Pos              17                                             /**< (USBHS_HSTISR) Pipe 9 Interrupt Position */
 #define USBHS_HSTISR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTISR_PEP_9_Pos)           /**< (USBHS_HSTISR) Pipe 9 Interrupt Mask */
 #define USBHS_HSTISR_PEP_9                  USBHS_HSTISR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_9_Msk instead */
-#define USBHS_HSTISR_PEP_10_Pos             18                                             /**< (USBHS_HSTISR) Pipe 10 Interrupt Position */
-#define USBHS_HSTISR_PEP_10_Msk             (_U_(0x1) << USBHS_HSTISR_PEP_10_Pos)          /**< (USBHS_HSTISR) Pipe 10 Interrupt Mask */
-#define USBHS_HSTISR_PEP_10                 USBHS_HSTISR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_10_Msk instead */
-#define USBHS_HSTISR_PEP_11_Pos             19                                             /**< (USBHS_HSTISR) Pipe 11 Interrupt Position */
-#define USBHS_HSTISR_PEP_11_Msk             (_U_(0x1) << USBHS_HSTISR_PEP_11_Pos)          /**< (USBHS_HSTISR) Pipe 11 Interrupt Mask */
-#define USBHS_HSTISR_PEP_11                 USBHS_HSTISR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_PEP_11_Msk instead */
-#define USBHS_HSTISR_DMA_1_Pos              25                                             /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Position */
+#define USBHS_HSTISR_DMA_0_Pos              25                                             /**< (USBHS_HSTISR) DMA Channel 0 Interrupt Position */
+#define USBHS_HSTISR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_0_Pos)           /**< (USBHS_HSTISR) DMA Channel 0 Interrupt Mask */
+#define USBHS_HSTISR_DMA_0                  USBHS_HSTISR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_0_Msk instead */
+#define USBHS_HSTISR_DMA_1_Pos              26                                             /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Position */
 #define USBHS_HSTISR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_1_Pos)           /**< (USBHS_HSTISR) DMA Channel 1 Interrupt Mask */
 #define USBHS_HSTISR_DMA_1                  USBHS_HSTISR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_1_Msk instead */
-#define USBHS_HSTISR_DMA_2_Pos              26                                             /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Position */
+#define USBHS_HSTISR_DMA_2_Pos              27                                             /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Position */
 #define USBHS_HSTISR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_2_Pos)           /**< (USBHS_HSTISR) DMA Channel 2 Interrupt Mask */
 #define USBHS_HSTISR_DMA_2                  USBHS_HSTISR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_2_Msk instead */
-#define USBHS_HSTISR_DMA_3_Pos              27                                             /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Position */
+#define USBHS_HSTISR_DMA_3_Pos              28                                             /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Position */
 #define USBHS_HSTISR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_3_Pos)           /**< (USBHS_HSTISR) DMA Channel 3 Interrupt Mask */
 #define USBHS_HSTISR_DMA_3                  USBHS_HSTISR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_3_Msk instead */
-#define USBHS_HSTISR_DMA_4_Pos              28                                             /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Position */
+#define USBHS_HSTISR_DMA_4_Pos              29                                             /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Position */
 #define USBHS_HSTISR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_4_Pos)           /**< (USBHS_HSTISR) DMA Channel 4 Interrupt Mask */
 #define USBHS_HSTISR_DMA_4                  USBHS_HSTISR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_4_Msk instead */
-#define USBHS_HSTISR_DMA_5_Pos              29                                             /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Position */
+#define USBHS_HSTISR_DMA_5_Pos              30                                             /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Position */
 #define USBHS_HSTISR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_5_Pos)           /**< (USBHS_HSTISR) DMA Channel 5 Interrupt Mask */
 #define USBHS_HSTISR_DMA_5                  USBHS_HSTISR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_5_Msk instead */
-#define USBHS_HSTISR_DMA_6_Pos              30                                             /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Position */
+#define USBHS_HSTISR_DMA_6_Pos              31                                             /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Position */
 #define USBHS_HSTISR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_6_Pos)           /**< (USBHS_HSTISR) DMA Channel 6 Interrupt Mask */
 #define USBHS_HSTISR_DMA_6                  USBHS_HSTISR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_6_Msk instead */
-#define USBHS_HSTISR_DMA_7_Pos              31                                             /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Position */
-#define USBHS_HSTISR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTISR_DMA_7_Pos)           /**< (USBHS_HSTISR) DMA Channel 7 Interrupt Mask */
-#define USBHS_HSTISR_DMA_7                  USBHS_HSTISR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTISR_DMA_7_Msk instead */
-#define USBHS_HSTISR_MASK                   _U_(0xFE0FFF7F)                                /**< \deprecated (USBHS_HSTISR) Register MASK  (Use USBHS_HSTISR_Msk instead)  */
-#define USBHS_HSTISR_Msk                    _U_(0xFE0FFF7F)                                /**< (USBHS_HSTISR) Register Mask  */
+#define USBHS_HSTISR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTISR) Register MASK  (Use USBHS_HSTISR_Msk instead)  */
+#define USBHS_HSTISR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTISR) Register Mask  */
 
 #define USBHS_HSTISR_PEP__Pos               8                                              /**< (USBHS_HSTISR Position) Pipe x Interrupt */
-#define USBHS_HSTISR_PEP__Msk               (_U_(0xFFF) << USBHS_HSTISR_PEP__Pos)          /**< (USBHS_HSTISR Mask) PEP_ */
+#define USBHS_HSTISR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTISR_PEP__Pos)          /**< (USBHS_HSTISR Mask) PEP_ */
 #define USBHS_HSTISR_PEP_(value)            (USBHS_HSTISR_PEP__Msk & ((value) << USBHS_HSTISR_PEP__Pos))  
-#define USBHS_HSTISR_DMA__Pos               25                                             /**< (USBHS_HSTISR Position) DMA Channel 7 Interrupt */
+#define USBHS_HSTISR_DMA__Pos               25                                             /**< (USBHS_HSTISR Position) DMA Channel 6 Interrupt */
 #define USBHS_HSTISR_DMA__Msk               (_U_(0x7F) << USBHS_HSTISR_DMA__Pos)           /**< (USBHS_HSTISR Mask) DMA_ */
 #define USBHS_HSTISR_DMA_(value)            (USBHS_HSTISR_DMA__Msk & ((value) << USBHS_HSTISR_DMA__Pos))  
 
 /* -------- USBHS_HSTICR : (USBHS Offset: 0x408) (/W 32) Host Global Interrupt Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIC:1;                 /**< bit:      0  Device Connection Interrupt Clear        */
@@ -1862,6 +2527,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTICR_OFFSET                 (0x408)                                       /**<  (USBHS_HSTICR) Host Global Interrupt Clear Register  Offset */
@@ -1893,6 +2559,7 @@ typedef union {
 
 /* -------- USBHS_HSTIFR : (USBHS Offset: 0x40c) (/W 32) Host Global Interrupt Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIS:1;                 /**< bit:      0  Device Connection Interrupt Set          */
@@ -1903,20 +2570,21 @@ typedef union {
     uint32_t HSOFIS:1;                  /**< bit:      5  Host Start of Frame Interrupt Set        */
     uint32_t HWUPIS:1;                  /**< bit:      6  Host Wake-Up Interrupt Set               */
     uint32_t :18;                       /**< bit:  7..24  Reserved */
-    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Set              */
-    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Set              */
-    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Set              */
-    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Set              */
-    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Set              */
-    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Set              */
-    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Set              */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Set              */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Set              */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Set              */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Set              */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Set              */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Set              */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Set              */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :25;                       /**< bit:  0..24  Reserved */
-    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Set              */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Set              */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIFR_OFFSET                 (0x40C)                                       /**<  (USBHS_HSTIFR) Host Global Interrupt Set Register  Offset */
@@ -1942,36 +2610,37 @@ typedef union {
 #define USBHS_HSTIFR_HWUPIS_Pos             6                                              /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Position */
 #define USBHS_HSTIFR_HWUPIS_Msk             (_U_(0x1) << USBHS_HSTIFR_HWUPIS_Pos)          /**< (USBHS_HSTIFR) Host Wake-Up Interrupt Set Mask */
 #define USBHS_HSTIFR_HWUPIS                 USBHS_HSTIFR_HWUPIS_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_HWUPIS_Msk instead */
-#define USBHS_HSTIFR_DMA_1_Pos              25                                             /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_0_Pos              25                                             /**< (USBHS_HSTIFR) DMA Channel 0 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_0_Pos)           /**< (USBHS_HSTIFR) DMA Channel 0 Interrupt Set Mask */
+#define USBHS_HSTIFR_DMA_0                  USBHS_HSTIFR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_0_Msk instead */
+#define USBHS_HSTIFR_DMA_1_Pos              26                                             /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_1_Pos)           /**< (USBHS_HSTIFR) DMA Channel 1 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_1                  USBHS_HSTIFR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_1_Msk instead */
-#define USBHS_HSTIFR_DMA_2_Pos              26                                             /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_2_Pos              27                                             /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_2_Pos)           /**< (USBHS_HSTIFR) DMA Channel 2 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_2                  USBHS_HSTIFR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_2_Msk instead */
-#define USBHS_HSTIFR_DMA_3_Pos              27                                             /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_3_Pos              28                                             /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_3_Pos)           /**< (USBHS_HSTIFR) DMA Channel 3 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_3                  USBHS_HSTIFR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_3_Msk instead */
-#define USBHS_HSTIFR_DMA_4_Pos              28                                             /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_4_Pos              29                                             /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_4_Pos)           /**< (USBHS_HSTIFR) DMA Channel 4 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_4                  USBHS_HSTIFR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_4_Msk instead */
-#define USBHS_HSTIFR_DMA_5_Pos              29                                             /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_5_Pos              30                                             /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_5_Pos)           /**< (USBHS_HSTIFR) DMA Channel 5 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_5                  USBHS_HSTIFR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_5_Msk instead */
-#define USBHS_HSTIFR_DMA_6_Pos              30                                             /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Position */
+#define USBHS_HSTIFR_DMA_6_Pos              31                                             /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Position */
 #define USBHS_HSTIFR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_6_Pos)           /**< (USBHS_HSTIFR) DMA Channel 6 Interrupt Set Mask */
 #define USBHS_HSTIFR_DMA_6                  USBHS_HSTIFR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_6_Msk instead */
-#define USBHS_HSTIFR_DMA_7_Pos              31                                             /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Position */
-#define USBHS_HSTIFR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIFR_DMA_7_Pos)           /**< (USBHS_HSTIFR) DMA Channel 7 Interrupt Set Mask */
-#define USBHS_HSTIFR_DMA_7                  USBHS_HSTIFR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIFR_DMA_7_Msk instead */
 #define USBHS_HSTIFR_MASK                   _U_(0xFE00007F)                                /**< \deprecated (USBHS_HSTIFR) Register MASK  (Use USBHS_HSTIFR_Msk instead)  */
 #define USBHS_HSTIFR_Msk                    _U_(0xFE00007F)                                /**< (USBHS_HSTIFR) Register Mask  */
 
-#define USBHS_HSTIFR_DMA__Pos               25                                             /**< (USBHS_HSTIFR Position) DMA Channel 7 Interrupt Set */
+#define USBHS_HSTIFR_DMA__Pos               25                                             /**< (USBHS_HSTIFR Position) DMA Channel 6 Interrupt Set */
 #define USBHS_HSTIFR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIFR_DMA__Pos)           /**< (USBHS_HSTIFR Mask) DMA_ */
 #define USBHS_HSTIFR_DMA_(value)            (USBHS_HSTIFR_DMA__Msk & ((value) << USBHS_HSTIFR_DMA__Pos))  
 
 /* -------- USBHS_HSTIMR : (USBHS Offset: 0x410) (R/ 32) Host Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIE:1;                 /**< bit:      0  Device Connection Interrupt Enable       */
@@ -1992,25 +2661,24 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
     uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
     uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
-    uint32_t PEP_10:1;                  /**< bit:     18  Pipe 10 Interrupt Enable                 */
-    uint32_t PEP_11:1;                  /**< bit:     19  Pipe 11 Interrupt Enable                 */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
-    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
-    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
-    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
-    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
-    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
-    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Enable           */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Enable           */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PEP_:12;                   /**< bit:  8..19  Pipe x Interrupt Enable                  */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Enable           */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIMR_OFFSET                 (0x410)                                       /**<  (USBHS_HSTIMR) Host Global Interrupt Mask Register  Offset */
@@ -2066,45 +2734,40 @@ typedef union {
 #define USBHS_HSTIMR_PEP_9_Pos              17                                             /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Position */
 #define USBHS_HSTIMR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIMR_PEP_9_Pos)           /**< (USBHS_HSTIMR) Pipe 9 Interrupt Enable Mask */
 #define USBHS_HSTIMR_PEP_9                  USBHS_HSTIMR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_9_Msk instead */
-#define USBHS_HSTIMR_PEP_10_Pos             18                                             /**< (USBHS_HSTIMR) Pipe 10 Interrupt Enable Position */
-#define USBHS_HSTIMR_PEP_10_Msk             (_U_(0x1) << USBHS_HSTIMR_PEP_10_Pos)          /**< (USBHS_HSTIMR) Pipe 10 Interrupt Enable Mask */
-#define USBHS_HSTIMR_PEP_10                 USBHS_HSTIMR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_10_Msk instead */
-#define USBHS_HSTIMR_PEP_11_Pos             19                                             /**< (USBHS_HSTIMR) Pipe 11 Interrupt Enable Position */
-#define USBHS_HSTIMR_PEP_11_Msk             (_U_(0x1) << USBHS_HSTIMR_PEP_11_Pos)          /**< (USBHS_HSTIMR) Pipe 11 Interrupt Enable Mask */
-#define USBHS_HSTIMR_PEP_11                 USBHS_HSTIMR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_PEP_11_Msk instead */
-#define USBHS_HSTIMR_DMA_1_Pos              25                                             /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_0_Pos              25                                             /**< (USBHS_HSTIMR) DMA Channel 0 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_0_Pos)           /**< (USBHS_HSTIMR) DMA Channel 0 Interrupt Enable Mask */
+#define USBHS_HSTIMR_DMA_0                  USBHS_HSTIMR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_0_Msk instead */
+#define USBHS_HSTIMR_DMA_1_Pos              26                                             /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_1_Pos)           /**< (USBHS_HSTIMR) DMA Channel 1 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_1                  USBHS_HSTIMR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_1_Msk instead */
-#define USBHS_HSTIMR_DMA_2_Pos              26                                             /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_2_Pos              27                                             /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_2_Pos)           /**< (USBHS_HSTIMR) DMA Channel 2 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_2                  USBHS_HSTIMR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_2_Msk instead */
-#define USBHS_HSTIMR_DMA_3_Pos              27                                             /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_3_Pos              28                                             /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_3_Pos)           /**< (USBHS_HSTIMR) DMA Channel 3 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_3                  USBHS_HSTIMR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_3_Msk instead */
-#define USBHS_HSTIMR_DMA_4_Pos              28                                             /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_4_Pos              29                                             /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_4_Pos)           /**< (USBHS_HSTIMR) DMA Channel 4 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_4                  USBHS_HSTIMR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_4_Msk instead */
-#define USBHS_HSTIMR_DMA_5_Pos              29                                             /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_5_Pos              30                                             /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_5_Pos)           /**< (USBHS_HSTIMR) DMA Channel 5 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_5                  USBHS_HSTIMR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_5_Msk instead */
-#define USBHS_HSTIMR_DMA_6_Pos              30                                             /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIMR_DMA_6_Pos              31                                             /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Position */
 #define USBHS_HSTIMR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_6_Pos)           /**< (USBHS_HSTIMR) DMA Channel 6 Interrupt Enable Mask */
 #define USBHS_HSTIMR_DMA_6                  USBHS_HSTIMR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_6_Msk instead */
-#define USBHS_HSTIMR_DMA_7_Pos              31                                             /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Position */
-#define USBHS_HSTIMR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIMR_DMA_7_Pos)           /**< (USBHS_HSTIMR) DMA Channel 7 Interrupt Enable Mask */
-#define USBHS_HSTIMR_DMA_7                  USBHS_HSTIMR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIMR_DMA_7_Msk instead */
-#define USBHS_HSTIMR_MASK                   _U_(0xFE0FFF7F)                                /**< \deprecated (USBHS_HSTIMR) Register MASK  (Use USBHS_HSTIMR_Msk instead)  */
-#define USBHS_HSTIMR_Msk                    _U_(0xFE0FFF7F)                                /**< (USBHS_HSTIMR) Register Mask  */
+#define USBHS_HSTIMR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIMR) Register MASK  (Use USBHS_HSTIMR_Msk instead)  */
+#define USBHS_HSTIMR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIMR) Register Mask  */
 
 #define USBHS_HSTIMR_PEP__Pos               8                                              /**< (USBHS_HSTIMR Position) Pipe x Interrupt Enable */
-#define USBHS_HSTIMR_PEP__Msk               (_U_(0xFFF) << USBHS_HSTIMR_PEP__Pos)          /**< (USBHS_HSTIMR Mask) PEP_ */
+#define USBHS_HSTIMR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIMR_PEP__Pos)          /**< (USBHS_HSTIMR Mask) PEP_ */
 #define USBHS_HSTIMR_PEP_(value)            (USBHS_HSTIMR_PEP__Msk & ((value) << USBHS_HSTIMR_PEP__Pos))  
-#define USBHS_HSTIMR_DMA__Pos               25                                             /**< (USBHS_HSTIMR Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_HSTIMR_DMA__Pos               25                                             /**< (USBHS_HSTIMR Position) DMA Channel 6 Interrupt Enable */
 #define USBHS_HSTIMR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIMR_DMA__Pos)           /**< (USBHS_HSTIMR Mask) DMA_ */
 #define USBHS_HSTIMR_DMA_(value)            (USBHS_HSTIMR_DMA__Msk & ((value) << USBHS_HSTIMR_DMA__Pos))  
 
 /* -------- USBHS_HSTIDR : (USBHS Offset: 0x414) (/W 32) Host Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIEC:1;                /**< bit:      0  Device Connection Interrupt Disable      */
@@ -2125,25 +2788,24 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Disable                 */
     uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Disable                 */
     uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Disable                 */
-    uint32_t PEP_10:1;                  /**< bit:     18  Pipe 10 Interrupt Disable                */
-    uint32_t PEP_11:1;                  /**< bit:     19  Pipe 11 Interrupt Disable                */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Disable          */
-    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Disable          */
-    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Disable          */
-    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Disable          */
-    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Disable          */
-    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Disable          */
-    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Disable          */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Disable          */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Disable          */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Disable          */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Disable          */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Disable          */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Disable          */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Disable          */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PEP_:12;                   /**< bit:  8..19  Pipe x Interrupt Disable                 */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Disable          */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Disable                 */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Disable          */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIDR_OFFSET                 (0x414)                                       /**<  (USBHS_HSTIDR) Host Global Interrupt Disable Register  Offset */
@@ -2199,45 +2861,40 @@ typedef union {
 #define USBHS_HSTIDR_PEP_9_Pos              17                                             /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Position */
 #define USBHS_HSTIDR_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIDR_PEP_9_Pos)           /**< (USBHS_HSTIDR) Pipe 9 Interrupt Disable Mask */
 #define USBHS_HSTIDR_PEP_9                  USBHS_HSTIDR_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_9_Msk instead */
-#define USBHS_HSTIDR_PEP_10_Pos             18                                             /**< (USBHS_HSTIDR) Pipe 10 Interrupt Disable Position */
-#define USBHS_HSTIDR_PEP_10_Msk             (_U_(0x1) << USBHS_HSTIDR_PEP_10_Pos)          /**< (USBHS_HSTIDR) Pipe 10 Interrupt Disable Mask */
-#define USBHS_HSTIDR_PEP_10                 USBHS_HSTIDR_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_10_Msk instead */
-#define USBHS_HSTIDR_PEP_11_Pos             19                                             /**< (USBHS_HSTIDR) Pipe 11 Interrupt Disable Position */
-#define USBHS_HSTIDR_PEP_11_Msk             (_U_(0x1) << USBHS_HSTIDR_PEP_11_Pos)          /**< (USBHS_HSTIDR) Pipe 11 Interrupt Disable Mask */
-#define USBHS_HSTIDR_PEP_11                 USBHS_HSTIDR_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_PEP_11_Msk instead */
-#define USBHS_HSTIDR_DMA_1_Pos              25                                             /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_0_Pos              25                                             /**< (USBHS_HSTIDR) DMA Channel 0 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_0_Pos)           /**< (USBHS_HSTIDR) DMA Channel 0 Interrupt Disable Mask */
+#define USBHS_HSTIDR_DMA_0                  USBHS_HSTIDR_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_0_Msk instead */
+#define USBHS_HSTIDR_DMA_1_Pos              26                                             /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_1_Pos)           /**< (USBHS_HSTIDR) DMA Channel 1 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_1                  USBHS_HSTIDR_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_1_Msk instead */
-#define USBHS_HSTIDR_DMA_2_Pos              26                                             /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_2_Pos              27                                             /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_2_Pos)           /**< (USBHS_HSTIDR) DMA Channel 2 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_2                  USBHS_HSTIDR_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_2_Msk instead */
-#define USBHS_HSTIDR_DMA_3_Pos              27                                             /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_3_Pos              28                                             /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_3_Pos)           /**< (USBHS_HSTIDR) DMA Channel 3 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_3                  USBHS_HSTIDR_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_3_Msk instead */
-#define USBHS_HSTIDR_DMA_4_Pos              28                                             /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_4_Pos              29                                             /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_4_Pos)           /**< (USBHS_HSTIDR) DMA Channel 4 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_4                  USBHS_HSTIDR_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_4_Msk instead */
-#define USBHS_HSTIDR_DMA_5_Pos              29                                             /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_5_Pos              30                                             /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_5_Pos)           /**< (USBHS_HSTIDR) DMA Channel 5 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_5                  USBHS_HSTIDR_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_5_Msk instead */
-#define USBHS_HSTIDR_DMA_6_Pos              30                                             /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Position */
+#define USBHS_HSTIDR_DMA_6_Pos              31                                             /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Position */
 #define USBHS_HSTIDR_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_6_Pos)           /**< (USBHS_HSTIDR) DMA Channel 6 Interrupt Disable Mask */
 #define USBHS_HSTIDR_DMA_6                  USBHS_HSTIDR_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_6_Msk instead */
-#define USBHS_HSTIDR_DMA_7_Pos              31                                             /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Position */
-#define USBHS_HSTIDR_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIDR_DMA_7_Pos)           /**< (USBHS_HSTIDR) DMA Channel 7 Interrupt Disable Mask */
-#define USBHS_HSTIDR_DMA_7                  USBHS_HSTIDR_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIDR_DMA_7_Msk instead */
-#define USBHS_HSTIDR_MASK                   _U_(0xFE0FFF7F)                                /**< \deprecated (USBHS_HSTIDR) Register MASK  (Use USBHS_HSTIDR_Msk instead)  */
-#define USBHS_HSTIDR_Msk                    _U_(0xFE0FFF7F)                                /**< (USBHS_HSTIDR) Register Mask  */
+#define USBHS_HSTIDR_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIDR) Register MASK  (Use USBHS_HSTIDR_Msk instead)  */
+#define USBHS_HSTIDR_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIDR) Register Mask  */
 
 #define USBHS_HSTIDR_PEP__Pos               8                                              /**< (USBHS_HSTIDR Position) Pipe x Interrupt Disable */
-#define USBHS_HSTIDR_PEP__Msk               (_U_(0xFFF) << USBHS_HSTIDR_PEP__Pos)          /**< (USBHS_HSTIDR Mask) PEP_ */
+#define USBHS_HSTIDR_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIDR_PEP__Pos)          /**< (USBHS_HSTIDR Mask) PEP_ */
 #define USBHS_HSTIDR_PEP_(value)            (USBHS_HSTIDR_PEP__Msk & ((value) << USBHS_HSTIDR_PEP__Pos))  
-#define USBHS_HSTIDR_DMA__Pos               25                                             /**< (USBHS_HSTIDR Position) DMA Channel 7 Interrupt Disable */
+#define USBHS_HSTIDR_DMA__Pos               25                                             /**< (USBHS_HSTIDR Position) DMA Channel 6 Interrupt Disable */
 #define USBHS_HSTIDR_DMA__Msk               (_U_(0x7F) << USBHS_HSTIDR_DMA__Pos)           /**< (USBHS_HSTIDR Mask) DMA_ */
 #define USBHS_HSTIDR_DMA_(value)            (USBHS_HSTIDR_DMA__Msk & ((value) << USBHS_HSTIDR_DMA__Pos))  
 
 /* -------- USBHS_HSTIER : (USBHS Offset: 0x418) (/W 32) Host Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DCONNIES:1;                /**< bit:      0  Device Connection Interrupt Enable       */
@@ -2258,25 +2915,24 @@ typedef union {
     uint32_t PEP_7:1;                   /**< bit:     15  Pipe 7 Interrupt Enable                  */
     uint32_t PEP_8:1;                   /**< bit:     16  Pipe 8 Interrupt Enable                  */
     uint32_t PEP_9:1;                   /**< bit:     17  Pipe 9 Interrupt Enable                  */
-    uint32_t PEP_10:1;                  /**< bit:     18  Pipe 10 Interrupt Enable                 */
-    uint32_t PEP_11:1;                  /**< bit:     19  Pipe 11 Interrupt Enable                 */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_1:1;                   /**< bit:     25  DMA Channel 1 Interrupt Enable           */
-    uint32_t DMA_2:1;                   /**< bit:     26  DMA Channel 2 Interrupt Enable           */
-    uint32_t DMA_3:1;                   /**< bit:     27  DMA Channel 3 Interrupt Enable           */
-    uint32_t DMA_4:1;                   /**< bit:     28  DMA Channel 4 Interrupt Enable           */
-    uint32_t DMA_5:1;                   /**< bit:     29  DMA Channel 5 Interrupt Enable           */
-    uint32_t DMA_6:1;                   /**< bit:     30  DMA Channel 6 Interrupt Enable           */
-    uint32_t DMA_7:1;                   /**< bit:     31  DMA Channel 7 Interrupt Enable           */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_0:1;                   /**< bit:     25  DMA Channel 0 Interrupt Enable           */
+    uint32_t DMA_1:1;                   /**< bit:     26  DMA Channel 1 Interrupt Enable           */
+    uint32_t DMA_2:1;                   /**< bit:     27  DMA Channel 2 Interrupt Enable           */
+    uint32_t DMA_3:1;                   /**< bit:     28  DMA Channel 3 Interrupt Enable           */
+    uint32_t DMA_4:1;                   /**< bit:     29  DMA Channel 4 Interrupt Enable           */
+    uint32_t DMA_5:1;                   /**< bit:     30  DMA Channel 5 Interrupt Enable           */
+    uint32_t DMA_6:1;                   /**< bit:     31  DMA Channel 6 Interrupt Enable           */
   } bit;                                /**< Structure used for bit  access */
   struct {
     uint32_t :8;                        /**< bit:   0..7  Reserved */
-    uint32_t PEP_:12;                   /**< bit:  8..19  Pipe x Interrupt Enable                  */
-    uint32_t :5;                        /**< bit: 20..24  Reserved */
-    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 7 Interrupt Enable           */
+    uint32_t PEP_:10;                   /**< bit:  8..17  Pipe x Interrupt Enable                  */
+    uint32_t :7;                        /**< bit: 18..24  Reserved */
+    uint32_t DMA_:7;                    /**< bit: 25..31  DMA Channel 6 Interrupt Enable           */
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTIER_OFFSET                 (0x418)                                       /**<  (USBHS_HSTIER) Host Global Interrupt Enable Register  Offset */
@@ -2332,45 +2988,40 @@ typedef union {
 #define USBHS_HSTIER_PEP_9_Pos              17                                             /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Position */
 #define USBHS_HSTIER_PEP_9_Msk              (_U_(0x1) << USBHS_HSTIER_PEP_9_Pos)           /**< (USBHS_HSTIER) Pipe 9 Interrupt Enable Mask */
 #define USBHS_HSTIER_PEP_9                  USBHS_HSTIER_PEP_9_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_9_Msk instead */
-#define USBHS_HSTIER_PEP_10_Pos             18                                             /**< (USBHS_HSTIER) Pipe 10 Interrupt Enable Position */
-#define USBHS_HSTIER_PEP_10_Msk             (_U_(0x1) << USBHS_HSTIER_PEP_10_Pos)          /**< (USBHS_HSTIER) Pipe 10 Interrupt Enable Mask */
-#define USBHS_HSTIER_PEP_10                 USBHS_HSTIER_PEP_10_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_10_Msk instead */
-#define USBHS_HSTIER_PEP_11_Pos             19                                             /**< (USBHS_HSTIER) Pipe 11 Interrupt Enable Position */
-#define USBHS_HSTIER_PEP_11_Msk             (_U_(0x1) << USBHS_HSTIER_PEP_11_Pos)          /**< (USBHS_HSTIER) Pipe 11 Interrupt Enable Mask */
-#define USBHS_HSTIER_PEP_11                 USBHS_HSTIER_PEP_11_Msk                        /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_PEP_11_Msk instead */
-#define USBHS_HSTIER_DMA_1_Pos              25                                             /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_0_Pos              25                                             /**< (USBHS_HSTIER) DMA Channel 0 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_0_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_0_Pos)           /**< (USBHS_HSTIER) DMA Channel 0 Interrupt Enable Mask */
+#define USBHS_HSTIER_DMA_0                  USBHS_HSTIER_DMA_0_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_0_Msk instead */
+#define USBHS_HSTIER_DMA_1_Pos              26                                             /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_1_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_1_Pos)           /**< (USBHS_HSTIER) DMA Channel 1 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_1                  USBHS_HSTIER_DMA_1_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_1_Msk instead */
-#define USBHS_HSTIER_DMA_2_Pos              26                                             /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_2_Pos              27                                             /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_2_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_2_Pos)           /**< (USBHS_HSTIER) DMA Channel 2 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_2                  USBHS_HSTIER_DMA_2_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_2_Msk instead */
-#define USBHS_HSTIER_DMA_3_Pos              27                                             /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_3_Pos              28                                             /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_3_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_3_Pos)           /**< (USBHS_HSTIER) DMA Channel 3 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_3                  USBHS_HSTIER_DMA_3_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_3_Msk instead */
-#define USBHS_HSTIER_DMA_4_Pos              28                                             /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_4_Pos              29                                             /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_4_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_4_Pos)           /**< (USBHS_HSTIER) DMA Channel 4 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_4                  USBHS_HSTIER_DMA_4_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_4_Msk instead */
-#define USBHS_HSTIER_DMA_5_Pos              29                                             /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_5_Pos              30                                             /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_5_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_5_Pos)           /**< (USBHS_HSTIER) DMA Channel 5 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_5                  USBHS_HSTIER_DMA_5_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_5_Msk instead */
-#define USBHS_HSTIER_DMA_6_Pos              30                                             /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Position */
+#define USBHS_HSTIER_DMA_6_Pos              31                                             /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Position */
 #define USBHS_HSTIER_DMA_6_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_6_Pos)           /**< (USBHS_HSTIER) DMA Channel 6 Interrupt Enable Mask */
 #define USBHS_HSTIER_DMA_6                  USBHS_HSTIER_DMA_6_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_6_Msk instead */
-#define USBHS_HSTIER_DMA_7_Pos              31                                             /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Position */
-#define USBHS_HSTIER_DMA_7_Msk              (_U_(0x1) << USBHS_HSTIER_DMA_7_Pos)           /**< (USBHS_HSTIER) DMA Channel 7 Interrupt Enable Mask */
-#define USBHS_HSTIER_DMA_7                  USBHS_HSTIER_DMA_7_Msk                         /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTIER_DMA_7_Msk instead */
-#define USBHS_HSTIER_MASK                   _U_(0xFE0FFF7F)                                /**< \deprecated (USBHS_HSTIER) Register MASK  (Use USBHS_HSTIER_Msk instead)  */
-#define USBHS_HSTIER_Msk                    _U_(0xFE0FFF7F)                                /**< (USBHS_HSTIER) Register Mask  */
+#define USBHS_HSTIER_MASK                   _U_(0xFE03FF7F)                                /**< \deprecated (USBHS_HSTIER) Register MASK  (Use USBHS_HSTIER_Msk instead)  */
+#define USBHS_HSTIER_Msk                    _U_(0xFE03FF7F)                                /**< (USBHS_HSTIER) Register Mask  */
 
 #define USBHS_HSTIER_PEP__Pos               8                                              /**< (USBHS_HSTIER Position) Pipe x Interrupt Enable */
-#define USBHS_HSTIER_PEP__Msk               (_U_(0xFFF) << USBHS_HSTIER_PEP__Pos)          /**< (USBHS_HSTIER Mask) PEP_ */
+#define USBHS_HSTIER_PEP__Msk               (_U_(0x3FF) << USBHS_HSTIER_PEP__Pos)          /**< (USBHS_HSTIER Mask) PEP_ */
 #define USBHS_HSTIER_PEP_(value)            (USBHS_HSTIER_PEP__Msk & ((value) << USBHS_HSTIER_PEP__Pos))  
-#define USBHS_HSTIER_DMA__Pos               25                                             /**< (USBHS_HSTIER Position) DMA Channel 7 Interrupt Enable */
+#define USBHS_HSTIER_DMA__Pos               25                                             /**< (USBHS_HSTIER Position) DMA Channel 6 Interrupt Enable */
 #define USBHS_HSTIER_DMA__Msk               (_U_(0x7F) << USBHS_HSTIER_DMA__Pos)           /**< (USBHS_HSTIER Mask) DMA_ */
 #define USBHS_HSTIER_DMA_(value)            (USBHS_HSTIER_DMA__Msk & ((value) << USBHS_HSTIER_DMA__Pos))  
 
 /* -------- USBHS_HSTPIP : (USBHS Offset: 0x41c) (R/W 32) Host Pipe Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PEN0:1;                    /**< bit:      0  Pipe 0 Enable                            */
@@ -2402,6 +3053,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTPIP_OFFSET                 (0x41C)                                       /**<  (USBHS_HSTPIP) Host Pipe Register  Offset */
@@ -2472,6 +3124,7 @@ typedef union {
 
 /* -------- USBHS_HSTFNUM : (USBHS Offset: 0x420) (R/W 32) Host Frame Number Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t MFNUM:3;                   /**< bit:   0..2  Micro Frame Number                       */
@@ -2482,6 +3135,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTFNUM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTFNUM_OFFSET                (0x420)                                       /**<  (USBHS_HSTFNUM) Host Frame Number Register  Offset */
@@ -2501,6 +3155,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR1 : (USBHS Offset: 0x424) (R/W 32) Host Address 1 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP0:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2514,6 +3169,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR1_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR1_OFFSET               (0x424)                                       /**<  (USBHS_HSTADDR1) Host Address 1 Register  Offset */
@@ -2536,6 +3192,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR2 : (USBHS Offset: 0x428) (R/W 32) Host Address 2 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP4:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2549,6 +3206,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR2_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR2_OFFSET               (0x428)                                       /**<  (USBHS_HSTADDR2) Host Address 2 Register  Offset */
@@ -2571,6 +3229,7 @@ typedef union {
 
 /* -------- USBHS_HSTADDR3 : (USBHS Offset: 0x42c) (R/W 32) Host Address 3 Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t HSTADDRP8:7;               /**< bit:   0..6  USB Host Address                         */
@@ -2580,6 +3239,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTADDR3_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_HSTADDR3_OFFSET               (0x42C)                                       /**<  (USBHS_HSTADDR3) Host Address 3 Register  Offset */
@@ -2594,8 +3254,9 @@ typedef union {
 #define USBHS_HSTADDR3_Msk                  _U_(0x7F7F)                                    /**< (USBHS_HSTADDR3) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPCFG : (USBHS Offset: 0x500) (R/W 32) Host Pipe Configuration Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPCFG : (USBHS Offset: 0x500) (R/W 32) Host Pipe Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :1;                        /**< bit:      0  Reserved */
@@ -2612,11 +3273,18 @@ typedef union {
     uint32_t :4;                        /**< bit: 20..23  Reserved */
     uint32_t INTFRQ:8;                  /**< bit: 24..31  Pipe Interrupt Request Frequency         */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL_BULK mode
+    uint32_t :20;                       /**< bit:  0..19  Reserved */
+    uint32_t PINGEN:1;                  /**< bit:     20  Ping Enable                              */
+    uint32_t :3;                        /**< bit: 21..23  Reserved */
+    uint32_t BINTERVAL:8;               /**< bit: 24..31  bInterval Parameter for the Bulk-Out/Ping Transaction */
+  } CTRL_BULK;                                /**< Structure used for CTRL_BULK mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPCFG_OFFSET              (0x500)                                       /**<  (USBHS_HSTPIPCFG) Host Pipe Configuration Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPCFG_OFFSET              (0x500)                                       /**<  (USBHS_HSTPIPCFG) Host Pipe Configuration Register  Offset */
 
 #define USBHS_HSTPIPCFG_ALLOC_Pos           1                                              /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Position */
 #define USBHS_HSTPIPCFG_ALLOC_Msk           (_U_(0x1) << USBHS_HSTPIPCFG_ALLOC_Pos)        /**< (USBHS_HSTPIPCFG) Pipe Memory Allocate Mask */
@@ -2681,18 +3349,29 @@ typedef union {
 #define USBHS_HSTPIPCFG_MASK                _U_(0xFF0F377E)                                /**< \deprecated (USBHS_HSTPIPCFG) Register MASK  (Use USBHS_HSTPIPCFG_Msk instead)  */
 #define USBHS_HSTPIPCFG_Msk                 _U_(0xFF0F377E)                                /**< (USBHS_HSTPIPCFG) Register Mask  */
 
+/* CTRL_BULK mode */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Pos 20                                             /**< (USBHS_HSTPIPCFG) Ping Enable Position */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk (_U_(0x1) << USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Pos)  /**< (USBHS_HSTPIPCFG) Ping Enable Mask */
+#define USBHS_HSTPIPCFG_CTRL_BULK_PINGEN    USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPCFG_CTRL_BULK_PINGEN_Msk instead */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos 24                                             /**< (USBHS_HSTPIPCFG) bInterval Parameter for the Bulk-Out/Ping Transaction Position */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Msk (_U_(0xFF) << USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos)  /**< (USBHS_HSTPIPCFG) bInterval Parameter for the Bulk-Out/Ping Transaction Mask */
+#define USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL(value) (USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Msk & ((value) << USBHS_HSTPIPCFG_CTRL_BULK_BINTERVAL_Pos))
+#define USBHS_HSTPIPCFG_CTRL_BULK_MASK      _U_(0xFF100000)                                /**< \deprecated (USBHS_HSTPIPCFG_CTRL_BULK) Register MASK  (Use USBHS_HSTPIPCFG_CTRL_BULK_Msk instead)  */
+#define USBHS_HSTPIPCFG_CTRL_BULK_Msk       _U_(0xFF100000)                                /**< (USBHS_HSTPIPCFG_CTRL_BULK) Register Mask  */
 
-/* -------- USBHS_HSTPIPISR : (USBHS Offset: 0x530) (R/ 32) Host Pipe Status Register (n = 0) 0 -------- */
+
+/* -------- USBHS_HSTPIPISR : (USBHS Offset: 0x530) (R/ 32) Host Pipe Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINI:1;                   /**< bit:      0  Received IN Data Interrupt               */
     uint32_t TXOUTI:1;                  /**< bit:      1  Transmitted OUT Data Interrupt           */
-    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t :1;                        /**< bit:      2  Reserved */
     uint32_t PERRI:1;                   /**< bit:      3  Pipe Error Interrupt                     */
     uint32_t NAKEDI:1;                  /**< bit:      4  NAKed Interrupt                          */
     uint32_t OVERFI:1;                  /**< bit:      5  Overflow Interrupt                       */
-    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETI:1;            /**< bit:      7  Short Packet Interrupt                   */
     uint32_t DTSEQ:2;                   /**< bit:   8..9  Data Toggle Sequence                     */
     uint32_t :2;                        /**< bit: 10..11  Reserved */
@@ -2705,11 +3384,40 @@ typedef union {
     uint32_t PBYCT:11;                  /**< bit: 20..30  Pipe Byte Count                          */
     uint32_t :1;                        /**< bit:     31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRI:1;                 /**< bit:      6  CRC Error Interrupt                      */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPI:1;                  /**< bit:      2  Transmitted SETUP Interrupt              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFI:1;                 /**< bit:      2  Underflow Interrupt                      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDI:1;               /**< bit:      6  Received STALLed Interrupt               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPISR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPISR_OFFSET              (0x530)                                       /**<  (USBHS_HSTPIPISR) Host Pipe Status Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPISR_OFFSET              (0x530)                                       /**<  (USBHS_HSTPIPISR) Host Pipe Status Register  Offset */
 
 #define USBHS_HSTPIPISR_RXINI_Pos           0                                              /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Position */
 #define USBHS_HSTPIPISR_RXINI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_RXINI_Pos)        /**< (USBHS_HSTPIPISR) Received IN Data Interrupt Mask */
@@ -2717,9 +3425,6 @@ typedef union {
 #define USBHS_HSTPIPISR_TXOUTI_Pos          1                                              /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Position */
 #define USBHS_HSTPIPISR_TXOUTI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_TXOUTI_Pos)       /**< (USBHS_HSTPIPISR) Transmitted OUT Data Interrupt Mask */
 #define USBHS_HSTPIPISR_TXOUTI              USBHS_HSTPIPISR_TXOUTI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXOUTI_Msk instead */
-#define USBHS_HSTPIPISR_TXSTPI_Pos          2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
-#define USBHS_HSTPIPISR_TXSTPI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_TXSTPI_Pos)       /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
-#define USBHS_HSTPIPISR_TXSTPI              USBHS_HSTPIPISR_TXSTPI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_TXSTPI_Msk instead */
 #define USBHS_HSTPIPISR_PERRI_Pos           3                                              /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Position */
 #define USBHS_HSTPIPISR_PERRI_Msk           (_U_(0x1) << USBHS_HSTPIPISR_PERRI_Pos)        /**< (USBHS_HSTPIPISR) Pipe Error Interrupt Mask */
 #define USBHS_HSTPIPISR_PERRI               USBHS_HSTPIPISR_PERRI_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_PERRI_Msk instead */
@@ -2729,9 +3434,6 @@ typedef union {
 #define USBHS_HSTPIPISR_OVERFI_Pos          5                                              /**< (USBHS_HSTPIPISR) Overflow Interrupt Position */
 #define USBHS_HSTPIPISR_OVERFI_Msk          (_U_(0x1) << USBHS_HSTPIPISR_OVERFI_Pos)       /**< (USBHS_HSTPIPISR) Overflow Interrupt Mask */
 #define USBHS_HSTPIPISR_OVERFI              USBHS_HSTPIPISR_OVERFI_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_OVERFI_Msk instead */
-#define USBHS_HSTPIPISR_RXSTALLDI_Pos       6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
-#define USBHS_HSTPIPISR_RXSTALLDI_Msk       (_U_(0x1) << USBHS_HSTPIPISR_RXSTALLDI_Pos)    /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
-#define USBHS_HSTPIPISR_RXSTALLDI           USBHS_HSTPIPISR_RXSTALLDI_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_RXSTALLDI_Msk instead */
 #define USBHS_HSTPIPISR_SHORTPACKETI_Pos    7                                              /**< (USBHS_HSTPIPISR) Short Packet Interrupt Position */
 #define USBHS_HSTPIPISR_SHORTPACKETI_Msk    (_U_(0x1) << USBHS_HSTPIPISR_SHORTPACKETI_Pos)  /**< (USBHS_HSTPIPISR) Short Packet Interrupt Mask */
 #define USBHS_HSTPIPISR_SHORTPACKETI        USBHS_HSTPIPISR_SHORTPACKETI_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_SHORTPACKETI_Msk instead */
@@ -2771,29 +3473,98 @@ typedef union {
 #define USBHS_HSTPIPISR_PBYCT_Pos           20                                             /**< (USBHS_HSTPIPISR) Pipe Byte Count Position */
 #define USBHS_HSTPIPISR_PBYCT_Msk           (_U_(0x7FF) << USBHS_HSTPIPISR_PBYCT_Pos)      /**< (USBHS_HSTPIPISR) Pipe Byte Count Mask */
 #define USBHS_HSTPIPISR_PBYCT(value)        (USBHS_HSTPIPISR_PBYCT_Msk & ((value) << USBHS_HSTPIPISR_PBYCT_Pos))
-#define USBHS_HSTPIPISR_MASK                _U_(0x7FF5F3FF)                                /**< \deprecated (USBHS_HSTPIPISR) Register MASK  (Use USBHS_HSTPIPISR_Msk instead)  */
-#define USBHS_HSTPIPISR_Msk                 _U_(0x7FF5F3FF)                                /**< (USBHS_HSTPIPISR) Register Mask  */
+#define USBHS_HSTPIPISR_MASK                _U_(0x7FF5F3BB)                                /**< \deprecated (USBHS_HSTPIPISR) Register MASK  (Use USBHS_HSTPIPISR_Msk instead)  */
+#define USBHS_HSTPIPISR_Msk                 _U_(0x7FF5F3BB)                                /**< (USBHS_HSTPIPISR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI_Pos     2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_CTRL_TXSTPI_Pos)  /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_CTRL_TXSTPI         USBHS_HSTPIPISR_CTRL_TXSTPI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CTRL_TXSTPI_Msk instead */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI_Pos  6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk  (_U_(0x1) << USBHS_HSTPIPISR_CTRL_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_CTRL_RXSTALLDI      USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_CTRL_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_CTRL) Register MASK  (Use USBHS_HSTPIPISR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPISR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPISR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPISR_ISO_UNDERFI_Pos     2                                              /**< (USBHS_HSTPIPISR) Underflow Interrupt Position */
+#define USBHS_HSTPIPISR_ISO_UNDERFI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_ISO_UNDERFI_Pos)  /**< (USBHS_HSTPIPISR) Underflow Interrupt Mask */
+#define USBHS_HSTPIPISR_ISO_UNDERFI         USBHS_HSTPIPISR_ISO_UNDERFI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_ISO_UNDERFI_Msk instead */
+#define USBHS_HSTPIPISR_ISO_CRCERRI_Pos     6                                              /**< (USBHS_HSTPIPISR) CRC Error Interrupt Position */
+#define USBHS_HSTPIPISR_ISO_CRCERRI_Msk     (_U_(0x1) << USBHS_HSTPIPISR_ISO_CRCERRI_Pos)  /**< (USBHS_HSTPIPISR) CRC Error Interrupt Mask */
+#define USBHS_HSTPIPISR_ISO_CRCERRI         USBHS_HSTPIPISR_ISO_CRCERRI_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_ISO_CRCERRI_Msk instead */
+#define USBHS_HSTPIPISR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_ISO) Register MASK  (Use USBHS_HSTPIPISR_ISO_Msk instead)  */
+#define USBHS_HSTPIPISR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPISR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPISR_BLK_TXSTPI_Pos      2                                              /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Position */
+#define USBHS_HSTPIPISR_BLK_TXSTPI_Msk      (_U_(0x1) << USBHS_HSTPIPISR_BLK_TXSTPI_Pos)   /**< (USBHS_HSTPIPISR) Transmitted SETUP Interrupt Mask */
+#define USBHS_HSTPIPISR_BLK_TXSTPI          USBHS_HSTPIPISR_BLK_TXSTPI_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_BLK_TXSTPI_Msk instead */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI_Pos   6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk   (_U_(0x1) << USBHS_HSTPIPISR_BLK_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_BLK_RXSTALLDI       USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_BLK_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_BLK) Register MASK  (Use USBHS_HSTPIPISR_BLK_Msk instead)  */
+#define USBHS_HSTPIPISR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPISR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI_Pos  2                                              /**< (USBHS_HSTPIPISR) Underflow Interrupt Position */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk  (_U_(0x1) << USBHS_HSTPIPISR_INTRPT_UNDERFI_Pos)  /**< (USBHS_HSTPIPISR) Underflow Interrupt Mask */
+#define USBHS_HSTPIPISR_INTRPT_UNDERFI      USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_INTRPT_UNDERFI_Msk instead */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Pos 6                                              /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Position */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk (_U_(0x1) << USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Pos)  /**< (USBHS_HSTPIPISR) Received STALLed Interrupt Mask */
+#define USBHS_HSTPIPISR_INTRPT_RXSTALLDI    USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPISR_INTRPT_RXSTALLDI_Msk instead */
+#define USBHS_HSTPIPISR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPISR_INTRPT) Register MASK  (Use USBHS_HSTPIPISR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPISR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPISR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPICR : (USBHS Offset: 0x560) (/W 32) Host Pipe Clear Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPICR : (USBHS Offset: 0x560) (/W 32) Host Pipe Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINIC:1;                  /**< bit:      0  Received IN Data Interrupt Clear         */
     uint32_t TXOUTIC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Clear     */
-    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
-    uint32_t :1;                        /**< bit:      3  Reserved */
+    uint32_t :2;                        /**< bit:   2..3  Reserved */
     uint32_t NAKEDIC:1;                 /**< bit:      4  NAKed Interrupt Clear                    */
     uint32_t OVERFIC:1;                 /**< bit:      5  Overflow Interrupt Clear                 */
-    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETIC:1;           /**< bit:      7  Short Packet Interrupt Clear             */
     uint32_t :24;                       /**< bit:  8..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRIC:1;                /**< bit:      6  CRC Error Interrupt Clear                */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Clear        */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIC:1;                /**< bit:      2  Underflow Interrupt Clear                */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIC:1;              /**< bit:      6  Received STALLed Interrupt Clear         */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPICR_OFFSET              (0x560)                                       /**<  (USBHS_HSTPIPICR) Host Pipe Clear Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPICR_OFFSET              (0x560)                                       /**<  (USBHS_HSTPIPICR) Host Pipe Clear Register  Offset */
 
 #define USBHS_HSTPIPICR_RXINIC_Pos          0                                              /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Position */
 #define USBHS_HSTPIPICR_RXINIC_Msk          (_U_(0x1) << USBHS_HSTPIPICR_RXINIC_Pos)       /**< (USBHS_HSTPIPICR) Received IN Data Interrupt Clear Mask */
@@ -2801,46 +3572,110 @@ typedef union {
 #define USBHS_HSTPIPICR_TXOUTIC_Pos         1                                              /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Position */
 #define USBHS_HSTPIPICR_TXOUTIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_TXOUTIC_Pos)      /**< (USBHS_HSTPIPICR) Transmitted OUT Data Interrupt Clear Mask */
 #define USBHS_HSTPIPICR_TXOUTIC             USBHS_HSTPIPICR_TXOUTIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXOUTIC_Msk instead */
-#define USBHS_HSTPIPICR_TXSTPIC_Pos         2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
-#define USBHS_HSTPIPICR_TXSTPIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_TXSTPIC_Pos)      /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
-#define USBHS_HSTPIPICR_TXSTPIC             USBHS_HSTPIPICR_TXSTPIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_TXSTPIC_Msk instead */
 #define USBHS_HSTPIPICR_NAKEDIC_Pos         4                                              /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Position */
 #define USBHS_HSTPIPICR_NAKEDIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_NAKEDIC_Pos)      /**< (USBHS_HSTPIPICR) NAKed Interrupt Clear Mask */
 #define USBHS_HSTPIPICR_NAKEDIC             USBHS_HSTPIPICR_NAKEDIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_NAKEDIC_Msk instead */
 #define USBHS_HSTPIPICR_OVERFIC_Pos         5                                              /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Position */
 #define USBHS_HSTPIPICR_OVERFIC_Msk         (_U_(0x1) << USBHS_HSTPIPICR_OVERFIC_Pos)      /**< (USBHS_HSTPIPICR) Overflow Interrupt Clear Mask */
 #define USBHS_HSTPIPICR_OVERFIC             USBHS_HSTPIPICR_OVERFIC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_OVERFIC_Msk instead */
-#define USBHS_HSTPIPICR_RXSTALLDIC_Pos      6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
-#define USBHS_HSTPIPICR_RXSTALLDIC_Msk      (_U_(0x1) << USBHS_HSTPIPICR_RXSTALLDIC_Pos)   /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
-#define USBHS_HSTPIPICR_RXSTALLDIC          USBHS_HSTPIPICR_RXSTALLDIC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_RXSTALLDIC_Msk instead */
 #define USBHS_HSTPIPICR_SHORTPACKETIC_Pos   7                                              /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Position */
 #define USBHS_HSTPIPICR_SHORTPACKETIC_Msk   (_U_(0x1) << USBHS_HSTPIPICR_SHORTPACKETIC_Pos)  /**< (USBHS_HSTPIPICR) Short Packet Interrupt Clear Mask */
 #define USBHS_HSTPIPICR_SHORTPACKETIC       USBHS_HSTPIPICR_SHORTPACKETIC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_SHORTPACKETIC_Msk instead */
-#define USBHS_HSTPIPICR_MASK                _U_(0xF7)                                      /**< \deprecated (USBHS_HSTPIPICR) Register MASK  (Use USBHS_HSTPIPICR_Msk instead)  */
-#define USBHS_HSTPIPICR_Msk                 _U_(0xF7)                                      /**< (USBHS_HSTPIPICR) Register Mask  */
+#define USBHS_HSTPIPICR_MASK                _U_(0xB3)                                      /**< \deprecated (USBHS_HSTPIPICR) Register MASK  (Use USBHS_HSTPIPICR_Msk instead)  */
+#define USBHS_HSTPIPICR_Msk                 _U_(0xB3)                                      /**< (USBHS_HSTPIPICR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC_Pos    2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_CTRL_TXSTPIC_Pos)  /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_CTRL_TXSTPIC        USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_CTRL_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Pos 6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_CTRL_RXSTALLDIC     USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_CTRL_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_CTRL) Register MASK  (Use USBHS_HSTPIPICR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPICR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPICR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC_Pos    2                                              /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_ISO_UNDERFIC_Pos)  /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_ISO_UNDERFIC        USBHS_HSTPIPICR_ISO_UNDERFIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_ISO_UNDERFIC_Msk instead */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC_Pos    6                                              /**< (USBHS_HSTPIPICR) CRC Error Interrupt Clear Position */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC_Msk    (_U_(0x1) << USBHS_HSTPIPICR_ISO_CRCERRIC_Pos)  /**< (USBHS_HSTPIPICR) CRC Error Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_ISO_CRCERRIC        USBHS_HSTPIPICR_ISO_CRCERRIC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_ISO_CRCERRIC_Msk instead */
+#define USBHS_HSTPIPICR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_ISO) Register MASK  (Use USBHS_HSTPIPICR_ISO_Msk instead)  */
+#define USBHS_HSTPIPICR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPICR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC_Pos     2                                              /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Position */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC_Msk     (_U_(0x1) << USBHS_HSTPIPICR_BLK_TXSTPIC_Pos)  /**< (USBHS_HSTPIPICR) Transmitted SETUP Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_BLK_TXSTPIC         USBHS_HSTPIPICR_BLK_TXSTPIC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_BLK_TXSTPIC_Msk instead */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC_Pos  6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk  (_U_(0x1) << USBHS_HSTPIPICR_BLK_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_BLK_RXSTALLDIC      USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_BLK_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_BLK) Register MASK  (Use USBHS_HSTPIPICR_BLK_Msk instead)  */
+#define USBHS_HSTPIPICR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPICR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC_Pos 2                                              /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Position */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_INTRPT_UNDERFIC_Pos)  /**< (USBHS_HSTPIPICR) Underflow Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_INTRPT_UNDERFIC     USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_INTRPT_UNDERFIC_Msk instead */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Pos 6                                              /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Position */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk (_U_(0x1) << USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Pos)  /**< (USBHS_HSTPIPICR) Received STALLed Interrupt Clear Mask */
+#define USBHS_HSTPIPICR_INTRPT_RXSTALLDIC   USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPICR_INTRPT_RXSTALLDIC_Msk instead */
+#define USBHS_HSTPIPICR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPICR_INTRPT) Register MASK  (Use USBHS_HSTPIPICR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPICR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPICR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPIFR : (USBHS Offset: 0x590) (/W 32) Host Pipe Set Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPIFR : (USBHS Offset: 0x590) (/W 32) Host Pipe Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINIS:1;                  /**< bit:      0  Received IN Data Interrupt Set           */
     uint32_t TXOUTIS:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Set       */
-    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t :1;                        /**< bit:      2  Reserved */
     uint32_t PERRIS:1;                  /**< bit:      3  Pipe Error Interrupt Set                 */
     uint32_t NAKEDIS:1;                 /**< bit:      4  NAKed Interrupt Set                      */
     uint32_t OVERFIS:1;                 /**< bit:      5  Overflow Interrupt Set                   */
-    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETIS:1;           /**< bit:      7  Short Packet Interrupt Set               */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKS:1;                /**< bit:     12  Number of Busy Banks Set                 */
     uint32_t :19;                       /**< bit: 13..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRIS:1;                /**< bit:      6  CRC Error Interrupt Set                  */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPIS:1;                 /**< bit:      2  Transmitted SETUP Interrupt Set          */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIS:1;                /**< bit:      2  Underflow Interrupt Set                  */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDIS:1;              /**< bit:      6  Received STALLed Interrupt Set           */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPIFR_OFFSET              (0x590)                                       /**<  (USBHS_HSTPIPIFR) Host Pipe Set Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPIFR_OFFSET              (0x590)                                       /**<  (USBHS_HSTPIPIFR) Host Pipe Set Register  Offset */
 
 #define USBHS_HSTPIPIFR_RXINIS_Pos          0                                              /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Position */
 #define USBHS_HSTPIPIFR_RXINIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_RXINIS_Pos)       /**< (USBHS_HSTPIPIFR) Received IN Data Interrupt Set Mask */
@@ -2848,9 +3683,6 @@ typedef union {
 #define USBHS_HSTPIPIFR_TXOUTIS_Pos         1                                              /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Position */
 #define USBHS_HSTPIPIFR_TXOUTIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_TXOUTIS_Pos)      /**< (USBHS_HSTPIPIFR) Transmitted OUT Data Interrupt Set Mask */
 #define USBHS_HSTPIPIFR_TXOUTIS             USBHS_HSTPIPIFR_TXOUTIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXOUTIS_Msk instead */
-#define USBHS_HSTPIPIFR_TXSTPIS_Pos         2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
-#define USBHS_HSTPIPIFR_TXSTPIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_TXSTPIS_Pos)      /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
-#define USBHS_HSTPIPIFR_TXSTPIS             USBHS_HSTPIPIFR_TXSTPIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_TXSTPIS_Msk instead */
 #define USBHS_HSTPIPIFR_PERRIS_Pos          3                                              /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Position */
 #define USBHS_HSTPIPIFR_PERRIS_Msk          (_U_(0x1) << USBHS_HSTPIPIFR_PERRIS_Pos)       /**< (USBHS_HSTPIPIFR) Pipe Error Interrupt Set Mask */
 #define USBHS_HSTPIPIFR_PERRIS              USBHS_HSTPIPIFR_PERRIS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_PERRIS_Msk instead */
@@ -2860,30 +3692,68 @@ typedef union {
 #define USBHS_HSTPIPIFR_OVERFIS_Pos         5                                              /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Position */
 #define USBHS_HSTPIPIFR_OVERFIS_Msk         (_U_(0x1) << USBHS_HSTPIPIFR_OVERFIS_Pos)      /**< (USBHS_HSTPIPIFR) Overflow Interrupt Set Mask */
 #define USBHS_HSTPIPIFR_OVERFIS             USBHS_HSTPIPIFR_OVERFIS_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_OVERFIS_Msk instead */
-#define USBHS_HSTPIPIFR_RXSTALLDIS_Pos      6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
-#define USBHS_HSTPIPIFR_RXSTALLDIS_Msk      (_U_(0x1) << USBHS_HSTPIPIFR_RXSTALLDIS_Pos)   /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
-#define USBHS_HSTPIPIFR_RXSTALLDIS          USBHS_HSTPIPIFR_RXSTALLDIS_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_RXSTALLDIS_Msk instead */
 #define USBHS_HSTPIPIFR_SHORTPACKETIS_Pos   7                                              /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Position */
 #define USBHS_HSTPIPIFR_SHORTPACKETIS_Msk   (_U_(0x1) << USBHS_HSTPIPIFR_SHORTPACKETIS_Pos)  /**< (USBHS_HSTPIPIFR) Short Packet Interrupt Set Mask */
 #define USBHS_HSTPIPIFR_SHORTPACKETIS       USBHS_HSTPIPIFR_SHORTPACKETIS_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_SHORTPACKETIS_Msk instead */
 #define USBHS_HSTPIPIFR_NBUSYBKS_Pos        12                                             /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Position */
 #define USBHS_HSTPIPIFR_NBUSYBKS_Msk        (_U_(0x1) << USBHS_HSTPIPIFR_NBUSYBKS_Pos)     /**< (USBHS_HSTPIPIFR) Number of Busy Banks Set Mask */
 #define USBHS_HSTPIPIFR_NBUSYBKS            USBHS_HSTPIPIFR_NBUSYBKS_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_NBUSYBKS_Msk instead */
-#define USBHS_HSTPIPIFR_MASK                _U_(0x10FF)                                    /**< \deprecated (USBHS_HSTPIPIFR) Register MASK  (Use USBHS_HSTPIPIFR_Msk instead)  */
-#define USBHS_HSTPIPIFR_Msk                 _U_(0x10FF)                                    /**< (USBHS_HSTPIPIFR) Register Mask  */
+#define USBHS_HSTPIPIFR_MASK                _U_(0x10BB)                                    /**< \deprecated (USBHS_HSTPIPIFR) Register MASK  (Use USBHS_HSTPIPIFR_Msk instead)  */
+#define USBHS_HSTPIPIFR_Msk                 _U_(0x10BB)                                    /**< (USBHS_HSTPIPIFR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS_Pos    2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_CTRL_TXSTPIS_Pos)  /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_CTRL_TXSTPIS        USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_CTRL_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Pos 6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_CTRL_RXSTALLDIS     USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_CTRL_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_CTRL) Register MASK  (Use USBHS_HSTPIPIFR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIFR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS_Pos    2                                              /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_ISO_UNDERFIS_Pos)  /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_ISO_UNDERFIS        USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_ISO_UNDERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS_Pos    6                                              /**< (USBHS_HSTPIPIFR) CRC Error Interrupt Set Position */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk    (_U_(0x1) << USBHS_HSTPIPIFR_ISO_CRCERRIS_Pos)  /**< (USBHS_HSTPIPIFR) CRC Error Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_ISO_CRCERRIS        USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_ISO_CRCERRIS_Msk instead */
+#define USBHS_HSTPIPIFR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_ISO) Register MASK  (Use USBHS_HSTPIPIFR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIFR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS_Pos     2                                              /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Position */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk     (_U_(0x1) << USBHS_HSTPIPIFR_BLK_TXSTPIS_Pos)  /**< (USBHS_HSTPIPIFR) Transmitted SETUP Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_BLK_TXSTPIS         USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_BLK_TXSTPIS_Msk instead */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Pos  6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk  (_U_(0x1) << USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_BLK_RXSTALLDIS      USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_BLK_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_BLK) Register MASK  (Use USBHS_HSTPIPIFR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIFR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Pos 2                                              /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Position */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Pos)  /**< (USBHS_HSTPIPIFR) Underflow Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_INTRPT_UNDERFIS     USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_INTRPT_UNDERFIS_Msk instead */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Pos 6                                              /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Position */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk (_U_(0x1) << USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Pos)  /**< (USBHS_HSTPIPIFR) Received STALLed Interrupt Set Mask */
+#define USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS   USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIFR_INTRPT_RXSTALLDIS_Msk instead */
+#define USBHS_HSTPIPIFR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIFR_INTRPT) Register MASK  (Use USBHS_HSTPIPIFR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIFR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIFR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPIMR : (USBHS Offset: 0x5c0) (R/ 32) Host Pipe Mask Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPIMR : (USBHS Offset: 0x5c0) (R/ 32) Host Pipe Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINE:1;                   /**< bit:      0  Received IN Data Interrupt Enable        */
     uint32_t TXOUTE:1;                  /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
-    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :1;                        /**< bit:      2  Reserved */
     uint32_t PERRE:1;                   /**< bit:      3  Pipe Error Interrupt Enable              */
     uint32_t NAKEDE:1;                  /**< bit:      4  NAKed Interrupt Enable                   */
     uint32_t OVERFIE:1;                 /**< bit:      5  Overflow Interrupt Enable                */
-    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETIE:1;           /**< bit:      7  Short Packet Interrupt Enable            */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKE:1;                /**< bit:     12  Number of Busy Banks Interrupt Enable    */
@@ -2895,11 +3765,40 @@ typedef union {
     uint32_t RSTDT:1;                   /**< bit:     18  Reset Data Toggle                        */
     uint32_t :13;                       /**< bit: 19..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIE:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRE:1;                 /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPE:1;                  /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIE:1;                /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDE:1;               /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIMR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPIMR_OFFSET              (0x5C0)                                       /**<  (USBHS_HSTPIPIMR) Host Pipe Mask Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPIMR_OFFSET              (0x5C0)                                       /**<  (USBHS_HSTPIPIMR) Host Pipe Mask Register  Offset */
 
 #define USBHS_HSTPIPIMR_RXINE_Pos           0                                              /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Position */
 #define USBHS_HSTPIPIMR_RXINE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RXINE_Pos)        /**< (USBHS_HSTPIPIMR) Received IN Data Interrupt Enable Mask */
@@ -2907,9 +3806,6 @@ typedef union {
 #define USBHS_HSTPIPIMR_TXOUTE_Pos          1                                              /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Position */
 #define USBHS_HSTPIPIMR_TXOUTE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_TXOUTE_Pos)       /**< (USBHS_HSTPIPIMR) Transmitted OUT Data Interrupt Enable Mask */
 #define USBHS_HSTPIPIMR_TXOUTE              USBHS_HSTPIPIMR_TXOUTE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXOUTE_Msk instead */
-#define USBHS_HSTPIPIMR_TXSTPE_Pos          2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
-#define USBHS_HSTPIPIMR_TXSTPE_Msk          (_U_(0x1) << USBHS_HSTPIPIMR_TXSTPE_Pos)       /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
-#define USBHS_HSTPIPIMR_TXSTPE              USBHS_HSTPIPIMR_TXSTPE_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_TXSTPE_Msk instead */
 #define USBHS_HSTPIPIMR_PERRE_Pos           3                                              /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Position */
 #define USBHS_HSTPIPIMR_PERRE_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_PERRE_Pos)        /**< (USBHS_HSTPIPIMR) Pipe Error Interrupt Enable Mask */
 #define USBHS_HSTPIPIMR_PERRE               USBHS_HSTPIPIMR_PERRE_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_PERRE_Msk instead */
@@ -2919,9 +3815,6 @@ typedef union {
 #define USBHS_HSTPIPIMR_OVERFIE_Pos         5                                              /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Position */
 #define USBHS_HSTPIPIMR_OVERFIE_Msk         (_U_(0x1) << USBHS_HSTPIPIMR_OVERFIE_Pos)      /**< (USBHS_HSTPIPIMR) Overflow Interrupt Enable Mask */
 #define USBHS_HSTPIPIMR_OVERFIE             USBHS_HSTPIPIMR_OVERFIE_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_OVERFIE_Msk instead */
-#define USBHS_HSTPIPIMR_RXSTALLDE_Pos       6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
-#define USBHS_HSTPIPIMR_RXSTALLDE_Msk       (_U_(0x1) << USBHS_HSTPIPIMR_RXSTALLDE_Pos)    /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
-#define USBHS_HSTPIPIMR_RXSTALLDE           USBHS_HSTPIPIMR_RXSTALLDE_Msk                  /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RXSTALLDE_Msk instead */
 #define USBHS_HSTPIPIMR_SHORTPACKETIE_Pos   7                                              /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Position */
 #define USBHS_HSTPIPIMR_SHORTPACKETIE_Msk   (_U_(0x1) << USBHS_HSTPIPIMR_SHORTPACKETIE_Pos)  /**< (USBHS_HSTPIPIMR) Short Packet Interrupt Enable Mask */
 #define USBHS_HSTPIPIMR_SHORTPACKETIE       USBHS_HSTPIPIMR_SHORTPACKETIE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_SHORTPACKETIE_Msk instead */
@@ -2940,21 +3833,62 @@ typedef union {
 #define USBHS_HSTPIPIMR_RSTDT_Pos           18                                             /**< (USBHS_HSTPIPIMR) Reset Data Toggle Position */
 #define USBHS_HSTPIPIMR_RSTDT_Msk           (_U_(0x1) << USBHS_HSTPIPIMR_RSTDT_Pos)        /**< (USBHS_HSTPIPIMR) Reset Data Toggle Mask */
 #define USBHS_HSTPIPIMR_RSTDT               USBHS_HSTPIPIMR_RSTDT_Msk                      /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_RSTDT_Msk instead */
-#define USBHS_HSTPIPIMR_MASK                _U_(0x750FF)                                   /**< \deprecated (USBHS_HSTPIPIMR) Register MASK  (Use USBHS_HSTPIPIMR_Msk instead)  */
-#define USBHS_HSTPIPIMR_Msk                 _U_(0x750FF)                                   /**< (USBHS_HSTPIPIMR) Register Mask  */
+#define USBHS_HSTPIPIMR_MASK                _U_(0x750BB)                                   /**< \deprecated (USBHS_HSTPIPIMR) Register MASK  (Use USBHS_HSTPIPIMR_Msk instead)  */
+#define USBHS_HSTPIPIMR_Msk                 _U_(0x750BB)                                   /**< (USBHS_HSTPIPIMR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE_Pos     2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk     (_U_(0x1) << USBHS_HSTPIPIMR_CTRL_TXSTPE_Pos)  /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_CTRL_TXSTPE         USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_CTRL_TXSTPE_Msk instead */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Pos  6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk  (_U_(0x1) << USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_CTRL_RXSTALLDE      USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_CTRL_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_CTRL) Register MASK  (Use USBHS_HSTPIPIMR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIMR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE_Pos    2                                              /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk    (_U_(0x1) << USBHS_HSTPIPIMR_ISO_UNDERFIE_Pos)  /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_ISO_UNDERFIE        USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_ISO_UNDERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE_Pos     6                                              /**< (USBHS_HSTPIPIMR) CRC Error Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE_Msk     (_U_(0x1) << USBHS_HSTPIPIMR_ISO_CRCERRE_Pos)  /**< (USBHS_HSTPIPIMR) CRC Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_ISO_CRCERRE         USBHS_HSTPIPIMR_ISO_CRCERRE_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_ISO_CRCERRE_Msk instead */
+#define USBHS_HSTPIPIMR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_ISO) Register MASK  (Use USBHS_HSTPIPIMR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIMR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE_Pos      2                                              /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE_Msk      (_U_(0x1) << USBHS_HSTPIPIMR_BLK_TXSTPE_Pos)   /**< (USBHS_HSTPIPIMR) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_BLK_TXSTPE          USBHS_HSTPIPIMR_BLK_TXSTPE_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_BLK_TXSTPE_Msk instead */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE_Pos   6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk   (_U_(0x1) << USBHS_HSTPIPIMR_BLK_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_BLK_RXSTALLDE       USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_BLK_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_BLK) Register MASK  (Use USBHS_HSTPIPIMR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIMR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Pos 2                                              /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk (_U_(0x1) << USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Pos)  /**< (USBHS_HSTPIPIMR) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_INTRPT_UNDERFIE     USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_INTRPT_UNDERFIE_Msk instead */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Pos 6                                              /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk (_U_(0x1) << USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Pos)  /**< (USBHS_HSTPIPIMR) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIMR_INTRPT_RXSTALLDE    USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIMR_INTRPT_RXSTALLDE_Msk instead */
+#define USBHS_HSTPIPIMR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIMR_INTRPT) Register MASK  (Use USBHS_HSTPIPIMR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIMR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIMR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPIER : (USBHS Offset: 0x5f0) (/W 32) Host Pipe Enable Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPIER : (USBHS Offset: 0x5f0) (/W 32) Host Pipe Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINES:1;                  /**< bit:      0  Received IN Data Interrupt Enable        */
     uint32_t TXOUTES:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Enable    */
-    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :1;                        /**< bit:      2  Reserved */
     uint32_t PERRES:1;                  /**< bit:      3  Pipe Error Interrupt Enable              */
     uint32_t NAKEDES:1;                 /**< bit:      4  NAKed Interrupt Enable                   */
     uint32_t OVERFIES:1;                /**< bit:      5  Overflow Interrupt Enable                */
-    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETIES:1;          /**< bit:      7  Short Packet Interrupt Enable            */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKES:1;               /**< bit:     12  Number of Busy Banks Enable              */
@@ -2964,11 +3898,40 @@ typedef union {
     uint32_t RSTDTS:1;                  /**< bit:     18  Reset Data Toggle Enable                 */
     uint32_t :13;                       /**< bit: 19..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIES:1;               /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERRES:1;                /**< bit:      6  CRC Error Interrupt Enable               */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPES:1;                 /**< bit:      2  Transmitted SETUP Interrupt Enable       */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIES:1;               /**< bit:      2  Underflow Interrupt Enable               */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDES:1;              /**< bit:      6  Received STALLed Interrupt Enable        */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIER_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPIER_OFFSET              (0x5F0)                                       /**<  (USBHS_HSTPIPIER) Host Pipe Enable Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPIER_OFFSET              (0x5F0)                                       /**<  (USBHS_HSTPIPIER) Host Pipe Enable Register  Offset */
 
 #define USBHS_HSTPIPIER_RXINES_Pos          0                                              /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Position */
 #define USBHS_HSTPIPIER_RXINES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RXINES_Pos)       /**< (USBHS_HSTPIPIER) Received IN Data Interrupt Enable Mask */
@@ -2976,9 +3939,6 @@ typedef union {
 #define USBHS_HSTPIPIER_TXOUTES_Pos         1                                              /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Position */
 #define USBHS_HSTPIPIER_TXOUTES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_TXOUTES_Pos)      /**< (USBHS_HSTPIPIER) Transmitted OUT Data Interrupt Enable Mask */
 #define USBHS_HSTPIPIER_TXOUTES             USBHS_HSTPIPIER_TXOUTES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXOUTES_Msk instead */
-#define USBHS_HSTPIPIER_TXSTPES_Pos         2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
-#define USBHS_HSTPIPIER_TXSTPES_Msk         (_U_(0x1) << USBHS_HSTPIPIER_TXSTPES_Pos)      /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
-#define USBHS_HSTPIPIER_TXSTPES             USBHS_HSTPIPIER_TXSTPES_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_TXSTPES_Msk instead */
 #define USBHS_HSTPIPIER_PERRES_Pos          3                                              /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Position */
 #define USBHS_HSTPIPIER_PERRES_Msk          (_U_(0x1) << USBHS_HSTPIPIER_PERRES_Pos)       /**< (USBHS_HSTPIPIER) Pipe Error Interrupt Enable Mask */
 #define USBHS_HSTPIPIER_PERRES              USBHS_HSTPIPIER_PERRES_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_PERRES_Msk instead */
@@ -2988,9 +3948,6 @@ typedef union {
 #define USBHS_HSTPIPIER_OVERFIES_Pos        5                                              /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Position */
 #define USBHS_HSTPIPIER_OVERFIES_Msk        (_U_(0x1) << USBHS_HSTPIPIER_OVERFIES_Pos)     /**< (USBHS_HSTPIPIER) Overflow Interrupt Enable Mask */
 #define USBHS_HSTPIPIER_OVERFIES            USBHS_HSTPIPIER_OVERFIES_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_OVERFIES_Msk instead */
-#define USBHS_HSTPIPIER_RXSTALLDES_Pos      6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
-#define USBHS_HSTPIPIER_RXSTALLDES_Msk      (_U_(0x1) << USBHS_HSTPIPIER_RXSTALLDES_Pos)   /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
-#define USBHS_HSTPIPIER_RXSTALLDES          USBHS_HSTPIPIER_RXSTALLDES_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RXSTALLDES_Msk instead */
 #define USBHS_HSTPIPIER_SHORTPACKETIES_Pos  7                                              /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Position */
 #define USBHS_HSTPIPIER_SHORTPACKETIES_Msk  (_U_(0x1) << USBHS_HSTPIPIER_SHORTPACKETIES_Pos)  /**< (USBHS_HSTPIPIER) Short Packet Interrupt Enable Mask */
 #define USBHS_HSTPIPIER_SHORTPACKETIES      USBHS_HSTPIPIER_SHORTPACKETIES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_SHORTPACKETIES_Msk instead */
@@ -3006,21 +3963,62 @@ typedef union {
 #define USBHS_HSTPIPIER_RSTDTS_Pos          18                                             /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Position */
 #define USBHS_HSTPIPIER_RSTDTS_Msk          (_U_(0x1) << USBHS_HSTPIPIER_RSTDTS_Pos)       /**< (USBHS_HSTPIPIER) Reset Data Toggle Enable Mask */
 #define USBHS_HSTPIPIER_RSTDTS              USBHS_HSTPIPIER_RSTDTS_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_RSTDTS_Msk instead */
-#define USBHS_HSTPIPIER_MASK                _U_(0x710FF)                                   /**< \deprecated (USBHS_HSTPIPIER) Register MASK  (Use USBHS_HSTPIPIER_Msk instead)  */
-#define USBHS_HSTPIPIER_Msk                 _U_(0x710FF)                                   /**< (USBHS_HSTPIPIER) Register Mask  */
+#define USBHS_HSTPIPIER_MASK                _U_(0x710BB)                                   /**< \deprecated (USBHS_HSTPIPIER) Register MASK  (Use USBHS_HSTPIPIER_Msk instead)  */
+#define USBHS_HSTPIPIER_Msk                 _U_(0x710BB)                                   /**< (USBHS_HSTPIPIER) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES_Pos    2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES_Msk    (_U_(0x1) << USBHS_HSTPIPIER_CTRL_TXSTPES_Pos)  /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_CTRL_TXSTPES        USBHS_HSTPIPIER_CTRL_TXSTPES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_CTRL_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES_Pos 6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk (_U_(0x1) << USBHS_HSTPIPIER_CTRL_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_CTRL_RXSTALLDES     USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_CTRL_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_CTRL) Register MASK  (Use USBHS_HSTPIPIER_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIER_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIER_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES_Pos   2                                              /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES_Msk   (_U_(0x1) << USBHS_HSTPIPIER_ISO_UNDERFIES_Pos)  /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_ISO_UNDERFIES       USBHS_HSTPIPIER_ISO_UNDERFIES_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_ISO_UNDERFIES_Msk instead */
+#define USBHS_HSTPIPIER_ISO_CRCERRES_Pos    6                                              /**< (USBHS_HSTPIPIER) CRC Error Interrupt Enable Position */
+#define USBHS_HSTPIPIER_ISO_CRCERRES_Msk    (_U_(0x1) << USBHS_HSTPIPIER_ISO_CRCERRES_Pos)  /**< (USBHS_HSTPIPIER) CRC Error Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_ISO_CRCERRES        USBHS_HSTPIPIER_ISO_CRCERRES_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_ISO_CRCERRES_Msk instead */
+#define USBHS_HSTPIPIER_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_ISO) Register MASK  (Use USBHS_HSTPIPIER_ISO_Msk instead)  */
+#define USBHS_HSTPIPIER_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIER_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIER_BLK_TXSTPES_Pos     2                                              /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Position */
+#define USBHS_HSTPIPIER_BLK_TXSTPES_Msk     (_U_(0x1) << USBHS_HSTPIPIER_BLK_TXSTPES_Pos)  /**< (USBHS_HSTPIPIER) Transmitted SETUP Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_BLK_TXSTPES         USBHS_HSTPIPIER_BLK_TXSTPES_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_BLK_TXSTPES_Msk instead */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES_Pos  6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk  (_U_(0x1) << USBHS_HSTPIPIER_BLK_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_BLK_RXSTALLDES      USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_BLK_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_BLK) Register MASK  (Use USBHS_HSTPIPIER_BLK_Msk instead)  */
+#define USBHS_HSTPIPIER_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIER_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES_Pos 2                                              /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Position */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk (_U_(0x1) << USBHS_HSTPIPIER_INTRPT_UNDERFIES_Pos)  /**< (USBHS_HSTPIPIER) Underflow Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_INTRPT_UNDERFIES    USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_INTRPT_UNDERFIES_Msk instead */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Pos 6                                              /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Position */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk (_U_(0x1) << USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Pos)  /**< (USBHS_HSTPIPIER) Received STALLed Interrupt Enable Mask */
+#define USBHS_HSTPIPIER_INTRPT_RXSTALLDES   USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIER_INTRPT_RXSTALLDES_Msk instead */
+#define USBHS_HSTPIPIER_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIER_INTRPT) Register MASK  (Use USBHS_HSTPIPIER_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIER_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIER_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPIDR : (USBHS Offset: 0x620) (/W 32) Host Pipe Disable Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPIDR : (USBHS Offset: 0x620) (/W 32) Host Pipe Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RXINEC:1;                  /**< bit:      0  Received IN Data Interrupt Disable       */
     uint32_t TXOUTEC:1;                 /**< bit:      1  Transmitted OUT Data Interrupt Disable   */
-    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t :1;                        /**< bit:      2  Reserved */
     uint32_t PERREC:1;                  /**< bit:      3  Pipe Error Interrupt Disable             */
     uint32_t NAKEDEC:1;                 /**< bit:      4  NAKed Interrupt Disable                  */
     uint32_t OVERFIEC:1;                /**< bit:      5  Overflow Interrupt Disable               */
-    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :1;                        /**< bit:      6  Reserved */
     uint32_t SHORTPACKETIEC:1;          /**< bit:      7  Short Packet Interrupt Disable           */
     uint32_t :4;                        /**< bit:  8..11  Reserved */
     uint32_t NBUSYBKEC:1;               /**< bit:     12  Number of Busy Banks Disable             */
@@ -3031,11 +4029,40 @@ typedef union {
     uint32_t PFREEZEC:1;                /**< bit:     17  Pipe Freeze Disable                      */
     uint32_t :14;                       /**< bit: 18..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct { // CTRL mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } CTRL;                                /**< Structure used for CTRL mode access */
+  struct { // ISO mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIEC:1;               /**< bit:      2  Underflow Interrupt Disable              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t CRCERREC:1;                /**< bit:      6  CRC Error Interrupt Disable              */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } ISO;                                /**< Structure used for ISO mode access */
+  struct { // BLK mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t TXSTPEC:1;                 /**< bit:      2  Transmitted SETUP Interrupt Disable      */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } BLK;                                /**< Structure used for BLK mode access */
+  struct { // INTRPT mode
+    uint32_t :2;                        /**< bit:   0..1  Reserved */
+    uint32_t UNDERFIEC:1;               /**< bit:      2  Underflow Interrupt Disable              */
+    uint32_t :3;                        /**< bit:   3..5  Reserved */
+    uint32_t RXSTALLDEC:1;              /**< bit:      6  Received STALLed Interrupt Disable       */
+    uint32_t :25;                       /**< bit:  7..31  Reserved */
+  } INTRPT;                                /**< Structure used for INTRPT mode access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPIDR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPIDR_OFFSET              (0x620)                                       /**<  (USBHS_HSTPIPIDR) Host Pipe Disable Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPIDR_OFFSET              (0x620)                                       /**<  (USBHS_HSTPIPIDR) Host Pipe Disable Register  Offset */
 
 #define USBHS_HSTPIPIDR_RXINEC_Pos          0                                              /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Position */
 #define USBHS_HSTPIPIDR_RXINEC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_RXINEC_Pos)       /**< (USBHS_HSTPIPIDR) Received IN Data Interrupt Disable Mask */
@@ -3043,9 +4070,6 @@ typedef union {
 #define USBHS_HSTPIPIDR_TXOUTEC_Pos         1                                              /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Position */
 #define USBHS_HSTPIPIDR_TXOUTEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_TXOUTEC_Pos)      /**< (USBHS_HSTPIPIDR) Transmitted OUT Data Interrupt Disable Mask */
 #define USBHS_HSTPIPIDR_TXOUTEC             USBHS_HSTPIPIDR_TXOUTEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXOUTEC_Msk instead */
-#define USBHS_HSTPIPIDR_TXSTPEC_Pos         2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
-#define USBHS_HSTPIPIDR_TXSTPEC_Msk         (_U_(0x1) << USBHS_HSTPIPIDR_TXSTPEC_Pos)      /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
-#define USBHS_HSTPIPIDR_TXSTPEC             USBHS_HSTPIPIDR_TXSTPEC_Msk                    /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_TXSTPEC_Msk instead */
 #define USBHS_HSTPIPIDR_PERREC_Pos          3                                              /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Position */
 #define USBHS_HSTPIPIDR_PERREC_Msk          (_U_(0x1) << USBHS_HSTPIPIDR_PERREC_Pos)       /**< (USBHS_HSTPIPIDR) Pipe Error Interrupt Disable Mask */
 #define USBHS_HSTPIPIDR_PERREC              USBHS_HSTPIPIDR_PERREC_Msk                     /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PERREC_Msk instead */
@@ -3055,9 +4079,6 @@ typedef union {
 #define USBHS_HSTPIPIDR_OVERFIEC_Pos        5                                              /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Position */
 #define USBHS_HSTPIPIDR_OVERFIEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_OVERFIEC_Pos)     /**< (USBHS_HSTPIPIDR) Overflow Interrupt Disable Mask */
 #define USBHS_HSTPIPIDR_OVERFIEC            USBHS_HSTPIPIDR_OVERFIEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_OVERFIEC_Msk instead */
-#define USBHS_HSTPIPIDR_RXSTALLDEC_Pos      6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
-#define USBHS_HSTPIPIDR_RXSTALLDEC_Msk      (_U_(0x1) << USBHS_HSTPIPIDR_RXSTALLDEC_Pos)   /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
-#define USBHS_HSTPIPIDR_RXSTALLDEC          USBHS_HSTPIPIDR_RXSTALLDEC_Msk                 /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_RXSTALLDEC_Msk instead */
 #define USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos  7                                              /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Position */
 #define USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk  (_U_(0x1) << USBHS_HSTPIPIDR_SHORTPACKETIEC_Pos)  /**< (USBHS_HSTPIPIDR) Short Packet Interrupt Disable Mask */
 #define USBHS_HSTPIPIDR_SHORTPACKETIEC      USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_SHORTPACKETIEC_Msk instead */
@@ -3073,12 +4094,53 @@ typedef union {
 #define USBHS_HSTPIPIDR_PFREEZEC_Pos        17                                             /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Position */
 #define USBHS_HSTPIPIDR_PFREEZEC_Msk        (_U_(0x1) << USBHS_HSTPIPIDR_PFREEZEC_Pos)     /**< (USBHS_HSTPIPIDR) Pipe Freeze Disable Mask */
 #define USBHS_HSTPIPIDR_PFREEZEC            USBHS_HSTPIPIDR_PFREEZEC_Msk                   /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_PFREEZEC_Msk instead */
-#define USBHS_HSTPIPIDR_MASK                _U_(0x350FF)                                   /**< \deprecated (USBHS_HSTPIPIDR) Register MASK  (Use USBHS_HSTPIPIDR_Msk instead)  */
-#define USBHS_HSTPIPIDR_Msk                 _U_(0x350FF)                                   /**< (USBHS_HSTPIPIDR) Register Mask  */
+#define USBHS_HSTPIPIDR_MASK                _U_(0x350BB)                                   /**< \deprecated (USBHS_HSTPIPIDR) Register MASK  (Use USBHS_HSTPIPIDR_Msk instead)  */
+#define USBHS_HSTPIPIDR_Msk                 _U_(0x350BB)                                   /**< (USBHS_HSTPIPIDR) Register Mask  */
+
+/* CTRL mode */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC_Pos    2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk    (_U_(0x1) << USBHS_HSTPIPIDR_CTRL_TXSTPEC_Pos)  /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_CTRL_TXSTPEC        USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_CTRL_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Pos 6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_CTRL_RXSTALLDEC     USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_CTRL_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_CTRL_MASK           _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_CTRL) Register MASK  (Use USBHS_HSTPIPIDR_CTRL_Msk instead)  */
+#define USBHS_HSTPIPIDR_CTRL_Msk            _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_CTRL) Register Mask  */
+
+/* ISO mode */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC_Pos   2                                              /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk   (_U_(0x1) << USBHS_HSTPIPIDR_ISO_UNDERFIEC_Pos)  /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_ISO_UNDERFIEC       USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk              /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_ISO_UNDERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC_Pos    6                                              /**< (USBHS_HSTPIPIDR) CRC Error Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC_Msk    (_U_(0x1) << USBHS_HSTPIPIDR_ISO_CRCERREC_Pos)  /**< (USBHS_HSTPIPIDR) CRC Error Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_ISO_CRCERREC        USBHS_HSTPIPIDR_ISO_CRCERREC_Msk               /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_ISO_CRCERREC_Msk instead */
+#define USBHS_HSTPIPIDR_ISO_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_ISO) Register MASK  (Use USBHS_HSTPIPIDR_ISO_Msk instead)  */
+#define USBHS_HSTPIPIDR_ISO_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_ISO) Register Mask  */
+
+/* BLK mode */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC_Pos     2                                              /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk     (_U_(0x1) << USBHS_HSTPIPIDR_BLK_TXSTPEC_Pos)  /**< (USBHS_HSTPIPIDR) Transmitted SETUP Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_BLK_TXSTPEC         USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk                /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_BLK_TXSTPEC_Msk instead */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Pos  6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk  (_U_(0x1) << USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_BLK_RXSTALLDEC      USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_BLK_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_BLK_MASK            _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_BLK) Register MASK  (Use USBHS_HSTPIPIDR_BLK_Msk instead)  */
+#define USBHS_HSTPIPIDR_BLK_Msk             _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_BLK) Register Mask  */
+
+/* INTRPT mode */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Pos 2                                              /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Pos)  /**< (USBHS_HSTPIPIDR) Underflow Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_INTRPT_UNDERFIEC    USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_INTRPT_UNDERFIEC_Msk instead */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Pos 6                                              /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Position */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk (_U_(0x1) << USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Pos)  /**< (USBHS_HSTPIPIDR) Received STALLed Interrupt Disable Mask */
+#define USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC   USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk          /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_HSTPIPIDR_INTRPT_RXSTALLDEC_Msk instead */
+#define USBHS_HSTPIPIDR_INTRPT_MASK         _U_(0x44)                                      /**< \deprecated (USBHS_HSTPIPIDR_INTRPT) Register MASK  (Use USBHS_HSTPIPIDR_INTRPT_Msk instead)  */
+#define USBHS_HSTPIPIDR_INTRPT_Msk          _U_(0x44)                                      /**< (USBHS_HSTPIPIDR_INTRPT) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPINRQ : (USBHS Offset: 0x650) (R/W 32) Host Pipe IN Request Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPINRQ : (USBHS Offset: 0x650) (R/W 32) Host Pipe IN Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t INRQ:8;                    /**< bit:   0..7  IN Request Number before Freeze          */
@@ -3087,9 +4149,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPINRQ_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPINRQ_OFFSET             (0x650)                                       /**<  (USBHS_HSTPIPINRQ) Host Pipe IN Request Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPINRQ_OFFSET             (0x650)                                       /**<  (USBHS_HSTPIPINRQ) Host Pipe IN Request Register  Offset */
 
 #define USBHS_HSTPIPINRQ_INRQ_Pos           0                                              /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Position */
 #define USBHS_HSTPIPINRQ_INRQ_Msk           (_U_(0xFF) << USBHS_HSTPIPINRQ_INRQ_Pos)       /**< (USBHS_HSTPIPINRQ) IN Request Number before Freeze Mask */
@@ -3101,8 +4164,9 @@ typedef union {
 #define USBHS_HSTPIPINRQ_Msk                _U_(0x1FF)                                     /**< (USBHS_HSTPIPINRQ) Register Mask  */
 
 
-/* -------- USBHS_HSTPIPERR : (USBHS Offset: 0x680) (R/W 32) Host Pipe Error Register (n = 0) 0 -------- */
+/* -------- USBHS_HSTPIPERR : (USBHS Offset: 0x680) (R/W 32) Host Pipe Error Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DATATGL:1;                 /**< bit:      0  Data Toggle Error                        */
@@ -3113,11 +4177,17 @@ typedef union {
     uint32_t COUNTER:2;                 /**< bit:   5..6  Error Counter                            */
     uint32_t :25;                       /**< bit:  7..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t :4;                        /**< bit:   0..3  Reserved */
+    uint32_t CRC:1;                     /**< bit:      4  CRCx6 Error                              */
+    uint32_t :27;                       /**< bit:  5..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_HSTPIPERR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define USBHS_HSTPIPERR_OFFSET              (0x680)                                       /**<  (USBHS_HSTPIPERR) Host Pipe Error Register (n = 0) 0  Offset */
+#define USBHS_HSTPIPERR_OFFSET              (0x680)                                       /**<  (USBHS_HSTPIPERR) Host Pipe Error Register  Offset */
 
 #define USBHS_HSTPIPERR_DATATGL_Pos         0                                              /**< (USBHS_HSTPIPERR) Data Toggle Error Position */
 #define USBHS_HSTPIPERR_DATATGL_Msk         (_U_(0x1) << USBHS_HSTPIPERR_DATATGL_Pos)      /**< (USBHS_HSTPIPERR) Data Toggle Error Mask */
@@ -3140,9 +4210,13 @@ typedef union {
 #define USBHS_HSTPIPERR_MASK                _U_(0x7F)                                      /**< \deprecated (USBHS_HSTPIPERR) Register MASK  (Use USBHS_HSTPIPERR_Msk instead)  */
 #define USBHS_HSTPIPERR_Msk                 _U_(0x7F)                                      /**< (USBHS_HSTPIPERR) Register Mask  */
 
+#define USBHS_HSTPIPERR_CRC_Pos             4                                              /**< (USBHS_HSTPIPERR Position) CRCx6 Error */
+#define USBHS_HSTPIPERR_CRC_Msk             (_U_(0x1) << USBHS_HSTPIPERR_CRC_Pos)          /**< (USBHS_HSTPIPERR Mask) CRC */
+#define USBHS_HSTPIPERR_CRC(value)          (USBHS_HSTPIPERR_CRC_Msk & ((value) << USBHS_HSTPIPERR_CRC_Pos))  
 
 /* -------- USBHS_CTRL : (USBHS Offset: 0x800) (R/W 32) General Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3152,12 +4226,14 @@ typedef union {
     uint32_t :5;                        /**< bit:  9..13  Reserved */
     uint32_t FRZCLK:1;                  /**< bit:     14  Freeze USB Clock                         */
     uint32_t USBE:1;                    /**< bit:     15  USBHS Enable                             */
-    uint32_t :9;                        /**< bit: 16..24  Reserved */
+    uint32_t :8;                        /**< bit: 16..23  Reserved */
+    uint32_t UID:1;                     /**< bit:     24  UID Pin Enable                           */
     uint32_t UIMOD:1;                   /**< bit:     25  USBHS Mode                               */
     uint32_t :6;                        /**< bit: 26..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_CTRL_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_CTRL_OFFSET                   (0x800)                                       /**<  (USBHS_CTRL) General Control Register  Offset */
@@ -3174,6 +4250,9 @@ typedef union {
 #define USBHS_CTRL_USBE_Pos                 15                                             /**< (USBHS_CTRL) USBHS Enable Position */
 #define USBHS_CTRL_USBE_Msk                 (_U_(0x1) << USBHS_CTRL_USBE_Pos)              /**< (USBHS_CTRL) USBHS Enable Mask */
 #define USBHS_CTRL_USBE                     USBHS_CTRL_USBE_Msk                            /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_USBE_Msk instead */
+#define USBHS_CTRL_UID_Pos                  24                                             /**< (USBHS_CTRL) UID Pin Enable Position */
+#define USBHS_CTRL_UID_Msk                  (_U_(0x1) << USBHS_CTRL_UID_Pos)               /**< (USBHS_CTRL) UID Pin Enable Mask */
+#define USBHS_CTRL_UID                      USBHS_CTRL_UID_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UID_Msk instead */
 #define USBHS_CTRL_UIMOD_Pos                25                                             /**< (USBHS_CTRL) USBHS Mode Position */
 #define USBHS_CTRL_UIMOD_Msk                (_U_(0x1) << USBHS_CTRL_UIMOD_Pos)             /**< (USBHS_CTRL) USBHS Mode Mask */
 #define USBHS_CTRL_UIMOD                    USBHS_CTRL_UIMOD_Msk                           /**< \deprecated Old style mask definition for 1 bit bitfield. Use USBHS_CTRL_UIMOD_Msk instead */
@@ -3181,12 +4260,13 @@ typedef union {
 #define   USBHS_CTRL_UIMOD_DEVICE_Val       _U_(0x1)                                       /**< (USBHS_CTRL) The module is in USB Device mode.  */
 #define USBHS_CTRL_UIMOD_HOST               (USBHS_CTRL_UIMOD_HOST_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Host mode. Position  */
 #define USBHS_CTRL_UIMOD_DEVICE             (USBHS_CTRL_UIMOD_DEVICE_Val << USBHS_CTRL_UIMOD_Pos)  /**< (USBHS_CTRL) The module is in USB Device mode. Position  */
-#define USBHS_CTRL_MASK                     _U_(0x200C110)                                 /**< \deprecated (USBHS_CTRL) Register MASK  (Use USBHS_CTRL_Msk instead)  */
-#define USBHS_CTRL_Msk                      _U_(0x200C110)                                 /**< (USBHS_CTRL) Register Mask  */
+#define USBHS_CTRL_MASK                     _U_(0x300C110)                                 /**< \deprecated (USBHS_CTRL) Register MASK  (Use USBHS_CTRL_Msk instead)  */
+#define USBHS_CTRL_Msk                      _U_(0x300C110)                                 /**< (USBHS_CTRL) Register Mask  */
 
 
 /* -------- USBHS_SR : (USBHS Offset: 0x804) (R/ 32) General Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3198,6 +4278,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SR_OFFSET                     (0x804)                                       /**<  (USBHS_SR) General Status Register  Offset */
@@ -3223,6 +4304,7 @@ typedef union {
 
 /* -------- USBHS_SCR : (USBHS Offset: 0x808) (/W 32) General Status Clear Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3231,6 +4313,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SCR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SCR_OFFSET                    (0x808)                                       /**<  (USBHS_SCR) General Status Clear Register  Offset */
@@ -3244,6 +4327,7 @@ typedef union {
 
 /* -------- USBHS_SFR : (USBHS Offset: 0x80c) (/W 32) General Status Set Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t :4;                        /**< bit:   0..3  Reserved */
@@ -3254,6 +4338,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } USBHS_SFR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define USBHS_SFR_OFFSET                    (0x80C)                                       /**<  (USBHS_SFR) General Status Set Register  Offset */
@@ -3272,18 +4357,18 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief USBHS_DEVDMA hardware registers */
 typedef struct {  
-  __IO uint32_t USBHS_DEVDMANXTDSC; /**< (USBHS_DEVDMA Offset: 0x00) Device DMA Channel Next Descriptor Address Register (n = 1) */
-  __IO uint32_t USBHS_DEVDMAADDRESS; /**< (USBHS_DEVDMA Offset: 0x04) Device DMA Channel Address Register (n = 1) */
-  __IO uint32_t USBHS_DEVDMACONTROL; /**< (USBHS_DEVDMA Offset: 0x08) Device DMA Channel Control Register (n = 1) */
-  __IO uint32_t USBHS_DEVDMASTATUS; /**< (USBHS_DEVDMA Offset: 0x0C) Device DMA Channel Status Register (n = 1) */
+  __IO uint32_t USBHS_DEVDMANXTDSC; /**< (USBHS_DEVDMA Offset: 0x00) Device DMA Channel Next Descriptor Address Register */
+  __IO uint32_t USBHS_DEVDMAADDRESS; /**< (USBHS_DEVDMA Offset: 0x04) Device DMA Channel Address Register */
+  __IO uint32_t USBHS_DEVDMACONTROL; /**< (USBHS_DEVDMA Offset: 0x08) Device DMA Channel Control Register */
+  __IO uint32_t USBHS_DEVDMASTATUS; /**< (USBHS_DEVDMA Offset: 0x0C) Device DMA Channel Status Register */
 } UsbhsDevdma;
 
 /** \brief USBHS_HSTDMA hardware registers */
 typedef struct {  
-  __IO uint32_t USBHS_HSTDMANXTDSC; /**< (USBHS_HSTDMA Offset: 0x00) Host DMA Channel Next Descriptor Address Register (n = 1) */
-  __IO uint32_t USBHS_HSTDMAADDRESS; /**< (USBHS_HSTDMA Offset: 0x04) Host DMA Channel Address Register (n = 1) */
-  __IO uint32_t USBHS_HSTDMACONTROL; /**< (USBHS_HSTDMA Offset: 0x08) Host DMA Channel Control Register (n = 1) */
-  __IO uint32_t USBHS_HSTDMASTATUS; /**< (USBHS_HSTDMA Offset: 0x0C) Host DMA Channel Status Register (n = 1) */
+  __IO uint32_t USBHS_HSTDMANXTDSC; /**< (USBHS_HSTDMA Offset: 0x00) Host DMA Channel Next Descriptor Address Register */
+  __IO uint32_t USBHS_HSTDMAADDRESS; /**< (USBHS_HSTDMA Offset: 0x04) Host DMA Channel Address Register */
+  __IO uint32_t USBHS_HSTDMACONTROL; /**< (USBHS_HSTDMA Offset: 0x08) Host DMA Channel Control Register */
+  __IO uint32_t USBHS_HSTDMASTATUS; /**< (USBHS_HSTDMA Offset: 0x0C) Host DMA Channel Status Register */
 } UsbhsHstdma;
 
 #define USBHSDEVDMA_NUMBER 7
@@ -3299,23 +4384,23 @@ typedef struct {
   __O  uint32_t USBHS_DEVIER;   /**< (USBHS Offset: 0x18) Device Global Interrupt Enable Register */
   __IO uint32_t USBHS_DEVEPT;   /**< (USBHS Offset: 0x1C) Device Endpoint Register */
   __I  uint32_t USBHS_DEVFNUM;  /**< (USBHS Offset: 0x20) Device Frame Number Register */
-  RoReg8  Reserved1[0xDC];
-  __IO uint32_t USBHS_DEVEPTCFG[10]; /**< (USBHS Offset: 0x100) Device Endpoint Configuration Register (n = 0) 0 */
-  RoReg8  Reserved2[0x8];
-  __I  uint32_t USBHS_DEVEPTISR[10]; /**< (USBHS Offset: 0x130) Device Endpoint Status Register (n = 0) 0 */
-  RoReg8  Reserved3[0x8];
-  __O  uint32_t USBHS_DEVEPTICR[10]; /**< (USBHS Offset: 0x160) Device Endpoint Clear Register (n = 0) 0 */
-  RoReg8  Reserved4[0x8];
-  __O  uint32_t USBHS_DEVEPTIFR[10]; /**< (USBHS Offset: 0x190) Device Endpoint Set Register (n = 0) 0 */
-  RoReg8  Reserved5[0x8];
-  __I  uint32_t USBHS_DEVEPTIMR[10]; /**< (USBHS Offset: 0x1C0) Device Endpoint Mask Register (n = 0) 0 */
-  RoReg8  Reserved6[0x8];
-  __O  uint32_t USBHS_DEVEPTIER[10]; /**< (USBHS Offset: 0x1F0) Device Endpoint Enable Register (n = 0) 0 */
-  RoReg8  Reserved7[0x8];
-  __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Disable Register (n = 0) 0 */
-  RoReg8  Reserved8[0xC8];
-       UsbhsDevdma USBHS_DEVDMA[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
-  RoReg8  Reserved9[0x80];
+  __I  uint8_t                        Reserved1[220];
+  __IO uint32_t USBHS_DEVEPTCFG[10]; /**< (USBHS Offset: 0x100) Device Endpoint Configuration Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  uint32_t USBHS_DEVEPTISR[10]; /**< (USBHS Offset: 0x130) Device Endpoint Interrupt Status Register */
+  __I  uint8_t                        Reserved3[8];
+  __O  uint32_t USBHS_DEVEPTICR[10]; /**< (USBHS Offset: 0x160) Device Endpoint Interrupt Clear Register */
+  __I  uint8_t                        Reserved4[8];
+  __O  uint32_t USBHS_DEVEPTIFR[10]; /**< (USBHS Offset: 0x190) Device Endpoint Interrupt Set Register */
+  __I  uint8_t                        Reserved5[8];
+  __I  uint32_t USBHS_DEVEPTIMR[10]; /**< (USBHS Offset: 0x1C0) Device Endpoint Interrupt Mask Register */
+  __I  uint8_t                        Reserved6[8];
+  __O  uint32_t USBHS_DEVEPTIER[10]; /**< (USBHS Offset: 0x1F0) Device Endpoint Interrupt Enable Register */
+  __I  uint8_t                        Reserved7[8];
+  __O  uint32_t USBHS_DEVEPTIDR[10]; /**< (USBHS Offset: 0x220) Device Endpoint Interrupt Disable Register */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma UsbhsDevdma[USBHSDEVDMA_NUMBER]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved9[128];
   __IO uint32_t USBHS_HSTCTRL;  /**< (USBHS Offset: 0x400) Host General Control Register */
   __I  uint32_t USBHS_HSTISR;   /**< (USBHS Offset: 0x404) Host Global Interrupt Status Register */
   __O  uint32_t USBHS_HSTICR;   /**< (USBHS Offset: 0x408) Host Global Interrupt Clear Register */
@@ -3328,27 +4413,27 @@ typedef struct {
   __IO uint32_t USBHS_HSTADDR1; /**< (USBHS Offset: 0x424) Host Address 1 Register */
   __IO uint32_t USBHS_HSTADDR2; /**< (USBHS Offset: 0x428) Host Address 2 Register */
   __IO uint32_t USBHS_HSTADDR3; /**< (USBHS Offset: 0x42C) Host Address 3 Register */
-  RoReg8  Reserved10[0xD0];
-  __IO uint32_t USBHS_HSTPIPCFG[10]; /**< (USBHS Offset: 0x500) Host Pipe Configuration Register (n = 0) 0 */
-  RoReg8  Reserved11[0x8];
-  __I  uint32_t USBHS_HSTPIPISR[10]; /**< (USBHS Offset: 0x530) Host Pipe Status Register (n = 0) 0 */
-  RoReg8  Reserved12[0x8];
-  __O  uint32_t USBHS_HSTPIPICR[10]; /**< (USBHS Offset: 0x560) Host Pipe Clear Register (n = 0) 0 */
-  RoReg8  Reserved13[0x8];
-  __O  uint32_t USBHS_HSTPIPIFR[10]; /**< (USBHS Offset: 0x590) Host Pipe Set Register (n = 0) 0 */
-  RoReg8  Reserved14[0x8];
-  __I  uint32_t USBHS_HSTPIPIMR[10]; /**< (USBHS Offset: 0x5C0) Host Pipe Mask Register (n = 0) 0 */
-  RoReg8  Reserved15[0x8];
-  __O  uint32_t USBHS_HSTPIPIER[10]; /**< (USBHS Offset: 0x5F0) Host Pipe Enable Register (n = 0) 0 */
-  RoReg8  Reserved16[0x8];
-  __O  uint32_t USBHS_HSTPIPIDR[10]; /**< (USBHS Offset: 0x620) Host Pipe Disable Register (n = 0) 0 */
-  RoReg8  Reserved17[0x8];
-  __IO uint32_t USBHS_HSTPIPINRQ[10]; /**< (USBHS Offset: 0x650) Host Pipe IN Request Register (n = 0) 0 */
-  RoReg8  Reserved18[0x8];
-  __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register (n = 0) 0 */
-  RoReg8  Reserved19[0x68];
-       UsbhsHstdma USBHS_HSTDMA[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
-  RoReg8  Reserved20[0x80];
+  __I  uint8_t                        Reserved10[208];
+  __IO uint32_t USBHS_HSTPIPCFG[10]; /**< (USBHS Offset: 0x500) Host Pipe Configuration Register */
+  __I  uint8_t                        Reserved11[8];
+  __I  uint32_t USBHS_HSTPIPISR[10]; /**< (USBHS Offset: 0x530) Host Pipe Status Register */
+  __I  uint8_t                        Reserved12[8];
+  __O  uint32_t USBHS_HSTPIPICR[10]; /**< (USBHS Offset: 0x560) Host Pipe Clear Register */
+  __I  uint8_t                        Reserved13[8];
+  __O  uint32_t USBHS_HSTPIPIFR[10]; /**< (USBHS Offset: 0x590) Host Pipe Set Register */
+  __I  uint8_t                        Reserved14[8];
+  __I  uint32_t USBHS_HSTPIPIMR[10]; /**< (USBHS Offset: 0x5C0) Host Pipe Mask Register */
+  __I  uint8_t                        Reserved15[8];
+  __O  uint32_t USBHS_HSTPIPIER[10]; /**< (USBHS Offset: 0x5F0) Host Pipe Enable Register */
+  __I  uint8_t                        Reserved16[8];
+  __O  uint32_t USBHS_HSTPIPIDR[10]; /**< (USBHS Offset: 0x620) Host Pipe Disable Register */
+  __I  uint8_t                        Reserved17[8];
+  __IO uint32_t USBHS_HSTPIPINRQ[10]; /**< (USBHS Offset: 0x650) Host Pipe IN Request Register */
+  __I  uint8_t                        Reserved18[8];
+  __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved20[128];
   __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
   __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
   __O  uint32_t USBHS_SCR;      /**< (USBHS Offset: 0x808) General Status Clear Register */
@@ -3358,18 +4443,18 @@ typedef struct {
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief USBHS_DEVDMA hardware registers */
 typedef struct {  
-  __IO USBHS_DEVDMANXTDSC_Type        USBHS_DEVDMANXTDSC; /**< Offset: 0x00 (R/W  32) Device DMA Channel Next Descriptor Address Register (n = 1) */
-  __IO USBHS_DEVDMAADDRESS_Type       USBHS_DEVDMAADDRESS; /**< Offset: 0x04 (R/W  32) Device DMA Channel Address Register (n = 1) */
-  __IO USBHS_DEVDMACONTROL_Type       USBHS_DEVDMACONTROL; /**< Offset: 0x08 (R/W  32) Device DMA Channel Control Register (n = 1) */
-  __IO USBHS_DEVDMASTATUS_Type        USBHS_DEVDMASTATUS; /**< Offset: 0x0C (R/W  32) Device DMA Channel Status Register (n = 1) */
+  __IO USBHS_DEVDMANXTDSC_Type        USBHS_DEVDMANXTDSC; /**< Offset: 0x00 (R/W  32) Device DMA Channel Next Descriptor Address Register */
+  __IO USBHS_DEVDMAADDRESS_Type       USBHS_DEVDMAADDRESS; /**< Offset: 0x04 (R/W  32) Device DMA Channel Address Register */
+  __IO USBHS_DEVDMACONTROL_Type       USBHS_DEVDMACONTROL; /**< Offset: 0x08 (R/W  32) Device DMA Channel Control Register */
+  __IO USBHS_DEVDMASTATUS_Type        USBHS_DEVDMASTATUS; /**< Offset: 0x0C (R/W  32) Device DMA Channel Status Register */
 } UsbhsDevdma;
 
 /** \brief USBHS_HSTDMA hardware registers */
 typedef struct {  
-  __IO USBHS_HSTDMANXTDSC_Type        USBHS_HSTDMANXTDSC; /**< Offset: 0x00 (R/W  32) Host DMA Channel Next Descriptor Address Register (n = 1) */
-  __IO USBHS_HSTDMAADDRESS_Type       USBHS_HSTDMAADDRESS; /**< Offset: 0x04 (R/W  32) Host DMA Channel Address Register (n = 1) */
-  __IO USBHS_HSTDMACONTROL_Type       USBHS_HSTDMACONTROL; /**< Offset: 0x08 (R/W  32) Host DMA Channel Control Register (n = 1) */
-  __IO USBHS_HSTDMASTATUS_Type        USBHS_HSTDMASTATUS; /**< Offset: 0x0C (R/W  32) Host DMA Channel Status Register (n = 1) */
+  __IO USBHS_HSTDMANXTDSC_Type        USBHS_HSTDMANXTDSC; /**< Offset: 0x00 (R/W  32) Host DMA Channel Next Descriptor Address Register */
+  __IO USBHS_HSTDMAADDRESS_Type       USBHS_HSTDMAADDRESS; /**< Offset: 0x04 (R/W  32) Host DMA Channel Address Register */
+  __IO USBHS_HSTDMACONTROL_Type       USBHS_HSTDMACONTROL; /**< Offset: 0x08 (R/W  32) Host DMA Channel Control Register */
+  __IO USBHS_HSTDMASTATUS_Type        USBHS_HSTDMASTATUS; /**< Offset: 0x0C (R/W  32) Host DMA Channel Status Register */
 } UsbhsHstdma;
 
 /** \brief USBHS hardware registers */
@@ -3383,23 +4468,23 @@ typedef struct {
   __O  USBHS_DEVIER_Type              USBHS_DEVIER;   /**< Offset: 0x18 ( /W  32) Device Global Interrupt Enable Register */
   __IO USBHS_DEVEPT_Type              USBHS_DEVEPT;   /**< Offset: 0x1C (R/W  32) Device Endpoint Register */
   __I  USBHS_DEVFNUM_Type             USBHS_DEVFNUM;  /**< Offset: 0x20 (R/   32) Device Frame Number Register */
-  __I  uint32_t                       Reserved1[55];
-  __IO USBHS_DEVEPTCFG_Type           USBHS_DEVEPTCFG[10]; /**< Offset: 0x100 (R/W  32) Device Endpoint Configuration Register (n = 0) 0 */
-  __I  uint32_t                       Reserved2[2];
-  __I  USBHS_DEVEPTISR_Type           USBHS_DEVEPTISR[10]; /**< Offset: 0x130 (R/   32) Device Endpoint Status Register (n = 0) 0 */
-  __I  uint32_t                       Reserved3[2];
-  __O  USBHS_DEVEPTICR_Type           USBHS_DEVEPTICR[10]; /**< Offset: 0x160 ( /W  32) Device Endpoint Clear Register (n = 0) 0 */
-  __I  uint32_t                       Reserved4[2];
-  __O  USBHS_DEVEPTIFR_Type           USBHS_DEVEPTIFR[10]; /**< Offset: 0x190 ( /W  32) Device Endpoint Set Register (n = 0) 0 */
-  __I  uint32_t                       Reserved5[2];
-  __I  USBHS_DEVEPTIMR_Type           USBHS_DEVEPTIMR[10]; /**< Offset: 0x1C0 (R/   32) Device Endpoint Mask Register (n = 0) 0 */
-  __I  uint32_t                       Reserved6[2];
-  __O  USBHS_DEVEPTIER_Type           USBHS_DEVEPTIER[10]; /**< Offset: 0x1F0 ( /W  32) Device Endpoint Enable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved7[2];
-  __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Disable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved8[50];
-       UsbhsDevdma                    USBHS_DEVDMA[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register (n = 1) */
-  __I  uint32_t                       Reserved9[32];
+  __I  uint8_t                        Reserved1[220];
+  __IO USBHS_DEVEPTCFG_Type           USBHS_DEVEPTCFG[10]; /**< Offset: 0x100 (R/W  32) Device Endpoint Configuration Register */
+  __I  uint8_t                        Reserved2[8];
+  __I  USBHS_DEVEPTISR_Type           USBHS_DEVEPTISR[10]; /**< Offset: 0x130 (R/   32) Device Endpoint Interrupt Status Register */
+  __I  uint8_t                        Reserved3[8];
+  __O  USBHS_DEVEPTICR_Type           USBHS_DEVEPTICR[10]; /**< Offset: 0x160 ( /W  32) Device Endpoint Interrupt Clear Register */
+  __I  uint8_t                        Reserved4[8];
+  __O  USBHS_DEVEPTIFR_Type           USBHS_DEVEPTIFR[10]; /**< Offset: 0x190 ( /W  32) Device Endpoint Interrupt Set Register */
+  __I  uint8_t                        Reserved5[8];
+  __I  USBHS_DEVEPTIMR_Type           USBHS_DEVEPTIMR[10]; /**< Offset: 0x1C0 (R/   32) Device Endpoint Interrupt Mask Register */
+  __I  uint8_t                        Reserved6[8];
+  __O  USBHS_DEVEPTIER_Type           USBHS_DEVEPTIER[10]; /**< Offset: 0x1F0 ( /W  32) Device Endpoint Interrupt Enable Register */
+  __I  uint8_t                        Reserved7[8];
+  __O  USBHS_DEVEPTIDR_Type           USBHS_DEVEPTIDR[10]; /**< Offset: 0x220 ( /W  32) Device Endpoint Interrupt Disable Register */
+  __I  uint8_t                        Reserved8[200];
+       UsbhsDevdma                    UsbhsDevdma[7]; /**< Offset: 0x310 Device DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved9[128];
   __IO USBHS_HSTCTRL_Type             USBHS_HSTCTRL;  /**< Offset: 0x400 (R/W  32) Host General Control Register */
   __I  USBHS_HSTISR_Type              USBHS_HSTISR;   /**< Offset: 0x404 (R/   32) Host Global Interrupt Status Register */
   __O  USBHS_HSTICR_Type              USBHS_HSTICR;   /**< Offset: 0x408 ( /W  32) Host Global Interrupt Clear Register */
@@ -3412,27 +4497,27 @@ typedef struct {
   __IO USBHS_HSTADDR1_Type            USBHS_HSTADDR1; /**< Offset: 0x424 (R/W  32) Host Address 1 Register */
   __IO USBHS_HSTADDR2_Type            USBHS_HSTADDR2; /**< Offset: 0x428 (R/W  32) Host Address 2 Register */
   __IO USBHS_HSTADDR3_Type            USBHS_HSTADDR3; /**< Offset: 0x42C (R/W  32) Host Address 3 Register */
-  __I  uint32_t                       Reserved10[52];
-  __IO USBHS_HSTPIPCFG_Type           USBHS_HSTPIPCFG[10]; /**< Offset: 0x500 (R/W  32) Host Pipe Configuration Register (n = 0) 0 */
-  __I  uint32_t                       Reserved11[2];
-  __I  USBHS_HSTPIPISR_Type           USBHS_HSTPIPISR[10]; /**< Offset: 0x530 (R/   32) Host Pipe Status Register (n = 0) 0 */
-  __I  uint32_t                       Reserved12[2];
-  __O  USBHS_HSTPIPICR_Type           USBHS_HSTPIPICR[10]; /**< Offset: 0x560 ( /W  32) Host Pipe Clear Register (n = 0) 0 */
-  __I  uint32_t                       Reserved13[2];
-  __O  USBHS_HSTPIPIFR_Type           USBHS_HSTPIPIFR[10]; /**< Offset: 0x590 ( /W  32) Host Pipe Set Register (n = 0) 0 */
-  __I  uint32_t                       Reserved14[2];
-  __I  USBHS_HSTPIPIMR_Type           USBHS_HSTPIPIMR[10]; /**< Offset: 0x5C0 (R/   32) Host Pipe Mask Register (n = 0) 0 */
-  __I  uint32_t                       Reserved15[2];
-  __O  USBHS_HSTPIPIER_Type           USBHS_HSTPIPIER[10]; /**< Offset: 0x5F0 ( /W  32) Host Pipe Enable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved16[2];
-  __O  USBHS_HSTPIPIDR_Type           USBHS_HSTPIPIDR[10]; /**< Offset: 0x620 ( /W  32) Host Pipe Disable Register (n = 0) 0 */
-  __I  uint32_t                       Reserved17[2];
-  __IO USBHS_HSTPIPINRQ_Type          USBHS_HSTPIPINRQ[10]; /**< Offset: 0x650 (R/W  32) Host Pipe IN Request Register (n = 0) 0 */
-  __I  uint32_t                       Reserved18[2];
-  __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register (n = 0) 0 */
-  __I  uint32_t                       Reserved19[26];
-       UsbhsHstdma                    USBHS_HSTDMA[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register (n = 1) */
-  __I  uint32_t                       Reserved20[32];
+  __I  uint8_t                        Reserved10[208];
+  __IO USBHS_HSTPIPCFG_Type           USBHS_HSTPIPCFG[10]; /**< Offset: 0x500 (R/W  32) Host Pipe Configuration Register */
+  __I  uint8_t                        Reserved11[8];
+  __I  USBHS_HSTPIPISR_Type           USBHS_HSTPIPISR[10]; /**< Offset: 0x530 (R/   32) Host Pipe Status Register */
+  __I  uint8_t                        Reserved12[8];
+  __O  USBHS_HSTPIPICR_Type           USBHS_HSTPIPICR[10]; /**< Offset: 0x560 ( /W  32) Host Pipe Clear Register */
+  __I  uint8_t                        Reserved13[8];
+  __O  USBHS_HSTPIPIFR_Type           USBHS_HSTPIPIFR[10]; /**< Offset: 0x590 ( /W  32) Host Pipe Set Register */
+  __I  uint8_t                        Reserved14[8];
+  __I  USBHS_HSTPIPIMR_Type           USBHS_HSTPIPIMR[10]; /**< Offset: 0x5C0 (R/   32) Host Pipe Mask Register */
+  __I  uint8_t                        Reserved15[8];
+  __O  USBHS_HSTPIPIER_Type           USBHS_HSTPIPIER[10]; /**< Offset: 0x5F0 ( /W  32) Host Pipe Enable Register */
+  __I  uint8_t                        Reserved16[8];
+  __O  USBHS_HSTPIPIDR_Type           USBHS_HSTPIPIDR[10]; /**< Offset: 0x620 ( /W  32) Host Pipe Disable Register */
+  __I  uint8_t                        Reserved17[8];
+  __IO USBHS_HSTPIPINRQ_Type          USBHS_HSTPIPINRQ[10]; /**< Offset: 0x650 (R/W  32) Host Pipe IN Request Register */
+  __I  uint8_t                        Reserved18[8];
+  __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register */
+  __I  uint8_t                        Reserved19[104];
+       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+  __I  uint8_t                        Reserved20[128];
   __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
   __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */
   __O  USBHS_SCR_Type                 USBHS_SCR;      /**< Offset: 0x808 ( /W  32) General Status Clear Register */
@@ -3446,4 +4531,7 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 /** @}  end of USB High-Speed Interface */
 
+#if !(defined(DO_NOT_USE_DEPRECATED_MACROS))
+#include "deprecated/usbhs.h"
+#endif /* DO_NOT_USE_DEPRECATED_MACROS */
 #endif /* _SAME70_USBHS_COMPONENT_H_ */

--- a/asf/sam/include/same70b/component/usbhs.h
+++ b/asf/sam/include/same70b/component/usbhs.h
@@ -4432,7 +4432,7 @@ typedef struct {
   __I  uint8_t                        Reserved18[8];
   __IO uint32_t USBHS_HSTPIPERR[10]; /**< (USBHS Offset: 0x680) Host Pipe Error Register */
   __I  uint8_t                        Reserved19[104];
-       UsbhsHstdma UsbhsHstdma[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+       UsbhsHstdma USBHS_HSTDMA[USBHSHSTDMA_NUMBER]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
   __I  uint8_t                        Reserved20[128];
   __IO uint32_t USBHS_CTRL;     /**< (USBHS Offset: 0x800) General Control Register */
   __I  uint32_t USBHS_SR;       /**< (USBHS Offset: 0x804) General Status Register */
@@ -4516,7 +4516,7 @@ typedef struct {
   __I  uint8_t                        Reserved18[8];
   __IO USBHS_HSTPIPERR_Type           USBHS_HSTPIPERR[10]; /**< Offset: 0x680 (R/W  32) Host Pipe Error Register */
   __I  uint8_t                        Reserved19[104];
-       UsbhsHstdma                    UsbhsHstdma[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
+       UsbhsHstdma                    USBHS_HSTDMA[7]; /**< Offset: 0x710 Host DMA Channel Next Descriptor Address Register */
   __I  uint8_t                        Reserved20[128];
   __IO USBHS_CTRL_Type                USBHS_CTRL;     /**< Offset: 0x800 (R/W  32) General Control Register */
   __I  USBHS_SR_Type                  USBHS_SR;       /**< Offset: 0x804 (R/   32) General Status Register */

--- a/asf/sam/include/same70b/component/utmi.h
+++ b/asf/sam/include/same70b/component/utmi.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for UTMI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UTMI_COMPONENT_H_
 #define _SAME70_UTMI_COMPONENT_H_
 #define _SAME70_UTMI_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- UTMI_OHCIICR : (UTMI Offset: 0x10) (R/W 32) OHCI Interrupt Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RES0:1;                    /**< bit:      0  USB PORTx Reset                          */
@@ -55,8 +58,13 @@ typedef union {
     uint32_t UDPPUDIS:1;                /**< bit:     23  USB Device Pull-up Disable               */
     uint32_t :8;                        /**< bit: 24..31  Reserved */
   } bit;                                /**< Structure used for bit  access */
+  struct {
+    uint32_t RES:1;                     /**< bit:      0  USB PORTx Reset                          */
+    uint32_t :31;                       /**< bit:  1..31 Reserved */
+  } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } UTMI_OHCIICR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UTMI_OHCIICR_OFFSET                 (0x10)                                        /**<  (UTMI_OHCIICR) OHCI Interrupt Configuration Register  Offset */
@@ -76,9 +84,13 @@ typedef union {
 #define UTMI_OHCIICR_MASK                   _U_(0x800031)                                  /**< \deprecated (UTMI_OHCIICR) Register MASK  (Use UTMI_OHCIICR_Msk instead)  */
 #define UTMI_OHCIICR_Msk                    _U_(0x800031)                                  /**< (UTMI_OHCIICR) Register Mask  */
 
+#define UTMI_OHCIICR_RES_Pos                0                                              /**< (UTMI_OHCIICR Position) USB PORTx Reset */
+#define UTMI_OHCIICR_RES_Msk                (_U_(0x1) << UTMI_OHCIICR_RES_Pos)             /**< (UTMI_OHCIICR Mask) RES */
+#define UTMI_OHCIICR_RES(value)             (UTMI_OHCIICR_RES_Msk & ((value) << UTMI_OHCIICR_RES_Pos))  
 
 /* -------- UTMI_CKTRIM : (UTMI Offset: 0x30) (R/W 32) UTMI Clock Trimming Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t FREQ:2;                    /**< bit:   0..1  UTMI Reference Clock Frequency           */
@@ -86,6 +98,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } UTMI_CKTRIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define UTMI_CKTRIM_OFFSET                  (0x30)                                        /**<  (UTMI_CKTRIM) UTMI Clock Trimming Register  Offset */
@@ -105,18 +118,18 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief UTMI hardware registers */
 typedef struct {  
-  RoReg8  Reserved1[0x10];
+  __I  uint8_t                        Reserved1[16];
   __IO uint32_t UTMI_OHCIICR;   /**< (UTMI Offset: 0x10) OHCI Interrupt Configuration Register */
-  RoReg8  Reserved2[0x1C];
+  __I  uint8_t                        Reserved2[28];
   __IO uint32_t UTMI_CKTRIM;    /**< (UTMI Offset: 0x30) UTMI Clock Trimming Register */
 } Utmi;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief UTMI hardware registers */
 typedef struct {  
-  __I  uint32_t                       Reserved1[4];
+  __I  uint8_t                        Reserved1[16];
   __IO UTMI_OHCIICR_Type              UTMI_OHCIICR;   /**< Offset: 0x10 (R/W  32) OHCI Interrupt Configuration Register */
-  __I  uint32_t                       Reserved2[7];
+  __I  uint8_t                        Reserved2[28];
   __IO UTMI_CKTRIM_Type               UTMI_CKTRIM;    /**< Offset: 0x30 (R/W  32) UTMI Clock Trimming Register */
 } Utmi;
 

--- a/asf/sam/include/same70b/component/wdt.h
+++ b/asf/sam/include/same70b/component/wdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for WDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_WDT_COMPONENT_H_
 #define _SAME70_WDT_COMPONENT_H_
 #define _SAME70_WDT_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -45,6 +47,7 @@
 
 /* -------- WDT_CR : (WDT Offset: 0x00) (/W 32) Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDRSTT:1;                  /**< bit:      0  Watchdog Restart                         */
@@ -53,6 +56,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_CR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_CR_OFFSET                       (0x00)                                        /**<  (WDT_CR) Control Register  Offset */
@@ -71,6 +75,7 @@ typedef union {
 
 /* -------- WDT_MR : (WDT Offset: 0x04) (R/W 32) Mode Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDV:12;                    /**< bit:  0..11  Watchdog Counter Value                   */
@@ -85,6 +90,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_MR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_MR_OFFSET                       (0x04)                                        /**<  (WDT_MR) Mode Register  Offset */
@@ -116,6 +122,7 @@ typedef union {
 
 /* -------- WDT_SR : (WDT Offset: 0x08) (R/ 32) Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WDUNF:1;                   /**< bit:      0  Watchdog Underflow (cleared on read)     */
@@ -124,6 +131,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } WDT_SR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define WDT_SR_OFFSET                       (0x08)                                        /**<  (WDT_SR) Status Register  Offset */

--- a/asf/sam/include/same70b/component/xdmac.h
+++ b/asf/sam/include/same70b/component/xdmac.h
@@ -2565,7 +2565,7 @@ typedef struct {
   __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
   __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
   __I  uint8_t                        Reserved1[12];
-       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register */
+       XdmacChid XDMAC_CHID[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register */
 } Xdmac;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
@@ -2608,7 +2608,7 @@ typedef struct {
   __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
   __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
   __I  uint8_t                        Reserved1[12];
-       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register */
+       XdmacChid                      XDMAC_CHID[24];  /**< Offset: 0x50 Channel Interrupt Enable Register */
 } Xdmac;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70b/component/xdmac.h
+++ b/asf/sam/include/same70b/component/xdmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Component description for XDMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_XDMAC_COMPONENT_H_
 #define _SAME70_XDMAC_COMPONENT_H_
 #define _SAME70_XDMAC_COMPONENT_         /**< \deprecated  Backward compatibility for ASF */
@@ -43,8 +45,9 @@
 #define XDMAC_11161                      /**< (XDMAC) Module ID */
 #define REV_XDMAC K                      /**< (XDMAC) Module revision */
 
-/* -------- XDMAC_CIE : (XDMAC Offset: 0x00) (/W 32) Channel Interrupt Enable Register (chid = 0) -------- */
+/* -------- XDMAC_CIE : (XDMAC Offset: 0x00) (/W 32) Channel Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIE:1;                     /**< bit:      0  End of Block Interrupt Enable Bit        */
@@ -58,9 +61,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CIE_OFFSET                    (0x00)                                        /**<  (XDMAC_CIE) Channel Interrupt Enable Register (chid = 0)  Offset */
+#define XDMAC_CIE_OFFSET                    (0x00)                                        /**<  (XDMAC_CIE) Channel Interrupt Enable Register  Offset */
 
 #define XDMAC_CIE_BIE_Pos                   0                                              /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Position */
 #define XDMAC_CIE_BIE_Msk                   (_U_(0x1) << XDMAC_CIE_BIE_Pos)                /**< (XDMAC_CIE) End of Block Interrupt Enable Bit Mask */
@@ -87,8 +91,9 @@ typedef union {
 #define XDMAC_CIE_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIE) Register Mask  */
 
 
-/* -------- XDMAC_CID : (XDMAC Offset: 0x04) (/W 32) Channel Interrupt Disable Register (chid = 0) -------- */
+/* -------- XDMAC_CID : (XDMAC Offset: 0x04) (/W 32) Channel Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BID:1;                     /**< bit:      0  End of Block Interrupt Disable Bit       */
@@ -102,9 +107,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CID_OFFSET                    (0x04)                                        /**<  (XDMAC_CID) Channel Interrupt Disable Register (chid = 0)  Offset */
+#define XDMAC_CID_OFFSET                    (0x04)                                        /**<  (XDMAC_CID) Channel Interrupt Disable Register  Offset */
 
 #define XDMAC_CID_BID_Pos                   0                                              /**< (XDMAC_CID) End of Block Interrupt Disable Bit Position */
 #define XDMAC_CID_BID_Msk                   (_U_(0x1) << XDMAC_CID_BID_Pos)                /**< (XDMAC_CID) End of Block Interrupt Disable Bit Mask */
@@ -131,8 +137,9 @@ typedef union {
 #define XDMAC_CID_Msk                       _U_(0x7F)                                      /**< (XDMAC_CID) Register Mask  */
 
 
-/* -------- XDMAC_CIM : (XDMAC Offset: 0x08) (R/ 32) Channel Interrupt Mask Register (chid = 0) -------- */
+/* -------- XDMAC_CIM : (XDMAC Offset: 0x08) (R/ 32) Channel Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIM:1;                     /**< bit:      0  End of Block Interrupt Mask Bit          */
@@ -146,9 +153,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CIM_OFFSET                    (0x08)                                        /**<  (XDMAC_CIM) Channel Interrupt Mask Register (chid = 0)  Offset */
+#define XDMAC_CIM_OFFSET                    (0x08)                                        /**<  (XDMAC_CIM) Channel Interrupt Mask Register  Offset */
 
 #define XDMAC_CIM_BIM_Pos                   0                                              /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Position */
 #define XDMAC_CIM_BIM_Msk                   (_U_(0x1) << XDMAC_CIM_BIM_Pos)                /**< (XDMAC_CIM) End of Block Interrupt Mask Bit Mask */
@@ -175,8 +183,9 @@ typedef union {
 #define XDMAC_CIM_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIM) Register Mask  */
 
 
-/* -------- XDMAC_CIS : (XDMAC Offset: 0x0c) (R/ 32) Channel Interrupt Status Register (chid = 0) -------- */
+/* -------- XDMAC_CIS : (XDMAC Offset: 0x0c) (R/ 32) Channel Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BIS:1;                     /**< bit:      0  End of Block Interrupt Status Bit        */
@@ -190,9 +199,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CIS_OFFSET                    (0x0C)                                        /**<  (XDMAC_CIS) Channel Interrupt Status Register (chid = 0)  Offset */
+#define XDMAC_CIS_OFFSET                    (0x0C)                                        /**<  (XDMAC_CIS) Channel Interrupt Status Register  Offset */
 
 #define XDMAC_CIS_BIS_Pos                   0                                              /**< (XDMAC_CIS) End of Block Interrupt Status Bit Position */
 #define XDMAC_CIS_BIS_Msk                   (_U_(0x1) << XDMAC_CIS_BIS_Pos)                /**< (XDMAC_CIS) End of Block Interrupt Status Bit Mask */
@@ -219,17 +229,19 @@ typedef union {
 #define XDMAC_CIS_Msk                       _U_(0x7F)                                      /**< (XDMAC_CIS) Register Mask  */
 
 
-/* -------- XDMAC_CSA : (XDMAC Offset: 0x10) (R/W 32) Channel Source Address Register (chid = 0) -------- */
+/* -------- XDMAC_CSA : (XDMAC Offset: 0x10) (R/W 32) Channel Source Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SA:32;                     /**< bit:  0..31  Channel x Source Address                 */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CSA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CSA_OFFSET                    (0x10)                                        /**<  (XDMAC_CSA) Channel Source Address Register (chid = 0)  Offset */
+#define XDMAC_CSA_OFFSET                    (0x10)                                        /**<  (XDMAC_CSA) Channel Source Address Register  Offset */
 
 #define XDMAC_CSA_SA_Pos                    0                                              /**< (XDMAC_CSA) Channel x Source Address Position */
 #define XDMAC_CSA_SA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CSA_SA_Pos)          /**< (XDMAC_CSA) Channel x Source Address Mask */
@@ -238,17 +250,19 @@ typedef union {
 #define XDMAC_CSA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CSA) Register Mask  */
 
 
-/* -------- XDMAC_CDA : (XDMAC Offset: 0x14) (R/W 32) Channel Destination Address Register (chid = 0) -------- */
+/* -------- XDMAC_CDA : (XDMAC Offset: 0x14) (R/W 32) Channel Destination Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DA:32;                     /**< bit:  0..31  Channel x Destination Address            */
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CDA_OFFSET                    (0x14)                                        /**<  (XDMAC_CDA) Channel Destination Address Register (chid = 0)  Offset */
+#define XDMAC_CDA_OFFSET                    (0x14)                                        /**<  (XDMAC_CDA) Channel Destination Address Register  Offset */
 
 #define XDMAC_CDA_DA_Pos                    0                                              /**< (XDMAC_CDA) Channel x Destination Address Position */
 #define XDMAC_CDA_DA_Msk                    (_U_(0xFFFFFFFF) << XDMAC_CDA_DA_Pos)          /**< (XDMAC_CDA) Channel x Destination Address Mask */
@@ -257,8 +271,9 @@ typedef union {
 #define XDMAC_CDA_Msk                       _U_(0xFFFFFFFF)                                /**< (XDMAC_CDA) Register Mask  */
 
 
-/* -------- XDMAC_CNDA : (XDMAC Offset: 0x18) (R/W 32) Channel Next Descriptor Address Register (chid = 0) -------- */
+/* -------- XDMAC_CNDA : (XDMAC Offset: 0x18) (R/W 32) Channel Next Descriptor Address Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NDAIF:1;                   /**< bit:      0  Channel x Next Descriptor Interface      */
@@ -267,9 +282,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CNDA_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CNDA_OFFSET                   (0x18)                                        /**<  (XDMAC_CNDA) Channel Next Descriptor Address Register (chid = 0)  Offset */
+#define XDMAC_CNDA_OFFSET                   (0x18)                                        /**<  (XDMAC_CNDA) Channel Next Descriptor Address Register  Offset */
 
 #define XDMAC_CNDA_NDAIF_Pos                0                                              /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Position */
 #define XDMAC_CNDA_NDAIF_Msk                (_U_(0x1) << XDMAC_CNDA_NDAIF_Pos)             /**< (XDMAC_CNDA) Channel x Next Descriptor Interface Mask */
@@ -281,8 +297,9 @@ typedef union {
 #define XDMAC_CNDA_Msk                      _U_(0xFFFFFFFD)                                /**< (XDMAC_CNDA) Register Mask  */
 
 
-/* -------- XDMAC_CNDC : (XDMAC Offset: 0x1c) (R/W 32) Channel Next Descriptor Control Register (chid = 0) -------- */
+/* -------- XDMAC_CNDC : (XDMAC Offset: 0x1c) (R/W 32) Channel Next Descriptor Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NDE:1;                     /**< bit:      0  Channel x Next Descriptor Enable         */
@@ -293,9 +310,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CNDC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CNDC_OFFSET                   (0x1C)                                        /**<  (XDMAC_CNDC) Channel Next Descriptor Control Register (chid = 0)  Offset */
+#define XDMAC_CNDC_OFFSET                   (0x1C)                                        /**<  (XDMAC_CNDC) Channel Next Descriptor Control Register  Offset */
 
 #define XDMAC_CNDC_NDE_Pos                  0                                              /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Position */
 #define XDMAC_CNDC_NDE_Msk                  (_U_(0x1) << XDMAC_CNDC_NDE_Pos)               /**< (XDMAC_CNDC) Channel x Next Descriptor Enable Mask */
@@ -333,8 +351,9 @@ typedef union {
 #define XDMAC_CNDC_Msk                      _U_(0x1F)                                      /**< (XDMAC_CNDC) Register Mask  */
 
 
-/* -------- XDMAC_CUBC : (XDMAC Offset: 0x20) (R/W 32) Channel Microblock Control Register (chid = 0) -------- */
+/* -------- XDMAC_CUBC : (XDMAC Offset: 0x20) (R/W 32) Channel Microblock Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t UBLEN:24;                  /**< bit:  0..23  Channel x Microblock Length              */
@@ -342,9 +361,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CUBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CUBC_OFFSET                   (0x20)                                        /**<  (XDMAC_CUBC) Channel Microblock Control Register (chid = 0)  Offset */
+#define XDMAC_CUBC_OFFSET                   (0x20)                                        /**<  (XDMAC_CUBC) Channel Microblock Control Register  Offset */
 
 #define XDMAC_CUBC_UBLEN_Pos                0                                              /**< (XDMAC_CUBC) Channel x Microblock Length Position */
 #define XDMAC_CUBC_UBLEN_Msk                (_U_(0xFFFFFF) << XDMAC_CUBC_UBLEN_Pos)        /**< (XDMAC_CUBC) Channel x Microblock Length Mask */
@@ -353,8 +373,9 @@ typedef union {
 #define XDMAC_CUBC_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CUBC) Register Mask  */
 
 
-/* -------- XDMAC_CBC : (XDMAC Offset: 0x24) (R/W 32) Channel Block Control Register (chid = 0) -------- */
+/* -------- XDMAC_CBC : (XDMAC Offset: 0x24) (R/W 32) Channel Block Control Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t BLEN:12;                   /**< bit:  0..11  Channel x Block Length                   */
@@ -362,9 +383,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CBC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CBC_OFFSET                    (0x24)                                        /**<  (XDMAC_CBC) Channel Block Control Register (chid = 0)  Offset */
+#define XDMAC_CBC_OFFSET                    (0x24)                                        /**<  (XDMAC_CBC) Channel Block Control Register  Offset */
 
 #define XDMAC_CBC_BLEN_Pos                  0                                              /**< (XDMAC_CBC) Channel x Block Length Position */
 #define XDMAC_CBC_BLEN_Msk                  (_U_(0xFFF) << XDMAC_CBC_BLEN_Pos)             /**< (XDMAC_CBC) Channel x Block Length Mask */
@@ -373,8 +395,9 @@ typedef union {
 #define XDMAC_CBC_Msk                       _U_(0xFFF)                                     /**< (XDMAC_CBC) Register Mask  */
 
 
-/* -------- XDMAC_CC : (XDMAC Offset: 0x28) (R/W 32) Channel Configuration Register (chid = 0) -------- */
+/* -------- XDMAC_CC : (XDMAC Offset: 0x28) (R/W 32) Channel Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t TYPE:1;                    /**< bit:      0  Channel x Transfer Type                  */
@@ -400,17 +423,18 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CC_OFFSET                     (0x28)                                        /**<  (XDMAC_CC) Channel Configuration Register (chid = 0)  Offset */
+#define XDMAC_CC_OFFSET                     (0x28)                                        /**<  (XDMAC_CC) Channel Configuration Register  Offset */
 
 #define XDMAC_CC_TYPE_Pos                   0                                              /**< (XDMAC_CC) Channel x Transfer Type Position */
 #define XDMAC_CC_TYPE_Msk                   (_U_(0x1) << XDMAC_CC_TYPE_Pos)                /**< (XDMAC_CC) Channel x Transfer Type Mask */
 #define XDMAC_CC_TYPE                       XDMAC_CC_TYPE_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_TYPE_Msk instead */
-#define   XDMAC_CC_TYPE_MEM_TRAN_Val        _U_(0x0)                                       /**< (XDMAC_CC) Self triggered mode (Memory to Memory Transfer).  */
-#define   XDMAC_CC_TYPE_PER_TRAN_Val        _U_(0x1)                                       /**< (XDMAC_CC) Synchronized mode (Peripheral to Memory or Memory to Peripheral Transfer).  */
-#define XDMAC_CC_TYPE_MEM_TRAN              (XDMAC_CC_TYPE_MEM_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Self triggered mode (Memory to Memory Transfer). Position  */
-#define XDMAC_CC_TYPE_PER_TRAN              (XDMAC_CC_TYPE_PER_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Synchronized mode (Peripheral to Memory or Memory to Peripheral Transfer). Position  */
+#define   XDMAC_CC_TYPE_MEM_TRAN_Val        _U_(0x0)                                       /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer).  */
+#define   XDMAC_CC_TYPE_PER_TRAN_Val        _U_(0x1)                                       /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer).  */
+#define XDMAC_CC_TYPE_MEM_TRAN              (XDMAC_CC_TYPE_MEM_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Self-triggered mode (memory-to-memory transfer). Position  */
+#define XDMAC_CC_TYPE_PER_TRAN              (XDMAC_CC_TYPE_PER_TRAN_Val << XDMAC_CC_TYPE_Pos)  /**< (XDMAC_CC) Synchronized mode (peripheral-to-memory or memory-to-peripheral transfer). Position  */
 #define XDMAC_CC_MBSIZE_Pos                 1                                              /**< (XDMAC_CC) Channel x Memory Burst Size Position */
 #define XDMAC_CC_MBSIZE_Msk                 (_U_(0x3) << XDMAC_CC_MBSIZE_Pos)              /**< (XDMAC_CC) Channel x Memory Burst Size Mask */
 #define XDMAC_CC_MBSIZE(value)              (XDMAC_CC_MBSIZE_Msk & ((value) << XDMAC_CC_MBSIZE_Pos))
@@ -425,10 +449,10 @@ typedef union {
 #define XDMAC_CC_DSYNC_Pos                  4                                              /**< (XDMAC_CC) Channel x Synchronization Position */
 #define XDMAC_CC_DSYNC_Msk                  (_U_(0x1) << XDMAC_CC_DSYNC_Pos)               /**< (XDMAC_CC) Channel x Synchronization Mask */
 #define XDMAC_CC_DSYNC                      XDMAC_CC_DSYNC_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_DSYNC_Msk instead */
-#define   XDMAC_CC_DSYNC_PER2MEM_Val        _U_(0x0)                                       /**< (XDMAC_CC) Peripheral to Memory transfer.  */
-#define   XDMAC_CC_DSYNC_MEM2PER_Val        _U_(0x1)                                       /**< (XDMAC_CC) Memory to Peripheral transfer.  */
-#define XDMAC_CC_DSYNC_PER2MEM              (XDMAC_CC_DSYNC_PER2MEM_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Peripheral to Memory transfer. Position  */
-#define XDMAC_CC_DSYNC_MEM2PER              (XDMAC_CC_DSYNC_MEM2PER_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Memory to Peripheral transfer. Position  */
+#define   XDMAC_CC_DSYNC_PER2MEM_Val        _U_(0x0)                                       /**< (XDMAC_CC) Peripheral-to-memory transfer.  */
+#define   XDMAC_CC_DSYNC_MEM2PER_Val        _U_(0x1)                                       /**< (XDMAC_CC) Memory-to-peripheral transfer.  */
+#define XDMAC_CC_DSYNC_PER2MEM              (XDMAC_CC_DSYNC_PER2MEM_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Peripheral-to-memory transfer. Position  */
+#define XDMAC_CC_DSYNC_MEM2PER              (XDMAC_CC_DSYNC_MEM2PER_Val << XDMAC_CC_DSYNC_Pos)  /**< (XDMAC_CC) Memory-to-peripheral transfer. Position  */
 #define XDMAC_CC_SWREQ_Pos                  6                                              /**< (XDMAC_CC) Channel x Software Request Trigger Position */
 #define XDMAC_CC_SWREQ_Msk                  (_U_(0x1) << XDMAC_CC_SWREQ_Pos)               /**< (XDMAC_CC) Channel x Software Request Trigger Mask */
 #define XDMAC_CC_SWREQ                      XDMAC_CC_SWREQ_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_SWREQ_Msk instead */
@@ -496,11 +520,11 @@ typedef union {
 #define   XDMAC_CC_DAM_FIXED_AM_Val         _U_(0x0)                                       /**< (XDMAC_CC) The address remains unchanged.  */
 #define   XDMAC_CC_DAM_INCREMENTED_AM_Val   _U_(0x1)                                       /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size).  */
 #define   XDMAC_CC_DAM_UBS_AM_Val           _U_(0x2)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary.  */
-#define   XDMAC_CC_DAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary.  */
+#define   XDMAC_CC_DAM_UBS_DS_AM_Val        _U_(0x3)                                       /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary.  */
 #define XDMAC_CC_DAM_FIXED_AM               (XDMAC_CC_DAM_FIXED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The address remains unchanged. Position  */
 #define XDMAC_CC_DAM_INCREMENTED_AM         (XDMAC_CC_DAM_INCREMENTED_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The addressing mode is incremented (the increment size is set to the data size). Position  */
 #define XDMAC_CC_DAM_UBS_AM                 (XDMAC_CC_DAM_UBS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary. Position  */
-#define XDMAC_CC_DAM_UBS_DS_AM              (XDMAC_CC_DAM_UBS_DS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary, the data stride is added at the data boundary. Position  */
+#define XDMAC_CC_DAM_UBS_DS_AM              (XDMAC_CC_DAM_UBS_DS_AM_Val << XDMAC_CC_DAM_Pos)  /**< (XDMAC_CC) The microblock stride is added at the microblock boundary; the data stride is added at the data boundary. Position  */
 #define XDMAC_CC_INITD_Pos                  21                                             /**< (XDMAC_CC) Channel Initialization Terminated (this bit is read-only) Position */
 #define XDMAC_CC_INITD_Msk                  (_U_(0x1) << XDMAC_CC_INITD_Pos)               /**< (XDMAC_CC) Channel Initialization Terminated (this bit is read-only) Mask */
 #define XDMAC_CC_INITD                      XDMAC_CC_INITD_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_INITD_Msk instead */
@@ -511,26 +535,131 @@ typedef union {
 #define XDMAC_CC_RDIP_Pos                   22                                             /**< (XDMAC_CC) Read in Progress (this bit is read-only) Position */
 #define XDMAC_CC_RDIP_Msk                   (_U_(0x1) << XDMAC_CC_RDIP_Pos)                /**< (XDMAC_CC) Read in Progress (this bit is read-only) Mask */
 #define XDMAC_CC_RDIP                       XDMAC_CC_RDIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_RDIP_Msk instead */
-#define   XDMAC_CC_RDIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No Active read transaction on the bus.  */
+#define   XDMAC_CC_RDIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active read transaction on the bus.  */
 #define   XDMAC_CC_RDIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A read transaction is in progress.  */
-#define XDMAC_CC_RDIP_DONE                  (XDMAC_CC_RDIP_DONE_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) No Active read transaction on the bus. Position  */
+#define XDMAC_CC_RDIP_DONE                  (XDMAC_CC_RDIP_DONE_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) No active read transaction on the bus. Position  */
 #define XDMAC_CC_RDIP_IN_PROGRESS           (XDMAC_CC_RDIP_IN_PROGRESS_Val << XDMAC_CC_RDIP_Pos)  /**< (XDMAC_CC) A read transaction is in progress. Position  */
 #define XDMAC_CC_WRIP_Pos                   23                                             /**< (XDMAC_CC) Write in Progress (this bit is read-only) Position */
 #define XDMAC_CC_WRIP_Msk                   (_U_(0x1) << XDMAC_CC_WRIP_Pos)                /**< (XDMAC_CC) Write in Progress (this bit is read-only) Mask */
 #define XDMAC_CC_WRIP                       XDMAC_CC_WRIP_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use XDMAC_CC_WRIP_Msk instead */
-#define   XDMAC_CC_WRIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No Active write transaction on the bus.  */
-#define   XDMAC_CC_WRIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A Write transaction is in progress.  */
-#define XDMAC_CC_WRIP_DONE                  (XDMAC_CC_WRIP_DONE_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) No Active write transaction on the bus. Position  */
-#define XDMAC_CC_WRIP_IN_PROGRESS           (XDMAC_CC_WRIP_IN_PROGRESS_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) A Write transaction is in progress. Position  */
+#define   XDMAC_CC_WRIP_DONE_Val            _U_(0x0)                                       /**< (XDMAC_CC) No active write transaction on the bus.  */
+#define   XDMAC_CC_WRIP_IN_PROGRESS_Val     _U_(0x1)                                       /**< (XDMAC_CC) A write transaction is in progress.  */
+#define XDMAC_CC_WRIP_DONE                  (XDMAC_CC_WRIP_DONE_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) No active write transaction on the bus. Position  */
+#define XDMAC_CC_WRIP_IN_PROGRESS           (XDMAC_CC_WRIP_IN_PROGRESS_Val << XDMAC_CC_WRIP_Pos)  /**< (XDMAC_CC) A write transaction is in progress. Position  */
 #define XDMAC_CC_PERID_Pos                  24                                             /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Position */
 #define XDMAC_CC_PERID_Msk                  (_U_(0x7F) << XDMAC_CC_PERID_Pos)              /**< (XDMAC_CC) Channel x Peripheral Hardware Request Line Identifier Mask */
 #define XDMAC_CC_PERID(value)               (XDMAC_CC_PERID_Msk & ((value) << XDMAC_CC_PERID_Pos))
+#define   XDMAC_CC_PERID_HSMCI_Val          _U_(0x0)                                       /**< (XDMAC_CC) HSMCI  */
+#define   XDMAC_CC_PERID_SPI0_TX_Val        _U_(0x1)                                       /**< (XDMAC_CC) SPI0_TX  */
+#define   XDMAC_CC_PERID_SPI0_RX_Val        _U_(0x2)                                       /**< (XDMAC_CC) SPI0_RX  */
+#define   XDMAC_CC_PERID_SPI1_TX_Val        _U_(0x3)                                       /**< (XDMAC_CC) SPI1_TX  */
+#define   XDMAC_CC_PERID_SPI1_RX_Val        _U_(0x4)                                       /**< (XDMAC_CC) SPI1_RX  */
+#define   XDMAC_CC_PERID_QSPI_TX_Val        _U_(0x5)                                       /**< (XDMAC_CC) QSPI_TX  */
+#define   XDMAC_CC_PERID_QSPI_RX_Val        _U_(0x6)                                       /**< (XDMAC_CC) QSPI_RX  */
+#define   XDMAC_CC_PERID_USART0_TX_Val      _U_(0x7)                                       /**< (XDMAC_CC) USART0_TX  */
+#define   XDMAC_CC_PERID_USART0_RX_Val      _U_(0x8)                                       /**< (XDMAC_CC) USART0_RX  */
+#define   XDMAC_CC_PERID_USART1_TX_Val      _U_(0x9)                                       /**< (XDMAC_CC) USART1_TX  */
+#define   XDMAC_CC_PERID_USART1_RX_Val      _U_(0xA)                                       /**< (XDMAC_CC) USART1_RX  */
+#define   XDMAC_CC_PERID_USART2_TX_Val      _U_(0xB)                                       /**< (XDMAC_CC) USART2_TX  */
+#define   XDMAC_CC_PERID_USART2_RX_Val      _U_(0xC)                                       /**< (XDMAC_CC) USART2_RX  */
+#define   XDMAC_CC_PERID_PWM0_Val           _U_(0xD)                                       /**< (XDMAC_CC) PWM0  */
+#define   XDMAC_CC_PERID_TWIHS0_TX_Val      _U_(0xE)                                       /**< (XDMAC_CC) TWIHS0_TX  */
+#define   XDMAC_CC_PERID_TWIHS0_RX_Val      _U_(0xF)                                       /**< (XDMAC_CC) TWIHS0_RX  */
+#define   XDMAC_CC_PERID_TWIHS1_TX_Val      _U_(0x10)                                      /**< (XDMAC_CC) TWIHS1_TX  */
+#define   XDMAC_CC_PERID_TWIHS1_RX_Val      _U_(0x11)                                      /**< (XDMAC_CC) TWIHS1_RX  */
+#define   XDMAC_CC_PERID_TWIHS2_TX_Val      _U_(0x12)                                      /**< (XDMAC_CC) TWIHS2_TX  */
+#define   XDMAC_CC_PERID_TWIHS2_RX_Val      _U_(0x13)                                      /**< (XDMAC_CC) TWIHS2_RX  */
+#define   XDMAC_CC_PERID_UART0_TX_Val       _U_(0x14)                                      /**< (XDMAC_CC) UART0_TX  */
+#define   XDMAC_CC_PERID_UART0_RX_Val       _U_(0x15)                                      /**< (XDMAC_CC) UART0_RX  */
+#define   XDMAC_CC_PERID_UART1_TX_Val       _U_(0x16)                                      /**< (XDMAC_CC) UART1_TX  */
+#define   XDMAC_CC_PERID_UART1_RX_Val       _U_(0x17)                                      /**< (XDMAC_CC) UART1_RX  */
+#define   XDMAC_CC_PERID_UART2_TX_Val       _U_(0x18)                                      /**< (XDMAC_CC) UART2_TX  */
+#define   XDMAC_CC_PERID_UART2_RX_Val       _U_(0x19)                                      /**< (XDMAC_CC) UART2_RX  */
+#define   XDMAC_CC_PERID_UART3_TX_Val       _U_(0x1A)                                      /**< (XDMAC_CC) UART3_TX  */
+#define   XDMAC_CC_PERID_UART3_RX_Val       _U_(0x1B)                                      /**< (XDMAC_CC) UART3_RX  */
+#define   XDMAC_CC_PERID_UART4_TX_Val       _U_(0x1C)                                      /**< (XDMAC_CC) UART4_TX  */
+#define   XDMAC_CC_PERID_UART4_RX_Val       _U_(0x1D)                                      /**< (XDMAC_CC) UART4_RX  */
+#define   XDMAC_CC_PERID_DACC0_Val          _U_(0x1E)                                      /**< (XDMAC_CC) DACC0  */
+#define   XDMAC_CC_PERID_DACC1_Val          _U_(0x1F)                                      /**< (XDMAC_CC) DACC1  */
+#define   XDMAC_CC_PERID_SSC_TX_Val         _U_(0x20)                                      /**< (XDMAC_CC) SSC_TX  */
+#define   XDMAC_CC_PERID_SSC_RX_Val         _U_(0x21)                                      /**< (XDMAC_CC) SSC_RX  */
+#define   XDMAC_CC_PERID_PIOA_Val           _U_(0x22)                                      /**< (XDMAC_CC) PIOA  */
+#define   XDMAC_CC_PERID_AFEC0_Val          _U_(0x23)                                      /**< (XDMAC_CC) AFEC0  */
+#define   XDMAC_CC_PERID_AFEC1_Val          _U_(0x24)                                      /**< (XDMAC_CC) AFEC1  */
+#define   XDMAC_CC_PERID_AES_TX_Val         _U_(0x25)                                      /**< (XDMAC_CC) AES_TX  */
+#define   XDMAC_CC_PERID_AES_RX_Val         _U_(0x26)                                      /**< (XDMAC_CC) AES_RX  */
+#define   XDMAC_CC_PERID_PWM1_Val           _U_(0x27)                                      /**< (XDMAC_CC) PWM1  */
+#define   XDMAC_CC_PERID_TC0_Val            _U_(0x28)                                      /**< (XDMAC_CC) TC0  */
+#define   XDMAC_CC_PERID_TC3_Val            _U_(0x29)                                      /**< (XDMAC_CC) TC3  */
+#define   XDMAC_CC_PERID_TC6_Val            _U_(0x2A)                                      /**< (XDMAC_CC) TC6  */
+#define   XDMAC_CC_PERID_TC9_Val            _U_(0x2B)                                      /**< (XDMAC_CC) TC9  */
+#define   XDMAC_CC_PERID_I2SC0_TX_LEFT_Val  _U_(0x2C)                                      /**< (XDMAC_CC) I2SC0_TX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC0_RX_LEFT_Val  _U_(0x2D)                                      /**< (XDMAC_CC) I2SC0_RX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC1_TX_LEFT_Val  _U_(0x2E)                                      /**< (XDMAC_CC) I2SC1_TX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC1_RX_LEFT_Val  _U_(0x2F)                                      /**< (XDMAC_CC) I2SC1_RX_LEFT  */
+#define   XDMAC_CC_PERID_I2SC0_TX_RIGHT_Val _U_(0x30)                                      /**< (XDMAC_CC) I2SC0_TX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC0_RX_RIGHT_Val _U_(0x31)                                      /**< (XDMAC_CC) I2SC0_RX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC1_TX_RIGHT_Val _U_(0x32)                                      /**< (XDMAC_CC) I2SC1_TX_RIGHT  */
+#define   XDMAC_CC_PERID_I2SC1_RX_RIGHT_Val _U_(0x33)                                      /**< (XDMAC_CC) I2SC1_RX_RIGHT  */
+#define XDMAC_CC_PERID_HSMCI                (XDMAC_CC_PERID_HSMCI_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) HSMCI Position  */
+#define XDMAC_CC_PERID_SPI0_TX              (XDMAC_CC_PERID_SPI0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI0_TX Position  */
+#define XDMAC_CC_PERID_SPI0_RX              (XDMAC_CC_PERID_SPI0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI0_RX Position  */
+#define XDMAC_CC_PERID_SPI1_TX              (XDMAC_CC_PERID_SPI1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI1_TX Position  */
+#define XDMAC_CC_PERID_SPI1_RX              (XDMAC_CC_PERID_SPI1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SPI1_RX Position  */
+#define XDMAC_CC_PERID_QSPI_TX              (XDMAC_CC_PERID_QSPI_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) QSPI_TX Position  */
+#define XDMAC_CC_PERID_QSPI_RX              (XDMAC_CC_PERID_QSPI_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) QSPI_RX Position  */
+#define XDMAC_CC_PERID_USART0_TX            (XDMAC_CC_PERID_USART0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART0_TX Position  */
+#define XDMAC_CC_PERID_USART0_RX            (XDMAC_CC_PERID_USART0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART0_RX Position  */
+#define XDMAC_CC_PERID_USART1_TX            (XDMAC_CC_PERID_USART1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART1_TX Position  */
+#define XDMAC_CC_PERID_USART1_RX            (XDMAC_CC_PERID_USART1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART1_RX Position  */
+#define XDMAC_CC_PERID_USART2_TX            (XDMAC_CC_PERID_USART2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART2_TX Position  */
+#define XDMAC_CC_PERID_USART2_RX            (XDMAC_CC_PERID_USART2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) USART2_RX Position  */
+#define XDMAC_CC_PERID_PWM0                 (XDMAC_CC_PERID_PWM0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PWM0 Position  */
+#define XDMAC_CC_PERID_TWIHS0_TX            (XDMAC_CC_PERID_TWIHS0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS0_TX Position  */
+#define XDMAC_CC_PERID_TWIHS0_RX            (XDMAC_CC_PERID_TWIHS0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS0_RX Position  */
+#define XDMAC_CC_PERID_TWIHS1_TX            (XDMAC_CC_PERID_TWIHS1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS1_TX Position  */
+#define XDMAC_CC_PERID_TWIHS1_RX            (XDMAC_CC_PERID_TWIHS1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS1_RX Position  */
+#define XDMAC_CC_PERID_TWIHS2_TX            (XDMAC_CC_PERID_TWIHS2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS2_TX Position  */
+#define XDMAC_CC_PERID_TWIHS2_RX            (XDMAC_CC_PERID_TWIHS2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TWIHS2_RX Position  */
+#define XDMAC_CC_PERID_UART0_TX             (XDMAC_CC_PERID_UART0_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART0_TX Position  */
+#define XDMAC_CC_PERID_UART0_RX             (XDMAC_CC_PERID_UART0_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART0_RX Position  */
+#define XDMAC_CC_PERID_UART1_TX             (XDMAC_CC_PERID_UART1_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART1_TX Position  */
+#define XDMAC_CC_PERID_UART1_RX             (XDMAC_CC_PERID_UART1_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART1_RX Position  */
+#define XDMAC_CC_PERID_UART2_TX             (XDMAC_CC_PERID_UART2_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART2_TX Position  */
+#define XDMAC_CC_PERID_UART2_RX             (XDMAC_CC_PERID_UART2_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART2_RX Position  */
+#define XDMAC_CC_PERID_UART3_TX             (XDMAC_CC_PERID_UART3_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART3_TX Position  */
+#define XDMAC_CC_PERID_UART3_RX             (XDMAC_CC_PERID_UART3_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART3_RX Position  */
+#define XDMAC_CC_PERID_UART4_TX             (XDMAC_CC_PERID_UART4_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART4_TX Position  */
+#define XDMAC_CC_PERID_UART4_RX             (XDMAC_CC_PERID_UART4_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) UART4_RX Position  */
+#define XDMAC_CC_PERID_DACC0                (XDMAC_CC_PERID_DACC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) DACC0 Position  */
+#define XDMAC_CC_PERID_DACC1                (XDMAC_CC_PERID_DACC1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) DACC1 Position  */
+#define XDMAC_CC_PERID_SSC_TX               (XDMAC_CC_PERID_SSC_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SSC_TX Position  */
+#define XDMAC_CC_PERID_SSC_RX               (XDMAC_CC_PERID_SSC_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) SSC_RX Position  */
+#define XDMAC_CC_PERID_PIOA                 (XDMAC_CC_PERID_PIOA_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PIOA Position  */
+#define XDMAC_CC_PERID_AFEC0                (XDMAC_CC_PERID_AFEC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AFEC0 Position  */
+#define XDMAC_CC_PERID_AFEC1                (XDMAC_CC_PERID_AFEC1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AFEC1 Position  */
+#define XDMAC_CC_PERID_AES_TX               (XDMAC_CC_PERID_AES_TX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AES_TX Position  */
+#define XDMAC_CC_PERID_AES_RX               (XDMAC_CC_PERID_AES_RX_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) AES_RX Position  */
+#define XDMAC_CC_PERID_PWM1                 (XDMAC_CC_PERID_PWM1_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) PWM1 Position  */
+#define XDMAC_CC_PERID_TC0                  (XDMAC_CC_PERID_TC0_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC0 Position  */
+#define XDMAC_CC_PERID_TC3                  (XDMAC_CC_PERID_TC3_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC3 Position  */
+#define XDMAC_CC_PERID_TC6                  (XDMAC_CC_PERID_TC6_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC6 Position  */
+#define XDMAC_CC_PERID_TC9                  (XDMAC_CC_PERID_TC9_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) TC9 Position  */
+#define XDMAC_CC_PERID_I2SC0_TX_LEFT        (XDMAC_CC_PERID_I2SC0_TX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_TX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC0_RX_LEFT        (XDMAC_CC_PERID_I2SC0_RX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_RX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC1_TX_LEFT        (XDMAC_CC_PERID_I2SC1_TX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_TX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC1_RX_LEFT        (XDMAC_CC_PERID_I2SC1_RX_LEFT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_RX_LEFT Position  */
+#define XDMAC_CC_PERID_I2SC0_TX_RIGHT       (XDMAC_CC_PERID_I2SC0_TX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_TX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC0_RX_RIGHT       (XDMAC_CC_PERID_I2SC0_RX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC0_RX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC1_TX_RIGHT       (XDMAC_CC_PERID_I2SC1_TX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_TX_RIGHT Position  */
+#define XDMAC_CC_PERID_I2SC1_RX_RIGHT       (XDMAC_CC_PERID_I2SC1_RX_RIGHT_Val << XDMAC_CC_PERID_Pos)  /**< (XDMAC_CC) I2SC1_RX_RIGHT Position  */
 #define XDMAC_CC_MASK                       _U_(0x7FEF7FD7)                                /**< \deprecated (XDMAC_CC) Register MASK  (Use XDMAC_CC_Msk instead)  */
 #define XDMAC_CC_Msk                        _U_(0x7FEF7FD7)                                /**< (XDMAC_CC) Register Mask  */
 
 
-/* -------- XDMAC_CDS_MSP : (XDMAC Offset: 0x2c) (R/W 32) Channel Data Stride Memory Set Pattern (chid = 0) -------- */
+/* -------- XDMAC_CDS_MSP : (XDMAC Offset: 0x2c) (R/W 32) Channel Data Stride Memory Set Pattern -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SDS_MSP:16;                /**< bit:  0..15  Channel x Source Data stride or Memory Set Pattern */
@@ -538,9 +667,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDS_MSP_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CDS_MSP_OFFSET                (0x2C)                                        /**<  (XDMAC_CDS_MSP) Channel Data Stride Memory Set Pattern (chid = 0)  Offset */
+#define XDMAC_CDS_MSP_OFFSET                (0x2C)                                        /**<  (XDMAC_CDS_MSP) Channel Data Stride Memory Set Pattern  Offset */
 
 #define XDMAC_CDS_MSP_SDS_MSP_Pos           0                                              /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Position */
 #define XDMAC_CDS_MSP_SDS_MSP_Msk           (_U_(0xFFFF) << XDMAC_CDS_MSP_SDS_MSP_Pos)     /**< (XDMAC_CDS_MSP) Channel x Source Data stride or Memory Set Pattern Mask */
@@ -552,8 +682,9 @@ typedef union {
 #define XDMAC_CDS_MSP_Msk                   _U_(0xFFFFFFFF)                                /**< (XDMAC_CDS_MSP) Register Mask  */
 
 
-/* -------- XDMAC_CSUS : (XDMAC Offset: 0x30) (R/W 32) Channel Source Microblock Stride (chid = 0) -------- */
+/* -------- XDMAC_CSUS : (XDMAC Offset: 0x30) (R/W 32) Channel Source Microblock Stride -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SUBS:24;                   /**< bit:  0..23  Channel x Source Microblock Stride       */
@@ -561,9 +692,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CSUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CSUS_OFFSET                   (0x30)                                        /**<  (XDMAC_CSUS) Channel Source Microblock Stride (chid = 0)  Offset */
+#define XDMAC_CSUS_OFFSET                   (0x30)                                        /**<  (XDMAC_CSUS) Channel Source Microblock Stride  Offset */
 
 #define XDMAC_CSUS_SUBS_Pos                 0                                              /**< (XDMAC_CSUS) Channel x Source Microblock Stride Position */
 #define XDMAC_CSUS_SUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CSUS_SUBS_Pos)         /**< (XDMAC_CSUS) Channel x Source Microblock Stride Mask */
@@ -572,8 +704,9 @@ typedef union {
 #define XDMAC_CSUS_Msk                      _U_(0xFFFFFF)                                  /**< (XDMAC_CSUS) Register Mask  */
 
 
-/* -------- XDMAC_CDUS : (XDMAC Offset: 0x34) (R/W 32) Channel Destination Microblock Stride (chid = 0) -------- */
+/* -------- XDMAC_CDUS : (XDMAC Offset: 0x34) (R/W 32) Channel Destination Microblock Stride -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DUBS:24;                   /**< bit:  0..23  Channel x Destination Microblock Stride  */
@@ -581,9 +714,10 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_CDUS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
-#define XDMAC_CDUS_OFFSET                   (0x34)                                        /**<  (XDMAC_CDUS) Channel Destination Microblock Stride (chid = 0)  Offset */
+#define XDMAC_CDUS_OFFSET                   (0x34)                                        /**<  (XDMAC_CDUS) Channel Destination Microblock Stride  Offset */
 
 #define XDMAC_CDUS_DUBS_Pos                 0                                              /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Position */
 #define XDMAC_CDUS_DUBS_Msk                 (_U_(0xFFFFFF) << XDMAC_CDUS_DUBS_Pos)         /**< (XDMAC_CDUS) Channel x Destination Microblock Stride Mask */
@@ -594,6 +728,7 @@ typedef union {
 
 /* -------- XDMAC_GTYPE : (XDMAC Offset: 0x00) (R/ 32) Global Type Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t NB_CH:5;                   /**< bit:   0..4  Number of Channels Minus One             */
@@ -603,6 +738,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GTYPE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GTYPE_OFFSET                  (0x00)                                        /**<  (XDMAC_GTYPE) Global Type Register  Offset */
@@ -622,6 +758,7 @@ typedef union {
 
 /* -------- XDMAC_GCFG : (XDMAC Offset: 0x04) (R/W 32) Global Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t CGDISREG:1;                /**< bit:      0  Configuration Registers Clock Gating Disable */
@@ -634,6 +771,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GCFG_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GCFG_OFFSET                   (0x04)                                        /**<  (XDMAC_GCFG) Global Configuration Register  Offset */
@@ -659,6 +797,7 @@ typedef union {
 
 /* -------- XDMAC_GWAC : (XDMAC Offset: 0x08) (R/W 32) Global Weighted Arbiter Configuration Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t PW0:4;                     /**< bit:   0..3  Pool Weight 0                            */
@@ -669,6 +808,7 @@ typedef union {
   } bit;                                /**< Structure used for bit  access */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GWAC_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GWAC_OFFSET                   (0x08)                                        /**<  (XDMAC_GWAC) Global Weighted Arbiter Configuration Register  Offset */
@@ -691,6 +831,7 @@ typedef union {
 
 /* -------- XDMAC_GIE : (XDMAC Offset: 0x0c) (/W 32) Global Interrupt Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IE0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Enable Bit     */
@@ -725,6 +866,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIE_OFFSET                    (0x0C)                                        /**<  (XDMAC_GIE) Global Interrupt Enable Register  Offset */
@@ -810,6 +952,7 @@ typedef union {
 
 /* -------- XDMAC_GID : (XDMAC Offset: 0x10) (/W 32) Global Interrupt Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ID0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Disable Bit    */
@@ -844,6 +987,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GID_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GID_OFFSET                    (0x10)                                        /**<  (XDMAC_GID) Global Interrupt Disable Register  Offset */
@@ -929,6 +1073,7 @@ typedef union {
 
 /* -------- XDMAC_GIM : (XDMAC Offset: 0x14) (R/ 32) Global Interrupt Mask Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IM0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Mask Bit       */
@@ -963,6 +1108,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIM_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIM_OFFSET                    (0x14)                                        /**<  (XDMAC_GIM) Global Interrupt Mask Register  Offset */
@@ -1048,6 +1194,7 @@ typedef union {
 
 /* -------- XDMAC_GIS : (XDMAC Offset: 0x18) (R/ 32) Global Interrupt Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t IS0:1;                     /**< bit:      0  XDMAC Channel 0 Interrupt Status Bit     */
@@ -1082,6 +1229,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GIS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GIS_OFFSET                    (0x18)                                        /**<  (XDMAC_GIS) Global Interrupt Status Register  Offset */
@@ -1167,6 +1315,7 @@ typedef union {
 
 /* -------- XDMAC_GE : (XDMAC Offset: 0x1c) (/W 32) Global Channel Enable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t EN0:1;                     /**< bit:      0  XDMAC Channel 0 Enable Bit               */
@@ -1201,6 +1350,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GE_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GE_OFFSET                     (0x1C)                                        /**<  (XDMAC_GE) Global Channel Enable Register  Offset */
@@ -1286,6 +1436,7 @@ typedef union {
 
 /* -------- XDMAC_GD : (XDMAC Offset: 0x20) (/W 32) Global Channel Disable Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t DI0:1;                     /**< bit:      0  XDMAC Channel 0 Disable Bit              */
@@ -1320,6 +1471,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GD_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GD_OFFSET                     (0x20)                                        /**<  (XDMAC_GD) Global Channel Disable Register  Offset */
@@ -1405,6 +1557,7 @@ typedef union {
 
 /* -------- XDMAC_GS : (XDMAC Offset: 0x24) (R/ 32) Global Channel Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t ST0:1;                     /**< bit:      0  XDMAC Channel 0 Status Bit               */
@@ -1439,6 +1592,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GS_OFFSET                     (0x24)                                        /**<  (XDMAC_GS) Global Channel Status Register  Offset */
@@ -1524,6 +1678,7 @@ typedef union {
 
 /* -------- XDMAC_GRS : (XDMAC Offset: 0x28) (R/W 32) Global Channel Read Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RS0:1;                     /**< bit:      0  XDMAC Channel 0 Read Suspend Bit         */
@@ -1558,6 +1713,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRS_OFFSET                    (0x28)                                        /**<  (XDMAC_GRS) Global Channel Read Suspend Register  Offset */
@@ -1643,6 +1799,7 @@ typedef union {
 
 /* -------- XDMAC_GWS : (XDMAC Offset: 0x2c) (R/W 32) Global Channel Write Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t WS0:1;                     /**< bit:      0  XDMAC Channel 0 Write Suspend Bit        */
@@ -1677,6 +1834,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GWS_OFFSET                    (0x2C)                                        /**<  (XDMAC_GWS) Global Channel Write Suspend Register  Offset */
@@ -1762,6 +1920,7 @@ typedef union {
 
 /* -------- XDMAC_GRWS : (XDMAC Offset: 0x30) (/W 32) Global Channel Read Write Suspend Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RWS0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Suspend Bit   */
@@ -1796,6 +1955,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRWS_OFFSET                   (0x30)                                        /**<  (XDMAC_GRWS) Global Channel Read Write Suspend Register  Offset */
@@ -1881,6 +2041,7 @@ typedef union {
 
 /* -------- XDMAC_GRWR : (XDMAC Offset: 0x34) (/W 32) Global Channel Read Write Resume Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t RWR0:1;                    /**< bit:      0  XDMAC Channel 0 Read Write Resume Bit    */
@@ -1915,6 +2076,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GRWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GRWR_OFFSET                   (0x34)                                        /**<  (XDMAC_GRWR) Global Channel Read Write Resume Register  Offset */
@@ -2000,6 +2162,7 @@ typedef union {
 
 /* -------- XDMAC_GSWR : (XDMAC Offset: 0x38) (/W 32) Global Channel Software Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWREQ0:1;                  /**< bit:      0  XDMAC Channel 0 Software Request Bit     */
@@ -2034,6 +2197,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWR_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWR_OFFSET                   (0x38)                                        /**<  (XDMAC_GSWR) Global Channel Software Request Register  Offset */
@@ -2119,6 +2283,7 @@ typedef union {
 
 /* -------- XDMAC_GSWS : (XDMAC Offset: 0x3c) (R/ 32) Global Channel Software Request Status Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWRS0:1;                   /**< bit:      0  XDMAC Channel 0 Software Request Status Bit */
@@ -2153,6 +2318,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWS_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWS_OFFSET                   (0x3C)                                        /**<  (XDMAC_GSWS) Global Channel Software Request Status Register  Offset */
@@ -2238,6 +2404,7 @@ typedef union {
 
 /* -------- XDMAC_GSWF : (XDMAC Offset: 0x40) (/W 32) Global Channel Software Flush Request Register -------- */
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
+#if COMPONENT_TYPEDEF_STYLE == 'N'
 typedef union { 
   struct {
     uint32_t SWF0:1;                    /**< bit:      0  XDMAC Channel 0 Software Flush Request Bit */
@@ -2272,6 +2439,7 @@ typedef union {
   } vec;                                /**< Structure used for vec  access  */
   uint32_t reg;                         /**< Type used for register access */
 } XDMAC_GSWF_Type;
+#endif
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #define XDMAC_GSWF_OFFSET                   (0x40)                                        /**<  (XDMAC_GSWF) Global Channel Software Flush Request Register  Offset */
@@ -2359,21 +2527,21 @@ typedef union {
 #if COMPONENT_TYPEDEF_STYLE == 'R'
 /** \brief XDMAC_CHID hardware registers */
 typedef struct {  
-  __O  uint32_t XDMAC_CIE;      /**< (XDMAC_CHID Offset: 0x00) Channel Interrupt Enable Register (chid = 0) */
-  __O  uint32_t XDMAC_CID;      /**< (XDMAC_CHID Offset: 0x04) Channel Interrupt Disable Register (chid = 0) */
-  __I  uint32_t XDMAC_CIM;      /**< (XDMAC_CHID Offset: 0x08) Channel Interrupt Mask Register (chid = 0) */
-  __I  uint32_t XDMAC_CIS;      /**< (XDMAC_CHID Offset: 0x0C) Channel Interrupt Status Register (chid = 0) */
-  __IO uint32_t XDMAC_CSA;      /**< (XDMAC_CHID Offset: 0x10) Channel Source Address Register (chid = 0) */
-  __IO uint32_t XDMAC_CDA;      /**< (XDMAC_CHID Offset: 0x14) Channel Destination Address Register (chid = 0) */
-  __IO uint32_t XDMAC_CNDA;     /**< (XDMAC_CHID Offset: 0x18) Channel Next Descriptor Address Register (chid = 0) */
-  __IO uint32_t XDMAC_CNDC;     /**< (XDMAC_CHID Offset: 0x1C) Channel Next Descriptor Control Register (chid = 0) */
-  __IO uint32_t XDMAC_CUBC;     /**< (XDMAC_CHID Offset: 0x20) Channel Microblock Control Register (chid = 0) */
-  __IO uint32_t XDMAC_CBC;      /**< (XDMAC_CHID Offset: 0x24) Channel Block Control Register (chid = 0) */
-  __IO uint32_t XDMAC_CC;       /**< (XDMAC_CHID Offset: 0x28) Channel Configuration Register (chid = 0) */
-  __IO uint32_t XDMAC_CDS_MSP;  /**< (XDMAC_CHID Offset: 0x2C) Channel Data Stride Memory Set Pattern (chid = 0) */
-  __IO uint32_t XDMAC_CSUS;     /**< (XDMAC_CHID Offset: 0x30) Channel Source Microblock Stride (chid = 0) */
-  __IO uint32_t XDMAC_CDUS;     /**< (XDMAC_CHID Offset: 0x34) Channel Destination Microblock Stride (chid = 0) */
-       RoReg8                         Reserved1[0x08];
+  __O  uint32_t XDMAC_CIE;      /**< (XDMAC_CHID Offset: 0x00) Channel Interrupt Enable Register */
+  __O  uint32_t XDMAC_CID;      /**< (XDMAC_CHID Offset: 0x04) Channel Interrupt Disable Register */
+  __I  uint32_t XDMAC_CIM;      /**< (XDMAC_CHID Offset: 0x08) Channel Interrupt Mask Register */
+  __I  uint32_t XDMAC_CIS;      /**< (XDMAC_CHID Offset: 0x0C) Channel Interrupt Status Register */
+  __IO uint32_t XDMAC_CSA;      /**< (XDMAC_CHID Offset: 0x10) Channel Source Address Register */
+  __IO uint32_t XDMAC_CDA;      /**< (XDMAC_CHID Offset: 0x14) Channel Destination Address Register */
+  __IO uint32_t XDMAC_CNDA;     /**< (XDMAC_CHID Offset: 0x18) Channel Next Descriptor Address Register */
+  __IO uint32_t XDMAC_CNDC;     /**< (XDMAC_CHID Offset: 0x1C) Channel Next Descriptor Control Register */
+  __IO uint32_t XDMAC_CUBC;     /**< (XDMAC_CHID Offset: 0x20) Channel Microblock Control Register */
+  __IO uint32_t XDMAC_CBC;      /**< (XDMAC_CHID Offset: 0x24) Channel Block Control Register */
+  __IO uint32_t XDMAC_CC;       /**< (XDMAC_CHID Offset: 0x28) Channel Configuration Register */
+  __IO uint32_t XDMAC_CDS_MSP;  /**< (XDMAC_CHID Offset: 0x2C) Channel Data Stride Memory Set Pattern */
+  __IO uint32_t XDMAC_CSUS;     /**< (XDMAC_CHID Offset: 0x30) Channel Source Microblock Stride */
+  __IO uint32_t XDMAC_CDUS;     /**< (XDMAC_CHID Offset: 0x34) Channel Destination Microblock Stride */
+  __I  uint8_t                        Reserved1[8];
 } XdmacChid;
 
 #define XDMACCHID_NUMBER 24
@@ -2396,28 +2564,28 @@ typedef struct {
   __O  uint32_t XDMAC_GSWR;     /**< (XDMAC Offset: 0x38) Global Channel Software Request Register */
   __I  uint32_t XDMAC_GSWS;     /**< (XDMAC Offset: 0x3C) Global Channel Software Request Status Register */
   __O  uint32_t XDMAC_GSWF;     /**< (XDMAC Offset: 0x40) Global Channel Software Flush Request Register */
-  RoReg8  Reserved1[0x0C];
-       XdmacChid XDMAC_CHID[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid XdmacChid[XDMACCHID_NUMBER]; /**< Offset: 0x50 Channel Interrupt Enable Register */
 } Xdmac;
 
 #elif COMPONENT_TYPEDEF_STYLE == 'N'
 /** \brief XDMAC_CHID hardware registers */
 typedef struct {  
-  __O  XDMAC_CIE_Type                 XDMAC_CIE;      /**< Offset: 0x00 ( /W  32) Channel Interrupt Enable Register (chid = 0) */
-  __O  XDMAC_CID_Type                 XDMAC_CID;      /**< Offset: 0x04 ( /W  32) Channel Interrupt Disable Register (chid = 0) */
-  __I  XDMAC_CIM_Type                 XDMAC_CIM;      /**< Offset: 0x08 (R/   32) Channel Interrupt Mask Register (chid = 0) */
-  __I  XDMAC_CIS_Type                 XDMAC_CIS;      /**< Offset: 0x0C (R/   32) Channel Interrupt Status Register (chid = 0) */
-  __IO XDMAC_CSA_Type                 XDMAC_CSA;      /**< Offset: 0x10 (R/W  32) Channel Source Address Register (chid = 0) */
-  __IO XDMAC_CDA_Type                 XDMAC_CDA;      /**< Offset: 0x14 (R/W  32) Channel Destination Address Register (chid = 0) */
-  __IO XDMAC_CNDA_Type                XDMAC_CNDA;     /**< Offset: 0x18 (R/W  32) Channel Next Descriptor Address Register (chid = 0) */
-  __IO XDMAC_CNDC_Type                XDMAC_CNDC;     /**< Offset: 0x1C (R/W  32) Channel Next Descriptor Control Register (chid = 0) */
-  __IO XDMAC_CUBC_Type                XDMAC_CUBC;     /**< Offset: 0x20 (R/W  32) Channel Microblock Control Register (chid = 0) */
-  __IO XDMAC_CBC_Type                 XDMAC_CBC;      /**< Offset: 0x24 (R/W  32) Channel Block Control Register (chid = 0) */
-  __IO XDMAC_CC_Type                  XDMAC_CC;       /**< Offset: 0x28 (R/W  32) Channel Configuration Register (chid = 0) */
-  __IO XDMAC_CDS_MSP_Type             XDMAC_CDS_MSP;  /**< Offset: 0x2C (R/W  32) Channel Data Stride Memory Set Pattern (chid = 0) */
-  __IO XDMAC_CSUS_Type                XDMAC_CSUS;     /**< Offset: 0x30 (R/W  32) Channel Source Microblock Stride (chid = 0) */
-  __IO XDMAC_CDUS_Type                XDMAC_CDUS;     /**< Offset: 0x34 (R/W  32) Channel Destination Microblock Stride (chid = 0) */
-       RoReg8                         Reserved1[0x08];
+  __O  XDMAC_CIE_Type                 XDMAC_CIE;      /**< Offset: 0x00 ( /W  32) Channel Interrupt Enable Register */
+  __O  XDMAC_CID_Type                 XDMAC_CID;      /**< Offset: 0x04 ( /W  32) Channel Interrupt Disable Register */
+  __I  XDMAC_CIM_Type                 XDMAC_CIM;      /**< Offset: 0x08 (R/   32) Channel Interrupt Mask Register */
+  __I  XDMAC_CIS_Type                 XDMAC_CIS;      /**< Offset: 0x0C (R/   32) Channel Interrupt Status Register */
+  __IO XDMAC_CSA_Type                 XDMAC_CSA;      /**< Offset: 0x10 (R/W  32) Channel Source Address Register */
+  __IO XDMAC_CDA_Type                 XDMAC_CDA;      /**< Offset: 0x14 (R/W  32) Channel Destination Address Register */
+  __IO XDMAC_CNDA_Type                XDMAC_CNDA;     /**< Offset: 0x18 (R/W  32) Channel Next Descriptor Address Register */
+  __IO XDMAC_CNDC_Type                XDMAC_CNDC;     /**< Offset: 0x1C (R/W  32) Channel Next Descriptor Control Register */
+  __IO XDMAC_CUBC_Type                XDMAC_CUBC;     /**< Offset: 0x20 (R/W  32) Channel Microblock Control Register */
+  __IO XDMAC_CBC_Type                 XDMAC_CBC;      /**< Offset: 0x24 (R/W  32) Channel Block Control Register */
+  __IO XDMAC_CC_Type                  XDMAC_CC;       /**< Offset: 0x28 (R/W  32) Channel Configuration Register */
+  __IO XDMAC_CDS_MSP_Type             XDMAC_CDS_MSP;  /**< Offset: 0x2C (R/W  32) Channel Data Stride Memory Set Pattern */
+  __IO XDMAC_CSUS_Type                XDMAC_CSUS;     /**< Offset: 0x30 (R/W  32) Channel Source Microblock Stride */
+  __IO XDMAC_CDUS_Type                XDMAC_CDUS;     /**< Offset: 0x34 (R/W  32) Channel Destination Microblock Stride */
+  __I  uint8_t                        Reserved1[8];
 } XdmacChid;
 
 /** \brief XDMAC hardware registers */
@@ -2439,8 +2607,8 @@ typedef struct {
   __O  XDMAC_GSWR_Type                XDMAC_GSWR;     /**< Offset: 0x38 ( /W  32) Global Channel Software Request Register */
   __I  XDMAC_GSWS_Type                XDMAC_GSWS;     /**< Offset: 0x3C (R/   32) Global Channel Software Request Status Register */
   __O  XDMAC_GSWF_Type                XDMAC_GSWF;     /**< Offset: 0x40 ( /W  32) Global Channel Software Flush Request Register */
-  __I  uint32_t                       Reserved1[3];
-       XdmacChid                      XDMAC_CHID[24]; /**< Offset: 0x50 Channel Interrupt Enable Register (chid = 0) */
+  __I  uint8_t                        Reserved1[12];
+       XdmacChid                      XdmacChid[24];  /**< Offset: 0x50 Channel Interrupt Enable Register */
 } Xdmac;
 
 #else /* COMPONENT_TYPEDEF_STYLE */

--- a/asf/sam/include/same70b/instance/acc.h
+++ b/asf/sam/include/same70b/instance/acc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ACC_INSTANCE_H_
 #define _SAME70_ACC_INSTANCE_H_
 
@@ -57,7 +59,15 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ACC peripheral ========== */
-#define ACC_INSTANCE_ID                          33        
-#define ACC_CLOCK_ID                             33        
+#define ACC_INSTANCE_ID                          33         
+#define ACC_CLOCK_ID                             33         
+#define ACC_HAS_PLUS_COMPARATOR_SELECTION        1          
+#define ACC_HAS_MINUS_COMPARATOR_SELECTION       1          
+#define ACC_HAS_INVERTED_COMPARATOR              1          
+#define ACC_HAS_EDGETYPE_SELECTION               1          
+#define ACC_HAS_INTERRUPTS                       1          
+#define ACC_HAS_CURRENT_SELECTION                1          
+#define ACC_HAS_HYSTERESIS                       1          
+#define ACC_HAS_FAULT_ENABLE                     1          
 
 #endif /* _SAME70_ACC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/aes.h
+++ b/asf/sam/include/same70b/instance/aes.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AES
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_AES_INSTANCE_H_
 #define _SAME70_AES_INSTANCE_H_
 
@@ -38,7 +40,7 @@
 #define REG_AES_IDR             (0x4006C014) /**< (AES) Interrupt Disable Register */
 #define REG_AES_IMR             (0x4006C018) /**< (AES) Interrupt Mask Register */
 #define REG_AES_ISR             (0x4006C01C) /**< (AES) Interrupt Status Register */
-#define REG_AES_KEYWR           (0x4006C020) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR           (0x4006C020) /**< (AES) Key Word Register */
 #define REG_AES_KEYWR0          (0x4006C020) /**< (AES) Key Word Register 0 */
 #define REG_AES_KEYWR1          (0x4006C024) /**< (AES) Key Word Register 1 */
 #define REG_AES_KEYWR2          (0x4006C028) /**< (AES) Key Word Register 2 */
@@ -47,35 +49,35 @@
 #define REG_AES_KEYWR5          (0x4006C034) /**< (AES) Key Word Register 5 */
 #define REG_AES_KEYWR6          (0x4006C038) /**< (AES) Key Word Register 6 */
 #define REG_AES_KEYWR7          (0x4006C03C) /**< (AES) Key Word Register 7 */
-#define REG_AES_IDATAR          (0x4006C040) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR          (0x4006C040) /**< (AES) Input Data Register */
 #define REG_AES_IDATAR0         (0x4006C040) /**< (AES) Input Data Register 0 */
 #define REG_AES_IDATAR1         (0x4006C044) /**< (AES) Input Data Register 1 */
 #define REG_AES_IDATAR2         (0x4006C048) /**< (AES) Input Data Register 2 */
 #define REG_AES_IDATAR3         (0x4006C04C) /**< (AES) Input Data Register 3 */
-#define REG_AES_ODATAR          (0x4006C050) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR          (0x4006C050) /**< (AES) Output Data Register */
 #define REG_AES_ODATAR0         (0x4006C050) /**< (AES) Output Data Register 0 */
 #define REG_AES_ODATAR1         (0x4006C054) /**< (AES) Output Data Register 1 */
 #define REG_AES_ODATAR2         (0x4006C058) /**< (AES) Output Data Register 2 */
 #define REG_AES_ODATAR3         (0x4006C05C) /**< (AES) Output Data Register 3 */
-#define REG_AES_IVR             (0x4006C060) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR             (0x4006C060) /**< (AES) Initialization Vector Register */
 #define REG_AES_IVR0            (0x4006C060) /**< (AES) Initialization Vector Register 0 */
 #define REG_AES_IVR1            (0x4006C064) /**< (AES) Initialization Vector Register 1 */
 #define REG_AES_IVR2            (0x4006C068) /**< (AES) Initialization Vector Register 2 */
 #define REG_AES_IVR3            (0x4006C06C) /**< (AES) Initialization Vector Register 3 */
 #define REG_AES_AADLENR         (0x4006C070) /**< (AES) Additional Authenticated Data Length Register */
 #define REG_AES_CLENR           (0x4006C074) /**< (AES) Plaintext/Ciphertext Length Register */
-#define REG_AES_GHASHR          (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR          (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register */
 #define REG_AES_GHASHR0         (0x4006C078) /**< (AES) GCM Intermediate Hash Word Register 0 */
 #define REG_AES_GHASHR1         (0x4006C07C) /**< (AES) GCM Intermediate Hash Word Register 1 */
 #define REG_AES_GHASHR2         (0x4006C080) /**< (AES) GCM Intermediate Hash Word Register 2 */
 #define REG_AES_GHASHR3         (0x4006C084) /**< (AES) GCM Intermediate Hash Word Register 3 */
-#define REG_AES_TAGR            (0x4006C088) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR            (0x4006C088) /**< (AES) GCM Authentication Tag Word Register */
 #define REG_AES_TAGR0           (0x4006C088) /**< (AES) GCM Authentication Tag Word Register 0 */
 #define REG_AES_TAGR1           (0x4006C08C) /**< (AES) GCM Authentication Tag Word Register 1 */
 #define REG_AES_TAGR2           (0x4006C090) /**< (AES) GCM Authentication Tag Word Register 2 */
 #define REG_AES_TAGR3           (0x4006C094) /**< (AES) GCM Authentication Tag Word Register 3 */
 #define REG_AES_CTRR            (0x4006C098) /**< (AES) GCM Encryption Counter Value Register */
-#define REG_AES_GCMHR           (0x4006C09C) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR           (0x4006C09C) /**< (AES) GCM H Word Register */
 #define REG_AES_GCMHR0          (0x4006C09C) /**< (AES) GCM H Word Register 0 */
 #define REG_AES_GCMHR1          (0x4006C0A0) /**< (AES) GCM H Word Register 1 */
 #define REG_AES_GCMHR2          (0x4006C0A4) /**< (AES) GCM H Word Register 2 */
@@ -89,7 +91,7 @@
 #define REG_AES_IDR             (*(__O  uint32_t*)0x4006C014U) /**< (AES) Interrupt Disable Register */
 #define REG_AES_IMR             (*(__I  uint32_t*)0x4006C018U) /**< (AES) Interrupt Mask Register */
 #define REG_AES_ISR             (*(__I  uint32_t*)0x4006C01CU) /**< (AES) Interrupt Status Register */
-#define REG_AES_KEYWR           (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register 0 */
+#define REG_AES_KEYWR           (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register */
 #define REG_AES_KEYWR0          (*(__O  uint32_t*)0x4006C020U) /**< (AES) Key Word Register 0 */
 #define REG_AES_KEYWR1          (*(__O  uint32_t*)0x4006C024U) /**< (AES) Key Word Register 1 */
 #define REG_AES_KEYWR2          (*(__O  uint32_t*)0x4006C028U) /**< (AES) Key Word Register 2 */
@@ -98,35 +100,35 @@
 #define REG_AES_KEYWR5          (*(__O  uint32_t*)0x4006C034U) /**< (AES) Key Word Register 5 */
 #define REG_AES_KEYWR6          (*(__O  uint32_t*)0x4006C038U) /**< (AES) Key Word Register 6 */
 #define REG_AES_KEYWR7          (*(__O  uint32_t*)0x4006C03CU) /**< (AES) Key Word Register 7 */
-#define REG_AES_IDATAR          (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register 0 */
+#define REG_AES_IDATAR          (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register */
 #define REG_AES_IDATAR0         (*(__O  uint32_t*)0x4006C040U) /**< (AES) Input Data Register 0 */
 #define REG_AES_IDATAR1         (*(__O  uint32_t*)0x4006C044U) /**< (AES) Input Data Register 1 */
 #define REG_AES_IDATAR2         (*(__O  uint32_t*)0x4006C048U) /**< (AES) Input Data Register 2 */
 #define REG_AES_IDATAR3         (*(__O  uint32_t*)0x4006C04CU) /**< (AES) Input Data Register 3 */
-#define REG_AES_ODATAR          (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register 0 */
+#define REG_AES_ODATAR          (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register */
 #define REG_AES_ODATAR0         (*(__I  uint32_t*)0x4006C050U) /**< (AES) Output Data Register 0 */
 #define REG_AES_ODATAR1         (*(__I  uint32_t*)0x4006C054U) /**< (AES) Output Data Register 1 */
 #define REG_AES_ODATAR2         (*(__I  uint32_t*)0x4006C058U) /**< (AES) Output Data Register 2 */
 #define REG_AES_ODATAR3         (*(__I  uint32_t*)0x4006C05CU) /**< (AES) Output Data Register 3 */
-#define REG_AES_IVR             (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register 0 */
+#define REG_AES_IVR             (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register */
 #define REG_AES_IVR0            (*(__O  uint32_t*)0x4006C060U) /**< (AES) Initialization Vector Register 0 */
 #define REG_AES_IVR1            (*(__O  uint32_t*)0x4006C064U) /**< (AES) Initialization Vector Register 1 */
 #define REG_AES_IVR2            (*(__O  uint32_t*)0x4006C068U) /**< (AES) Initialization Vector Register 2 */
 #define REG_AES_IVR3            (*(__O  uint32_t*)0x4006C06CU) /**< (AES) Initialization Vector Register 3 */
 #define REG_AES_AADLENR         (*(__IO uint32_t*)0x4006C070U) /**< (AES) Additional Authenticated Data Length Register */
 #define REG_AES_CLENR           (*(__IO uint32_t*)0x4006C074U) /**< (AES) Plaintext/Ciphertext Length Register */
-#define REG_AES_GHASHR          (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register 0 */
+#define REG_AES_GHASHR          (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register */
 #define REG_AES_GHASHR0         (*(__IO uint32_t*)0x4006C078U) /**< (AES) GCM Intermediate Hash Word Register 0 */
 #define REG_AES_GHASHR1         (*(__IO uint32_t*)0x4006C07CU) /**< (AES) GCM Intermediate Hash Word Register 1 */
 #define REG_AES_GHASHR2         (*(__IO uint32_t*)0x4006C080U) /**< (AES) GCM Intermediate Hash Word Register 2 */
 #define REG_AES_GHASHR3         (*(__IO uint32_t*)0x4006C084U) /**< (AES) GCM Intermediate Hash Word Register 3 */
-#define REG_AES_TAGR            (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register 0 */
+#define REG_AES_TAGR            (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register */
 #define REG_AES_TAGR0           (*(__I  uint32_t*)0x4006C088U) /**< (AES) GCM Authentication Tag Word Register 0 */
 #define REG_AES_TAGR1           (*(__I  uint32_t*)0x4006C08CU) /**< (AES) GCM Authentication Tag Word Register 1 */
 #define REG_AES_TAGR2           (*(__I  uint32_t*)0x4006C090U) /**< (AES) GCM Authentication Tag Word Register 2 */
 #define REG_AES_TAGR3           (*(__I  uint32_t*)0x4006C094U) /**< (AES) GCM Authentication Tag Word Register 3 */
 #define REG_AES_CTRR            (*(__I  uint32_t*)0x4006C098U) /**< (AES) GCM Encryption Counter Value Register */
-#define REG_AES_GCMHR           (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register 0 */
+#define REG_AES_GCMHR           (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register */
 #define REG_AES_GCMHR0          (*(__IO uint32_t*)0x4006C09CU) /**< (AES) GCM H Word Register 0 */
 #define REG_AES_GCMHR1          (*(__IO uint32_t*)0x4006C0A0U) /**< (AES) GCM H Word Register 1 */
 #define REG_AES_GCMHR2          (*(__IO uint32_t*)0x4006C0A4U) /**< (AES) GCM H Word Register 2 */
@@ -135,9 +137,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AES peripheral ========== */
-#define AES_INSTANCE_ID                          56        
-#define AES_CLOCK_ID                             56        
-#define AES_DMAC_ID_TX                           37        
-#define AES_DMAC_ID_RX                           38        
+#define AES_DMAC_ID_TX                           37         
+#define AES_DMAC_ID_RX                           38         
+#define AES_INSTANCE_ID                          56         
+#define AES_CLOCK_ID                             56         
 
 #endif /* _SAME70_AES_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/afec0.h
+++ b/asf/sam/include/same70b/instance/afec0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AFEC0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_AFEC0_INSTANCE_H_
 #define _SAME70_AFEC0_INSTANCE_H_
 
@@ -97,8 +99,15 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AFEC0 peripheral ========== */
-#define AFEC0_INSTANCE_ID                        29        
-#define AFEC0_CLOCK_ID                           29        
-#define AFEC0_DMAC_ID_RX                         35        
+#define AFEC0_DMAC_ID_RX                         35         
+#define AFEC0_INSTANCE_ID                        29         
+#define AFEC0_CLOCK_ID                           29         
+#define AFEC0_TRGSEL_AFEC_TRIG0                  0x0        /* External ADC Trigger Input (AFE0_ADTRG pin) */
+#define AFEC0_TRGSEL_AFEC_TRIG1                  0x1        /* TC0 Channel 0 Output (TIOA0) */
+#define AFEC0_TRGSEL_AFEC_TRIG2                  0x2        /* TC0 Channel 1 Output (TIOA1) */
+#define AFEC0_TRGSEL_AFEC_TRIG3                  0x3        /* TC0 Channel 2 Output (TIOA2) */
+#define AFEC0_TRGSEL_AFEC_TRIG4                  0x4        /* PWM0 event line 0 */
+#define AFEC0_TRGSEL_AFEC_TRIG5                  0x5        /* PWM0 event line 1 */
+#define AFEC0_TRGSEL_AFEC_TRIG6                  0x6        /* Analog Comparator Fault Output */
 
 #endif /* _SAME70_AFEC0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/afec1.h
+++ b/asf/sam/include/same70b/instance/afec1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for AFEC1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_AFEC1_INSTANCE_H_
 #define _SAME70_AFEC1_INSTANCE_H_
 
@@ -97,8 +99,15 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for AFEC1 peripheral ========== */
-#define AFEC1_INSTANCE_ID                        40        
-#define AFEC1_CLOCK_ID                           40        
-#define AFEC1_DMAC_ID_RX                         36        
+#define AFEC1_DMAC_ID_RX                         36         
+#define AFEC1_INSTANCE_ID                        40         
+#define AFEC1_CLOCK_ID                           40         
+#define AFEC1_TRGSEL_AFEC_TRIG0                  0x0        /* External ADC Trigger Input (AFE1_ADTRG Pin) */
+#define AFEC1_TRGSEL_AFEC_TRIG1                  0x1        /* TC1 Channel 0 Output (TIOA3) */
+#define AFEC1_TRGSEL_AFEC_TRIG2                  0x2        /* TC1 Channel 1 Output (TIOA4) */
+#define AFEC1_TRGSEL_AFEC_TRIG3                  0x3        /* TC1 Channel 2 Output (TIOA5) */
+#define AFEC1_TRGSEL_AFEC_TRIG4                  0x4        /* PWM1 event line 0 */
+#define AFEC1_TRGSEL_AFEC_TRIG5                  0x5        /* PWM1 event line 1 */
+#define AFEC1_TRGSEL_AFEC_TRIG6                  0x6        /* Analog Comparator Fault Output */
 
 #endif /* _SAME70_AFEC1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/chipid.h
+++ b/asf/sam/include/same70b/instance/chipid.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for CHIPID
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_CHIPID_INSTANCE_H_
 #define _SAME70_CHIPID_INSTANCE_H_
 

--- a/asf/sam/include/same70b/instance/dacc.h
+++ b/asf/sam/include/same70b/instance/dacc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for DACC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_DACC_INSTANCE_H_
 #define _SAME70_DACC_INSTANCE_H_
 
@@ -71,8 +73,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for DACC peripheral ========== */
-#define DACC_INSTANCE_ID                         30        
-#define DACC_CLOCK_ID                            30        
-#define DACC_DMAC_ID_TX                          30        
+#define DACC_DMAC_ID_TX                          30         
+#define DACC_INSTANCE_ID                         30         
+#define DACC_CLOCK_ID                            30         
 
 #endif /* _SAME70_DACC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/efc.h
+++ b/asf/sam/include/same70b/instance/efc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for EFC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_EFC_INSTANCE_H_
 #define _SAME70_EFC_INSTANCE_H_
 
@@ -49,9 +51,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for EFC peripheral ========== */
-#define EFC_FLASH_SIZE                           2097152   
-#define EFC_INSTANCE_ID                          6         
-#define EFC_PAGES_PR_REGION                      32        
-#define EFC_PAGE_SIZE                            512       
+#define EFC_FLASH_SIZE                           2097152    
+#define EFC_PAGE_SIZE                            512        
+#define EFC_INSTANCE_ID                          6          
+#define EFC_PAGES_PR_REGION                      32         
 
 #endif /* _SAME70_EFC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/gmac.h
+++ b/asf/sam/include/same70b/instance/gmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for GMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_GMAC_INSTANCE_H_
 #define _SAME70_GMAC_INSTANCE_H_
 
@@ -40,6 +42,54 @@
 #define REG_GMAC_SAT3           (0x4005009C) /**< (GMAC) Specific Address 1 Top Register 2 */
 #define REG_GMAC_SAB4           (0x400500A0) /**< (GMAC) Specific Address 1 Bottom Register 3 */
 #define REG_GMAC_SAT4           (0x400500A4) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_ST2CW00        (0x40050700) /**< (GMAC) Screening Type 2 Compare Word 0 Register 0 */
+#define REG_GMAC_ST2CW10        (0x40050704) /**< (GMAC) Screening Type 2 Compare Word 1 Register 0 */
+#define REG_GMAC_ST2CW01        (0x40050708) /**< (GMAC) Screening Type 2 Compare Word 0 Register 1 */
+#define REG_GMAC_ST2CW11        (0x4005070C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 1 */
+#define REG_GMAC_ST2CW02        (0x40050710) /**< (GMAC) Screening Type 2 Compare Word 0 Register 2 */
+#define REG_GMAC_ST2CW12        (0x40050714) /**< (GMAC) Screening Type 2 Compare Word 1 Register 2 */
+#define REG_GMAC_ST2CW03        (0x40050718) /**< (GMAC) Screening Type 2 Compare Word 0 Register 3 */
+#define REG_GMAC_ST2CW13        (0x4005071C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 3 */
+#define REG_GMAC_ST2CW04        (0x40050720) /**< (GMAC) Screening Type 2 Compare Word 0 Register 4 */
+#define REG_GMAC_ST2CW14        (0x40050724) /**< (GMAC) Screening Type 2 Compare Word 1 Register 4 */
+#define REG_GMAC_ST2CW05        (0x40050728) /**< (GMAC) Screening Type 2 Compare Word 0 Register 5 */
+#define REG_GMAC_ST2CW15        (0x4005072C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 5 */
+#define REG_GMAC_ST2CW06        (0x40050730) /**< (GMAC) Screening Type 2 Compare Word 0 Register 6 */
+#define REG_GMAC_ST2CW16        (0x40050734) /**< (GMAC) Screening Type 2 Compare Word 1 Register 6 */
+#define REG_GMAC_ST2CW07        (0x40050738) /**< (GMAC) Screening Type 2 Compare Word 0 Register 7 */
+#define REG_GMAC_ST2CW17        (0x4005073C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 7 */
+#define REG_GMAC_ST2CW08        (0x40050740) /**< (GMAC) Screening Type 2 Compare Word 0 Register 8 */
+#define REG_GMAC_ST2CW18        (0x40050744) /**< (GMAC) Screening Type 2 Compare Word 1 Register 8 */
+#define REG_GMAC_ST2CW09        (0x40050748) /**< (GMAC) Screening Type 2 Compare Word 0 Register 9 */
+#define REG_GMAC_ST2CW19        (0x4005074C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 9 */
+#define REG_GMAC_ST2CW010       (0x40050750) /**< (GMAC) Screening Type 2 Compare Word 0 Register 10 */
+#define REG_GMAC_ST2CW110       (0x40050754) /**< (GMAC) Screening Type 2 Compare Word 1 Register 10 */
+#define REG_GMAC_ST2CW011       (0x40050758) /**< (GMAC) Screening Type 2 Compare Word 0 Register 11 */
+#define REG_GMAC_ST2CW111       (0x4005075C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 11 */
+#define REG_GMAC_ST2CW012       (0x40050760) /**< (GMAC) Screening Type 2 Compare Word 0 Register 12 */
+#define REG_GMAC_ST2CW112       (0x40050764) /**< (GMAC) Screening Type 2 Compare Word 1 Register 12 */
+#define REG_GMAC_ST2CW013       (0x40050768) /**< (GMAC) Screening Type 2 Compare Word 0 Register 13 */
+#define REG_GMAC_ST2CW113       (0x4005076C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 13 */
+#define REG_GMAC_ST2CW014       (0x40050770) /**< (GMAC) Screening Type 2 Compare Word 0 Register 14 */
+#define REG_GMAC_ST2CW114       (0x40050774) /**< (GMAC) Screening Type 2 Compare Word 1 Register 14 */
+#define REG_GMAC_ST2CW015       (0x40050778) /**< (GMAC) Screening Type 2 Compare Word 0 Register 15 */
+#define REG_GMAC_ST2CW115       (0x4005077C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 15 */
+#define REG_GMAC_ST2CW016       (0x40050780) /**< (GMAC) Screening Type 2 Compare Word 0 Register 16 */
+#define REG_GMAC_ST2CW116       (0x40050784) /**< (GMAC) Screening Type 2 Compare Word 1 Register 16 */
+#define REG_GMAC_ST2CW017       (0x40050788) /**< (GMAC) Screening Type 2 Compare Word 0 Register 17 */
+#define REG_GMAC_ST2CW117       (0x4005078C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 17 */
+#define REG_GMAC_ST2CW018       (0x40050790) /**< (GMAC) Screening Type 2 Compare Word 0 Register 18 */
+#define REG_GMAC_ST2CW118       (0x40050794) /**< (GMAC) Screening Type 2 Compare Word 1 Register 18 */
+#define REG_GMAC_ST2CW019       (0x40050798) /**< (GMAC) Screening Type 2 Compare Word 0 Register 19 */
+#define REG_GMAC_ST2CW119       (0x4005079C) /**< (GMAC) Screening Type 2 Compare Word 1 Register 19 */
+#define REG_GMAC_ST2CW020       (0x400507A0) /**< (GMAC) Screening Type 2 Compare Word 0 Register 20 */
+#define REG_GMAC_ST2CW120       (0x400507A4) /**< (GMAC) Screening Type 2 Compare Word 1 Register 20 */
+#define REG_GMAC_ST2CW021       (0x400507A8) /**< (GMAC) Screening Type 2 Compare Word 0 Register 21 */
+#define REG_GMAC_ST2CW121       (0x400507AC) /**< (GMAC) Screening Type 2 Compare Word 1 Register 21 */
+#define REG_GMAC_ST2CW022       (0x400507B0) /**< (GMAC) Screening Type 2 Compare Word 0 Register 22 */
+#define REG_GMAC_ST2CW122       (0x400507B4) /**< (GMAC) Screening Type 2 Compare Word 1 Register 22 */
+#define REG_GMAC_ST2CW023       (0x400507B8) /**< (GMAC) Screening Type 2 Compare Word 0 Register 23 */
+#define REG_GMAC_ST2CW123       (0x400507BC) /**< (GMAC) Screening Type 2 Compare Word 1 Register 23 */
 #define REG_GMAC_NCR            (0x40050000) /**< (GMAC) Network Control Register */
 #define REG_GMAC_NCFGR          (0x40050004) /**< (GMAC) Network Configuration Register */
 #define REG_GMAC_NSR            (0x40050008) /**< (GMAC) Network Status Register */
@@ -141,118 +191,70 @@
 #define REG_GMAC_RXLPITIME      (0x40050274) /**< (GMAC) Received LPI Time */
 #define REG_GMAC_TXLPI          (0x40050278) /**< (GMAC) Transmit LPI Transitions */
 #define REG_GMAC_TXLPITIME      (0x4005027C) /**< (GMAC) Transmit LPI Time */
-#define REG_GMAC_ISRPQ          (0x400503FC) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_ISRPQ0         (0x400503FC) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_ISRPQ1         (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_ISRPQ2         (0x40050404) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_ISRPQ3         (0x40050408) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_ISRPQ4         (0x4005040C) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_TBQBAPQ        (0x4005043C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_TBQBAPQ0       (0x4005043C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_TBQBAPQ1       (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_TBQBAPQ2       (0x40050444) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_TBQBAPQ3       (0x40050448) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_TBQBAPQ4       (0x4005044C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_RBQBAPQ        (0x4005047C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBQBAPQ0       (0x4005047C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBQBAPQ1       (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_RBQBAPQ2       (0x40050484) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_RBQBAPQ3       (0x40050488) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_RBQBAPQ4       (0x4005048C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_RBSRPQ         (0x4005049C) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBSRPQ0        (0x4005049C) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBSRPQ1        (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_RBSRPQ2        (0x400504A4) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_RBSRPQ3        (0x400504A8) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_RBSRPQ4        (0x400504AC) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 4 */
+#define REG_GMAC_ISRPQ          (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) */
+#define REG_GMAC_ISRPQ0         (0x40050400) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 0 */
+#define REG_GMAC_ISRPQ1         (0x40050404) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 1 */
+#define REG_GMAC_ISRPQ2         (0x40050408) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 2 */
+#define REG_GMAC_ISRPQ3         (0x4005040C) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 3 */
+#define REG_GMAC_ISRPQ4         (0x40050410) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 4 */
+#define REG_GMAC_TBQBAPQ        (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_TBQBAPQ0       (0x40050440) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_TBQBAPQ1       (0x40050444) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_TBQBAPQ2       (0x40050448) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_TBQBAPQ3       (0x4005044C) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_TBQBAPQ4       (0x40050450) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBQBAPQ        (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_RBQBAPQ0       (0x40050480) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBQBAPQ1       (0x40050484) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBQBAPQ2       (0x40050488) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBQBAPQ3       (0x4005048C) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBQBAPQ4       (0x40050490) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBSRPQ         (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) */
+#define REG_GMAC_RBSRPQ0        (0x400504A0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBSRPQ1        (0x400504A4) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBSRPQ2        (0x400504A8) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBSRPQ3        (0x400504AC) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBSRPQ4        (0x400504B0) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 4 */
 #define REG_GMAC_CBSCR          (0x400504BC) /**< (GMAC) Credit-Based Shaping Control Register */
 #define REG_GMAC_CBSISQA        (0x400504C0) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
 #define REG_GMAC_CBSISQB        (0x400504C4) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
-#define REG_GMAC_ST1RPQ         (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST1RPQ0        (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST1RPQ1        (0x40050504) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 1 */
-#define REG_GMAC_ST1RPQ2        (0x40050508) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 2 */
-#define REG_GMAC_ST1RPQ3        (0x4005050C) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 3 */
-#define REG_GMAC_ST2RPQ         (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST2RPQ0        (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST2RPQ1        (0x40050544) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 1 */
-#define REG_GMAC_ST2RPQ2        (0x40050548) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 2 */
-#define REG_GMAC_ST2RPQ3        (0x4005054C) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 3 */
-#define REG_GMAC_ST2RPQ4        (0x40050550) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 4 */
-#define REG_GMAC_ST2RPQ5        (0x40050554) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 5 */
-#define REG_GMAC_ST2RPQ6        (0x40050558) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 6 */
-#define REG_GMAC_ST2RPQ7        (0x4005055C) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 7 */
-#define REG_GMAC_IERPQ          (0x400505FC) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IERPQ0         (0x400505FC) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IERPQ1         (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IERPQ2         (0x40050604) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IERPQ3         (0x40050608) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IERPQ4         (0x4005060C) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_IDRPQ          (0x4005061C) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IDRPQ0         (0x4005061C) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IDRPQ1         (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IDRPQ2         (0x40050624) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IDRPQ3         (0x40050628) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IDRPQ4         (0x4005062C) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_IMRPQ          (0x4005063C) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IMRPQ0         (0x4005063C) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IMRPQ1         (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IMRPQ2         (0x40050644) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IMRPQ3         (0x40050648) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IMRPQ4         (0x4005064C) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_ST2ER          (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
-#define REG_GMAC_ST2ER0         (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
-#define REG_GMAC_ST2ER1         (0x400506E4) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 1 */
-#define REG_GMAC_ST2ER2         (0x400506E8) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 2 */
-#define REG_GMAC_ST2ER3         (0x400506EC) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 3 */
-#define REG_GMAC_ST2CW00        (0x40050700) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 0) */
-#define REG_GMAC_ST2CW10        (0x40050704) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 0) */
-#define REG_GMAC_ST2CW01        (0x40050708) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 1) */
-#define REG_GMAC_ST2CW11        (0x4005070C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 1) */
-#define REG_GMAC_ST2CW02        (0x40050710) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 2) */
-#define REG_GMAC_ST2CW12        (0x40050714) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 2) */
-#define REG_GMAC_ST2CW03        (0x40050718) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 3) */
-#define REG_GMAC_ST2CW13        (0x4005071C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 3) */
-#define REG_GMAC_ST2CW04        (0x40050720) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 4) */
-#define REG_GMAC_ST2CW14        (0x40050724) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 4) */
-#define REG_GMAC_ST2CW05        (0x40050728) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 5) */
-#define REG_GMAC_ST2CW15        (0x4005072C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 5) */
-#define REG_GMAC_ST2CW06        (0x40050730) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 6) */
-#define REG_GMAC_ST2CW16        (0x40050734) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 6) */
-#define REG_GMAC_ST2CW07        (0x40050738) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 7) */
-#define REG_GMAC_ST2CW17        (0x4005073C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 7) */
-#define REG_GMAC_ST2CW08        (0x40050740) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 8) */
-#define REG_GMAC_ST2CW18        (0x40050744) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 8) */
-#define REG_GMAC_ST2CW09        (0x40050748) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 9) */
-#define REG_GMAC_ST2CW19        (0x4005074C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 9) */
-#define REG_GMAC_ST2CW010       (0x40050750) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 10) */
-#define REG_GMAC_ST2CW110       (0x40050754) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 10) */
-#define REG_GMAC_ST2CW011       (0x40050758) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 11) */
-#define REG_GMAC_ST2CW111       (0x4005075C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 11) */
-#define REG_GMAC_ST2CW012       (0x40050760) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 12) */
-#define REG_GMAC_ST2CW112       (0x40050764) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 12) */
-#define REG_GMAC_ST2CW013       (0x40050768) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 13) */
-#define REG_GMAC_ST2CW113       (0x4005076C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 13) */
-#define REG_GMAC_ST2CW014       (0x40050770) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 14) */
-#define REG_GMAC_ST2CW114       (0x40050774) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 14) */
-#define REG_GMAC_ST2CW015       (0x40050778) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 15) */
-#define REG_GMAC_ST2CW115       (0x4005077C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 15) */
-#define REG_GMAC_ST2CW016       (0x40050780) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 16) */
-#define REG_GMAC_ST2CW116       (0x40050784) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 16) */
-#define REG_GMAC_ST2CW017       (0x40050788) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 17) */
-#define REG_GMAC_ST2CW117       (0x4005078C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 17) */
-#define REG_GMAC_ST2CW018       (0x40050790) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 18) */
-#define REG_GMAC_ST2CW118       (0x40050794) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 18) */
-#define REG_GMAC_ST2CW019       (0x40050798) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 19) */
-#define REG_GMAC_ST2CW119       (0x4005079C) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 19) */
-#define REG_GMAC_ST2CW020       (0x400507A0) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 20) */
-#define REG_GMAC_ST2CW120       (0x400507A4) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 20) */
-#define REG_GMAC_ST2CW021       (0x400507A8) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 21) */
-#define REG_GMAC_ST2CW121       (0x400507AC) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 21) */
-#define REG_GMAC_ST2CW022       (0x400507B0) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 22) */
-#define REG_GMAC_ST2CW122       (0x400507B4) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 22) */
-#define REG_GMAC_ST2CW023       (0x400507B8) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 23) */
-#define REG_GMAC_ST2CW123       (0x400507BC) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 23) */
+#define REG_GMAC_ST1RPQ         (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue */
+#define REG_GMAC_ST1RPQ0        (0x40050500) /**< (GMAC) Screening Type 1 Register Priority Queue 0 */
+#define REG_GMAC_ST1RPQ1        (0x40050504) /**< (GMAC) Screening Type 1 Register Priority Queue 1 */
+#define REG_GMAC_ST1RPQ2        (0x40050508) /**< (GMAC) Screening Type 1 Register Priority Queue 2 */
+#define REG_GMAC_ST1RPQ3        (0x4005050C) /**< (GMAC) Screening Type 1 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ         (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue */
+#define REG_GMAC_ST2RPQ0        (0x40050540) /**< (GMAC) Screening Type 2 Register Priority Queue 0 */
+#define REG_GMAC_ST2RPQ1        (0x40050544) /**< (GMAC) Screening Type 2 Register Priority Queue 1 */
+#define REG_GMAC_ST2RPQ2        (0x40050548) /**< (GMAC) Screening Type 2 Register Priority Queue 2 */
+#define REG_GMAC_ST2RPQ3        (0x4005054C) /**< (GMAC) Screening Type 2 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ4        (0x40050550) /**< (GMAC) Screening Type 2 Register Priority Queue 4 */
+#define REG_GMAC_ST2RPQ5        (0x40050554) /**< (GMAC) Screening Type 2 Register Priority Queue 5 */
+#define REG_GMAC_ST2RPQ6        (0x40050558) /**< (GMAC) Screening Type 2 Register Priority Queue 6 */
+#define REG_GMAC_ST2RPQ7        (0x4005055C) /**< (GMAC) Screening Type 2 Register Priority Queue 7 */
+#define REG_GMAC_IERPQ          (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) */
+#define REG_GMAC_IERPQ0         (0x40050600) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IERPQ1         (0x40050604) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IERPQ2         (0x40050608) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IERPQ3         (0x4005060C) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IERPQ4         (0x40050610) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IDRPQ          (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) */
+#define REG_GMAC_IDRPQ0         (0x40050620) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IDRPQ1         (0x40050624) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IDRPQ2         (0x40050628) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IDRPQ3         (0x4005062C) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IDRPQ4         (0x40050630) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IMRPQ          (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) */
+#define REG_GMAC_IMRPQ0         (0x40050640) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IMRPQ1         (0x40050644) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IMRPQ2         (0x40050648) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IMRPQ3         (0x4005064C) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IMRPQ4         (0x40050650) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 4 */
+#define REG_GMAC_ST2ER          (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register */
+#define REG_GMAC_ST2ER0         (0x400506E0) /**< (GMAC) Screening Type 2 Ethertype Register 0 */
+#define REG_GMAC_ST2ER1         (0x400506E4) /**< (GMAC) Screening Type 2 Ethertype Register 1 */
+#define REG_GMAC_ST2ER2         (0x400506E8) /**< (GMAC) Screening Type 2 Ethertype Register 2 */
+#define REG_GMAC_ST2ER3         (0x400506EC) /**< (GMAC) Screening Type 2 Ethertype Register 3 */
 
 #else
 
@@ -264,6 +266,54 @@
 #define REG_GMAC_SAT3           (*(__IO uint32_t*)0x4005009CU) /**< (GMAC) Specific Address 1 Top Register 2 */
 #define REG_GMAC_SAB4           (*(__IO uint32_t*)0x400500A0U) /**< (GMAC) Specific Address 1 Bottom Register 3 */
 #define REG_GMAC_SAT4           (*(__IO uint32_t*)0x400500A4U) /**< (GMAC) Specific Address 1 Top Register 3 */
+#define REG_GMAC_ST2CW00        (*(__IO uint32_t*)0x40050700U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 0 */
+#define REG_GMAC_ST2CW10        (*(__IO uint32_t*)0x40050704U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 0 */
+#define REG_GMAC_ST2CW01        (*(__IO uint32_t*)0x40050708U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 1 */
+#define REG_GMAC_ST2CW11        (*(__IO uint32_t*)0x4005070CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 1 */
+#define REG_GMAC_ST2CW02        (*(__IO uint32_t*)0x40050710U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 2 */
+#define REG_GMAC_ST2CW12        (*(__IO uint32_t*)0x40050714U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 2 */
+#define REG_GMAC_ST2CW03        (*(__IO uint32_t*)0x40050718U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 3 */
+#define REG_GMAC_ST2CW13        (*(__IO uint32_t*)0x4005071CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 3 */
+#define REG_GMAC_ST2CW04        (*(__IO uint32_t*)0x40050720U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 4 */
+#define REG_GMAC_ST2CW14        (*(__IO uint32_t*)0x40050724U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 4 */
+#define REG_GMAC_ST2CW05        (*(__IO uint32_t*)0x40050728U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 5 */
+#define REG_GMAC_ST2CW15        (*(__IO uint32_t*)0x4005072CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 5 */
+#define REG_GMAC_ST2CW06        (*(__IO uint32_t*)0x40050730U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 6 */
+#define REG_GMAC_ST2CW16        (*(__IO uint32_t*)0x40050734U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 6 */
+#define REG_GMAC_ST2CW07        (*(__IO uint32_t*)0x40050738U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 7 */
+#define REG_GMAC_ST2CW17        (*(__IO uint32_t*)0x4005073CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 7 */
+#define REG_GMAC_ST2CW08        (*(__IO uint32_t*)0x40050740U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 8 */
+#define REG_GMAC_ST2CW18        (*(__IO uint32_t*)0x40050744U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 8 */
+#define REG_GMAC_ST2CW09        (*(__IO uint32_t*)0x40050748U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 9 */
+#define REG_GMAC_ST2CW19        (*(__IO uint32_t*)0x4005074CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 9 */
+#define REG_GMAC_ST2CW010       (*(__IO uint32_t*)0x40050750U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 10 */
+#define REG_GMAC_ST2CW110       (*(__IO uint32_t*)0x40050754U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 10 */
+#define REG_GMAC_ST2CW011       (*(__IO uint32_t*)0x40050758U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 11 */
+#define REG_GMAC_ST2CW111       (*(__IO uint32_t*)0x4005075CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 11 */
+#define REG_GMAC_ST2CW012       (*(__IO uint32_t*)0x40050760U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 12 */
+#define REG_GMAC_ST2CW112       (*(__IO uint32_t*)0x40050764U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 12 */
+#define REG_GMAC_ST2CW013       (*(__IO uint32_t*)0x40050768U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 13 */
+#define REG_GMAC_ST2CW113       (*(__IO uint32_t*)0x4005076CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 13 */
+#define REG_GMAC_ST2CW014       (*(__IO uint32_t*)0x40050770U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 14 */
+#define REG_GMAC_ST2CW114       (*(__IO uint32_t*)0x40050774U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 14 */
+#define REG_GMAC_ST2CW015       (*(__IO uint32_t*)0x40050778U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 15 */
+#define REG_GMAC_ST2CW115       (*(__IO uint32_t*)0x4005077CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 15 */
+#define REG_GMAC_ST2CW016       (*(__IO uint32_t*)0x40050780U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 16 */
+#define REG_GMAC_ST2CW116       (*(__IO uint32_t*)0x40050784U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 16 */
+#define REG_GMAC_ST2CW017       (*(__IO uint32_t*)0x40050788U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 17 */
+#define REG_GMAC_ST2CW117       (*(__IO uint32_t*)0x4005078CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 17 */
+#define REG_GMAC_ST2CW018       (*(__IO uint32_t*)0x40050790U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 18 */
+#define REG_GMAC_ST2CW118       (*(__IO uint32_t*)0x40050794U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 18 */
+#define REG_GMAC_ST2CW019       (*(__IO uint32_t*)0x40050798U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 19 */
+#define REG_GMAC_ST2CW119       (*(__IO uint32_t*)0x4005079CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 19 */
+#define REG_GMAC_ST2CW020       (*(__IO uint32_t*)0x400507A0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 20 */
+#define REG_GMAC_ST2CW120       (*(__IO uint32_t*)0x400507A4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 20 */
+#define REG_GMAC_ST2CW021       (*(__IO uint32_t*)0x400507A8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 21 */
+#define REG_GMAC_ST2CW121       (*(__IO uint32_t*)0x400507ACU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 21 */
+#define REG_GMAC_ST2CW022       (*(__IO uint32_t*)0x400507B0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 22 */
+#define REG_GMAC_ST2CW122       (*(__IO uint32_t*)0x400507B4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register 22 */
+#define REG_GMAC_ST2CW023       (*(__IO uint32_t*)0x400507B8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register 23 */
+#define REG_GMAC_ST2CW123       (*(__IO uint32_t*)0x400507BCU) /**< (GMAC) Screening Type 2 Compare Word 1 Register 23 */
 #define REG_GMAC_NCR            (*(__IO uint32_t*)0x40050000U) /**< (GMAC) Network Control Register */
 #define REG_GMAC_NCFGR          (*(__IO uint32_t*)0x40050004U) /**< (GMAC) Network Configuration Register */
 #define REG_GMAC_NSR            (*(__I  uint32_t*)0x40050008U) /**< (GMAC) Network Status Register */
@@ -365,123 +415,75 @@
 #define REG_GMAC_RXLPITIME      (*(__I  uint32_t*)0x40050274U) /**< (GMAC) Received LPI Time */
 #define REG_GMAC_TXLPI          (*(__I  uint32_t*)0x40050278U) /**< (GMAC) Transmit LPI Transitions */
 #define REG_GMAC_TXLPITIME      (*(__I  uint32_t*)0x4005027CU) /**< (GMAC) Transmit LPI Time */
-#define REG_GMAC_ISRPQ          (*(__I  uint32_t*)0x400503FCU) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_ISRPQ0         (*(__I  uint32_t*)0x400503FCU) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_ISRPQ1         (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_ISRPQ2         (*(__I  uint32_t*)0x40050404U) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_ISRPQ3         (*(__I  uint32_t*)0x40050408U) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_ISRPQ4         (*(__I  uint32_t*)0x4005040CU) /**< (GMAC) Interrupt Status Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_TBQBAPQ        (*(__IO uint32_t*)0x4005043CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_TBQBAPQ0       (*(__IO uint32_t*)0x4005043CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_TBQBAPQ1       (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_TBQBAPQ2       (*(__IO uint32_t*)0x40050444U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_TBQBAPQ3       (*(__IO uint32_t*)0x40050448U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_TBQBAPQ4       (*(__IO uint32_t*)0x4005044CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_RBQBAPQ        (*(__IO uint32_t*)0x4005047CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBQBAPQ0       (*(__IO uint32_t*)0x4005047CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBQBAPQ1       (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_RBQBAPQ2       (*(__IO uint32_t*)0x40050484U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_RBQBAPQ3       (*(__IO uint32_t*)0x40050488U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_RBQBAPQ4       (*(__IO uint32_t*)0x4005048CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_RBSRPQ         (*(__IO uint32_t*)0x4005049CU) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBSRPQ0        (*(__IO uint32_t*)0x4005049CU) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_RBSRPQ1        (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_RBSRPQ2        (*(__IO uint32_t*)0x400504A4U) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_RBSRPQ3        (*(__IO uint32_t*)0x400504A8U) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_RBSRPQ4        (*(__IO uint32_t*)0x400504ACU) /**< (GMAC) Receive Buffer Size Register Priority Queue (index = 1) 4 */
+#define REG_GMAC_ISRPQ          (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) */
+#define REG_GMAC_ISRPQ0         (*(__I  uint32_t*)0x40050400U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 0 */
+#define REG_GMAC_ISRPQ1         (*(__I  uint32_t*)0x40050404U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 1 */
+#define REG_GMAC_ISRPQ2         (*(__I  uint32_t*)0x40050408U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 2 */
+#define REG_GMAC_ISRPQ3         (*(__I  uint32_t*)0x4005040CU) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 3 */
+#define REG_GMAC_ISRPQ4         (*(__I  uint32_t*)0x40050410U) /**< (GMAC) Interrupt Status Register Priority Queue (1..5) 4 */
+#define REG_GMAC_TBQBAPQ        (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_TBQBAPQ0       (*(__IO uint32_t*)0x40050440U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_TBQBAPQ1       (*(__IO uint32_t*)0x40050444U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_TBQBAPQ2       (*(__IO uint32_t*)0x40050448U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_TBQBAPQ3       (*(__IO uint32_t*)0x4005044CU) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_TBQBAPQ4       (*(__IO uint32_t*)0x40050450U) /**< (GMAC) Transmit Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBQBAPQ        (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) */
+#define REG_GMAC_RBQBAPQ0       (*(__IO uint32_t*)0x40050480U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBQBAPQ1       (*(__IO uint32_t*)0x40050484U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBQBAPQ2       (*(__IO uint32_t*)0x40050488U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBQBAPQ3       (*(__IO uint32_t*)0x4005048CU) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBQBAPQ4       (*(__IO uint32_t*)0x40050490U) /**< (GMAC) Receive Buffer Queue Base Address Register Priority Queue (1..5) 4 */
+#define REG_GMAC_RBSRPQ         (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) */
+#define REG_GMAC_RBSRPQ0        (*(__IO uint32_t*)0x400504A0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 0 */
+#define REG_GMAC_RBSRPQ1        (*(__IO uint32_t*)0x400504A4U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 1 */
+#define REG_GMAC_RBSRPQ2        (*(__IO uint32_t*)0x400504A8U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 2 */
+#define REG_GMAC_RBSRPQ3        (*(__IO uint32_t*)0x400504ACU) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 3 */
+#define REG_GMAC_RBSRPQ4        (*(__IO uint32_t*)0x400504B0U) /**< (GMAC) Receive Buffer Size Register Priority Queue (1..5) 4 */
 #define REG_GMAC_CBSCR          (*(__IO uint32_t*)0x400504BCU) /**< (GMAC) Credit-Based Shaping Control Register */
 #define REG_GMAC_CBSISQA        (*(__IO uint32_t*)0x400504C0U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue A */
 #define REG_GMAC_CBSISQB        (*(__IO uint32_t*)0x400504C4U) /**< (GMAC) Credit-Based Shaping IdleSlope Register for Queue B */
-#define REG_GMAC_ST1RPQ         (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST1RPQ0        (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST1RPQ1        (*(__IO uint32_t*)0x40050504U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 1 */
-#define REG_GMAC_ST1RPQ2        (*(__IO uint32_t*)0x40050508U) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 2 */
-#define REG_GMAC_ST1RPQ3        (*(__IO uint32_t*)0x4005050CU) /**< (GMAC) Screening Type 1 Register Priority Queue (index = 0) 3 */
-#define REG_GMAC_ST2RPQ         (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST2RPQ0        (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 0 */
-#define REG_GMAC_ST2RPQ1        (*(__IO uint32_t*)0x40050544U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 1 */
-#define REG_GMAC_ST2RPQ2        (*(__IO uint32_t*)0x40050548U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 2 */
-#define REG_GMAC_ST2RPQ3        (*(__IO uint32_t*)0x4005054CU) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 3 */
-#define REG_GMAC_ST2RPQ4        (*(__IO uint32_t*)0x40050550U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 4 */
-#define REG_GMAC_ST2RPQ5        (*(__IO uint32_t*)0x40050554U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 5 */
-#define REG_GMAC_ST2RPQ6        (*(__IO uint32_t*)0x40050558U) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 6 */
-#define REG_GMAC_ST2RPQ7        (*(__IO uint32_t*)0x4005055CU) /**< (GMAC) Screening Type 2 Register Priority Queue (index = 0) 7 */
-#define REG_GMAC_IERPQ          (*(__O  uint32_t*)0x400505FCU) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IERPQ0         (*(__O  uint32_t*)0x400505FCU) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IERPQ1         (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IERPQ2         (*(__O  uint32_t*)0x40050604U) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IERPQ3         (*(__O  uint32_t*)0x40050608U) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IERPQ4         (*(__O  uint32_t*)0x4005060CU) /**< (GMAC) Interrupt Enable Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_IDRPQ          (*(__O  uint32_t*)0x4005061CU) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IDRPQ0         (*(__O  uint32_t*)0x4005061CU) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IDRPQ1         (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IDRPQ2         (*(__O  uint32_t*)0x40050624U) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IDRPQ3         (*(__O  uint32_t*)0x40050628U) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IDRPQ4         (*(__O  uint32_t*)0x4005062CU) /**< (GMAC) Interrupt Disable Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_IMRPQ          (*(__IO uint32_t*)0x4005063CU) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IMRPQ0         (*(__IO uint32_t*)0x4005063CU) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 0 */
-#define REG_GMAC_IMRPQ1         (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 1 */
-#define REG_GMAC_IMRPQ2         (*(__IO uint32_t*)0x40050644U) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 2 */
-#define REG_GMAC_IMRPQ3         (*(__IO uint32_t*)0x40050648U) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 3 */
-#define REG_GMAC_IMRPQ4         (*(__IO uint32_t*)0x4005064CU) /**< (GMAC) Interrupt Mask Register Priority Queue (index = 1) 4 */
-#define REG_GMAC_ST2ER          (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
-#define REG_GMAC_ST2ER0         (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 0 */
-#define REG_GMAC_ST2ER1         (*(__IO uint32_t*)0x400506E4U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 1 */
-#define REG_GMAC_ST2ER2         (*(__IO uint32_t*)0x400506E8U) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 2 */
-#define REG_GMAC_ST2ER3         (*(__IO uint32_t*)0x400506ECU) /**< (GMAC) Screening Type 2 Ethertype Register (index = 0) 3 */
-#define REG_GMAC_ST2CW00        (*(__IO uint32_t*)0x40050700U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 0) */
-#define REG_GMAC_ST2CW10        (*(__IO uint32_t*)0x40050704U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 0) */
-#define REG_GMAC_ST2CW01        (*(__IO uint32_t*)0x40050708U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 1) */
-#define REG_GMAC_ST2CW11        (*(__IO uint32_t*)0x4005070CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 1) */
-#define REG_GMAC_ST2CW02        (*(__IO uint32_t*)0x40050710U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 2) */
-#define REG_GMAC_ST2CW12        (*(__IO uint32_t*)0x40050714U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 2) */
-#define REG_GMAC_ST2CW03        (*(__IO uint32_t*)0x40050718U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 3) */
-#define REG_GMAC_ST2CW13        (*(__IO uint32_t*)0x4005071CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 3) */
-#define REG_GMAC_ST2CW04        (*(__IO uint32_t*)0x40050720U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 4) */
-#define REG_GMAC_ST2CW14        (*(__IO uint32_t*)0x40050724U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 4) */
-#define REG_GMAC_ST2CW05        (*(__IO uint32_t*)0x40050728U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 5) */
-#define REG_GMAC_ST2CW15        (*(__IO uint32_t*)0x4005072CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 5) */
-#define REG_GMAC_ST2CW06        (*(__IO uint32_t*)0x40050730U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 6) */
-#define REG_GMAC_ST2CW16        (*(__IO uint32_t*)0x40050734U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 6) */
-#define REG_GMAC_ST2CW07        (*(__IO uint32_t*)0x40050738U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 7) */
-#define REG_GMAC_ST2CW17        (*(__IO uint32_t*)0x4005073CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 7) */
-#define REG_GMAC_ST2CW08        (*(__IO uint32_t*)0x40050740U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 8) */
-#define REG_GMAC_ST2CW18        (*(__IO uint32_t*)0x40050744U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 8) */
-#define REG_GMAC_ST2CW09        (*(__IO uint32_t*)0x40050748U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 9) */
-#define REG_GMAC_ST2CW19        (*(__IO uint32_t*)0x4005074CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 9) */
-#define REG_GMAC_ST2CW010       (*(__IO uint32_t*)0x40050750U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 10) */
-#define REG_GMAC_ST2CW110       (*(__IO uint32_t*)0x40050754U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 10) */
-#define REG_GMAC_ST2CW011       (*(__IO uint32_t*)0x40050758U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 11) */
-#define REG_GMAC_ST2CW111       (*(__IO uint32_t*)0x4005075CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 11) */
-#define REG_GMAC_ST2CW012       (*(__IO uint32_t*)0x40050760U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 12) */
-#define REG_GMAC_ST2CW112       (*(__IO uint32_t*)0x40050764U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 12) */
-#define REG_GMAC_ST2CW013       (*(__IO uint32_t*)0x40050768U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 13) */
-#define REG_GMAC_ST2CW113       (*(__IO uint32_t*)0x4005076CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 13) */
-#define REG_GMAC_ST2CW014       (*(__IO uint32_t*)0x40050770U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 14) */
-#define REG_GMAC_ST2CW114       (*(__IO uint32_t*)0x40050774U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 14) */
-#define REG_GMAC_ST2CW015       (*(__IO uint32_t*)0x40050778U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 15) */
-#define REG_GMAC_ST2CW115       (*(__IO uint32_t*)0x4005077CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 15) */
-#define REG_GMAC_ST2CW016       (*(__IO uint32_t*)0x40050780U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 16) */
-#define REG_GMAC_ST2CW116       (*(__IO uint32_t*)0x40050784U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 16) */
-#define REG_GMAC_ST2CW017       (*(__IO uint32_t*)0x40050788U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 17) */
-#define REG_GMAC_ST2CW117       (*(__IO uint32_t*)0x4005078CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 17) */
-#define REG_GMAC_ST2CW018       (*(__IO uint32_t*)0x40050790U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 18) */
-#define REG_GMAC_ST2CW118       (*(__IO uint32_t*)0x40050794U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 18) */
-#define REG_GMAC_ST2CW019       (*(__IO uint32_t*)0x40050798U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 19) */
-#define REG_GMAC_ST2CW119       (*(__IO uint32_t*)0x4005079CU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 19) */
-#define REG_GMAC_ST2CW020       (*(__IO uint32_t*)0x400507A0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 20) */
-#define REG_GMAC_ST2CW120       (*(__IO uint32_t*)0x400507A4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 20) */
-#define REG_GMAC_ST2CW021       (*(__IO uint32_t*)0x400507A8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 21) */
-#define REG_GMAC_ST2CW121       (*(__IO uint32_t*)0x400507ACU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 21) */
-#define REG_GMAC_ST2CW022       (*(__IO uint32_t*)0x400507B0U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 22) */
-#define REG_GMAC_ST2CW122       (*(__IO uint32_t*)0x400507B4U) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 22) */
-#define REG_GMAC_ST2CW023       (*(__IO uint32_t*)0x400507B8U) /**< (GMAC) Screening Type 2 Compare Word 0 Register (index = 23) */
-#define REG_GMAC_ST2CW123       (*(__IO uint32_t*)0x400507BCU) /**< (GMAC) Screening Type 2 Compare Word 1 Register (index = 23) */
+#define REG_GMAC_ST1RPQ         (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue */
+#define REG_GMAC_ST1RPQ0        (*(__IO uint32_t*)0x40050500U) /**< (GMAC) Screening Type 1 Register Priority Queue 0 */
+#define REG_GMAC_ST1RPQ1        (*(__IO uint32_t*)0x40050504U) /**< (GMAC) Screening Type 1 Register Priority Queue 1 */
+#define REG_GMAC_ST1RPQ2        (*(__IO uint32_t*)0x40050508U) /**< (GMAC) Screening Type 1 Register Priority Queue 2 */
+#define REG_GMAC_ST1RPQ3        (*(__IO uint32_t*)0x4005050CU) /**< (GMAC) Screening Type 1 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ         (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue */
+#define REG_GMAC_ST2RPQ0        (*(__IO uint32_t*)0x40050540U) /**< (GMAC) Screening Type 2 Register Priority Queue 0 */
+#define REG_GMAC_ST2RPQ1        (*(__IO uint32_t*)0x40050544U) /**< (GMAC) Screening Type 2 Register Priority Queue 1 */
+#define REG_GMAC_ST2RPQ2        (*(__IO uint32_t*)0x40050548U) /**< (GMAC) Screening Type 2 Register Priority Queue 2 */
+#define REG_GMAC_ST2RPQ3        (*(__IO uint32_t*)0x4005054CU) /**< (GMAC) Screening Type 2 Register Priority Queue 3 */
+#define REG_GMAC_ST2RPQ4        (*(__IO uint32_t*)0x40050550U) /**< (GMAC) Screening Type 2 Register Priority Queue 4 */
+#define REG_GMAC_ST2RPQ5        (*(__IO uint32_t*)0x40050554U) /**< (GMAC) Screening Type 2 Register Priority Queue 5 */
+#define REG_GMAC_ST2RPQ6        (*(__IO uint32_t*)0x40050558U) /**< (GMAC) Screening Type 2 Register Priority Queue 6 */
+#define REG_GMAC_ST2RPQ7        (*(__IO uint32_t*)0x4005055CU) /**< (GMAC) Screening Type 2 Register Priority Queue 7 */
+#define REG_GMAC_IERPQ          (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) */
+#define REG_GMAC_IERPQ0         (*(__O  uint32_t*)0x40050600U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IERPQ1         (*(__O  uint32_t*)0x40050604U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IERPQ2         (*(__O  uint32_t*)0x40050608U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IERPQ3         (*(__O  uint32_t*)0x4005060CU) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IERPQ4         (*(__O  uint32_t*)0x40050610U) /**< (GMAC) Interrupt Enable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IDRPQ          (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) */
+#define REG_GMAC_IDRPQ0         (*(__O  uint32_t*)0x40050620U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IDRPQ1         (*(__O  uint32_t*)0x40050624U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IDRPQ2         (*(__O  uint32_t*)0x40050628U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IDRPQ3         (*(__O  uint32_t*)0x4005062CU) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IDRPQ4         (*(__O  uint32_t*)0x40050630U) /**< (GMAC) Interrupt Disable Register Priority Queue (1..5) 4 */
+#define REG_GMAC_IMRPQ          (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) */
+#define REG_GMAC_IMRPQ0         (*(__IO uint32_t*)0x40050640U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 0 */
+#define REG_GMAC_IMRPQ1         (*(__IO uint32_t*)0x40050644U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 1 */
+#define REG_GMAC_IMRPQ2         (*(__IO uint32_t*)0x40050648U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 2 */
+#define REG_GMAC_IMRPQ3         (*(__IO uint32_t*)0x4005064CU) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 3 */
+#define REG_GMAC_IMRPQ4         (*(__IO uint32_t*)0x40050650U) /**< (GMAC) Interrupt Mask Register Priority Queue (1..5) 4 */
+#define REG_GMAC_ST2ER          (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register */
+#define REG_GMAC_ST2ER0         (*(__IO uint32_t*)0x400506E0U) /**< (GMAC) Screening Type 2 Ethertype Register 0 */
+#define REG_GMAC_ST2ER1         (*(__IO uint32_t*)0x400506E4U) /**< (GMAC) Screening Type 2 Ethertype Register 1 */
+#define REG_GMAC_ST2ER2         (*(__IO uint32_t*)0x400506E8U) /**< (GMAC) Screening Type 2 Ethertype Register 2 */
+#define REG_GMAC_ST2ER3         (*(__IO uint32_t*)0x400506ECU) /**< (GMAC) Screening Type 2 Ethertype Register 3 */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for GMAC peripheral ========== */
-#define GMAC_INSTANCE_ID                         39        
-#define GMAC_CLOCK_ID                            39        
+#define GMAC_INSTANCE_ID                         39         
+#define GMAC_CLOCK_ID                            39         
 
 #endif /* _SAME70_GMAC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/gpbr.h
+++ b/asf/sam/include/same70b/instance/gpbr.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for GPBR
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_GPBR_INSTANCE_H_
 #define _SAME70_GPBR_INSTANCE_H_
 

--- a/asf/sam/include/same70b/instance/hsmci.h
+++ b/asf/sam/include/same70b/instance/hsmci.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for HSMCI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_HSMCI_INSTANCE_H_
 #define _SAME70_HSMCI_INSTANCE_H_
 
@@ -599,9 +601,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for HSMCI peripheral ========== */
-#define HSMCI_INSTANCE_ID                        18        
-#define HSMCI_CLOCK_ID                           18        
-#define HSMCI_DMAC_ID_TX                         0         
-#define HSMCI_DMAC_ID_RX                         0         
+#define HSMCI_DMAC_ID_RX                         0          
+#define HSMCI_DMAC_ID_TX                         0          
+#define HSMCI_INSTANCE_ID                        18         
+#define HSMCI_CLOCK_ID                           18         
 
 #endif /* _SAME70_HSMCI_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/i2sc0.h
+++ b/asf/sam/include/same70b/instance/i2sc0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for I2SC0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_I2SC0_INSTANCE_H_
 #define _SAME70_I2SC0_INSTANCE_H_
 
@@ -59,7 +61,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for I2SC0 peripheral ========== */
-#define I2SC0_INSTANCE_ID                        69        
-#define I2SC0_CLOCK_ID                           69        
+#define I2SC0_INSTANCE_ID                        69         
+#define I2SC0_CLOCK_ID                           69         
+#define I2SC0_DMAC_ID_TX_LEFT                    44         
+#define I2SC0_DMAC_ID_RX_LEFT                    45         
+#define I2SC0_DMAC_ID_TX_RIGHT                   48         
+#define I2SC0_DMAC_ID_RX_RIGHT                   49         
 
 #endif /* _SAME70_I2SC0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/i2sc1.h
+++ b/asf/sam/include/same70b/instance/i2sc1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for I2SC1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_I2SC1_INSTANCE_H_
 #define _SAME70_I2SC1_INSTANCE_H_
 
@@ -59,7 +61,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for I2SC1 peripheral ========== */
-#define I2SC1_INSTANCE_ID                        70        
-#define I2SC1_CLOCK_ID                           70        
+#define I2SC1_INSTANCE_ID                        70         
+#define I2SC1_CLOCK_ID                           70         
+#define I2SC1_DMAC_ID_TX_LEFT                    46         
+#define I2SC1_DMAC_ID_RX_LEFT                    47         
+#define I2SC1_DMAC_ID_TX_RIGHT                   50         
+#define I2SC1_DMAC_ID_RX_RIGHT                   51         
 
 #endif /* _SAME70_I2SC1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/icm.h
+++ b/asf/sam/include/same70b/instance/icm.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ICM
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ICM_INSTANCE_H_
 #define _SAME70_ICM_INSTANCE_H_
 
@@ -77,7 +79,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ICM peripheral ========== */
-#define ICM_INSTANCE_ID                          32        
-#define ICM_CLOCK_ID                             32        
+#define ICM_INSTANCE_ID                          32         
+#define ICM_CLOCK_ID                             32         
 
 #endif /* _SAME70_ICM_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/isi.h
+++ b/asf/sam/include/same70b/instance/isi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for ISI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_ISI_INSTANCE_H_
 #define _SAME70_ISI_INSTANCE_H_
 
@@ -89,7 +91,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for ISI peripheral ========== */
-#define ISI_INSTANCE_ID                          59        
-#define ISI_CLOCK_ID                             59        
+#define ISI_INSTANCE_ID                          59         
+#define ISI_CLOCK_ID                             59         
 
 #endif /* _SAME70_ISI_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/matrix.h
+++ b/asf/sam/include/same70b/instance/matrix.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MATRIX
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_MATRIX_INSTANCE_H_
 #define _SAME70_MATRIX_INSTANCE_H_
 

--- a/asf/sam/include/same70b/instance/mcan0.h
+++ b/asf/sam/include/same70b/instance/mcan0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MCAN0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_MCAN0_INSTANCE_H_
 #define _SAME70_MCAN0_INSTANCE_H_
 
@@ -133,7 +135,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for MCAN0 peripheral ========== */
-#define MCAN0_INSTANCE_ID                        35        
-#define MCAN0_CLOCK_ID                           35        
+#define MCAN0_INSTANCE_ID                        35         
+#define MCAN0_CLOCK_ID                           35         
 
 #endif /* _SAME70_MCAN0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/mcan1.h
+++ b/asf/sam/include/same70b/instance/mcan1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for MCAN1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_MCAN1_INSTANCE_H_
 #define _SAME70_MCAN1_INSTANCE_H_
 
@@ -133,7 +135,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for MCAN1 peripheral ========== */
-#define MCAN1_INSTANCE_ID                        37        
-#define MCAN1_CLOCK_ID                           37        
+#define MCAN1_INSTANCE_ID                        37         
+#define MCAN1_CLOCK_ID                           37         
 
 #endif /* _SAME70_MCAN1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pioa.h
+++ b/asf/sam/include/same70b/instance/pioa.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOA
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIOA_INSTANCE_H_
 #define _SAME70_PIOA_INSTANCE_H_
 
@@ -151,8 +153,8 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOA peripheral ========== */
-#define PIOA_INSTANCE_ID                         10        
-#define PIOA_CLOCK_ID                            10        
-#define PIOA_DMAC_ID_RX                          34        
+#define PIOA_DMAC_ID_RX                          34         
+#define PIOA_INSTANCE_ID                         10         
+#define PIOA_CLOCK_ID                            10         
 
 #endif /* _SAME70_PIOA_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/piob.h
+++ b/asf/sam/include/same70b/instance/piob.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOB
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIOB_INSTANCE_H_
 #define _SAME70_PIOB_INSTANCE_H_
 
@@ -151,7 +153,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOB peripheral ========== */
-#define PIOB_INSTANCE_ID                         11        
-#define PIOB_CLOCK_ID                            11        
+#define PIOB_INSTANCE_ID                         11         
+#define PIOB_CLOCK_ID                            11         
 
 #endif /* _SAME70_PIOB_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pioc.h
+++ b/asf/sam/include/same70b/instance/pioc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIOC_INSTANCE_H_
 #define _SAME70_PIOC_INSTANCE_H_
 
@@ -151,7 +153,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOC peripheral ========== */
-#define PIOC_INSTANCE_ID                         12        
-#define PIOC_CLOCK_ID                            12        
+#define PIOC_INSTANCE_ID                         12         
+#define PIOC_CLOCK_ID                            12         
 
 #endif /* _SAME70_PIOC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/piod.h
+++ b/asf/sam/include/same70b/instance/piod.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOD
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIOD_INSTANCE_H_
 #define _SAME70_PIOD_INSTANCE_H_
 
@@ -151,7 +153,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOD peripheral ========== */
-#define PIOD_INSTANCE_ID                         16        
-#define PIOD_CLOCK_ID                            16        
+#define PIOD_INSTANCE_ID                         16         
+#define PIOD_CLOCK_ID                            16         
 
 #endif /* _SAME70_PIOD_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pioe.h
+++ b/asf/sam/include/same70b/instance/pioe.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PIOE
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PIOE_INSTANCE_H_
 #define _SAME70_PIOE_INSTANCE_H_
 
@@ -151,7 +153,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PIOE peripheral ========== */
-#define PIOE_INSTANCE_ID                         17        
-#define PIOE_CLOCK_ID                            17        
+#define PIOE_INSTANCE_ID                         17         
+#define PIOE_CLOCK_ID                            17         
 
 #endif /* _SAME70_PIOE_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pmc.h
+++ b/asf/sam/include/same70b/instance/pmc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PMC_INSTANCE_H_
 #define _SAME70_PMC_INSTANCE_H_
 
@@ -129,6 +131,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PMC peripheral ========== */
-#define PMC_INSTANCE_ID                          5         
+#define PMC_INSTANCE_ID                          5          
 
 #endif /* _SAME70_PMC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pwm0.h
+++ b/asf/sam/include/same70b/instance/pwm0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PWM0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PWM0_INSTANCE_H_
 #define _SAME70_PWM0_INSTANCE_H_
 
@@ -64,38 +66,38 @@
 #define REG_PWM0_CMPVUPD7       (0x400201A4) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
 #define REG_PWM0_CMPM7          (0x400201A8) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
 #define REG_PWM0_CMPMUPD7       (0x400201AC) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
-#define REG_PWM0_CMR0           (0x40020200) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 0 */
-#define REG_PWM0_CDTY0          (0x40020204) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
-#define REG_PWM0_CDTYUPD0       (0x40020208) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CPRD0          (0x4002020C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 0 */
-#define REG_PWM0_CPRDUPD0       (0x40020210) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CCNT0          (0x40020214) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 0 */
-#define REG_PWM0_DT0            (0x40020218) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 0 */
-#define REG_PWM0_DTUPD0         (0x4002021C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CMR1           (0x40020220) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 1 */
-#define REG_PWM0_CDTY1          (0x40020224) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
-#define REG_PWM0_CDTYUPD1       (0x40020228) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CPRD1          (0x4002022C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 1 */
-#define REG_PWM0_CPRDUPD1       (0x40020230) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CCNT1          (0x40020234) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 1 */
-#define REG_PWM0_DT1            (0x40020238) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 1 */
-#define REG_PWM0_DTUPD1         (0x4002023C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CMR2           (0x40020240) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 2 */
-#define REG_PWM0_CDTY2          (0x40020244) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
-#define REG_PWM0_CDTYUPD2       (0x40020248) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CPRD2          (0x4002024C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 2 */
-#define REG_PWM0_CPRDUPD2       (0x40020250) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CCNT2          (0x40020254) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 2 */
-#define REG_PWM0_DT2            (0x40020258) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 2 */
-#define REG_PWM0_DTUPD2         (0x4002025C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CMR3           (0x40020260) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 3 */
-#define REG_PWM0_CDTY3          (0x40020264) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
-#define REG_PWM0_CDTYUPD3       (0x40020268) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
-#define REG_PWM0_CPRD3          (0x4002026C) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 3 */
-#define REG_PWM0_CPRDUPD3       (0x40020270) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 3 */
-#define REG_PWM0_CCNT3          (0x40020274) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 3 */
-#define REG_PWM0_DT3            (0x40020278) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 3 */
-#define REG_PWM0_DTUPD3         (0x4002027C) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CMR0           (0x40020200) /**< (PWM0) PWM Channel Mode Register 0 */
+#define REG_PWM0_CDTY0          (0x40020204) /**< (PWM0) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM0_CDTYUPD0       (0x40020208) /**< (PWM0) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM0_CPRD0          (0x4002020C) /**< (PWM0) PWM Channel Period Register 0 */
+#define REG_PWM0_CPRDUPD0       (0x40020210) /**< (PWM0) PWM Channel Period Update Register 0 */
+#define REG_PWM0_CCNT0          (0x40020214) /**< (PWM0) PWM Channel Counter Register 0 */
+#define REG_PWM0_DT0            (0x40020218) /**< (PWM0) PWM Channel Dead Time Register 0 */
+#define REG_PWM0_DTUPD0         (0x4002021C) /**< (PWM0) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM0_CMR1           (0x40020220) /**< (PWM0) PWM Channel Mode Register 1 */
+#define REG_PWM0_CDTY1          (0x40020224) /**< (PWM0) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM0_CDTYUPD1       (0x40020228) /**< (PWM0) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM0_CPRD1          (0x4002022C) /**< (PWM0) PWM Channel Period Register 1 */
+#define REG_PWM0_CPRDUPD1       (0x40020230) /**< (PWM0) PWM Channel Period Update Register 1 */
+#define REG_PWM0_CCNT1          (0x40020234) /**< (PWM0) PWM Channel Counter Register 1 */
+#define REG_PWM0_DT1            (0x40020238) /**< (PWM0) PWM Channel Dead Time Register 1 */
+#define REG_PWM0_DTUPD1         (0x4002023C) /**< (PWM0) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM0_CMR2           (0x40020240) /**< (PWM0) PWM Channel Mode Register 2 */
+#define REG_PWM0_CDTY2          (0x40020244) /**< (PWM0) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM0_CDTYUPD2       (0x40020248) /**< (PWM0) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM0_CPRD2          (0x4002024C) /**< (PWM0) PWM Channel Period Register 2 */
+#define REG_PWM0_CPRDUPD2       (0x40020250) /**< (PWM0) PWM Channel Period Update Register 2 */
+#define REG_PWM0_CCNT2          (0x40020254) /**< (PWM0) PWM Channel Counter Register 2 */
+#define REG_PWM0_DT2            (0x40020258) /**< (PWM0) PWM Channel Dead Time Register 2 */
+#define REG_PWM0_DTUPD2         (0x4002025C) /**< (PWM0) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM0_CMR3           (0x40020260) /**< (PWM0) PWM Channel Mode Register 3 */
+#define REG_PWM0_CDTY3          (0x40020264) /**< (PWM0) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM0_CDTYUPD3       (0x40020268) /**< (PWM0) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM0_CPRD3          (0x4002026C) /**< (PWM0) PWM Channel Period Register 3 */
+#define REG_PWM0_CPRDUPD3       (0x40020270) /**< (PWM0) PWM Channel Period Update Register 3 */
+#define REG_PWM0_CCNT3          (0x40020274) /**< (PWM0) PWM Channel Counter Register 3 */
+#define REG_PWM0_DT3            (0x40020278) /**< (PWM0) PWM Channel Dead Time Register 3 */
+#define REG_PWM0_DTUPD3         (0x4002027C) /**< (PWM0) PWM Channel Dead Time Update Register 3 */
 #define REG_PWM0_CLK            (0x40020000) /**< (PWM0) PWM Clock Register */
 #define REG_PWM0_ENA            (0x40020004) /**< (PWM0) PWM Enable Register */
 #define REG_PWM0_DIS            (0x40020008) /**< (PWM0) PWM Disable Register */
@@ -176,38 +178,38 @@
 #define REG_PWM0_CMPVUPD7       (*(__O  uint32_t*)0x400201A4U) /**< (PWM0) PWM Comparison 0 Value Update Register 7 */
 #define REG_PWM0_CMPM7          (*(__IO uint32_t*)0x400201A8U) /**< (PWM0) PWM Comparison 0 Mode Register 7 */
 #define REG_PWM0_CMPMUPD7       (*(__O  uint32_t*)0x400201ACU) /**< (PWM0) PWM Comparison 0 Mode Update Register 7 */
-#define REG_PWM0_CMR0           (*(__IO uint32_t*)0x40020200U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 0 */
-#define REG_PWM0_CDTY0          (*(__IO uint32_t*)0x40020204U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
-#define REG_PWM0_CDTYUPD0       (*(__O  uint32_t*)0x40020208U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CPRD0          (*(__IO uint32_t*)0x4002020CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 0 */
-#define REG_PWM0_CPRDUPD0       (*(__O  uint32_t*)0x40020210U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CCNT0          (*(__I  uint32_t*)0x40020214U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 0 */
-#define REG_PWM0_DT0            (*(__IO uint32_t*)0x40020218U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 0 */
-#define REG_PWM0_DTUPD0         (*(__O  uint32_t*)0x4002021CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
-#define REG_PWM0_CMR1           (*(__IO uint32_t*)0x40020220U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 1 */
-#define REG_PWM0_CDTY1          (*(__IO uint32_t*)0x40020224U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
-#define REG_PWM0_CDTYUPD1       (*(__O  uint32_t*)0x40020228U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CPRD1          (*(__IO uint32_t*)0x4002022CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 1 */
-#define REG_PWM0_CPRDUPD1       (*(__O  uint32_t*)0x40020230U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CCNT1          (*(__I  uint32_t*)0x40020234U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 1 */
-#define REG_PWM0_DT1            (*(__IO uint32_t*)0x40020238U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 1 */
-#define REG_PWM0_DTUPD1         (*(__O  uint32_t*)0x4002023CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
-#define REG_PWM0_CMR2           (*(__IO uint32_t*)0x40020240U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 2 */
-#define REG_PWM0_CDTY2          (*(__IO uint32_t*)0x40020244U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
-#define REG_PWM0_CDTYUPD2       (*(__O  uint32_t*)0x40020248U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CPRD2          (*(__IO uint32_t*)0x4002024CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 2 */
-#define REG_PWM0_CPRDUPD2       (*(__O  uint32_t*)0x40020250U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CCNT2          (*(__I  uint32_t*)0x40020254U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 2 */
-#define REG_PWM0_DT2            (*(__IO uint32_t*)0x40020258U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 2 */
-#define REG_PWM0_DTUPD2         (*(__O  uint32_t*)0x4002025CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
-#define REG_PWM0_CMR3           (*(__IO uint32_t*)0x40020260U) /**< (PWM0) PWM Channel Mode Register (ch_num = 0) 3 */
-#define REG_PWM0_CDTY3          (*(__IO uint32_t*)0x40020264U) /**< (PWM0) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
-#define REG_PWM0_CDTYUPD3       (*(__O  uint32_t*)0x40020268U) /**< (PWM0) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
-#define REG_PWM0_CPRD3          (*(__IO uint32_t*)0x4002026CU) /**< (PWM0) PWM Channel Period Register (ch_num = 0) 3 */
-#define REG_PWM0_CPRDUPD3       (*(__O  uint32_t*)0x40020270U) /**< (PWM0) PWM Channel Period Update Register (ch_num = 0) 3 */
-#define REG_PWM0_CCNT3          (*(__I  uint32_t*)0x40020274U) /**< (PWM0) PWM Channel Counter Register (ch_num = 0) 3 */
-#define REG_PWM0_DT3            (*(__IO uint32_t*)0x40020278U) /**< (PWM0) PWM Channel Dead Time Register (ch_num = 0) 3 */
-#define REG_PWM0_DTUPD3         (*(__O  uint32_t*)0x4002027CU) /**< (PWM0) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM0_CMR0           (*(__IO uint32_t*)0x40020200U) /**< (PWM0) PWM Channel Mode Register 0 */
+#define REG_PWM0_CDTY0          (*(__IO uint32_t*)0x40020204U) /**< (PWM0) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM0_CDTYUPD0       (*(__O  uint32_t*)0x40020208U) /**< (PWM0) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM0_CPRD0          (*(__IO uint32_t*)0x4002020CU) /**< (PWM0) PWM Channel Period Register 0 */
+#define REG_PWM0_CPRDUPD0       (*(__O  uint32_t*)0x40020210U) /**< (PWM0) PWM Channel Period Update Register 0 */
+#define REG_PWM0_CCNT0          (*(__I  uint32_t*)0x40020214U) /**< (PWM0) PWM Channel Counter Register 0 */
+#define REG_PWM0_DT0            (*(__IO uint32_t*)0x40020218U) /**< (PWM0) PWM Channel Dead Time Register 0 */
+#define REG_PWM0_DTUPD0         (*(__O  uint32_t*)0x4002021CU) /**< (PWM0) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM0_CMR1           (*(__IO uint32_t*)0x40020220U) /**< (PWM0) PWM Channel Mode Register 1 */
+#define REG_PWM0_CDTY1          (*(__IO uint32_t*)0x40020224U) /**< (PWM0) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM0_CDTYUPD1       (*(__O  uint32_t*)0x40020228U) /**< (PWM0) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM0_CPRD1          (*(__IO uint32_t*)0x4002022CU) /**< (PWM0) PWM Channel Period Register 1 */
+#define REG_PWM0_CPRDUPD1       (*(__O  uint32_t*)0x40020230U) /**< (PWM0) PWM Channel Period Update Register 1 */
+#define REG_PWM0_CCNT1          (*(__I  uint32_t*)0x40020234U) /**< (PWM0) PWM Channel Counter Register 1 */
+#define REG_PWM0_DT1            (*(__IO uint32_t*)0x40020238U) /**< (PWM0) PWM Channel Dead Time Register 1 */
+#define REG_PWM0_DTUPD1         (*(__O  uint32_t*)0x4002023CU) /**< (PWM0) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM0_CMR2           (*(__IO uint32_t*)0x40020240U) /**< (PWM0) PWM Channel Mode Register 2 */
+#define REG_PWM0_CDTY2          (*(__IO uint32_t*)0x40020244U) /**< (PWM0) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM0_CDTYUPD2       (*(__O  uint32_t*)0x40020248U) /**< (PWM0) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM0_CPRD2          (*(__IO uint32_t*)0x4002024CU) /**< (PWM0) PWM Channel Period Register 2 */
+#define REG_PWM0_CPRDUPD2       (*(__O  uint32_t*)0x40020250U) /**< (PWM0) PWM Channel Period Update Register 2 */
+#define REG_PWM0_CCNT2          (*(__I  uint32_t*)0x40020254U) /**< (PWM0) PWM Channel Counter Register 2 */
+#define REG_PWM0_DT2            (*(__IO uint32_t*)0x40020258U) /**< (PWM0) PWM Channel Dead Time Register 2 */
+#define REG_PWM0_DTUPD2         (*(__O  uint32_t*)0x4002025CU) /**< (PWM0) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM0_CMR3           (*(__IO uint32_t*)0x40020260U) /**< (PWM0) PWM Channel Mode Register 3 */
+#define REG_PWM0_CDTY3          (*(__IO uint32_t*)0x40020264U) /**< (PWM0) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM0_CDTYUPD3       (*(__O  uint32_t*)0x40020268U) /**< (PWM0) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM0_CPRD3          (*(__IO uint32_t*)0x4002026CU) /**< (PWM0) PWM Channel Period Register 3 */
+#define REG_PWM0_CPRDUPD3       (*(__O  uint32_t*)0x40020270U) /**< (PWM0) PWM Channel Period Update Register 3 */
+#define REG_PWM0_CCNT3          (*(__I  uint32_t*)0x40020274U) /**< (PWM0) PWM Channel Counter Register 3 */
+#define REG_PWM0_DT3            (*(__IO uint32_t*)0x40020278U) /**< (PWM0) PWM Channel Dead Time Register 3 */
+#define REG_PWM0_DTUPD3         (*(__O  uint32_t*)0x4002027CU) /**< (PWM0) PWM Channel Dead Time Update Register 3 */
 #define REG_PWM0_CLK            (*(__IO uint32_t*)0x40020000U) /**< (PWM0) PWM Clock Register */
 #define REG_PWM0_ENA            (*(__O  uint32_t*)0x40020004U) /**< (PWM0) PWM Enable Register */
 #define REG_PWM0_DIS            (*(__O  uint32_t*)0x40020008U) /**< (PWM0) PWM Disable Register */
@@ -257,8 +259,16 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PWM0 peripheral ========== */
-#define PWM0_INSTANCE_ID                         31        
-#define PWM0_CLOCK_ID                            31        
-#define PWM0_DMAC_ID_TX                          13        
+#define PWM0_DMAC_ID_TX                          13         
+#define PWM0_INSTANCE_ID                         31         
+#define PWM0_CLOCK_ID                            31         
+#define PWM0_FAULT_PWM_ID0                       0x0        /* Fault 0 - PWM0_PWMFI0 Input pin */
+#define PWM0_FAULT_PWM_ID1                       0x1        /* Fault 1 - PWM0_PWMFI1 Input pin */
+#define PWM0_FAULT_PWM_ID2                       0x2        /* Fault 2 - PWM0_PWMFI2 Input pin */
+#define PWM0_FAULT_PWM_ID3                       0x3        /* Fault 3 - MAIN_OSC_PMC */
+#define PWM0_FAULT_PWM_ID4                       0x4        /* Fault 4 - AFEC0 */
+#define PWM0_FAULT_PWM_ID5                       0x5        /* Fault 5 - AFEC1 */
+#define PWM0_FAULT_PWM_ID6                       0x6        /* Fault 6 - ACC */
+#define PWM0_FAULT_PWM_ID7                       0x7        /* Fault 7 - TC0 */
 
 #endif /* _SAME70_PWM0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/pwm1.h
+++ b/asf/sam/include/same70b/instance/pwm1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for PWM1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_PWM1_INSTANCE_H_
 #define _SAME70_PWM1_INSTANCE_H_
 
@@ -64,38 +66,38 @@
 #define REG_PWM1_CMPVUPD7       (0x4005C1A4) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
 #define REG_PWM1_CMPM7          (0x4005C1A8) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
 #define REG_PWM1_CMPMUPD7       (0x4005C1AC) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
-#define REG_PWM1_CMR0           (0x4005C200) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 0 */
-#define REG_PWM1_CDTY0          (0x4005C204) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
-#define REG_PWM1_CDTYUPD0       (0x4005C208) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CPRD0          (0x4005C20C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 0 */
-#define REG_PWM1_CPRDUPD0       (0x4005C210) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CCNT0          (0x4005C214) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 0 */
-#define REG_PWM1_DT0            (0x4005C218) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 0 */
-#define REG_PWM1_DTUPD0         (0x4005C21C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CMR1           (0x4005C220) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 1 */
-#define REG_PWM1_CDTY1          (0x4005C224) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
-#define REG_PWM1_CDTYUPD1       (0x4005C228) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CPRD1          (0x4005C22C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 1 */
-#define REG_PWM1_CPRDUPD1       (0x4005C230) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CCNT1          (0x4005C234) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 1 */
-#define REG_PWM1_DT1            (0x4005C238) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 1 */
-#define REG_PWM1_DTUPD1         (0x4005C23C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CMR2           (0x4005C240) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 2 */
-#define REG_PWM1_CDTY2          (0x4005C244) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
-#define REG_PWM1_CDTYUPD2       (0x4005C248) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CPRD2          (0x4005C24C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 2 */
-#define REG_PWM1_CPRDUPD2       (0x4005C250) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CCNT2          (0x4005C254) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 2 */
-#define REG_PWM1_DT2            (0x4005C258) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 2 */
-#define REG_PWM1_DTUPD2         (0x4005C25C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CMR3           (0x4005C260) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 3 */
-#define REG_PWM1_CDTY3          (0x4005C264) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
-#define REG_PWM1_CDTYUPD3       (0x4005C268) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
-#define REG_PWM1_CPRD3          (0x4005C26C) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 3 */
-#define REG_PWM1_CPRDUPD3       (0x4005C270) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 3 */
-#define REG_PWM1_CCNT3          (0x4005C274) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 3 */
-#define REG_PWM1_DT3            (0x4005C278) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 3 */
-#define REG_PWM1_DTUPD3         (0x4005C27C) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CMR0           (0x4005C200) /**< (PWM1) PWM Channel Mode Register 0 */
+#define REG_PWM1_CDTY0          (0x4005C204) /**< (PWM1) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM1_CDTYUPD0       (0x4005C208) /**< (PWM1) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM1_CPRD0          (0x4005C20C) /**< (PWM1) PWM Channel Period Register 0 */
+#define REG_PWM1_CPRDUPD0       (0x4005C210) /**< (PWM1) PWM Channel Period Update Register 0 */
+#define REG_PWM1_CCNT0          (0x4005C214) /**< (PWM1) PWM Channel Counter Register 0 */
+#define REG_PWM1_DT0            (0x4005C218) /**< (PWM1) PWM Channel Dead Time Register 0 */
+#define REG_PWM1_DTUPD0         (0x4005C21C) /**< (PWM1) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM1_CMR1           (0x4005C220) /**< (PWM1) PWM Channel Mode Register 1 */
+#define REG_PWM1_CDTY1          (0x4005C224) /**< (PWM1) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM1_CDTYUPD1       (0x4005C228) /**< (PWM1) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM1_CPRD1          (0x4005C22C) /**< (PWM1) PWM Channel Period Register 1 */
+#define REG_PWM1_CPRDUPD1       (0x4005C230) /**< (PWM1) PWM Channel Period Update Register 1 */
+#define REG_PWM1_CCNT1          (0x4005C234) /**< (PWM1) PWM Channel Counter Register 1 */
+#define REG_PWM1_DT1            (0x4005C238) /**< (PWM1) PWM Channel Dead Time Register 1 */
+#define REG_PWM1_DTUPD1         (0x4005C23C) /**< (PWM1) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM1_CMR2           (0x4005C240) /**< (PWM1) PWM Channel Mode Register 2 */
+#define REG_PWM1_CDTY2          (0x4005C244) /**< (PWM1) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM1_CDTYUPD2       (0x4005C248) /**< (PWM1) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM1_CPRD2          (0x4005C24C) /**< (PWM1) PWM Channel Period Register 2 */
+#define REG_PWM1_CPRDUPD2       (0x4005C250) /**< (PWM1) PWM Channel Period Update Register 2 */
+#define REG_PWM1_CCNT2          (0x4005C254) /**< (PWM1) PWM Channel Counter Register 2 */
+#define REG_PWM1_DT2            (0x4005C258) /**< (PWM1) PWM Channel Dead Time Register 2 */
+#define REG_PWM1_DTUPD2         (0x4005C25C) /**< (PWM1) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM1_CMR3           (0x4005C260) /**< (PWM1) PWM Channel Mode Register 3 */
+#define REG_PWM1_CDTY3          (0x4005C264) /**< (PWM1) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM1_CDTYUPD3       (0x4005C268) /**< (PWM1) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM1_CPRD3          (0x4005C26C) /**< (PWM1) PWM Channel Period Register 3 */
+#define REG_PWM1_CPRDUPD3       (0x4005C270) /**< (PWM1) PWM Channel Period Update Register 3 */
+#define REG_PWM1_CCNT3          (0x4005C274) /**< (PWM1) PWM Channel Counter Register 3 */
+#define REG_PWM1_DT3            (0x4005C278) /**< (PWM1) PWM Channel Dead Time Register 3 */
+#define REG_PWM1_DTUPD3         (0x4005C27C) /**< (PWM1) PWM Channel Dead Time Update Register 3 */
 #define REG_PWM1_CLK            (0x4005C000) /**< (PWM1) PWM Clock Register */
 #define REG_PWM1_ENA            (0x4005C004) /**< (PWM1) PWM Enable Register */
 #define REG_PWM1_DIS            (0x4005C008) /**< (PWM1) PWM Disable Register */
@@ -176,38 +178,38 @@
 #define REG_PWM1_CMPVUPD7       (*(__O  uint32_t*)0x4005C1A4U) /**< (PWM1) PWM Comparison 0 Value Update Register 7 */
 #define REG_PWM1_CMPM7          (*(__IO uint32_t*)0x4005C1A8U) /**< (PWM1) PWM Comparison 0 Mode Register 7 */
 #define REG_PWM1_CMPMUPD7       (*(__O  uint32_t*)0x4005C1ACU) /**< (PWM1) PWM Comparison 0 Mode Update Register 7 */
-#define REG_PWM1_CMR0           (*(__IO uint32_t*)0x4005C200U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 0 */
-#define REG_PWM1_CDTY0          (*(__IO uint32_t*)0x4005C204U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 0 */
-#define REG_PWM1_CDTYUPD0       (*(__O  uint32_t*)0x4005C208U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CPRD0          (*(__IO uint32_t*)0x4005C20CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 0 */
-#define REG_PWM1_CPRDUPD0       (*(__O  uint32_t*)0x4005C210U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CCNT0          (*(__I  uint32_t*)0x4005C214U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 0 */
-#define REG_PWM1_DT0            (*(__IO uint32_t*)0x4005C218U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 0 */
-#define REG_PWM1_DTUPD0         (*(__O  uint32_t*)0x4005C21CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 0 */
-#define REG_PWM1_CMR1           (*(__IO uint32_t*)0x4005C220U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 1 */
-#define REG_PWM1_CDTY1          (*(__IO uint32_t*)0x4005C224U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 1 */
-#define REG_PWM1_CDTYUPD1       (*(__O  uint32_t*)0x4005C228U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CPRD1          (*(__IO uint32_t*)0x4005C22CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 1 */
-#define REG_PWM1_CPRDUPD1       (*(__O  uint32_t*)0x4005C230U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CCNT1          (*(__I  uint32_t*)0x4005C234U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 1 */
-#define REG_PWM1_DT1            (*(__IO uint32_t*)0x4005C238U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 1 */
-#define REG_PWM1_DTUPD1         (*(__O  uint32_t*)0x4005C23CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 1 */
-#define REG_PWM1_CMR2           (*(__IO uint32_t*)0x4005C240U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 2 */
-#define REG_PWM1_CDTY2          (*(__IO uint32_t*)0x4005C244U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 2 */
-#define REG_PWM1_CDTYUPD2       (*(__O  uint32_t*)0x4005C248U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CPRD2          (*(__IO uint32_t*)0x4005C24CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 2 */
-#define REG_PWM1_CPRDUPD2       (*(__O  uint32_t*)0x4005C250U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CCNT2          (*(__I  uint32_t*)0x4005C254U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 2 */
-#define REG_PWM1_DT2            (*(__IO uint32_t*)0x4005C258U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 2 */
-#define REG_PWM1_DTUPD2         (*(__O  uint32_t*)0x4005C25CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 2 */
-#define REG_PWM1_CMR3           (*(__IO uint32_t*)0x4005C260U) /**< (PWM1) PWM Channel Mode Register (ch_num = 0) 3 */
-#define REG_PWM1_CDTY3          (*(__IO uint32_t*)0x4005C264U) /**< (PWM1) PWM Channel Duty Cycle Register (ch_num = 0) 3 */
-#define REG_PWM1_CDTYUPD3       (*(__O  uint32_t*)0x4005C268U) /**< (PWM1) PWM Channel Duty Cycle Update Register (ch_num = 0) 3 */
-#define REG_PWM1_CPRD3          (*(__IO uint32_t*)0x4005C26CU) /**< (PWM1) PWM Channel Period Register (ch_num = 0) 3 */
-#define REG_PWM1_CPRDUPD3       (*(__O  uint32_t*)0x4005C270U) /**< (PWM1) PWM Channel Period Update Register (ch_num = 0) 3 */
-#define REG_PWM1_CCNT3          (*(__I  uint32_t*)0x4005C274U) /**< (PWM1) PWM Channel Counter Register (ch_num = 0) 3 */
-#define REG_PWM1_DT3            (*(__IO uint32_t*)0x4005C278U) /**< (PWM1) PWM Channel Dead Time Register (ch_num = 0) 3 */
-#define REG_PWM1_DTUPD3         (*(__O  uint32_t*)0x4005C27CU) /**< (PWM1) PWM Channel Dead Time Update Register (ch_num = 0) 3 */
+#define REG_PWM1_CMR0           (*(__IO uint32_t*)0x4005C200U) /**< (PWM1) PWM Channel Mode Register 0 */
+#define REG_PWM1_CDTY0          (*(__IO uint32_t*)0x4005C204U) /**< (PWM1) PWM Channel Duty Cycle Register 0 */
+#define REG_PWM1_CDTYUPD0       (*(__O  uint32_t*)0x4005C208U) /**< (PWM1) PWM Channel Duty Cycle Update Register 0 */
+#define REG_PWM1_CPRD0          (*(__IO uint32_t*)0x4005C20CU) /**< (PWM1) PWM Channel Period Register 0 */
+#define REG_PWM1_CPRDUPD0       (*(__O  uint32_t*)0x4005C210U) /**< (PWM1) PWM Channel Period Update Register 0 */
+#define REG_PWM1_CCNT0          (*(__I  uint32_t*)0x4005C214U) /**< (PWM1) PWM Channel Counter Register 0 */
+#define REG_PWM1_DT0            (*(__IO uint32_t*)0x4005C218U) /**< (PWM1) PWM Channel Dead Time Register 0 */
+#define REG_PWM1_DTUPD0         (*(__O  uint32_t*)0x4005C21CU) /**< (PWM1) PWM Channel Dead Time Update Register 0 */
+#define REG_PWM1_CMR1           (*(__IO uint32_t*)0x4005C220U) /**< (PWM1) PWM Channel Mode Register 1 */
+#define REG_PWM1_CDTY1          (*(__IO uint32_t*)0x4005C224U) /**< (PWM1) PWM Channel Duty Cycle Register 1 */
+#define REG_PWM1_CDTYUPD1       (*(__O  uint32_t*)0x4005C228U) /**< (PWM1) PWM Channel Duty Cycle Update Register 1 */
+#define REG_PWM1_CPRD1          (*(__IO uint32_t*)0x4005C22CU) /**< (PWM1) PWM Channel Period Register 1 */
+#define REG_PWM1_CPRDUPD1       (*(__O  uint32_t*)0x4005C230U) /**< (PWM1) PWM Channel Period Update Register 1 */
+#define REG_PWM1_CCNT1          (*(__I  uint32_t*)0x4005C234U) /**< (PWM1) PWM Channel Counter Register 1 */
+#define REG_PWM1_DT1            (*(__IO uint32_t*)0x4005C238U) /**< (PWM1) PWM Channel Dead Time Register 1 */
+#define REG_PWM1_DTUPD1         (*(__O  uint32_t*)0x4005C23CU) /**< (PWM1) PWM Channel Dead Time Update Register 1 */
+#define REG_PWM1_CMR2           (*(__IO uint32_t*)0x4005C240U) /**< (PWM1) PWM Channel Mode Register 2 */
+#define REG_PWM1_CDTY2          (*(__IO uint32_t*)0x4005C244U) /**< (PWM1) PWM Channel Duty Cycle Register 2 */
+#define REG_PWM1_CDTYUPD2       (*(__O  uint32_t*)0x4005C248U) /**< (PWM1) PWM Channel Duty Cycle Update Register 2 */
+#define REG_PWM1_CPRD2          (*(__IO uint32_t*)0x4005C24CU) /**< (PWM1) PWM Channel Period Register 2 */
+#define REG_PWM1_CPRDUPD2       (*(__O  uint32_t*)0x4005C250U) /**< (PWM1) PWM Channel Period Update Register 2 */
+#define REG_PWM1_CCNT2          (*(__I  uint32_t*)0x4005C254U) /**< (PWM1) PWM Channel Counter Register 2 */
+#define REG_PWM1_DT2            (*(__IO uint32_t*)0x4005C258U) /**< (PWM1) PWM Channel Dead Time Register 2 */
+#define REG_PWM1_DTUPD2         (*(__O  uint32_t*)0x4005C25CU) /**< (PWM1) PWM Channel Dead Time Update Register 2 */
+#define REG_PWM1_CMR3           (*(__IO uint32_t*)0x4005C260U) /**< (PWM1) PWM Channel Mode Register 3 */
+#define REG_PWM1_CDTY3          (*(__IO uint32_t*)0x4005C264U) /**< (PWM1) PWM Channel Duty Cycle Register 3 */
+#define REG_PWM1_CDTYUPD3       (*(__O  uint32_t*)0x4005C268U) /**< (PWM1) PWM Channel Duty Cycle Update Register 3 */
+#define REG_PWM1_CPRD3          (*(__IO uint32_t*)0x4005C26CU) /**< (PWM1) PWM Channel Period Register 3 */
+#define REG_PWM1_CPRDUPD3       (*(__O  uint32_t*)0x4005C270U) /**< (PWM1) PWM Channel Period Update Register 3 */
+#define REG_PWM1_CCNT3          (*(__I  uint32_t*)0x4005C274U) /**< (PWM1) PWM Channel Counter Register 3 */
+#define REG_PWM1_DT3            (*(__IO uint32_t*)0x4005C278U) /**< (PWM1) PWM Channel Dead Time Register 3 */
+#define REG_PWM1_DTUPD3         (*(__O  uint32_t*)0x4005C27CU) /**< (PWM1) PWM Channel Dead Time Update Register 3 */
 #define REG_PWM1_CLK            (*(__IO uint32_t*)0x4005C000U) /**< (PWM1) PWM Clock Register */
 #define REG_PWM1_ENA            (*(__O  uint32_t*)0x4005C004U) /**< (PWM1) PWM Enable Register */
 #define REG_PWM1_DIS            (*(__O  uint32_t*)0x4005C008U) /**< (PWM1) PWM Disable Register */
@@ -257,8 +259,16 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for PWM1 peripheral ========== */
-#define PWM1_INSTANCE_ID                         60        
-#define PWM1_CLOCK_ID                            60        
-#define PWM1_DMAC_ID_TX                          39        
+#define PWM1_DMAC_ID_TX                          39         
+#define PWM1_INSTANCE_ID                         60         
+#define PWM1_CLOCK_ID                            60         
+#define PWM1_FAULT_PWM_ID0                       0x0        /* Fault 0 - PWM0_PWMFI0 Input pin */
+#define PWM1_FAULT_PWM_ID1                       0x1        /* Fault 1 - PWM0_PWMFI1 Input pin */
+#define PWM1_FAULT_PWM_ID2                       0x2        /* Fault 2 - PWM0_PWMFI2 Input pin */
+#define PWM1_FAULT_PWM_ID3                       0x3        /* Fault 3 - MAIN_OSC_PMC */
+#define PWM1_FAULT_PWM_ID4                       0x4        /* Fault 4 - AFEC0 */
+#define PWM1_FAULT_PWM_ID5                       0x5        /* Fault 5 - AFEC1 */
+#define PWM1_FAULT_PWM_ID6                       0x6        /* Fault 6 - ACC */
+#define PWM1_FAULT_PWM_ID7                       0x7        /* Fault 7 - TC1 */
 
 #endif /* _SAME70_PWM1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/qspi.h
+++ b/asf/sam/include/same70b/instance/qspi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for QSPI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_QSPI_INSTANCE_H_
 #define _SAME70_QSPI_INSTANCE_H_
 
@@ -71,9 +73,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for QSPI peripheral ========== */
-#define QSPI_INSTANCE_ID                         43        
-#define QSPI_CLOCK_ID                            43        
-#define QSPI_DMAC_ID_TX                          5         
-#define QSPI_DMAC_ID_RX                          6         
+#define QSPI_DMAC_ID_RX                          6          
+#define QSPI_DMAC_ID_TX                          5          
+#define QSPI_INSTANCE_ID                         43         
+#define QSPI_CLOCK_ID                            43         
 
 #endif /* _SAME70_QSPI_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/rstc.h
+++ b/asf/sam/include/same70b/instance/rstc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RSTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RSTC_INSTANCE_H_
 #define _SAME70_RSTC_INSTANCE_H_
 
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RSTC peripheral ========== */
-#define RSTC_INSTANCE_ID                         1         
+#define RSTC_INSTANCE_ID                         1          
 
 #endif /* _SAME70_RSTC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/rswdt.h
+++ b/asf/sam/include/same70b/instance/rswdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RSWDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RSWDT_INSTANCE_H_
 #define _SAME70_RSWDT_INSTANCE_H_
 
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RSWDT peripheral ========== */
-#define RSWDT_INSTANCE_ID                        63        
+#define RSWDT_INSTANCE_ID                        63         
 
 #endif /* _SAME70_RSWDT_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/rtc.h
+++ b/asf/sam/include/same70b/instance/rtc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RTC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RTC_INSTANCE_H_
 #define _SAME70_RTC_INSTANCE_H_
 
@@ -44,7 +46,6 @@
 #define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
-#define REG_RTC_WPMR            (0x400E1944) /**< (RTC) Write Protection Mode Register */
 
 #else
 
@@ -60,11 +61,10 @@
 #define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
-#define REG_RTC_WPMR            (*(__IO uint32_t*)0x400E1944U) /**< (RTC) Write Protection Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2         
+#define RTC_INSTANCE_ID                          2          
 
 #endif /* _SAME70_RTC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/rtt.h
+++ b/asf/sam/include/same70b/instance/rtt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for RTT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_RTT_INSTANCE_H_
 #define _SAME70_RTT_INSTANCE_H_
 
@@ -47,6 +49,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTT peripheral ========== */
-#define RTT_INSTANCE_ID                          3         
+#define RTT_INSTANCE_ID                          3          
 
 #endif /* _SAME70_RTT_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/sdramc.h
+++ b/asf/sam/include/same70b/instance/sdramc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SDRAMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SDRAMC_INSTANCE_H_
 #define _SAME70_SDRAMC_INSTANCE_H_
 
@@ -65,7 +67,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SDRAMC peripheral ========== */
-#define SDRAMC_INSTANCE_ID                       62        
-#define SDRAMC_CLOCK_ID                          62        
+#define SDRAMC_INSTANCE_ID                       62         
+#define SDRAMC_CLOCK_ID                          62         
 
 #endif /* _SAME70_SDRAMC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/smc.h
+++ b/asf/sam/include/same70b/instance/smc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SMC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,63 +27,63 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SMC_INSTANCE_H_
 #define _SAME70_SMC_INSTANCE_H_
 
 /* ========== Register definition for SMC peripheral ========== */
 #if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 
-#define REG_SMC_SETUP0          (0x40080000) /**< (SMC) SMC Setup Register (CS_number = 0) 0 */
-#define REG_SMC_PULSE0          (0x40080004) /**< (SMC) SMC Pulse Register (CS_number = 0) 0 */
-#define REG_SMC_CYCLE0          (0x40080008) /**< (SMC) SMC Cycle Register (CS_number = 0) 0 */
-#define REG_SMC_MODE0           (0x4008000C) /**< (SMC) SMC MODE Register (CS_number = 0) 0 */
-#define REG_SMC_SETUP1          (0x40080010) /**< (SMC) SMC Setup Register (CS_number = 0) 1 */
-#define REG_SMC_PULSE1          (0x40080014) /**< (SMC) SMC Pulse Register (CS_number = 0) 1 */
-#define REG_SMC_CYCLE1          (0x40080018) /**< (SMC) SMC Cycle Register (CS_number = 0) 1 */
-#define REG_SMC_MODE1           (0x4008001C) /**< (SMC) SMC MODE Register (CS_number = 0) 1 */
-#define REG_SMC_SETUP2          (0x40080020) /**< (SMC) SMC Setup Register (CS_number = 0) 2 */
-#define REG_SMC_PULSE2          (0x40080024) /**< (SMC) SMC Pulse Register (CS_number = 0) 2 */
-#define REG_SMC_CYCLE2          (0x40080028) /**< (SMC) SMC Cycle Register (CS_number = 0) 2 */
-#define REG_SMC_MODE2           (0x4008002C) /**< (SMC) SMC MODE Register (CS_number = 0) 2 */
-#define REG_SMC_SETUP3          (0x40080030) /**< (SMC) SMC Setup Register (CS_number = 0) 3 */
-#define REG_SMC_PULSE3          (0x40080034) /**< (SMC) SMC Pulse Register (CS_number = 0) 3 */
-#define REG_SMC_CYCLE3          (0x40080038) /**< (SMC) SMC Cycle Register (CS_number = 0) 3 */
-#define REG_SMC_MODE3           (0x4008003C) /**< (SMC) SMC MODE Register (CS_number = 0) 3 */
-#define REG_SMC_OCMS            (0x40080080) /**< (SMC) SMC OCMS MODE Register */
-#define REG_SMC_KEY1            (0x40080084) /**< (SMC) SMC OCMS KEY1 Register */
-#define REG_SMC_KEY2            (0x40080088) /**< (SMC) SMC OCMS KEY2 Register */
+#define REG_SMC_SETUP0          (0x40080000) /**< (SMC) SMC Setup Register 0 */
+#define REG_SMC_PULSE0          (0x40080004) /**< (SMC) SMC Pulse Register 0 */
+#define REG_SMC_CYCLE0          (0x40080008) /**< (SMC) SMC Cycle Register 0 */
+#define REG_SMC_MODE0           (0x4008000C) /**< (SMC) SMC Mode Register 0 */
+#define REG_SMC_SETUP1          (0x40080010) /**< (SMC) SMC Setup Register 1 */
+#define REG_SMC_PULSE1          (0x40080014) /**< (SMC) SMC Pulse Register 1 */
+#define REG_SMC_CYCLE1          (0x40080018) /**< (SMC) SMC Cycle Register 1 */
+#define REG_SMC_MODE1           (0x4008001C) /**< (SMC) SMC Mode Register 1 */
+#define REG_SMC_SETUP2          (0x40080020) /**< (SMC) SMC Setup Register 2 */
+#define REG_SMC_PULSE2          (0x40080024) /**< (SMC) SMC Pulse Register 2 */
+#define REG_SMC_CYCLE2          (0x40080028) /**< (SMC) SMC Cycle Register 2 */
+#define REG_SMC_MODE2           (0x4008002C) /**< (SMC) SMC Mode Register 2 */
+#define REG_SMC_SETUP3          (0x40080030) /**< (SMC) SMC Setup Register 3 */
+#define REG_SMC_PULSE3          (0x40080034) /**< (SMC) SMC Pulse Register 3 */
+#define REG_SMC_CYCLE3          (0x40080038) /**< (SMC) SMC Cycle Register 3 */
+#define REG_SMC_MODE3           (0x4008003C) /**< (SMC) SMC Mode Register 3 */
+#define REG_SMC_OCMS            (0x40080080) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (0x40080084) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (0x40080088) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
 #define REG_SMC_WPMR            (0x400800E4) /**< (SMC) SMC Write Protection Mode Register */
 #define REG_SMC_WPSR            (0x400800E8) /**< (SMC) SMC Write Protection Status Register */
 
 #else
 
-#define REG_SMC_SETUP0          (*(__IO uint32_t*)0x40080000U) /**< (SMC) SMC Setup Register (CS_number = 0) 0 */
-#define REG_SMC_PULSE0          (*(__IO uint32_t*)0x40080004U) /**< (SMC) SMC Pulse Register (CS_number = 0) 0 */
-#define REG_SMC_CYCLE0          (*(__IO uint32_t*)0x40080008U) /**< (SMC) SMC Cycle Register (CS_number = 0) 0 */
-#define REG_SMC_MODE0           (*(__IO uint32_t*)0x4008000CU) /**< (SMC) SMC MODE Register (CS_number = 0) 0 */
-#define REG_SMC_SETUP1          (*(__IO uint32_t*)0x40080010U) /**< (SMC) SMC Setup Register (CS_number = 0) 1 */
-#define REG_SMC_PULSE1          (*(__IO uint32_t*)0x40080014U) /**< (SMC) SMC Pulse Register (CS_number = 0) 1 */
-#define REG_SMC_CYCLE1          (*(__IO uint32_t*)0x40080018U) /**< (SMC) SMC Cycle Register (CS_number = 0) 1 */
-#define REG_SMC_MODE1           (*(__IO uint32_t*)0x4008001CU) /**< (SMC) SMC MODE Register (CS_number = 0) 1 */
-#define REG_SMC_SETUP2          (*(__IO uint32_t*)0x40080020U) /**< (SMC) SMC Setup Register (CS_number = 0) 2 */
-#define REG_SMC_PULSE2          (*(__IO uint32_t*)0x40080024U) /**< (SMC) SMC Pulse Register (CS_number = 0) 2 */
-#define REG_SMC_CYCLE2          (*(__IO uint32_t*)0x40080028U) /**< (SMC) SMC Cycle Register (CS_number = 0) 2 */
-#define REG_SMC_MODE2           (*(__IO uint32_t*)0x4008002CU) /**< (SMC) SMC MODE Register (CS_number = 0) 2 */
-#define REG_SMC_SETUP3          (*(__IO uint32_t*)0x40080030U) /**< (SMC) SMC Setup Register (CS_number = 0) 3 */
-#define REG_SMC_PULSE3          (*(__IO uint32_t*)0x40080034U) /**< (SMC) SMC Pulse Register (CS_number = 0) 3 */
-#define REG_SMC_CYCLE3          (*(__IO uint32_t*)0x40080038U) /**< (SMC) SMC Cycle Register (CS_number = 0) 3 */
-#define REG_SMC_MODE3           (*(__IO uint32_t*)0x4008003CU) /**< (SMC) SMC MODE Register (CS_number = 0) 3 */
-#define REG_SMC_OCMS            (*(__IO uint32_t*)0x40080080U) /**< (SMC) SMC OCMS MODE Register */
-#define REG_SMC_KEY1            (*(__O  uint32_t*)0x40080084U) /**< (SMC) SMC OCMS KEY1 Register */
-#define REG_SMC_KEY2            (*(__O  uint32_t*)0x40080088U) /**< (SMC) SMC OCMS KEY2 Register */
+#define REG_SMC_SETUP0          (*(__IO uint32_t*)0x40080000U) /**< (SMC) SMC Setup Register 0 */
+#define REG_SMC_PULSE0          (*(__IO uint32_t*)0x40080004U) /**< (SMC) SMC Pulse Register 0 */
+#define REG_SMC_CYCLE0          (*(__IO uint32_t*)0x40080008U) /**< (SMC) SMC Cycle Register 0 */
+#define REG_SMC_MODE0           (*(__IO uint32_t*)0x4008000CU) /**< (SMC) SMC Mode Register 0 */
+#define REG_SMC_SETUP1          (*(__IO uint32_t*)0x40080010U) /**< (SMC) SMC Setup Register 1 */
+#define REG_SMC_PULSE1          (*(__IO uint32_t*)0x40080014U) /**< (SMC) SMC Pulse Register 1 */
+#define REG_SMC_CYCLE1          (*(__IO uint32_t*)0x40080018U) /**< (SMC) SMC Cycle Register 1 */
+#define REG_SMC_MODE1           (*(__IO uint32_t*)0x4008001CU) /**< (SMC) SMC Mode Register 1 */
+#define REG_SMC_SETUP2          (*(__IO uint32_t*)0x40080020U) /**< (SMC) SMC Setup Register 2 */
+#define REG_SMC_PULSE2          (*(__IO uint32_t*)0x40080024U) /**< (SMC) SMC Pulse Register 2 */
+#define REG_SMC_CYCLE2          (*(__IO uint32_t*)0x40080028U) /**< (SMC) SMC Cycle Register 2 */
+#define REG_SMC_MODE2           (*(__IO uint32_t*)0x4008002CU) /**< (SMC) SMC Mode Register 2 */
+#define REG_SMC_SETUP3          (*(__IO uint32_t*)0x40080030U) /**< (SMC) SMC Setup Register 3 */
+#define REG_SMC_PULSE3          (*(__IO uint32_t*)0x40080034U) /**< (SMC) SMC Pulse Register 3 */
+#define REG_SMC_CYCLE3          (*(__IO uint32_t*)0x40080038U) /**< (SMC) SMC Cycle Register 3 */
+#define REG_SMC_MODE3           (*(__IO uint32_t*)0x4008003CU) /**< (SMC) SMC Mode Register 3 */
+#define REG_SMC_OCMS            (*(__IO uint32_t*)0x40080080U) /**< (SMC) SMC Off-Chip Memory Scrambling Register */
+#define REG_SMC_KEY1            (*(__O  uint32_t*)0x40080084U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY1 Register */
+#define REG_SMC_KEY2            (*(__O  uint32_t*)0x40080088U) /**< (SMC) SMC Off-Chip Memory Scrambling KEY2 Register */
 #define REG_SMC_WPMR            (*(__IO uint32_t*)0x400800E4U) /**< (SMC) SMC Write Protection Mode Register */
 #define REG_SMC_WPSR            (*(__I  uint32_t*)0x400800E8U) /**< (SMC) SMC Write Protection Status Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SMC peripheral ========== */
-#define SMC_INSTANCE_ID                          9         
-#define SMC_CLOCK_ID                             9         
+#define SMC_INSTANCE_ID                          9          
+#define SMC_CLOCK_ID                             9          
 
 #endif /* _SAME70_SMC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/spi0.h
+++ b/asf/sam/include/same70b/instance/spi0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SPI0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SPI0_INSTANCE_H_
 #define _SAME70_SPI0_INSTANCE_H_
 
@@ -40,7 +42,7 @@
 #define REG_SPI0_IER            (0x40008014) /**< (SPI0) Interrupt Enable Register */
 #define REG_SPI0_IDR            (0x40008018) /**< (SPI0) Interrupt Disable Register */
 #define REG_SPI0_IMR            (0x4000801C) /**< (SPI0) Interrupt Mask Register */
-#define REG_SPI0_CSR            (0x40008030) /**< (SPI0) Chip Select Register 0 */
+#define REG_SPI0_CSR            (0x40008030) /**< (SPI0) Chip Select Register */
 #define REG_SPI0_CSR0           (0x40008030) /**< (SPI0) Chip Select Register 0 */
 #define REG_SPI0_CSR1           (0x40008034) /**< (SPI0) Chip Select Register 1 */
 #define REG_SPI0_CSR2           (0x40008038) /**< (SPI0) Chip Select Register 2 */
@@ -58,7 +60,7 @@
 #define REG_SPI0_IER            (*(__O  uint32_t*)0x40008014U) /**< (SPI0) Interrupt Enable Register */
 #define REG_SPI0_IDR            (*(__O  uint32_t*)0x40008018U) /**< (SPI0) Interrupt Disable Register */
 #define REG_SPI0_IMR            (*(__I  uint32_t*)0x4000801CU) /**< (SPI0) Interrupt Mask Register */
-#define REG_SPI0_CSR            (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register 0 */
+#define REG_SPI0_CSR            (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register */
 #define REG_SPI0_CSR0           (*(__IO uint32_t*)0x40008030U) /**< (SPI0) Chip Select Register 0 */
 #define REG_SPI0_CSR1           (*(__IO uint32_t*)0x40008034U) /**< (SPI0) Chip Select Register 1 */
 #define REG_SPI0_CSR2           (*(__IO uint32_t*)0x40008038U) /**< (SPI0) Chip Select Register 2 */
@@ -69,9 +71,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SPI0 peripheral ========== */
-#define SPI0_INSTANCE_ID                         21        
-#define SPI0_CLOCK_ID                            21        
-#define SPI0_DMAC_ID_TX                          1         
-#define SPI0_DMAC_ID_RX                          2         
+#define SPI0_DMAC_ID_RX                          2          
+#define SPI0_DMAC_ID_TX                          1          
+#define SPI0_INSTANCE_ID                         21         
+#define SPI0_CLOCK_ID                            21         
 
 #endif /* _SAME70_SPI0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/spi1.h
+++ b/asf/sam/include/same70b/instance/spi1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SPI1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SPI1_INSTANCE_H_
 #define _SAME70_SPI1_INSTANCE_H_
 
@@ -40,7 +42,7 @@
 #define REG_SPI1_IER            (0x40058014) /**< (SPI1) Interrupt Enable Register */
 #define REG_SPI1_IDR            (0x40058018) /**< (SPI1) Interrupt Disable Register */
 #define REG_SPI1_IMR            (0x4005801C) /**< (SPI1) Interrupt Mask Register */
-#define REG_SPI1_CSR            (0x40058030) /**< (SPI1) Chip Select Register 0 */
+#define REG_SPI1_CSR            (0x40058030) /**< (SPI1) Chip Select Register */
 #define REG_SPI1_CSR0           (0x40058030) /**< (SPI1) Chip Select Register 0 */
 #define REG_SPI1_CSR1           (0x40058034) /**< (SPI1) Chip Select Register 1 */
 #define REG_SPI1_CSR2           (0x40058038) /**< (SPI1) Chip Select Register 2 */
@@ -58,7 +60,7 @@
 #define REG_SPI1_IER            (*(__O  uint32_t*)0x40058014U) /**< (SPI1) Interrupt Enable Register */
 #define REG_SPI1_IDR            (*(__O  uint32_t*)0x40058018U) /**< (SPI1) Interrupt Disable Register */
 #define REG_SPI1_IMR            (*(__I  uint32_t*)0x4005801CU) /**< (SPI1) Interrupt Mask Register */
-#define REG_SPI1_CSR            (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register 0 */
+#define REG_SPI1_CSR            (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register */
 #define REG_SPI1_CSR0           (*(__IO uint32_t*)0x40058030U) /**< (SPI1) Chip Select Register 0 */
 #define REG_SPI1_CSR1           (*(__IO uint32_t*)0x40058034U) /**< (SPI1) Chip Select Register 1 */
 #define REG_SPI1_CSR2           (*(__IO uint32_t*)0x40058038U) /**< (SPI1) Chip Select Register 2 */
@@ -69,9 +71,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SPI1 peripheral ========== */
-#define SPI1_INSTANCE_ID                         42        
-#define SPI1_CLOCK_ID                            42        
-#define SPI1_DMAC_ID_TX                          3         
-#define SPI1_DMAC_ID_RX                          4         
+#define SPI1_DMAC_ID_RX                          4          
+#define SPI1_DMAC_ID_TX                          3          
+#define SPI1_INSTANCE_ID                         42         
+#define SPI1_CLOCK_ID                            42         
 
 #endif /* _SAME70_SPI1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/ssc.h
+++ b/asf/sam/include/same70b/instance/ssc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SSC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SSC_INSTANCE_H_
 #define _SAME70_SSC_INSTANCE_H_
 
@@ -75,9 +77,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SSC peripheral ========== */
-#define SSC_INSTANCE_ID                          22        
-#define SSC_CLOCK_ID                             22        
-#define SSC_DMAC_ID_TX                           32        
-#define SSC_DMAC_ID_RX                           33        
+#define SSC_DMAC_ID_RX                           33         
+#define SSC_DMAC_ID_TX                           32         
+#define SSC_INSTANCE_ID                          22         
+#define SSC_CLOCK_ID                             22         
 
 #endif /* _SAME70_SSC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/supc.h
+++ b/asf/sam/include/same70b/instance/supc.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for SUPC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_SUPC_INSTANCE_H_
 #define _SAME70_SUPC_INSTANCE_H_
 
@@ -51,6 +53,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for SUPC peripheral ========== */
-#define SUPC_INSTANCE_ID                         0         
+#define SUPC_INSTANCE_ID                         0          
 
 #endif /* _SAME70_SUPC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/tc0.h
+++ b/asf/sam/include/same70b/instance/tc0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TC0_INSTANCE_H_
 #define _SAME70_TC0_INSTANCE_H_
 
@@ -133,9 +135,23 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC0 peripheral ========== */
-#define TC0_INSTANCE_ID_CHANNEL1                 24        
-#define TC0_INSTANCE_ID_CHANNEL0                 23        
-#define TC0_INSTANCE_ID_CHANNEL2                 25        
-#define TC0_DMAC_ID_RX                           40        
+#define TC0_DMAC_ID_RX                           40         
+#define TC0_INSTANCE_ID_CHANNEL0                 23         
+#define TC0_INSTANCE_ID_CHANNEL1                 24         
+#define TC0_INSTANCE_ID_CHANNEL2                 25         
+#define TC0_CLOCK_ID_CHANNEL0                    23         
+#define TC0_CLOCK_ID_CHANNEL1                    24         
+#define TC0_CLOCK_ID_CHANNEL2                    25         
+#define TC0_TCCLKS_                              0          /* MCK */
+#define TC0_TCCLKS_TIMER_CLOCK1                  1          /* PCK */
+#define TC0_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC0_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC0_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC0_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC0_TCCLKS_XC0                           6          /* XC0 */
+#define TC0_TCCLKS_XC1                           7          /* XC1 */
+#define TC0_TCCLKS_XC2                           8          /* XC2 */
+#define TC0_NUM_INTERRUPT_LINES                  3          
+#define TC0_TIMER_WIDTH                          16         
 
 #endif /* _SAME70_TC0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/tc1.h
+++ b/asf/sam/include/same70b/instance/tc1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TC1_INSTANCE_H_
 #define _SAME70_TC1_INSTANCE_H_
 
@@ -133,9 +135,23 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC1 peripheral ========== */
-#define TC1_INSTANCE_ID_CHANNEL1                 27        
-#define TC1_INSTANCE_ID_CHANNEL0                 26        
-#define TC1_INSTANCE_ID_CHANNEL2                 28        
-#define TC1_DMAC_ID_RX                           41        
+#define TC1_DMAC_ID_RX                           41         
+#define TC1_INSTANCE_ID_CHANNEL0                 26         
+#define TC1_INSTANCE_ID_CHANNEL1                 27         
+#define TC1_INSTANCE_ID_CHANNEL2                 28         
+#define TC1_CLOCK_ID_CHANNEL0                    26         
+#define TC1_CLOCK_ID_CHANNEL1                    27         
+#define TC1_CLOCK_ID_CHANNEL2                    28         
+#define TC1_TCCLKS_                              0          /* MCK */
+#define TC1_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC1_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC1_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC1_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC1_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC1_TCCLKS_XC0                           6          /* XC0 */
+#define TC1_TCCLKS_XC1                           7          /* XC1 */
+#define TC1_TCCLKS_XC2                           8          /* XC2 */
+#define TC1_NUM_INTERRUPT_LINES                  3          
+#define TC1_TIMER_WIDTH                          16         
 
 #endif /* _SAME70_TC1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/tc2.h
+++ b/asf/sam/include/same70b/instance/tc2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TC2_INSTANCE_H_
 #define _SAME70_TC2_INSTANCE_H_
 
@@ -133,9 +135,23 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC2 peripheral ========== */
-#define TC2_INSTANCE_ID_CHANNEL1                 48        
-#define TC2_INSTANCE_ID_CHANNEL0                 47        
-#define TC2_INSTANCE_ID_CHANNEL2                 49        
-#define TC2_DMAC_ID_RX                           42        
+#define TC2_DMAC_ID_RX                           42         
+#define TC2_INSTANCE_ID_CHANNEL0                 47         
+#define TC2_INSTANCE_ID_CHANNEL1                 48         
+#define TC2_INSTANCE_ID_CHANNEL2                 49         
+#define TC2_CLOCK_ID_CHANNEL0                    47         
+#define TC2_CLOCK_ID_CHANNEL1                    48         
+#define TC2_CLOCK_ID_CHANNEL2                    49         
+#define TC2_TCCLKS_                              0          /* MCK */
+#define TC2_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC2_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC2_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC2_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC2_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC2_TCCLKS_XC0                           6          /* XC0 */
+#define TC2_TCCLKS_XC1                           7          /* XC1 */
+#define TC2_TCCLKS_XC2                           8          /* XC2 */
+#define TC2_NUM_INTERRUPT_LINES                  3          
+#define TC2_TIMER_WIDTH                          16         
 
 #endif /* _SAME70_TC2_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/tc3.h
+++ b/asf/sam/include/same70b/instance/tc3.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TC3
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TC3_INSTANCE_H_
 #define _SAME70_TC3_INSTANCE_H_
 
@@ -133,9 +135,23 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TC3 peripheral ========== */
-#define TC3_INSTANCE_ID_CHANNEL1                 51        
-#define TC3_INSTANCE_ID_CHANNEL0                 50        
-#define TC3_INSTANCE_ID_CHANNEL2                 52        
-#define TC3_DMAC_ID_RX                           43        
+#define TC3_DMAC_ID_RX                           43         
+#define TC3_INSTANCE_ID_CHANNEL0                 50         
+#define TC3_INSTANCE_ID_CHANNEL1                 51         
+#define TC3_INSTANCE_ID_CHANNEL2                 52         
+#define TC3_CLOCK_ID_CHANNEL0                    50         
+#define TC3_CLOCK_ID_CHANNEL1                    51         
+#define TC3_CLOCK_ID_CHANNEL2                    52         
+#define TC3_TCCLKS_                              0          /* MCK */
+#define TC3_TCCLKS_TIMER_CLOCK1                  1          /* PCK6 */
+#define TC3_TCCLKS_TIMER_CLOCK2                  2          /* MCK/8 */
+#define TC3_TCCLKS_TIMER_CLOCK3                  3          /* MCK/32 */
+#define TC3_TCCLKS_TIMER_CLOCK4                  4          /* MCK/128 */
+#define TC3_TCCLKS_TIMER_CLOCK5                  5          /* SLCK */
+#define TC3_TCCLKS_XC0                           6          /* XC0 */
+#define TC3_TCCLKS_XC1                           7          /* XC1 */
+#define TC3_TCCLKS_XC2                           8          /* XC2 */
+#define TC3_NUM_INTERRUPT_LINES                  3          
+#define TC3_TIMER_WIDTH                          16         
 
 #endif /* _SAME70_TC3_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/trng.h
+++ b/asf/sam/include/same70b/instance/trng.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TRNG
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TRNG_INSTANCE_H_
 #define _SAME70_TRNG_INSTANCE_H_
 
@@ -51,7 +53,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TRNG peripheral ========== */
-#define TRNG_INSTANCE_ID                         57        
-#define TRNG_CLOCK_ID                            57        
+#define TRNG_INSTANCE_ID                         57         
+#define TRNG_CLOCK_ID                            57         
 
 #endif /* _SAME70_TRNG_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/twihs0.h
+++ b/asf/sam/include/same70b/instance/twihs0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TWIHS0_INSTANCE_H_
 #define _SAME70_TWIHS0_INSTANCE_H_
 
@@ -71,9 +73,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS0 peripheral ========== */
-#define TWIHS0_INSTANCE_ID                       19        
-#define TWIHS0_CLOCK_ID                          19        
-#define TWIHS0_DMAC_ID_TX                        14        
-#define TWIHS0_DMAC_ID_RX                        15        
+#define TWIHS0_DMAC_ID_RX                        15         
+#define TWIHS0_DMAC_ID_TX                        14         
+#define TWIHS0_INSTANCE_ID                       19         
+#define TWIHS0_CLOCK_ID                          19         
 
 #endif /* _SAME70_TWIHS0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/twihs1.h
+++ b/asf/sam/include/same70b/instance/twihs1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TWIHS1_INSTANCE_H_
 #define _SAME70_TWIHS1_INSTANCE_H_
 
@@ -71,9 +73,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS1 peripheral ========== */
-#define TWIHS1_INSTANCE_ID                       20        
-#define TWIHS1_CLOCK_ID                          20        
-#define TWIHS1_DMAC_ID_TX                        16        
-#define TWIHS1_DMAC_ID_RX                        17        
+#define TWIHS1_DMAC_ID_RX                        17         
+#define TWIHS1_DMAC_ID_TX                        16         
+#define TWIHS1_INSTANCE_ID                       20         
+#define TWIHS1_CLOCK_ID                          20         
 
 #endif /* _SAME70_TWIHS1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/twihs2.h
+++ b/asf/sam/include/same70b/instance/twihs2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for TWIHS2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_TWIHS2_INSTANCE_H_
 #define _SAME70_TWIHS2_INSTANCE_H_
 
@@ -71,9 +73,9 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for TWIHS2 peripheral ========== */
-#define TWIHS2_INSTANCE_ID                       41        
-#define TWIHS2_CLOCK_ID                          41        
-#define TWIHS2_DMAC_ID_TX                        18        
-#define TWIHS2_DMAC_ID_RX                        19        
+#define TWIHS2_DMAC_ID_RX                        19         
+#define TWIHS2_DMAC_ID_TX                        18         
+#define TWIHS2_INSTANCE_ID                       41         
+#define TWIHS2_CLOCK_ID                          41         
 
 #endif /* _SAME70_TWIHS2_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/uart0.h
+++ b/asf/sam/include/same70b/instance/uart0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART0_INSTANCE_H_
 #define _SAME70_UART0_INSTANCE_H_
 
@@ -61,9 +63,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART0 peripheral ========== */
-#define UART0_INSTANCE_ID                        7         
-#define UART0_CLOCK_ID                           7         
-#define UART0_DMAC_ID_TX                         20        
-#define UART0_DMAC_ID_RX                         21        
+#define UART0_DMAC_ID_RX                         21         
+#define UART0_DMAC_ID_TX                         20         
+#define UART0_INSTANCE_ID                        7          
+#define UART0_CLOCK_ID                           7          
+#define UART0_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART0_BRSRCCK_PMC_PCK                    0          /* PCK4 */
 
 #endif /* _SAME70_UART0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/uart1.h
+++ b/asf/sam/include/same70b/instance/uart1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART1_INSTANCE_H_
 #define _SAME70_UART1_INSTANCE_H_
 
@@ -61,9 +63,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART1 peripheral ========== */
-#define UART1_INSTANCE_ID                        8         
-#define UART1_CLOCK_ID                           8         
-#define UART1_DMAC_ID_TX                         22        
-#define UART1_DMAC_ID_RX                         23        
+#define UART1_DMAC_ID_RX                         23         
+#define UART1_DMAC_ID_TX                         22         
+#define UART1_INSTANCE_ID                        8          
+#define UART1_CLOCK_ID                           8          
+#define UART1_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART1_BRSRCCK_PMC_PCK                    0          /* PCK4 */
 
 #endif /* _SAME70_UART1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/uart2.h
+++ b/asf/sam/include/same70b/instance/uart2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART2_INSTANCE_H_
 #define _SAME70_UART2_INSTANCE_H_
 
@@ -61,9 +63,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART2 peripheral ========== */
-#define UART2_INSTANCE_ID                        44        
-#define UART2_CLOCK_ID                           44        
-#define UART2_DMAC_ID_TX                         24        
-#define UART2_DMAC_ID_RX                         25        
+#define UART2_DMAC_ID_RX                         25         
+#define UART2_DMAC_ID_TX                         24         
+#define UART2_INSTANCE_ID                        44         
+#define UART2_CLOCK_ID                           44         
+#define UART2_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART2_BRSRCCK_PMC_PCK                    0          /* PCK4 */
 
 #endif /* _SAME70_UART2_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/uart3.h
+++ b/asf/sam/include/same70b/instance/uart3.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART3
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART3_INSTANCE_H_
 #define _SAME70_UART3_INSTANCE_H_
 
@@ -61,9 +63,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART3 peripheral ========== */
-#define UART3_INSTANCE_ID                        45        
-#define UART3_CLOCK_ID                           45        
-#define UART3_DMAC_ID_TX                         26        
-#define UART3_DMAC_ID_RX                         27        
+#define UART3_DMAC_ID_RX                         27         
+#define UART3_DMAC_ID_TX                         26         
+#define UART3_INSTANCE_ID                        45         
+#define UART3_CLOCK_ID                           45         
+#define UART3_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART3_BRSRCCK_PMC_PCK                    0          /* PCK4 */
 
 #endif /* _SAME70_UART3_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/uart4.h
+++ b/asf/sam/include/same70b/instance/uart4.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UART4
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UART4_INSTANCE_H_
 #define _SAME70_UART4_INSTANCE_H_
 
@@ -61,9 +63,11 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for UART4 peripheral ========== */
-#define UART4_INSTANCE_ID                        46        
-#define UART4_CLOCK_ID                           46        
-#define UART4_DMAC_ID_TX                         28        
-#define UART4_DMAC_ID_RX                         29        
+#define UART4_DMAC_ID_RX                         29         
+#define UART4_DMAC_ID_TX                         28         
+#define UART4_INSTANCE_ID                        46         
+#define UART4_CLOCK_ID                           46         
+#define UART4_BRSRCCK_PERIPH_CLK                 0          /* MCK */
+#define UART4_BRSRCCK_PMC_PCK                    0          /* PCK4 */
 
 #endif /* _SAME70_UART4_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/usart0.h
+++ b/asf/sam/include/same70b/instance/usart0.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART0
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USART0_INSTANCE_H_
 #define _SAME70_USART0_INSTANCE_H_
 
@@ -41,7 +43,7 @@
 #define REG_USART0_US_RHR       (0x40024018) /**< (USART0) Receive Holding Register */
 #define REG_USART0_US_THR       (0x4002401C) /**< (USART0) Transmit Holding Register */
 #define REG_USART0_US_BRGR      (0x40024020) /**< (USART0) Baud Rate Generator Register */
-#define REG_USART0_US_RTOR      (0x40024024) /**< (USART0) Receiver Time-out Register */
+#define REG_USART0_US_RTOR      (0x40024024) /**< (USART0) Receiver Timeout Register */
 #define REG_USART0_US_TTGR      (0x40024028) /**< (USART0) Transmitter Timeguard Register */
 #define REG_USART0_US_FIDI      (0x40024040) /**< (USART0) FI DI Ratio Register */
 #define REG_USART0_US_NER       (0x40024044) /**< (USART0) Number of Errors Register */
@@ -75,7 +77,7 @@
 #define REG_USART0_US_RHR       (*(__I  uint32_t*)0x40024018U) /**< (USART0) Receive Holding Register */
 #define REG_USART0_US_THR       (*(__O  uint32_t*)0x4002401CU) /**< (USART0) Transmit Holding Register */
 #define REG_USART0_US_BRGR      (*(__IO uint32_t*)0x40024020U) /**< (USART0) Baud Rate Generator Register */
-#define REG_USART0_US_RTOR      (*(__IO uint32_t*)0x40024024U) /**< (USART0) Receiver Time-out Register */
+#define REG_USART0_US_RTOR      (*(__IO uint32_t*)0x40024024U) /**< (USART0) Receiver Timeout Register */
 #define REG_USART0_US_TTGR      (*(__IO uint32_t*)0x40024028U) /**< (USART0) Transmitter Timeguard Register */
 #define REG_USART0_US_FIDI      (*(__IO uint32_t*)0x40024040U) /**< (USART0) FI DI Ratio Register */
 #define REG_USART0_US_NER       (*(__I  uint32_t*)0x40024044U) /**< (USART0) Number of Errors Register */
@@ -101,9 +103,13 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART0 peripheral ========== */
-#define USART0_INSTANCE_ID                       13        
-#define USART0_CLOCK_ID                          13        
-#define USART0_DMAC_ID_TX                        7         
-#define USART0_DMAC_ID_RX                        8         
+#define USART0_DMAC_ID_RX                        8          
+#define USART0_DMAC_ID_TX                        7          
+#define USART0_INSTANCE_ID                       13         
+#define USART0_CLOCK_ID                          13         
+#define USART0_USCLKS_MCK                        0          /* MCK */
+#define USART0_USCLKS_DIV                        1          /* MCK/8 */
+#define USART0_USCLKS_PCK                        2          /* PCK4 */
+#define USART0_USCLKS_SCK                        3          /* SCK */
 
 #endif /* _SAME70_USART0_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/usart1.h
+++ b/asf/sam/include/same70b/instance/usart1.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART1
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USART1_INSTANCE_H_
 #define _SAME70_USART1_INSTANCE_H_
 
@@ -41,7 +43,7 @@
 #define REG_USART1_US_RHR       (0x40028018) /**< (USART1) Receive Holding Register */
 #define REG_USART1_US_THR       (0x4002801C) /**< (USART1) Transmit Holding Register */
 #define REG_USART1_US_BRGR      (0x40028020) /**< (USART1) Baud Rate Generator Register */
-#define REG_USART1_US_RTOR      (0x40028024) /**< (USART1) Receiver Time-out Register */
+#define REG_USART1_US_RTOR      (0x40028024) /**< (USART1) Receiver Timeout Register */
 #define REG_USART1_US_TTGR      (0x40028028) /**< (USART1) Transmitter Timeguard Register */
 #define REG_USART1_US_FIDI      (0x40028040) /**< (USART1) FI DI Ratio Register */
 #define REG_USART1_US_NER       (0x40028044) /**< (USART1) Number of Errors Register */
@@ -75,7 +77,7 @@
 #define REG_USART1_US_RHR       (*(__I  uint32_t*)0x40028018U) /**< (USART1) Receive Holding Register */
 #define REG_USART1_US_THR       (*(__O  uint32_t*)0x4002801CU) /**< (USART1) Transmit Holding Register */
 #define REG_USART1_US_BRGR      (*(__IO uint32_t*)0x40028020U) /**< (USART1) Baud Rate Generator Register */
-#define REG_USART1_US_RTOR      (*(__IO uint32_t*)0x40028024U) /**< (USART1) Receiver Time-out Register */
+#define REG_USART1_US_RTOR      (*(__IO uint32_t*)0x40028024U) /**< (USART1) Receiver Timeout Register */
 #define REG_USART1_US_TTGR      (*(__IO uint32_t*)0x40028028U) /**< (USART1) Transmitter Timeguard Register */
 #define REG_USART1_US_FIDI      (*(__IO uint32_t*)0x40028040U) /**< (USART1) FI DI Ratio Register */
 #define REG_USART1_US_NER       (*(__I  uint32_t*)0x40028044U) /**< (USART1) Number of Errors Register */
@@ -101,9 +103,13 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART1 peripheral ========== */
-#define USART1_INSTANCE_ID                       14        
-#define USART1_CLOCK_ID                          14        
-#define USART1_DMAC_ID_TX                        9         
-#define USART1_DMAC_ID_RX                        10        
+#define USART1_DMAC_ID_RX                        10         
+#define USART1_DMAC_ID_TX                        9          
+#define USART1_INSTANCE_ID                       14         
+#define USART1_CLOCK_ID                          14         
+#define USART1_USCLKS_MCK                        0          /* MCK */
+#define USART1_USCLKS_DIV                        1          /* MCK/8 */
+#define USART1_USCLKS_PCK                        2          /* PCK4 */
+#define USART1_USCLKS_SCK                        3          /* SCK */
 
 #endif /* _SAME70_USART1_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/usart2.h
+++ b/asf/sam/include/same70b/instance/usart2.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USART2
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USART2_INSTANCE_H_
 #define _SAME70_USART2_INSTANCE_H_
 
@@ -41,7 +43,7 @@
 #define REG_USART2_US_RHR       (0x4002C018) /**< (USART2) Receive Holding Register */
 #define REG_USART2_US_THR       (0x4002C01C) /**< (USART2) Transmit Holding Register */
 #define REG_USART2_US_BRGR      (0x4002C020) /**< (USART2) Baud Rate Generator Register */
-#define REG_USART2_US_RTOR      (0x4002C024) /**< (USART2) Receiver Time-out Register */
+#define REG_USART2_US_RTOR      (0x4002C024) /**< (USART2) Receiver Timeout Register */
 #define REG_USART2_US_TTGR      (0x4002C028) /**< (USART2) Transmitter Timeguard Register */
 #define REG_USART2_US_FIDI      (0x4002C040) /**< (USART2) FI DI Ratio Register */
 #define REG_USART2_US_NER       (0x4002C044) /**< (USART2) Number of Errors Register */
@@ -75,7 +77,7 @@
 #define REG_USART2_US_RHR       (*(__I  uint32_t*)0x4002C018U) /**< (USART2) Receive Holding Register */
 #define REG_USART2_US_THR       (*(__O  uint32_t*)0x4002C01CU) /**< (USART2) Transmit Holding Register */
 #define REG_USART2_US_BRGR      (*(__IO uint32_t*)0x4002C020U) /**< (USART2) Baud Rate Generator Register */
-#define REG_USART2_US_RTOR      (*(__IO uint32_t*)0x4002C024U) /**< (USART2) Receiver Time-out Register */
+#define REG_USART2_US_RTOR      (*(__IO uint32_t*)0x4002C024U) /**< (USART2) Receiver Timeout Register */
 #define REG_USART2_US_TTGR      (*(__IO uint32_t*)0x4002C028U) /**< (USART2) Transmitter Timeguard Register */
 #define REG_USART2_US_FIDI      (*(__IO uint32_t*)0x4002C040U) /**< (USART2) FI DI Ratio Register */
 #define REG_USART2_US_NER       (*(__I  uint32_t*)0x4002C044U) /**< (USART2) Number of Errors Register */
@@ -101,9 +103,13 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USART2 peripheral ========== */
-#define USART2_INSTANCE_ID                       15        
-#define USART2_CLOCK_ID                          15        
-#define USART2_DMAC_ID_TX                        11        
-#define USART2_DMAC_ID_RX                        12        
+#define USART2_DMAC_ID_RX                        12         
+#define USART2_DMAC_ID_TX                        11         
+#define USART2_INSTANCE_ID                       15         
+#define USART2_CLOCK_ID                          15         
+#define USART2_USCLKS_MCK                        0          /* MCK */
+#define USART2_USCLKS_DIV                        1          /* MCK/8 */
+#define USART2_USCLKS_PCK                        2          /* PCK4 */
+#define USART2_USCLKS_SCK                        3          /* SCK */
 
 #endif /* _SAME70_USART2_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/usbhs.h
+++ b/asf/sam/include/same70b/instance/usbhs.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for USBHS
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,69 +27,69 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_USBHS_INSTANCE_H_
 #define _SAME70_USBHS_INSTANCE_H_
 
 /* ========== Register definition for USBHS peripheral ========== */
 #if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 
-#define REG_USBHS_DEVDMANXTDSC0 (0x40038310) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 0 */
-#define REG_USBHS_DEVDMAADDRESS0 (0x40038314) /**< (USBHS) Device DMA Channel Address Register (n = 1) 0 */
-#define REG_USBHS_DEVDMACONTROL0 (0x40038318) /**< (USBHS) Device DMA Channel Control Register (n = 1) 0 */
-#define REG_USBHS_DEVDMASTATUS0 (0x4003831C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 0 */
-#define REG_USBHS_DEVDMANXTDSC1 (0x40038320) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 1 */
-#define REG_USBHS_DEVDMAADDRESS1 (0x40038324) /**< (USBHS) Device DMA Channel Address Register (n = 1) 1 */
-#define REG_USBHS_DEVDMACONTROL1 (0x40038328) /**< (USBHS) Device DMA Channel Control Register (n = 1) 1 */
-#define REG_USBHS_DEVDMASTATUS1 (0x4003832C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 1 */
-#define REG_USBHS_DEVDMANXTDSC2 (0x40038330) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 2 */
-#define REG_USBHS_DEVDMAADDRESS2 (0x40038334) /**< (USBHS) Device DMA Channel Address Register (n = 1) 2 */
-#define REG_USBHS_DEVDMACONTROL2 (0x40038338) /**< (USBHS) Device DMA Channel Control Register (n = 1) 2 */
-#define REG_USBHS_DEVDMASTATUS2 (0x4003833C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 2 */
-#define REG_USBHS_DEVDMANXTDSC3 (0x40038340) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 3 */
-#define REG_USBHS_DEVDMAADDRESS3 (0x40038344) /**< (USBHS) Device DMA Channel Address Register (n = 1) 3 */
-#define REG_USBHS_DEVDMACONTROL3 (0x40038348) /**< (USBHS) Device DMA Channel Control Register (n = 1) 3 */
-#define REG_USBHS_DEVDMASTATUS3 (0x4003834C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 3 */
-#define REG_USBHS_DEVDMANXTDSC4 (0x40038350) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 4 */
-#define REG_USBHS_DEVDMAADDRESS4 (0x40038354) /**< (USBHS) Device DMA Channel Address Register (n = 1) 4 */
-#define REG_USBHS_DEVDMACONTROL4 (0x40038358) /**< (USBHS) Device DMA Channel Control Register (n = 1) 4 */
-#define REG_USBHS_DEVDMASTATUS4 (0x4003835C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 4 */
-#define REG_USBHS_DEVDMANXTDSC5 (0x40038360) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 5 */
-#define REG_USBHS_DEVDMAADDRESS5 (0x40038364) /**< (USBHS) Device DMA Channel Address Register (n = 1) 5 */
-#define REG_USBHS_DEVDMACONTROL5 (0x40038368) /**< (USBHS) Device DMA Channel Control Register (n = 1) 5 */
-#define REG_USBHS_DEVDMASTATUS5 (0x4003836C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 5 */
-#define REG_USBHS_DEVDMANXTDSC6 (0x40038370) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 6 */
-#define REG_USBHS_DEVDMAADDRESS6 (0x40038374) /**< (USBHS) Device DMA Channel Address Register (n = 1) 6 */
-#define REG_USBHS_DEVDMACONTROL6 (0x40038378) /**< (USBHS) Device DMA Channel Control Register (n = 1) 6 */
-#define REG_USBHS_DEVDMASTATUS6 (0x4003837C) /**< (USBHS) Device DMA Channel Status Register (n = 1) 6 */
-#define REG_USBHS_HSTDMANXTDSC0 (0x40038710) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 0 */
-#define REG_USBHS_HSTDMAADDRESS0 (0x40038714) /**< (USBHS) Host DMA Channel Address Register (n = 1) 0 */
-#define REG_USBHS_HSTDMACONTROL0 (0x40038718) /**< (USBHS) Host DMA Channel Control Register (n = 1) 0 */
-#define REG_USBHS_HSTDMASTATUS0 (0x4003871C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 0 */
-#define REG_USBHS_HSTDMANXTDSC1 (0x40038720) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 1 */
-#define REG_USBHS_HSTDMAADDRESS1 (0x40038724) /**< (USBHS) Host DMA Channel Address Register (n = 1) 1 */
-#define REG_USBHS_HSTDMACONTROL1 (0x40038728) /**< (USBHS) Host DMA Channel Control Register (n = 1) 1 */
-#define REG_USBHS_HSTDMASTATUS1 (0x4003872C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 1 */
-#define REG_USBHS_HSTDMANXTDSC2 (0x40038730) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 2 */
-#define REG_USBHS_HSTDMAADDRESS2 (0x40038734) /**< (USBHS) Host DMA Channel Address Register (n = 1) 2 */
-#define REG_USBHS_HSTDMACONTROL2 (0x40038738) /**< (USBHS) Host DMA Channel Control Register (n = 1) 2 */
-#define REG_USBHS_HSTDMASTATUS2 (0x4003873C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 2 */
-#define REG_USBHS_HSTDMANXTDSC3 (0x40038740) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 3 */
-#define REG_USBHS_HSTDMAADDRESS3 (0x40038744) /**< (USBHS) Host DMA Channel Address Register (n = 1) 3 */
-#define REG_USBHS_HSTDMACONTROL3 (0x40038748) /**< (USBHS) Host DMA Channel Control Register (n = 1) 3 */
-#define REG_USBHS_HSTDMASTATUS3 (0x4003874C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 3 */
-#define REG_USBHS_HSTDMANXTDSC4 (0x40038750) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 4 */
-#define REG_USBHS_HSTDMAADDRESS4 (0x40038754) /**< (USBHS) Host DMA Channel Address Register (n = 1) 4 */
-#define REG_USBHS_HSTDMACONTROL4 (0x40038758) /**< (USBHS) Host DMA Channel Control Register (n = 1) 4 */
-#define REG_USBHS_HSTDMASTATUS4 (0x4003875C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 4 */
-#define REG_USBHS_HSTDMANXTDSC5 (0x40038760) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 5 */
-#define REG_USBHS_HSTDMAADDRESS5 (0x40038764) /**< (USBHS) Host DMA Channel Address Register (n = 1) 5 */
-#define REG_USBHS_HSTDMACONTROL5 (0x40038768) /**< (USBHS) Host DMA Channel Control Register (n = 1) 5 */
-#define REG_USBHS_HSTDMASTATUS5 (0x4003876C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 5 */
-#define REG_USBHS_HSTDMANXTDSC6 (0x40038770) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 6 */
-#define REG_USBHS_HSTDMAADDRESS6 (0x40038774) /**< (USBHS) Host DMA Channel Address Register (n = 1) 6 */
-#define REG_USBHS_HSTDMACONTROL6 (0x40038778) /**< (USBHS) Host DMA Channel Control Register (n = 1) 6 */
-#define REG_USBHS_HSTDMASTATUS6 (0x4003877C) /**< (USBHS) Host DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_DEVDMANXTDSC0 (0x40038310) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (0x40038314) /**< (USBHS) Device DMA Channel Address Register 0 */
+#define REG_USBHS_DEVDMACONTROL0 (0x40038318) /**< (USBHS) Device DMA Channel Control Register 0 */
+#define REG_USBHS_DEVDMASTATUS0 (0x4003831C) /**< (USBHS) Device DMA Channel Status Register 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (0x40038320) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (0x40038324) /**< (USBHS) Device DMA Channel Address Register 1 */
+#define REG_USBHS_DEVDMACONTROL1 (0x40038328) /**< (USBHS) Device DMA Channel Control Register 1 */
+#define REG_USBHS_DEVDMASTATUS1 (0x4003832C) /**< (USBHS) Device DMA Channel Status Register 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (0x40038330) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (0x40038334) /**< (USBHS) Device DMA Channel Address Register 2 */
+#define REG_USBHS_DEVDMACONTROL2 (0x40038338) /**< (USBHS) Device DMA Channel Control Register 2 */
+#define REG_USBHS_DEVDMASTATUS2 (0x4003833C) /**< (USBHS) Device DMA Channel Status Register 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (0x40038340) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (0x40038344) /**< (USBHS) Device DMA Channel Address Register 3 */
+#define REG_USBHS_DEVDMACONTROL3 (0x40038348) /**< (USBHS) Device DMA Channel Control Register 3 */
+#define REG_USBHS_DEVDMASTATUS3 (0x4003834C) /**< (USBHS) Device DMA Channel Status Register 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (0x40038350) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (0x40038354) /**< (USBHS) Device DMA Channel Address Register 4 */
+#define REG_USBHS_DEVDMACONTROL4 (0x40038358) /**< (USBHS) Device DMA Channel Control Register 4 */
+#define REG_USBHS_DEVDMASTATUS4 (0x4003835C) /**< (USBHS) Device DMA Channel Status Register 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (0x40038360) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (0x40038364) /**< (USBHS) Device DMA Channel Address Register 5 */
+#define REG_USBHS_DEVDMACONTROL5 (0x40038368) /**< (USBHS) Device DMA Channel Control Register 5 */
+#define REG_USBHS_DEVDMASTATUS5 (0x4003836C) /**< (USBHS) Device DMA Channel Status Register 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (0x40038370) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (0x40038374) /**< (USBHS) Device DMA Channel Address Register 6 */
+#define REG_USBHS_DEVDMACONTROL6 (0x40038378) /**< (USBHS) Device DMA Channel Control Register 6 */
+#define REG_USBHS_DEVDMASTATUS6 (0x4003837C) /**< (USBHS) Device DMA Channel Status Register 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (0x40038710) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (0x40038714) /**< (USBHS) Host DMA Channel Address Register 0 */
+#define REG_USBHS_HSTDMACONTROL0 (0x40038718) /**< (USBHS) Host DMA Channel Control Register 0 */
+#define REG_USBHS_HSTDMASTATUS0 (0x4003871C) /**< (USBHS) Host DMA Channel Status Register 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (0x40038720) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (0x40038724) /**< (USBHS) Host DMA Channel Address Register 1 */
+#define REG_USBHS_HSTDMACONTROL1 (0x40038728) /**< (USBHS) Host DMA Channel Control Register 1 */
+#define REG_USBHS_HSTDMASTATUS1 (0x4003872C) /**< (USBHS) Host DMA Channel Status Register 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (0x40038730) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (0x40038734) /**< (USBHS) Host DMA Channel Address Register 2 */
+#define REG_USBHS_HSTDMACONTROL2 (0x40038738) /**< (USBHS) Host DMA Channel Control Register 2 */
+#define REG_USBHS_HSTDMASTATUS2 (0x4003873C) /**< (USBHS) Host DMA Channel Status Register 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (0x40038740) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (0x40038744) /**< (USBHS) Host DMA Channel Address Register 3 */
+#define REG_USBHS_HSTDMACONTROL3 (0x40038748) /**< (USBHS) Host DMA Channel Control Register 3 */
+#define REG_USBHS_HSTDMASTATUS3 (0x4003874C) /**< (USBHS) Host DMA Channel Status Register 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (0x40038750) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (0x40038754) /**< (USBHS) Host DMA Channel Address Register 4 */
+#define REG_USBHS_HSTDMACONTROL4 (0x40038758) /**< (USBHS) Host DMA Channel Control Register 4 */
+#define REG_USBHS_HSTDMASTATUS4 (0x4003875C) /**< (USBHS) Host DMA Channel Status Register 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (0x40038760) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (0x40038764) /**< (USBHS) Host DMA Channel Address Register 5 */
+#define REG_USBHS_HSTDMACONTROL5 (0x40038768) /**< (USBHS) Host DMA Channel Control Register 5 */
+#define REG_USBHS_HSTDMASTATUS5 (0x4003876C) /**< (USBHS) Host DMA Channel Status Register 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (0x40038770) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (0x40038774) /**< (USBHS) Host DMA Channel Address Register 6 */
+#define REG_USBHS_HSTDMACONTROL6 (0x40038778) /**< (USBHS) Host DMA Channel Control Register 6 */
+#define REG_USBHS_HSTDMASTATUS6 (0x4003877C) /**< (USBHS) Host DMA Channel Status Register 6 */
 #define REG_USBHS_DEVCTRL       (0x40038000) /**< (USBHS) Device General Control Register */
 #define REG_USBHS_DEVISR        (0x40038004) /**< (USBHS) Device Global Interrupt Status Register */
 #define REG_USBHS_DEVICR        (0x40038008) /**< (USBHS) Device Global Interrupt Clear Register */
@@ -97,83 +99,83 @@
 #define REG_USBHS_DEVIER        (0x40038018) /**< (USBHS) Device Global Interrupt Enable Register */
 #define REG_USBHS_DEVEPT        (0x4003801C) /**< (USBHS) Device Endpoint Register */
 #define REG_USBHS_DEVFNUM       (0x40038020) /**< (USBHS) Device Frame Number Register */
-#define REG_USBHS_DEVEPTCFG     (0x40038100) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTCFG0    (0x40038100) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTCFG1    (0x40038104) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTCFG2    (0x40038108) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTCFG3    (0x4003810C) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTCFG4    (0x40038110) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTCFG5    (0x40038114) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTCFG6    (0x40038118) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTCFG7    (0x4003811C) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTCFG8    (0x40038120) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTCFG9    (0x40038124) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTISR     (0x40038130) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTISR0    (0x40038130) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTISR1    (0x40038134) /**< (USBHS) Device Endpoint Status Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTISR2    (0x40038138) /**< (USBHS) Device Endpoint Status Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTISR3    (0x4003813C) /**< (USBHS) Device Endpoint Status Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTISR4    (0x40038140) /**< (USBHS) Device Endpoint Status Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTISR5    (0x40038144) /**< (USBHS) Device Endpoint Status Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTISR6    (0x40038148) /**< (USBHS) Device Endpoint Status Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTISR7    (0x4003814C) /**< (USBHS) Device Endpoint Status Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTISR8    (0x40038150) /**< (USBHS) Device Endpoint Status Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTISR9    (0x40038154) /**< (USBHS) Device Endpoint Status Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTICR     (0x40038160) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTICR0    (0x40038160) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTICR1    (0x40038164) /**< (USBHS) Device Endpoint Clear Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTICR2    (0x40038168) /**< (USBHS) Device Endpoint Clear Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTICR3    (0x4003816C) /**< (USBHS) Device Endpoint Clear Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTICR4    (0x40038170) /**< (USBHS) Device Endpoint Clear Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTICR5    (0x40038174) /**< (USBHS) Device Endpoint Clear Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTICR6    (0x40038178) /**< (USBHS) Device Endpoint Clear Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTICR7    (0x4003817C) /**< (USBHS) Device Endpoint Clear Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTICR8    (0x40038180) /**< (USBHS) Device Endpoint Clear Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTICR9    (0x40038184) /**< (USBHS) Device Endpoint Clear Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIFR     (0x40038190) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIFR0    (0x40038190) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIFR1    (0x40038194) /**< (USBHS) Device Endpoint Set Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIFR2    (0x40038198) /**< (USBHS) Device Endpoint Set Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIFR3    (0x4003819C) /**< (USBHS) Device Endpoint Set Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIFR4    (0x400381A0) /**< (USBHS) Device Endpoint Set Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIFR5    (0x400381A4) /**< (USBHS) Device Endpoint Set Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIFR6    (0x400381A8) /**< (USBHS) Device Endpoint Set Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIFR7    (0x400381AC) /**< (USBHS) Device Endpoint Set Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIFR8    (0x400381B0) /**< (USBHS) Device Endpoint Set Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIFR9    (0x400381B4) /**< (USBHS) Device Endpoint Set Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIMR     (0x400381C0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIMR0    (0x400381C0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIMR1    (0x400381C4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIMR2    (0x400381C8) /**< (USBHS) Device Endpoint Mask Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIMR3    (0x400381CC) /**< (USBHS) Device Endpoint Mask Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIMR4    (0x400381D0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIMR5    (0x400381D4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIMR6    (0x400381D8) /**< (USBHS) Device Endpoint Mask Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIMR7    (0x400381DC) /**< (USBHS) Device Endpoint Mask Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIMR8    (0x400381E0) /**< (USBHS) Device Endpoint Mask Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIMR9    (0x400381E4) /**< (USBHS) Device Endpoint Mask Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIER     (0x400381F0) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIER0    (0x400381F0) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIER1    (0x400381F4) /**< (USBHS) Device Endpoint Enable Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIER2    (0x400381F8) /**< (USBHS) Device Endpoint Enable Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIER3    (0x400381FC) /**< (USBHS) Device Endpoint Enable Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIER4    (0x40038200) /**< (USBHS) Device Endpoint Enable Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIER5    (0x40038204) /**< (USBHS) Device Endpoint Enable Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIER6    (0x40038208) /**< (USBHS) Device Endpoint Enable Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIER7    (0x4003820C) /**< (USBHS) Device Endpoint Enable Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIER8    (0x40038210) /**< (USBHS) Device Endpoint Enable Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIER9    (0x40038214) /**< (USBHS) Device Endpoint Enable Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIDR     (0x40038220) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIDR0    (0x40038220) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIDR1    (0x40038224) /**< (USBHS) Device Endpoint Disable Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIDR2    (0x40038228) /**< (USBHS) Device Endpoint Disable Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIDR3    (0x4003822C) /**< (USBHS) Device Endpoint Disable Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIDR4    (0x40038230) /**< (USBHS) Device Endpoint Disable Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIDR5    (0x40038234) /**< (USBHS) Device Endpoint Disable Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIDR6    (0x40038238) /**< (USBHS) Device Endpoint Disable Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIDR7    (0x4003823C) /**< (USBHS) Device Endpoint Disable Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIDR8    (0x40038240) /**< (USBHS) Device Endpoint Disable Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIDR9    (0x40038244) /**< (USBHS) Device Endpoint Disable Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTCFG     (0x40038100) /**< (USBHS) Device Endpoint Configuration Register */
+#define REG_USBHS_DEVEPTCFG0    (0x40038100) /**< (USBHS) Device Endpoint Configuration Register 0 */
+#define REG_USBHS_DEVEPTCFG1    (0x40038104) /**< (USBHS) Device Endpoint Configuration Register 1 */
+#define REG_USBHS_DEVEPTCFG2    (0x40038108) /**< (USBHS) Device Endpoint Configuration Register 2 */
+#define REG_USBHS_DEVEPTCFG3    (0x4003810C) /**< (USBHS) Device Endpoint Configuration Register 3 */
+#define REG_USBHS_DEVEPTCFG4    (0x40038110) /**< (USBHS) Device Endpoint Configuration Register 4 */
+#define REG_USBHS_DEVEPTCFG5    (0x40038114) /**< (USBHS) Device Endpoint Configuration Register 5 */
+#define REG_USBHS_DEVEPTCFG6    (0x40038118) /**< (USBHS) Device Endpoint Configuration Register 6 */
+#define REG_USBHS_DEVEPTCFG7    (0x4003811C) /**< (USBHS) Device Endpoint Configuration Register 7 */
+#define REG_USBHS_DEVEPTCFG8    (0x40038120) /**< (USBHS) Device Endpoint Configuration Register 8 */
+#define REG_USBHS_DEVEPTCFG9    (0x40038124) /**< (USBHS) Device Endpoint Configuration Register 9 */
+#define REG_USBHS_DEVEPTISR     (0x40038130) /**< (USBHS) Device Endpoint Interrupt Status Register */
+#define REG_USBHS_DEVEPTISR0    (0x40038130) /**< (USBHS) Device Endpoint Interrupt Status Register 0 */
+#define REG_USBHS_DEVEPTISR1    (0x40038134) /**< (USBHS) Device Endpoint Interrupt Status Register 1 */
+#define REG_USBHS_DEVEPTISR2    (0x40038138) /**< (USBHS) Device Endpoint Interrupt Status Register 2 */
+#define REG_USBHS_DEVEPTISR3    (0x4003813C) /**< (USBHS) Device Endpoint Interrupt Status Register 3 */
+#define REG_USBHS_DEVEPTISR4    (0x40038140) /**< (USBHS) Device Endpoint Interrupt Status Register 4 */
+#define REG_USBHS_DEVEPTISR5    (0x40038144) /**< (USBHS) Device Endpoint Interrupt Status Register 5 */
+#define REG_USBHS_DEVEPTISR6    (0x40038148) /**< (USBHS) Device Endpoint Interrupt Status Register 6 */
+#define REG_USBHS_DEVEPTISR7    (0x4003814C) /**< (USBHS) Device Endpoint Interrupt Status Register 7 */
+#define REG_USBHS_DEVEPTISR8    (0x40038150) /**< (USBHS) Device Endpoint Interrupt Status Register 8 */
+#define REG_USBHS_DEVEPTISR9    (0x40038154) /**< (USBHS) Device Endpoint Interrupt Status Register 9 */
+#define REG_USBHS_DEVEPTICR     (0x40038160) /**< (USBHS) Device Endpoint Interrupt Clear Register */
+#define REG_USBHS_DEVEPTICR0    (0x40038160) /**< (USBHS) Device Endpoint Interrupt Clear Register 0 */
+#define REG_USBHS_DEVEPTICR1    (0x40038164) /**< (USBHS) Device Endpoint Interrupt Clear Register 1 */
+#define REG_USBHS_DEVEPTICR2    (0x40038168) /**< (USBHS) Device Endpoint Interrupt Clear Register 2 */
+#define REG_USBHS_DEVEPTICR3    (0x4003816C) /**< (USBHS) Device Endpoint Interrupt Clear Register 3 */
+#define REG_USBHS_DEVEPTICR4    (0x40038170) /**< (USBHS) Device Endpoint Interrupt Clear Register 4 */
+#define REG_USBHS_DEVEPTICR5    (0x40038174) /**< (USBHS) Device Endpoint Interrupt Clear Register 5 */
+#define REG_USBHS_DEVEPTICR6    (0x40038178) /**< (USBHS) Device Endpoint Interrupt Clear Register 6 */
+#define REG_USBHS_DEVEPTICR7    (0x4003817C) /**< (USBHS) Device Endpoint Interrupt Clear Register 7 */
+#define REG_USBHS_DEVEPTICR8    (0x40038180) /**< (USBHS) Device Endpoint Interrupt Clear Register 8 */
+#define REG_USBHS_DEVEPTICR9    (0x40038184) /**< (USBHS) Device Endpoint Interrupt Clear Register 9 */
+#define REG_USBHS_DEVEPTIFR     (0x40038190) /**< (USBHS) Device Endpoint Interrupt Set Register */
+#define REG_USBHS_DEVEPTIFR0    (0x40038190) /**< (USBHS) Device Endpoint Interrupt Set Register 0 */
+#define REG_USBHS_DEVEPTIFR1    (0x40038194) /**< (USBHS) Device Endpoint Interrupt Set Register 1 */
+#define REG_USBHS_DEVEPTIFR2    (0x40038198) /**< (USBHS) Device Endpoint Interrupt Set Register 2 */
+#define REG_USBHS_DEVEPTIFR3    (0x4003819C) /**< (USBHS) Device Endpoint Interrupt Set Register 3 */
+#define REG_USBHS_DEVEPTIFR4    (0x400381A0) /**< (USBHS) Device Endpoint Interrupt Set Register 4 */
+#define REG_USBHS_DEVEPTIFR5    (0x400381A4) /**< (USBHS) Device Endpoint Interrupt Set Register 5 */
+#define REG_USBHS_DEVEPTIFR6    (0x400381A8) /**< (USBHS) Device Endpoint Interrupt Set Register 6 */
+#define REG_USBHS_DEVEPTIFR7    (0x400381AC) /**< (USBHS) Device Endpoint Interrupt Set Register 7 */
+#define REG_USBHS_DEVEPTIFR8    (0x400381B0) /**< (USBHS) Device Endpoint Interrupt Set Register 8 */
+#define REG_USBHS_DEVEPTIFR9    (0x400381B4) /**< (USBHS) Device Endpoint Interrupt Set Register 9 */
+#define REG_USBHS_DEVEPTIMR     (0x400381C0) /**< (USBHS) Device Endpoint Interrupt Mask Register */
+#define REG_USBHS_DEVEPTIMR0    (0x400381C0) /**< (USBHS) Device Endpoint Interrupt Mask Register 0 */
+#define REG_USBHS_DEVEPTIMR1    (0x400381C4) /**< (USBHS) Device Endpoint Interrupt Mask Register 1 */
+#define REG_USBHS_DEVEPTIMR2    (0x400381C8) /**< (USBHS) Device Endpoint Interrupt Mask Register 2 */
+#define REG_USBHS_DEVEPTIMR3    (0x400381CC) /**< (USBHS) Device Endpoint Interrupt Mask Register 3 */
+#define REG_USBHS_DEVEPTIMR4    (0x400381D0) /**< (USBHS) Device Endpoint Interrupt Mask Register 4 */
+#define REG_USBHS_DEVEPTIMR5    (0x400381D4) /**< (USBHS) Device Endpoint Interrupt Mask Register 5 */
+#define REG_USBHS_DEVEPTIMR6    (0x400381D8) /**< (USBHS) Device Endpoint Interrupt Mask Register 6 */
+#define REG_USBHS_DEVEPTIMR7    (0x400381DC) /**< (USBHS) Device Endpoint Interrupt Mask Register 7 */
+#define REG_USBHS_DEVEPTIMR8    (0x400381E0) /**< (USBHS) Device Endpoint Interrupt Mask Register 8 */
+#define REG_USBHS_DEVEPTIMR9    (0x400381E4) /**< (USBHS) Device Endpoint Interrupt Mask Register 9 */
+#define REG_USBHS_DEVEPTIER     (0x400381F0) /**< (USBHS) Device Endpoint Interrupt Enable Register */
+#define REG_USBHS_DEVEPTIER0    (0x400381F0) /**< (USBHS) Device Endpoint Interrupt Enable Register 0 */
+#define REG_USBHS_DEVEPTIER1    (0x400381F4) /**< (USBHS) Device Endpoint Interrupt Enable Register 1 */
+#define REG_USBHS_DEVEPTIER2    (0x400381F8) /**< (USBHS) Device Endpoint Interrupt Enable Register 2 */
+#define REG_USBHS_DEVEPTIER3    (0x400381FC) /**< (USBHS) Device Endpoint Interrupt Enable Register 3 */
+#define REG_USBHS_DEVEPTIER4    (0x40038200) /**< (USBHS) Device Endpoint Interrupt Enable Register 4 */
+#define REG_USBHS_DEVEPTIER5    (0x40038204) /**< (USBHS) Device Endpoint Interrupt Enable Register 5 */
+#define REG_USBHS_DEVEPTIER6    (0x40038208) /**< (USBHS) Device Endpoint Interrupt Enable Register 6 */
+#define REG_USBHS_DEVEPTIER7    (0x4003820C) /**< (USBHS) Device Endpoint Interrupt Enable Register 7 */
+#define REG_USBHS_DEVEPTIER8    (0x40038210) /**< (USBHS) Device Endpoint Interrupt Enable Register 8 */
+#define REG_USBHS_DEVEPTIER9    (0x40038214) /**< (USBHS) Device Endpoint Interrupt Enable Register 9 */
+#define REG_USBHS_DEVEPTIDR     (0x40038220) /**< (USBHS) Device Endpoint Interrupt Disable Register */
+#define REG_USBHS_DEVEPTIDR0    (0x40038220) /**< (USBHS) Device Endpoint Interrupt Disable Register 0 */
+#define REG_USBHS_DEVEPTIDR1    (0x40038224) /**< (USBHS) Device Endpoint Interrupt Disable Register 1 */
+#define REG_USBHS_DEVEPTIDR2    (0x40038228) /**< (USBHS) Device Endpoint Interrupt Disable Register 2 */
+#define REG_USBHS_DEVEPTIDR3    (0x4003822C) /**< (USBHS) Device Endpoint Interrupt Disable Register 3 */
+#define REG_USBHS_DEVEPTIDR4    (0x40038230) /**< (USBHS) Device Endpoint Interrupt Disable Register 4 */
+#define REG_USBHS_DEVEPTIDR5    (0x40038234) /**< (USBHS) Device Endpoint Interrupt Disable Register 5 */
+#define REG_USBHS_DEVEPTIDR6    (0x40038238) /**< (USBHS) Device Endpoint Interrupt Disable Register 6 */
+#define REG_USBHS_DEVEPTIDR7    (0x4003823C) /**< (USBHS) Device Endpoint Interrupt Disable Register 7 */
+#define REG_USBHS_DEVEPTIDR8    (0x40038240) /**< (USBHS) Device Endpoint Interrupt Disable Register 8 */
+#define REG_USBHS_DEVEPTIDR9    (0x40038244) /**< (USBHS) Device Endpoint Interrupt Disable Register 9 */
 #define REG_USBHS_HSTCTRL       (0x40038400) /**< (USBHS) Host General Control Register */
 #define REG_USBHS_HSTISR        (0x40038404) /**< (USBHS) Host Global Interrupt Status Register */
 #define REG_USBHS_HSTICR        (0x40038408) /**< (USBHS) Host Global Interrupt Clear Register */
@@ -186,105 +188,105 @@
 #define REG_USBHS_HSTADDR1      (0x40038424) /**< (USBHS) Host Address 1 Register */
 #define REG_USBHS_HSTADDR2      (0x40038428) /**< (USBHS) Host Address 2 Register */
 #define REG_USBHS_HSTADDR3      (0x4003842C) /**< (USBHS) Host Address 3 Register */
-#define REG_USBHS_HSTPIPCFG     (0x40038500) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPCFG0    (0x40038500) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPCFG1    (0x40038504) /**< (USBHS) Host Pipe Configuration Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPCFG2    (0x40038508) /**< (USBHS) Host Pipe Configuration Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPCFG3    (0x4003850C) /**< (USBHS) Host Pipe Configuration Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPCFG4    (0x40038510) /**< (USBHS) Host Pipe Configuration Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPCFG5    (0x40038514) /**< (USBHS) Host Pipe Configuration Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPCFG6    (0x40038518) /**< (USBHS) Host Pipe Configuration Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPCFG7    (0x4003851C) /**< (USBHS) Host Pipe Configuration Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPCFG8    (0x40038520) /**< (USBHS) Host Pipe Configuration Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPCFG9    (0x40038524) /**< (USBHS) Host Pipe Configuration Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPISR     (0x40038530) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPISR0    (0x40038530) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPISR1    (0x40038534) /**< (USBHS) Host Pipe Status Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPISR2    (0x40038538) /**< (USBHS) Host Pipe Status Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPISR3    (0x4003853C) /**< (USBHS) Host Pipe Status Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPISR4    (0x40038540) /**< (USBHS) Host Pipe Status Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPISR5    (0x40038544) /**< (USBHS) Host Pipe Status Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPISR6    (0x40038548) /**< (USBHS) Host Pipe Status Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPISR7    (0x4003854C) /**< (USBHS) Host Pipe Status Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPISR8    (0x40038550) /**< (USBHS) Host Pipe Status Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPISR9    (0x40038554) /**< (USBHS) Host Pipe Status Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPICR     (0x40038560) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPICR0    (0x40038560) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPICR1    (0x40038564) /**< (USBHS) Host Pipe Clear Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPICR2    (0x40038568) /**< (USBHS) Host Pipe Clear Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPICR3    (0x4003856C) /**< (USBHS) Host Pipe Clear Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPICR4    (0x40038570) /**< (USBHS) Host Pipe Clear Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPICR5    (0x40038574) /**< (USBHS) Host Pipe Clear Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPICR6    (0x40038578) /**< (USBHS) Host Pipe Clear Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPICR7    (0x4003857C) /**< (USBHS) Host Pipe Clear Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPICR8    (0x40038580) /**< (USBHS) Host Pipe Clear Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPICR9    (0x40038584) /**< (USBHS) Host Pipe Clear Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIFR     (0x40038590) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIFR0    (0x40038590) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIFR1    (0x40038594) /**< (USBHS) Host Pipe Set Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIFR2    (0x40038598) /**< (USBHS) Host Pipe Set Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIFR3    (0x4003859C) /**< (USBHS) Host Pipe Set Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIFR4    (0x400385A0) /**< (USBHS) Host Pipe Set Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIFR5    (0x400385A4) /**< (USBHS) Host Pipe Set Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIFR6    (0x400385A8) /**< (USBHS) Host Pipe Set Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIFR7    (0x400385AC) /**< (USBHS) Host Pipe Set Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIFR8    (0x400385B0) /**< (USBHS) Host Pipe Set Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIFR9    (0x400385B4) /**< (USBHS) Host Pipe Set Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIMR     (0x400385C0) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIMR0    (0x400385C0) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIMR1    (0x400385C4) /**< (USBHS) Host Pipe Mask Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIMR2    (0x400385C8) /**< (USBHS) Host Pipe Mask Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIMR3    (0x400385CC) /**< (USBHS) Host Pipe Mask Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIMR4    (0x400385D0) /**< (USBHS) Host Pipe Mask Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIMR5    (0x400385D4) /**< (USBHS) Host Pipe Mask Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIMR6    (0x400385D8) /**< (USBHS) Host Pipe Mask Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIMR7    (0x400385DC) /**< (USBHS) Host Pipe Mask Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIMR8    (0x400385E0) /**< (USBHS) Host Pipe Mask Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIMR9    (0x400385E4) /**< (USBHS) Host Pipe Mask Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIER     (0x400385F0) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIER0    (0x400385F0) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIER1    (0x400385F4) /**< (USBHS) Host Pipe Enable Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIER2    (0x400385F8) /**< (USBHS) Host Pipe Enable Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIER3    (0x400385FC) /**< (USBHS) Host Pipe Enable Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIER4    (0x40038600) /**< (USBHS) Host Pipe Enable Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIER5    (0x40038604) /**< (USBHS) Host Pipe Enable Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIER6    (0x40038608) /**< (USBHS) Host Pipe Enable Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIER7    (0x4003860C) /**< (USBHS) Host Pipe Enable Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIER8    (0x40038610) /**< (USBHS) Host Pipe Enable Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIER9    (0x40038614) /**< (USBHS) Host Pipe Enable Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIDR     (0x40038620) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIDR0    (0x40038620) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIDR1    (0x40038624) /**< (USBHS) Host Pipe Disable Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIDR2    (0x40038628) /**< (USBHS) Host Pipe Disable Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIDR3    (0x4003862C) /**< (USBHS) Host Pipe Disable Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIDR4    (0x40038630) /**< (USBHS) Host Pipe Disable Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIDR5    (0x40038634) /**< (USBHS) Host Pipe Disable Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIDR6    (0x40038638) /**< (USBHS) Host Pipe Disable Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIDR7    (0x4003863C) /**< (USBHS) Host Pipe Disable Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIDR8    (0x40038640) /**< (USBHS) Host Pipe Disable Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIDR9    (0x40038644) /**< (USBHS) Host Pipe Disable Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPINRQ    (0x40038650) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPINRQ0   (0x40038650) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPINRQ1   (0x40038654) /**< (USBHS) Host Pipe IN Request Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPINRQ2   (0x40038658) /**< (USBHS) Host Pipe IN Request Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPINRQ3   (0x4003865C) /**< (USBHS) Host Pipe IN Request Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPINRQ4   (0x40038660) /**< (USBHS) Host Pipe IN Request Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPINRQ5   (0x40038664) /**< (USBHS) Host Pipe IN Request Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPINRQ6   (0x40038668) /**< (USBHS) Host Pipe IN Request Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPINRQ7   (0x4003866C) /**< (USBHS) Host Pipe IN Request Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPINRQ8   (0x40038670) /**< (USBHS) Host Pipe IN Request Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPINRQ9   (0x40038674) /**< (USBHS) Host Pipe IN Request Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPERR     (0x40038680) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPERR0    (0x40038680) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPERR1    (0x40038684) /**< (USBHS) Host Pipe Error Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPERR2    (0x40038688) /**< (USBHS) Host Pipe Error Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPERR3    (0x4003868C) /**< (USBHS) Host Pipe Error Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPERR4    (0x40038690) /**< (USBHS) Host Pipe Error Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPERR5    (0x40038694) /**< (USBHS) Host Pipe Error Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPERR6    (0x40038698) /**< (USBHS) Host Pipe Error Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPERR7    (0x4003869C) /**< (USBHS) Host Pipe Error Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPERR8    (0x400386A0) /**< (USBHS) Host Pipe Error Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPERR9    (0x400386A4) /**< (USBHS) Host Pipe Error Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPCFG     (0x40038500) /**< (USBHS) Host Pipe Configuration Register */
+#define REG_USBHS_HSTPIPCFG0    (0x40038500) /**< (USBHS) Host Pipe Configuration Register 0 */
+#define REG_USBHS_HSTPIPCFG1    (0x40038504) /**< (USBHS) Host Pipe Configuration Register 1 */
+#define REG_USBHS_HSTPIPCFG2    (0x40038508) /**< (USBHS) Host Pipe Configuration Register 2 */
+#define REG_USBHS_HSTPIPCFG3    (0x4003850C) /**< (USBHS) Host Pipe Configuration Register 3 */
+#define REG_USBHS_HSTPIPCFG4    (0x40038510) /**< (USBHS) Host Pipe Configuration Register 4 */
+#define REG_USBHS_HSTPIPCFG5    (0x40038514) /**< (USBHS) Host Pipe Configuration Register 5 */
+#define REG_USBHS_HSTPIPCFG6    (0x40038518) /**< (USBHS) Host Pipe Configuration Register 6 */
+#define REG_USBHS_HSTPIPCFG7    (0x4003851C) /**< (USBHS) Host Pipe Configuration Register 7 */
+#define REG_USBHS_HSTPIPCFG8    (0x40038520) /**< (USBHS) Host Pipe Configuration Register 8 */
+#define REG_USBHS_HSTPIPCFG9    (0x40038524) /**< (USBHS) Host Pipe Configuration Register 9 */
+#define REG_USBHS_HSTPIPISR     (0x40038530) /**< (USBHS) Host Pipe Status Register */
+#define REG_USBHS_HSTPIPISR0    (0x40038530) /**< (USBHS) Host Pipe Status Register 0 */
+#define REG_USBHS_HSTPIPISR1    (0x40038534) /**< (USBHS) Host Pipe Status Register 1 */
+#define REG_USBHS_HSTPIPISR2    (0x40038538) /**< (USBHS) Host Pipe Status Register 2 */
+#define REG_USBHS_HSTPIPISR3    (0x4003853C) /**< (USBHS) Host Pipe Status Register 3 */
+#define REG_USBHS_HSTPIPISR4    (0x40038540) /**< (USBHS) Host Pipe Status Register 4 */
+#define REG_USBHS_HSTPIPISR5    (0x40038544) /**< (USBHS) Host Pipe Status Register 5 */
+#define REG_USBHS_HSTPIPISR6    (0x40038548) /**< (USBHS) Host Pipe Status Register 6 */
+#define REG_USBHS_HSTPIPISR7    (0x4003854C) /**< (USBHS) Host Pipe Status Register 7 */
+#define REG_USBHS_HSTPIPISR8    (0x40038550) /**< (USBHS) Host Pipe Status Register 8 */
+#define REG_USBHS_HSTPIPISR9    (0x40038554) /**< (USBHS) Host Pipe Status Register 9 */
+#define REG_USBHS_HSTPIPICR     (0x40038560) /**< (USBHS) Host Pipe Clear Register */
+#define REG_USBHS_HSTPIPICR0    (0x40038560) /**< (USBHS) Host Pipe Clear Register 0 */
+#define REG_USBHS_HSTPIPICR1    (0x40038564) /**< (USBHS) Host Pipe Clear Register 1 */
+#define REG_USBHS_HSTPIPICR2    (0x40038568) /**< (USBHS) Host Pipe Clear Register 2 */
+#define REG_USBHS_HSTPIPICR3    (0x4003856C) /**< (USBHS) Host Pipe Clear Register 3 */
+#define REG_USBHS_HSTPIPICR4    (0x40038570) /**< (USBHS) Host Pipe Clear Register 4 */
+#define REG_USBHS_HSTPIPICR5    (0x40038574) /**< (USBHS) Host Pipe Clear Register 5 */
+#define REG_USBHS_HSTPIPICR6    (0x40038578) /**< (USBHS) Host Pipe Clear Register 6 */
+#define REG_USBHS_HSTPIPICR7    (0x4003857C) /**< (USBHS) Host Pipe Clear Register 7 */
+#define REG_USBHS_HSTPIPICR8    (0x40038580) /**< (USBHS) Host Pipe Clear Register 8 */
+#define REG_USBHS_HSTPIPICR9    (0x40038584) /**< (USBHS) Host Pipe Clear Register 9 */
+#define REG_USBHS_HSTPIPIFR     (0x40038590) /**< (USBHS) Host Pipe Set Register */
+#define REG_USBHS_HSTPIPIFR0    (0x40038590) /**< (USBHS) Host Pipe Set Register 0 */
+#define REG_USBHS_HSTPIPIFR1    (0x40038594) /**< (USBHS) Host Pipe Set Register 1 */
+#define REG_USBHS_HSTPIPIFR2    (0x40038598) /**< (USBHS) Host Pipe Set Register 2 */
+#define REG_USBHS_HSTPIPIFR3    (0x4003859C) /**< (USBHS) Host Pipe Set Register 3 */
+#define REG_USBHS_HSTPIPIFR4    (0x400385A0) /**< (USBHS) Host Pipe Set Register 4 */
+#define REG_USBHS_HSTPIPIFR5    (0x400385A4) /**< (USBHS) Host Pipe Set Register 5 */
+#define REG_USBHS_HSTPIPIFR6    (0x400385A8) /**< (USBHS) Host Pipe Set Register 6 */
+#define REG_USBHS_HSTPIPIFR7    (0x400385AC) /**< (USBHS) Host Pipe Set Register 7 */
+#define REG_USBHS_HSTPIPIFR8    (0x400385B0) /**< (USBHS) Host Pipe Set Register 8 */
+#define REG_USBHS_HSTPIPIFR9    (0x400385B4) /**< (USBHS) Host Pipe Set Register 9 */
+#define REG_USBHS_HSTPIPIMR     (0x400385C0) /**< (USBHS) Host Pipe Mask Register */
+#define REG_USBHS_HSTPIPIMR0    (0x400385C0) /**< (USBHS) Host Pipe Mask Register 0 */
+#define REG_USBHS_HSTPIPIMR1    (0x400385C4) /**< (USBHS) Host Pipe Mask Register 1 */
+#define REG_USBHS_HSTPIPIMR2    (0x400385C8) /**< (USBHS) Host Pipe Mask Register 2 */
+#define REG_USBHS_HSTPIPIMR3    (0x400385CC) /**< (USBHS) Host Pipe Mask Register 3 */
+#define REG_USBHS_HSTPIPIMR4    (0x400385D0) /**< (USBHS) Host Pipe Mask Register 4 */
+#define REG_USBHS_HSTPIPIMR5    (0x400385D4) /**< (USBHS) Host Pipe Mask Register 5 */
+#define REG_USBHS_HSTPIPIMR6    (0x400385D8) /**< (USBHS) Host Pipe Mask Register 6 */
+#define REG_USBHS_HSTPIPIMR7    (0x400385DC) /**< (USBHS) Host Pipe Mask Register 7 */
+#define REG_USBHS_HSTPIPIMR8    (0x400385E0) /**< (USBHS) Host Pipe Mask Register 8 */
+#define REG_USBHS_HSTPIPIMR9    (0x400385E4) /**< (USBHS) Host Pipe Mask Register 9 */
+#define REG_USBHS_HSTPIPIER     (0x400385F0) /**< (USBHS) Host Pipe Enable Register */
+#define REG_USBHS_HSTPIPIER0    (0x400385F0) /**< (USBHS) Host Pipe Enable Register 0 */
+#define REG_USBHS_HSTPIPIER1    (0x400385F4) /**< (USBHS) Host Pipe Enable Register 1 */
+#define REG_USBHS_HSTPIPIER2    (0x400385F8) /**< (USBHS) Host Pipe Enable Register 2 */
+#define REG_USBHS_HSTPIPIER3    (0x400385FC) /**< (USBHS) Host Pipe Enable Register 3 */
+#define REG_USBHS_HSTPIPIER4    (0x40038600) /**< (USBHS) Host Pipe Enable Register 4 */
+#define REG_USBHS_HSTPIPIER5    (0x40038604) /**< (USBHS) Host Pipe Enable Register 5 */
+#define REG_USBHS_HSTPIPIER6    (0x40038608) /**< (USBHS) Host Pipe Enable Register 6 */
+#define REG_USBHS_HSTPIPIER7    (0x4003860C) /**< (USBHS) Host Pipe Enable Register 7 */
+#define REG_USBHS_HSTPIPIER8    (0x40038610) /**< (USBHS) Host Pipe Enable Register 8 */
+#define REG_USBHS_HSTPIPIER9    (0x40038614) /**< (USBHS) Host Pipe Enable Register 9 */
+#define REG_USBHS_HSTPIPIDR     (0x40038620) /**< (USBHS) Host Pipe Disable Register */
+#define REG_USBHS_HSTPIPIDR0    (0x40038620) /**< (USBHS) Host Pipe Disable Register 0 */
+#define REG_USBHS_HSTPIPIDR1    (0x40038624) /**< (USBHS) Host Pipe Disable Register 1 */
+#define REG_USBHS_HSTPIPIDR2    (0x40038628) /**< (USBHS) Host Pipe Disable Register 2 */
+#define REG_USBHS_HSTPIPIDR3    (0x4003862C) /**< (USBHS) Host Pipe Disable Register 3 */
+#define REG_USBHS_HSTPIPIDR4    (0x40038630) /**< (USBHS) Host Pipe Disable Register 4 */
+#define REG_USBHS_HSTPIPIDR5    (0x40038634) /**< (USBHS) Host Pipe Disable Register 5 */
+#define REG_USBHS_HSTPIPIDR6    (0x40038638) /**< (USBHS) Host Pipe Disable Register 6 */
+#define REG_USBHS_HSTPIPIDR7    (0x4003863C) /**< (USBHS) Host Pipe Disable Register 7 */
+#define REG_USBHS_HSTPIPIDR8    (0x40038640) /**< (USBHS) Host Pipe Disable Register 8 */
+#define REG_USBHS_HSTPIPIDR9    (0x40038644) /**< (USBHS) Host Pipe Disable Register 9 */
+#define REG_USBHS_HSTPIPINRQ    (0x40038650) /**< (USBHS) Host Pipe IN Request Register */
+#define REG_USBHS_HSTPIPINRQ0   (0x40038650) /**< (USBHS) Host Pipe IN Request Register 0 */
+#define REG_USBHS_HSTPIPINRQ1   (0x40038654) /**< (USBHS) Host Pipe IN Request Register 1 */
+#define REG_USBHS_HSTPIPINRQ2   (0x40038658) /**< (USBHS) Host Pipe IN Request Register 2 */
+#define REG_USBHS_HSTPIPINRQ3   (0x4003865C) /**< (USBHS) Host Pipe IN Request Register 3 */
+#define REG_USBHS_HSTPIPINRQ4   (0x40038660) /**< (USBHS) Host Pipe IN Request Register 4 */
+#define REG_USBHS_HSTPIPINRQ5   (0x40038664) /**< (USBHS) Host Pipe IN Request Register 5 */
+#define REG_USBHS_HSTPIPINRQ6   (0x40038668) /**< (USBHS) Host Pipe IN Request Register 6 */
+#define REG_USBHS_HSTPIPINRQ7   (0x4003866C) /**< (USBHS) Host Pipe IN Request Register 7 */
+#define REG_USBHS_HSTPIPINRQ8   (0x40038670) /**< (USBHS) Host Pipe IN Request Register 8 */
+#define REG_USBHS_HSTPIPINRQ9   (0x40038674) /**< (USBHS) Host Pipe IN Request Register 9 */
+#define REG_USBHS_HSTPIPERR     (0x40038680) /**< (USBHS) Host Pipe Error Register */
+#define REG_USBHS_HSTPIPERR0    (0x40038680) /**< (USBHS) Host Pipe Error Register 0 */
+#define REG_USBHS_HSTPIPERR1    (0x40038684) /**< (USBHS) Host Pipe Error Register 1 */
+#define REG_USBHS_HSTPIPERR2    (0x40038688) /**< (USBHS) Host Pipe Error Register 2 */
+#define REG_USBHS_HSTPIPERR3    (0x4003868C) /**< (USBHS) Host Pipe Error Register 3 */
+#define REG_USBHS_HSTPIPERR4    (0x40038690) /**< (USBHS) Host Pipe Error Register 4 */
+#define REG_USBHS_HSTPIPERR5    (0x40038694) /**< (USBHS) Host Pipe Error Register 5 */
+#define REG_USBHS_HSTPIPERR6    (0x40038698) /**< (USBHS) Host Pipe Error Register 6 */
+#define REG_USBHS_HSTPIPERR7    (0x4003869C) /**< (USBHS) Host Pipe Error Register 7 */
+#define REG_USBHS_HSTPIPERR8    (0x400386A0) /**< (USBHS) Host Pipe Error Register 8 */
+#define REG_USBHS_HSTPIPERR9    (0x400386A4) /**< (USBHS) Host Pipe Error Register 9 */
 #define REG_USBHS_CTRL          (0x40038800) /**< (USBHS) General Control Register */
 #define REG_USBHS_SR            (0x40038804) /**< (USBHS) General Status Register */
 #define REG_USBHS_SCR           (0x40038808) /**< (USBHS) General Status Clear Register */
@@ -292,62 +294,62 @@
 
 #else
 
-#define REG_USBHS_DEVDMANXTDSC0 (*(__IO uint32_t*)0x40038310U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 0 */
-#define REG_USBHS_DEVDMAADDRESS0 (*(__IO uint32_t*)0x40038314U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 0 */
-#define REG_USBHS_DEVDMACONTROL0 (*(__IO uint32_t*)0x40038318U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 0 */
-#define REG_USBHS_DEVDMASTATUS0 (*(__IO uint32_t*)0x4003831CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 0 */
-#define REG_USBHS_DEVDMANXTDSC1 (*(__IO uint32_t*)0x40038320U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 1 */
-#define REG_USBHS_DEVDMAADDRESS1 (*(__IO uint32_t*)0x40038324U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 1 */
-#define REG_USBHS_DEVDMACONTROL1 (*(__IO uint32_t*)0x40038328U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 1 */
-#define REG_USBHS_DEVDMASTATUS1 (*(__IO uint32_t*)0x4003832CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 1 */
-#define REG_USBHS_DEVDMANXTDSC2 (*(__IO uint32_t*)0x40038330U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 2 */
-#define REG_USBHS_DEVDMAADDRESS2 (*(__IO uint32_t*)0x40038334U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 2 */
-#define REG_USBHS_DEVDMACONTROL2 (*(__IO uint32_t*)0x40038338U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 2 */
-#define REG_USBHS_DEVDMASTATUS2 (*(__IO uint32_t*)0x4003833CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 2 */
-#define REG_USBHS_DEVDMANXTDSC3 (*(__IO uint32_t*)0x40038340U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 3 */
-#define REG_USBHS_DEVDMAADDRESS3 (*(__IO uint32_t*)0x40038344U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 3 */
-#define REG_USBHS_DEVDMACONTROL3 (*(__IO uint32_t*)0x40038348U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 3 */
-#define REG_USBHS_DEVDMASTATUS3 (*(__IO uint32_t*)0x4003834CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 3 */
-#define REG_USBHS_DEVDMANXTDSC4 (*(__IO uint32_t*)0x40038350U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 4 */
-#define REG_USBHS_DEVDMAADDRESS4 (*(__IO uint32_t*)0x40038354U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 4 */
-#define REG_USBHS_DEVDMACONTROL4 (*(__IO uint32_t*)0x40038358U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 4 */
-#define REG_USBHS_DEVDMASTATUS4 (*(__IO uint32_t*)0x4003835CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 4 */
-#define REG_USBHS_DEVDMANXTDSC5 (*(__IO uint32_t*)0x40038360U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 5 */
-#define REG_USBHS_DEVDMAADDRESS5 (*(__IO uint32_t*)0x40038364U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 5 */
-#define REG_USBHS_DEVDMACONTROL5 (*(__IO uint32_t*)0x40038368U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 5 */
-#define REG_USBHS_DEVDMASTATUS5 (*(__IO uint32_t*)0x4003836CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 5 */
-#define REG_USBHS_DEVDMANXTDSC6 (*(__IO uint32_t*)0x40038370U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register (n = 1) 6 */
-#define REG_USBHS_DEVDMAADDRESS6 (*(__IO uint32_t*)0x40038374U) /**< (USBHS) Device DMA Channel Address Register (n = 1) 6 */
-#define REG_USBHS_DEVDMACONTROL6 (*(__IO uint32_t*)0x40038378U) /**< (USBHS) Device DMA Channel Control Register (n = 1) 6 */
-#define REG_USBHS_DEVDMASTATUS6 (*(__IO uint32_t*)0x4003837CU) /**< (USBHS) Device DMA Channel Status Register (n = 1) 6 */
-#define REG_USBHS_HSTDMANXTDSC0 (*(__IO uint32_t*)0x40038710U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 0 */
-#define REG_USBHS_HSTDMAADDRESS0 (*(__IO uint32_t*)0x40038714U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 0 */
-#define REG_USBHS_HSTDMACONTROL0 (*(__IO uint32_t*)0x40038718U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 0 */
-#define REG_USBHS_HSTDMASTATUS0 (*(__IO uint32_t*)0x4003871CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 0 */
-#define REG_USBHS_HSTDMANXTDSC1 (*(__IO uint32_t*)0x40038720U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 1 */
-#define REG_USBHS_HSTDMAADDRESS1 (*(__IO uint32_t*)0x40038724U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 1 */
-#define REG_USBHS_HSTDMACONTROL1 (*(__IO uint32_t*)0x40038728U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 1 */
-#define REG_USBHS_HSTDMASTATUS1 (*(__IO uint32_t*)0x4003872CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 1 */
-#define REG_USBHS_HSTDMANXTDSC2 (*(__IO uint32_t*)0x40038730U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 2 */
-#define REG_USBHS_HSTDMAADDRESS2 (*(__IO uint32_t*)0x40038734U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 2 */
-#define REG_USBHS_HSTDMACONTROL2 (*(__IO uint32_t*)0x40038738U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 2 */
-#define REG_USBHS_HSTDMASTATUS2 (*(__IO uint32_t*)0x4003873CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 2 */
-#define REG_USBHS_HSTDMANXTDSC3 (*(__IO uint32_t*)0x40038740U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 3 */
-#define REG_USBHS_HSTDMAADDRESS3 (*(__IO uint32_t*)0x40038744U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 3 */
-#define REG_USBHS_HSTDMACONTROL3 (*(__IO uint32_t*)0x40038748U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 3 */
-#define REG_USBHS_HSTDMASTATUS3 (*(__IO uint32_t*)0x4003874CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 3 */
-#define REG_USBHS_HSTDMANXTDSC4 (*(__IO uint32_t*)0x40038750U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 4 */
-#define REG_USBHS_HSTDMAADDRESS4 (*(__IO uint32_t*)0x40038754U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 4 */
-#define REG_USBHS_HSTDMACONTROL4 (*(__IO uint32_t*)0x40038758U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 4 */
-#define REG_USBHS_HSTDMASTATUS4 (*(__IO uint32_t*)0x4003875CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 4 */
-#define REG_USBHS_HSTDMANXTDSC5 (*(__IO uint32_t*)0x40038760U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 5 */
-#define REG_USBHS_HSTDMAADDRESS5 (*(__IO uint32_t*)0x40038764U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 5 */
-#define REG_USBHS_HSTDMACONTROL5 (*(__IO uint32_t*)0x40038768U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 5 */
-#define REG_USBHS_HSTDMASTATUS5 (*(__IO uint32_t*)0x4003876CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 5 */
-#define REG_USBHS_HSTDMANXTDSC6 (*(__IO uint32_t*)0x40038770U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register (n = 1) 6 */
-#define REG_USBHS_HSTDMAADDRESS6 (*(__IO uint32_t*)0x40038774U) /**< (USBHS) Host DMA Channel Address Register (n = 1) 6 */
-#define REG_USBHS_HSTDMACONTROL6 (*(__IO uint32_t*)0x40038778U) /**< (USBHS) Host DMA Channel Control Register (n = 1) 6 */
-#define REG_USBHS_HSTDMASTATUS6 (*(__IO uint32_t*)0x4003877CU) /**< (USBHS) Host DMA Channel Status Register (n = 1) 6 */
+#define REG_USBHS_DEVDMANXTDSC0 (*(__IO uint32_t*)0x40038310U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_DEVDMAADDRESS0 (*(__IO uint32_t*)0x40038314U) /**< (USBHS) Device DMA Channel Address Register 0 */
+#define REG_USBHS_DEVDMACONTROL0 (*(__IO uint32_t*)0x40038318U) /**< (USBHS) Device DMA Channel Control Register 0 */
+#define REG_USBHS_DEVDMASTATUS0 (*(__IO uint32_t*)0x4003831CU) /**< (USBHS) Device DMA Channel Status Register 0 */
+#define REG_USBHS_DEVDMANXTDSC1 (*(__IO uint32_t*)0x40038320U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_DEVDMAADDRESS1 (*(__IO uint32_t*)0x40038324U) /**< (USBHS) Device DMA Channel Address Register 1 */
+#define REG_USBHS_DEVDMACONTROL1 (*(__IO uint32_t*)0x40038328U) /**< (USBHS) Device DMA Channel Control Register 1 */
+#define REG_USBHS_DEVDMASTATUS1 (*(__IO uint32_t*)0x4003832CU) /**< (USBHS) Device DMA Channel Status Register 1 */
+#define REG_USBHS_DEVDMANXTDSC2 (*(__IO uint32_t*)0x40038330U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_DEVDMAADDRESS2 (*(__IO uint32_t*)0x40038334U) /**< (USBHS) Device DMA Channel Address Register 2 */
+#define REG_USBHS_DEVDMACONTROL2 (*(__IO uint32_t*)0x40038338U) /**< (USBHS) Device DMA Channel Control Register 2 */
+#define REG_USBHS_DEVDMASTATUS2 (*(__IO uint32_t*)0x4003833CU) /**< (USBHS) Device DMA Channel Status Register 2 */
+#define REG_USBHS_DEVDMANXTDSC3 (*(__IO uint32_t*)0x40038340U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_DEVDMAADDRESS3 (*(__IO uint32_t*)0x40038344U) /**< (USBHS) Device DMA Channel Address Register 3 */
+#define REG_USBHS_DEVDMACONTROL3 (*(__IO uint32_t*)0x40038348U) /**< (USBHS) Device DMA Channel Control Register 3 */
+#define REG_USBHS_DEVDMASTATUS3 (*(__IO uint32_t*)0x4003834CU) /**< (USBHS) Device DMA Channel Status Register 3 */
+#define REG_USBHS_DEVDMANXTDSC4 (*(__IO uint32_t*)0x40038350U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_DEVDMAADDRESS4 (*(__IO uint32_t*)0x40038354U) /**< (USBHS) Device DMA Channel Address Register 4 */
+#define REG_USBHS_DEVDMACONTROL4 (*(__IO uint32_t*)0x40038358U) /**< (USBHS) Device DMA Channel Control Register 4 */
+#define REG_USBHS_DEVDMASTATUS4 (*(__IO uint32_t*)0x4003835CU) /**< (USBHS) Device DMA Channel Status Register 4 */
+#define REG_USBHS_DEVDMANXTDSC5 (*(__IO uint32_t*)0x40038360U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_DEVDMAADDRESS5 (*(__IO uint32_t*)0x40038364U) /**< (USBHS) Device DMA Channel Address Register 5 */
+#define REG_USBHS_DEVDMACONTROL5 (*(__IO uint32_t*)0x40038368U) /**< (USBHS) Device DMA Channel Control Register 5 */
+#define REG_USBHS_DEVDMASTATUS5 (*(__IO uint32_t*)0x4003836CU) /**< (USBHS) Device DMA Channel Status Register 5 */
+#define REG_USBHS_DEVDMANXTDSC6 (*(__IO uint32_t*)0x40038370U) /**< (USBHS) Device DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_DEVDMAADDRESS6 (*(__IO uint32_t*)0x40038374U) /**< (USBHS) Device DMA Channel Address Register 6 */
+#define REG_USBHS_DEVDMACONTROL6 (*(__IO uint32_t*)0x40038378U) /**< (USBHS) Device DMA Channel Control Register 6 */
+#define REG_USBHS_DEVDMASTATUS6 (*(__IO uint32_t*)0x4003837CU) /**< (USBHS) Device DMA Channel Status Register 6 */
+#define REG_USBHS_HSTDMANXTDSC0 (*(__IO uint32_t*)0x40038710U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 0 */
+#define REG_USBHS_HSTDMAADDRESS0 (*(__IO uint32_t*)0x40038714U) /**< (USBHS) Host DMA Channel Address Register 0 */
+#define REG_USBHS_HSTDMACONTROL0 (*(__IO uint32_t*)0x40038718U) /**< (USBHS) Host DMA Channel Control Register 0 */
+#define REG_USBHS_HSTDMASTATUS0 (*(__IO uint32_t*)0x4003871CU) /**< (USBHS) Host DMA Channel Status Register 0 */
+#define REG_USBHS_HSTDMANXTDSC1 (*(__IO uint32_t*)0x40038720U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 1 */
+#define REG_USBHS_HSTDMAADDRESS1 (*(__IO uint32_t*)0x40038724U) /**< (USBHS) Host DMA Channel Address Register 1 */
+#define REG_USBHS_HSTDMACONTROL1 (*(__IO uint32_t*)0x40038728U) /**< (USBHS) Host DMA Channel Control Register 1 */
+#define REG_USBHS_HSTDMASTATUS1 (*(__IO uint32_t*)0x4003872CU) /**< (USBHS) Host DMA Channel Status Register 1 */
+#define REG_USBHS_HSTDMANXTDSC2 (*(__IO uint32_t*)0x40038730U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 2 */
+#define REG_USBHS_HSTDMAADDRESS2 (*(__IO uint32_t*)0x40038734U) /**< (USBHS) Host DMA Channel Address Register 2 */
+#define REG_USBHS_HSTDMACONTROL2 (*(__IO uint32_t*)0x40038738U) /**< (USBHS) Host DMA Channel Control Register 2 */
+#define REG_USBHS_HSTDMASTATUS2 (*(__IO uint32_t*)0x4003873CU) /**< (USBHS) Host DMA Channel Status Register 2 */
+#define REG_USBHS_HSTDMANXTDSC3 (*(__IO uint32_t*)0x40038740U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 3 */
+#define REG_USBHS_HSTDMAADDRESS3 (*(__IO uint32_t*)0x40038744U) /**< (USBHS) Host DMA Channel Address Register 3 */
+#define REG_USBHS_HSTDMACONTROL3 (*(__IO uint32_t*)0x40038748U) /**< (USBHS) Host DMA Channel Control Register 3 */
+#define REG_USBHS_HSTDMASTATUS3 (*(__IO uint32_t*)0x4003874CU) /**< (USBHS) Host DMA Channel Status Register 3 */
+#define REG_USBHS_HSTDMANXTDSC4 (*(__IO uint32_t*)0x40038750U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 4 */
+#define REG_USBHS_HSTDMAADDRESS4 (*(__IO uint32_t*)0x40038754U) /**< (USBHS) Host DMA Channel Address Register 4 */
+#define REG_USBHS_HSTDMACONTROL4 (*(__IO uint32_t*)0x40038758U) /**< (USBHS) Host DMA Channel Control Register 4 */
+#define REG_USBHS_HSTDMASTATUS4 (*(__IO uint32_t*)0x4003875CU) /**< (USBHS) Host DMA Channel Status Register 4 */
+#define REG_USBHS_HSTDMANXTDSC5 (*(__IO uint32_t*)0x40038760U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 5 */
+#define REG_USBHS_HSTDMAADDRESS5 (*(__IO uint32_t*)0x40038764U) /**< (USBHS) Host DMA Channel Address Register 5 */
+#define REG_USBHS_HSTDMACONTROL5 (*(__IO uint32_t*)0x40038768U) /**< (USBHS) Host DMA Channel Control Register 5 */
+#define REG_USBHS_HSTDMASTATUS5 (*(__IO uint32_t*)0x4003876CU) /**< (USBHS) Host DMA Channel Status Register 5 */
+#define REG_USBHS_HSTDMANXTDSC6 (*(__IO uint32_t*)0x40038770U) /**< (USBHS) Host DMA Channel Next Descriptor Address Register 6 */
+#define REG_USBHS_HSTDMAADDRESS6 (*(__IO uint32_t*)0x40038774U) /**< (USBHS) Host DMA Channel Address Register 6 */
+#define REG_USBHS_HSTDMACONTROL6 (*(__IO uint32_t*)0x40038778U) /**< (USBHS) Host DMA Channel Control Register 6 */
+#define REG_USBHS_HSTDMASTATUS6 (*(__IO uint32_t*)0x4003877CU) /**< (USBHS) Host DMA Channel Status Register 6 */
 #define REG_USBHS_DEVCTRL       (*(__IO uint32_t*)0x40038000U) /**< (USBHS) Device General Control Register */
 #define REG_USBHS_DEVISR        (*(__I  uint32_t*)0x40038004U) /**< (USBHS) Device Global Interrupt Status Register */
 #define REG_USBHS_DEVICR        (*(__O  uint32_t*)0x40038008U) /**< (USBHS) Device Global Interrupt Clear Register */
@@ -357,83 +359,83 @@
 #define REG_USBHS_DEVIER        (*(__O  uint32_t*)0x40038018U) /**< (USBHS) Device Global Interrupt Enable Register */
 #define REG_USBHS_DEVEPT        (*(__IO uint32_t*)0x4003801CU) /**< (USBHS) Device Endpoint Register */
 #define REG_USBHS_DEVFNUM       (*(__I  uint32_t*)0x40038020U) /**< (USBHS) Device Frame Number Register */
-#define REG_USBHS_DEVEPTCFG     (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTCFG0    (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTCFG1    (*(__IO uint32_t*)0x40038104U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTCFG2    (*(__IO uint32_t*)0x40038108U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTCFG3    (*(__IO uint32_t*)0x4003810CU) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTCFG4    (*(__IO uint32_t*)0x40038110U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTCFG5    (*(__IO uint32_t*)0x40038114U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTCFG6    (*(__IO uint32_t*)0x40038118U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTCFG7    (*(__IO uint32_t*)0x4003811CU) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTCFG8    (*(__IO uint32_t*)0x40038120U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTCFG9    (*(__IO uint32_t*)0x40038124U) /**< (USBHS) Device Endpoint Configuration Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTISR     (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTISR0    (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Status Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTISR1    (*(__I  uint32_t*)0x40038134U) /**< (USBHS) Device Endpoint Status Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTISR2    (*(__I  uint32_t*)0x40038138U) /**< (USBHS) Device Endpoint Status Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTISR3    (*(__I  uint32_t*)0x4003813CU) /**< (USBHS) Device Endpoint Status Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTISR4    (*(__I  uint32_t*)0x40038140U) /**< (USBHS) Device Endpoint Status Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTISR5    (*(__I  uint32_t*)0x40038144U) /**< (USBHS) Device Endpoint Status Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTISR6    (*(__I  uint32_t*)0x40038148U) /**< (USBHS) Device Endpoint Status Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTISR7    (*(__I  uint32_t*)0x4003814CU) /**< (USBHS) Device Endpoint Status Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTISR8    (*(__I  uint32_t*)0x40038150U) /**< (USBHS) Device Endpoint Status Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTISR9    (*(__I  uint32_t*)0x40038154U) /**< (USBHS) Device Endpoint Status Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTICR     (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTICR0    (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTICR1    (*(__O  uint32_t*)0x40038164U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTICR2    (*(__O  uint32_t*)0x40038168U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTICR3    (*(__O  uint32_t*)0x4003816CU) /**< (USBHS) Device Endpoint Clear Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTICR4    (*(__O  uint32_t*)0x40038170U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTICR5    (*(__O  uint32_t*)0x40038174U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTICR6    (*(__O  uint32_t*)0x40038178U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTICR7    (*(__O  uint32_t*)0x4003817CU) /**< (USBHS) Device Endpoint Clear Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTICR8    (*(__O  uint32_t*)0x40038180U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTICR9    (*(__O  uint32_t*)0x40038184U) /**< (USBHS) Device Endpoint Clear Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIFR     (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIFR0    (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Set Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIFR1    (*(__O  uint32_t*)0x40038194U) /**< (USBHS) Device Endpoint Set Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIFR2    (*(__O  uint32_t*)0x40038198U) /**< (USBHS) Device Endpoint Set Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIFR3    (*(__O  uint32_t*)0x4003819CU) /**< (USBHS) Device Endpoint Set Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIFR4    (*(__O  uint32_t*)0x400381A0U) /**< (USBHS) Device Endpoint Set Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIFR5    (*(__O  uint32_t*)0x400381A4U) /**< (USBHS) Device Endpoint Set Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIFR6    (*(__O  uint32_t*)0x400381A8U) /**< (USBHS) Device Endpoint Set Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIFR7    (*(__O  uint32_t*)0x400381ACU) /**< (USBHS) Device Endpoint Set Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIFR8    (*(__O  uint32_t*)0x400381B0U) /**< (USBHS) Device Endpoint Set Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIFR9    (*(__O  uint32_t*)0x400381B4U) /**< (USBHS) Device Endpoint Set Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIMR     (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIMR0    (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIMR1    (*(__I  uint32_t*)0x400381C4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIMR2    (*(__I  uint32_t*)0x400381C8U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIMR3    (*(__I  uint32_t*)0x400381CCU) /**< (USBHS) Device Endpoint Mask Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIMR4    (*(__I  uint32_t*)0x400381D0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIMR5    (*(__I  uint32_t*)0x400381D4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIMR6    (*(__I  uint32_t*)0x400381D8U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIMR7    (*(__I  uint32_t*)0x400381DCU) /**< (USBHS) Device Endpoint Mask Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIMR8    (*(__I  uint32_t*)0x400381E0U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIMR9    (*(__I  uint32_t*)0x400381E4U) /**< (USBHS) Device Endpoint Mask Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIER     (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIER0    (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIER1    (*(__O  uint32_t*)0x400381F4U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIER2    (*(__O  uint32_t*)0x400381F8U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIER3    (*(__O  uint32_t*)0x400381FCU) /**< (USBHS) Device Endpoint Enable Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIER4    (*(__O  uint32_t*)0x40038200U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIER5    (*(__O  uint32_t*)0x40038204U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIER6    (*(__O  uint32_t*)0x40038208U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIER7    (*(__O  uint32_t*)0x4003820CU) /**< (USBHS) Device Endpoint Enable Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIER8    (*(__O  uint32_t*)0x40038210U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIER9    (*(__O  uint32_t*)0x40038214U) /**< (USBHS) Device Endpoint Enable Register (n = 0) 9 */
-#define REG_USBHS_DEVEPTIDR     (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIDR0    (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 0 */
-#define REG_USBHS_DEVEPTIDR1    (*(__O  uint32_t*)0x40038224U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 1 */
-#define REG_USBHS_DEVEPTIDR2    (*(__O  uint32_t*)0x40038228U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 2 */
-#define REG_USBHS_DEVEPTIDR3    (*(__O  uint32_t*)0x4003822CU) /**< (USBHS) Device Endpoint Disable Register (n = 0) 3 */
-#define REG_USBHS_DEVEPTIDR4    (*(__O  uint32_t*)0x40038230U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 4 */
-#define REG_USBHS_DEVEPTIDR5    (*(__O  uint32_t*)0x40038234U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 5 */
-#define REG_USBHS_DEVEPTIDR6    (*(__O  uint32_t*)0x40038238U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 6 */
-#define REG_USBHS_DEVEPTIDR7    (*(__O  uint32_t*)0x4003823CU) /**< (USBHS) Device Endpoint Disable Register (n = 0) 7 */
-#define REG_USBHS_DEVEPTIDR8    (*(__O  uint32_t*)0x40038240U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 8 */
-#define REG_USBHS_DEVEPTIDR9    (*(__O  uint32_t*)0x40038244U) /**< (USBHS) Device Endpoint Disable Register (n = 0) 9 */
+#define REG_USBHS_DEVEPTCFG     (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register */
+#define REG_USBHS_DEVEPTCFG0    (*(__IO uint32_t*)0x40038100U) /**< (USBHS) Device Endpoint Configuration Register 0 */
+#define REG_USBHS_DEVEPTCFG1    (*(__IO uint32_t*)0x40038104U) /**< (USBHS) Device Endpoint Configuration Register 1 */
+#define REG_USBHS_DEVEPTCFG2    (*(__IO uint32_t*)0x40038108U) /**< (USBHS) Device Endpoint Configuration Register 2 */
+#define REG_USBHS_DEVEPTCFG3    (*(__IO uint32_t*)0x4003810CU) /**< (USBHS) Device Endpoint Configuration Register 3 */
+#define REG_USBHS_DEVEPTCFG4    (*(__IO uint32_t*)0x40038110U) /**< (USBHS) Device Endpoint Configuration Register 4 */
+#define REG_USBHS_DEVEPTCFG5    (*(__IO uint32_t*)0x40038114U) /**< (USBHS) Device Endpoint Configuration Register 5 */
+#define REG_USBHS_DEVEPTCFG6    (*(__IO uint32_t*)0x40038118U) /**< (USBHS) Device Endpoint Configuration Register 6 */
+#define REG_USBHS_DEVEPTCFG7    (*(__IO uint32_t*)0x4003811CU) /**< (USBHS) Device Endpoint Configuration Register 7 */
+#define REG_USBHS_DEVEPTCFG8    (*(__IO uint32_t*)0x40038120U) /**< (USBHS) Device Endpoint Configuration Register 8 */
+#define REG_USBHS_DEVEPTCFG9    (*(__IO uint32_t*)0x40038124U) /**< (USBHS) Device Endpoint Configuration Register 9 */
+#define REG_USBHS_DEVEPTISR     (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Interrupt Status Register */
+#define REG_USBHS_DEVEPTISR0    (*(__I  uint32_t*)0x40038130U) /**< (USBHS) Device Endpoint Interrupt Status Register 0 */
+#define REG_USBHS_DEVEPTISR1    (*(__I  uint32_t*)0x40038134U) /**< (USBHS) Device Endpoint Interrupt Status Register 1 */
+#define REG_USBHS_DEVEPTISR2    (*(__I  uint32_t*)0x40038138U) /**< (USBHS) Device Endpoint Interrupt Status Register 2 */
+#define REG_USBHS_DEVEPTISR3    (*(__I  uint32_t*)0x4003813CU) /**< (USBHS) Device Endpoint Interrupt Status Register 3 */
+#define REG_USBHS_DEVEPTISR4    (*(__I  uint32_t*)0x40038140U) /**< (USBHS) Device Endpoint Interrupt Status Register 4 */
+#define REG_USBHS_DEVEPTISR5    (*(__I  uint32_t*)0x40038144U) /**< (USBHS) Device Endpoint Interrupt Status Register 5 */
+#define REG_USBHS_DEVEPTISR6    (*(__I  uint32_t*)0x40038148U) /**< (USBHS) Device Endpoint Interrupt Status Register 6 */
+#define REG_USBHS_DEVEPTISR7    (*(__I  uint32_t*)0x4003814CU) /**< (USBHS) Device Endpoint Interrupt Status Register 7 */
+#define REG_USBHS_DEVEPTISR8    (*(__I  uint32_t*)0x40038150U) /**< (USBHS) Device Endpoint Interrupt Status Register 8 */
+#define REG_USBHS_DEVEPTISR9    (*(__I  uint32_t*)0x40038154U) /**< (USBHS) Device Endpoint Interrupt Status Register 9 */
+#define REG_USBHS_DEVEPTICR     (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Interrupt Clear Register */
+#define REG_USBHS_DEVEPTICR0    (*(__O  uint32_t*)0x40038160U) /**< (USBHS) Device Endpoint Interrupt Clear Register 0 */
+#define REG_USBHS_DEVEPTICR1    (*(__O  uint32_t*)0x40038164U) /**< (USBHS) Device Endpoint Interrupt Clear Register 1 */
+#define REG_USBHS_DEVEPTICR2    (*(__O  uint32_t*)0x40038168U) /**< (USBHS) Device Endpoint Interrupt Clear Register 2 */
+#define REG_USBHS_DEVEPTICR3    (*(__O  uint32_t*)0x4003816CU) /**< (USBHS) Device Endpoint Interrupt Clear Register 3 */
+#define REG_USBHS_DEVEPTICR4    (*(__O  uint32_t*)0x40038170U) /**< (USBHS) Device Endpoint Interrupt Clear Register 4 */
+#define REG_USBHS_DEVEPTICR5    (*(__O  uint32_t*)0x40038174U) /**< (USBHS) Device Endpoint Interrupt Clear Register 5 */
+#define REG_USBHS_DEVEPTICR6    (*(__O  uint32_t*)0x40038178U) /**< (USBHS) Device Endpoint Interrupt Clear Register 6 */
+#define REG_USBHS_DEVEPTICR7    (*(__O  uint32_t*)0x4003817CU) /**< (USBHS) Device Endpoint Interrupt Clear Register 7 */
+#define REG_USBHS_DEVEPTICR8    (*(__O  uint32_t*)0x40038180U) /**< (USBHS) Device Endpoint Interrupt Clear Register 8 */
+#define REG_USBHS_DEVEPTICR9    (*(__O  uint32_t*)0x40038184U) /**< (USBHS) Device Endpoint Interrupt Clear Register 9 */
+#define REG_USBHS_DEVEPTIFR     (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Interrupt Set Register */
+#define REG_USBHS_DEVEPTIFR0    (*(__O  uint32_t*)0x40038190U) /**< (USBHS) Device Endpoint Interrupt Set Register 0 */
+#define REG_USBHS_DEVEPTIFR1    (*(__O  uint32_t*)0x40038194U) /**< (USBHS) Device Endpoint Interrupt Set Register 1 */
+#define REG_USBHS_DEVEPTIFR2    (*(__O  uint32_t*)0x40038198U) /**< (USBHS) Device Endpoint Interrupt Set Register 2 */
+#define REG_USBHS_DEVEPTIFR3    (*(__O  uint32_t*)0x4003819CU) /**< (USBHS) Device Endpoint Interrupt Set Register 3 */
+#define REG_USBHS_DEVEPTIFR4    (*(__O  uint32_t*)0x400381A0U) /**< (USBHS) Device Endpoint Interrupt Set Register 4 */
+#define REG_USBHS_DEVEPTIFR5    (*(__O  uint32_t*)0x400381A4U) /**< (USBHS) Device Endpoint Interrupt Set Register 5 */
+#define REG_USBHS_DEVEPTIFR6    (*(__O  uint32_t*)0x400381A8U) /**< (USBHS) Device Endpoint Interrupt Set Register 6 */
+#define REG_USBHS_DEVEPTIFR7    (*(__O  uint32_t*)0x400381ACU) /**< (USBHS) Device Endpoint Interrupt Set Register 7 */
+#define REG_USBHS_DEVEPTIFR8    (*(__O  uint32_t*)0x400381B0U) /**< (USBHS) Device Endpoint Interrupt Set Register 8 */
+#define REG_USBHS_DEVEPTIFR9    (*(__O  uint32_t*)0x400381B4U) /**< (USBHS) Device Endpoint Interrupt Set Register 9 */
+#define REG_USBHS_DEVEPTIMR     (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Interrupt Mask Register */
+#define REG_USBHS_DEVEPTIMR0    (*(__I  uint32_t*)0x400381C0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 0 */
+#define REG_USBHS_DEVEPTIMR1    (*(__I  uint32_t*)0x400381C4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 1 */
+#define REG_USBHS_DEVEPTIMR2    (*(__I  uint32_t*)0x400381C8U) /**< (USBHS) Device Endpoint Interrupt Mask Register 2 */
+#define REG_USBHS_DEVEPTIMR3    (*(__I  uint32_t*)0x400381CCU) /**< (USBHS) Device Endpoint Interrupt Mask Register 3 */
+#define REG_USBHS_DEVEPTIMR4    (*(__I  uint32_t*)0x400381D0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 4 */
+#define REG_USBHS_DEVEPTIMR5    (*(__I  uint32_t*)0x400381D4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 5 */
+#define REG_USBHS_DEVEPTIMR6    (*(__I  uint32_t*)0x400381D8U) /**< (USBHS) Device Endpoint Interrupt Mask Register 6 */
+#define REG_USBHS_DEVEPTIMR7    (*(__I  uint32_t*)0x400381DCU) /**< (USBHS) Device Endpoint Interrupt Mask Register 7 */
+#define REG_USBHS_DEVEPTIMR8    (*(__I  uint32_t*)0x400381E0U) /**< (USBHS) Device Endpoint Interrupt Mask Register 8 */
+#define REG_USBHS_DEVEPTIMR9    (*(__I  uint32_t*)0x400381E4U) /**< (USBHS) Device Endpoint Interrupt Mask Register 9 */
+#define REG_USBHS_DEVEPTIER     (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Interrupt Enable Register */
+#define REG_USBHS_DEVEPTIER0    (*(__O  uint32_t*)0x400381F0U) /**< (USBHS) Device Endpoint Interrupt Enable Register 0 */
+#define REG_USBHS_DEVEPTIER1    (*(__O  uint32_t*)0x400381F4U) /**< (USBHS) Device Endpoint Interrupt Enable Register 1 */
+#define REG_USBHS_DEVEPTIER2    (*(__O  uint32_t*)0x400381F8U) /**< (USBHS) Device Endpoint Interrupt Enable Register 2 */
+#define REG_USBHS_DEVEPTIER3    (*(__O  uint32_t*)0x400381FCU) /**< (USBHS) Device Endpoint Interrupt Enable Register 3 */
+#define REG_USBHS_DEVEPTIER4    (*(__O  uint32_t*)0x40038200U) /**< (USBHS) Device Endpoint Interrupt Enable Register 4 */
+#define REG_USBHS_DEVEPTIER5    (*(__O  uint32_t*)0x40038204U) /**< (USBHS) Device Endpoint Interrupt Enable Register 5 */
+#define REG_USBHS_DEVEPTIER6    (*(__O  uint32_t*)0x40038208U) /**< (USBHS) Device Endpoint Interrupt Enable Register 6 */
+#define REG_USBHS_DEVEPTIER7    (*(__O  uint32_t*)0x4003820CU) /**< (USBHS) Device Endpoint Interrupt Enable Register 7 */
+#define REG_USBHS_DEVEPTIER8    (*(__O  uint32_t*)0x40038210U) /**< (USBHS) Device Endpoint Interrupt Enable Register 8 */
+#define REG_USBHS_DEVEPTIER9    (*(__O  uint32_t*)0x40038214U) /**< (USBHS) Device Endpoint Interrupt Enable Register 9 */
+#define REG_USBHS_DEVEPTIDR     (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Interrupt Disable Register */
+#define REG_USBHS_DEVEPTIDR0    (*(__O  uint32_t*)0x40038220U) /**< (USBHS) Device Endpoint Interrupt Disable Register 0 */
+#define REG_USBHS_DEVEPTIDR1    (*(__O  uint32_t*)0x40038224U) /**< (USBHS) Device Endpoint Interrupt Disable Register 1 */
+#define REG_USBHS_DEVEPTIDR2    (*(__O  uint32_t*)0x40038228U) /**< (USBHS) Device Endpoint Interrupt Disable Register 2 */
+#define REG_USBHS_DEVEPTIDR3    (*(__O  uint32_t*)0x4003822CU) /**< (USBHS) Device Endpoint Interrupt Disable Register 3 */
+#define REG_USBHS_DEVEPTIDR4    (*(__O  uint32_t*)0x40038230U) /**< (USBHS) Device Endpoint Interrupt Disable Register 4 */
+#define REG_USBHS_DEVEPTIDR5    (*(__O  uint32_t*)0x40038234U) /**< (USBHS) Device Endpoint Interrupt Disable Register 5 */
+#define REG_USBHS_DEVEPTIDR6    (*(__O  uint32_t*)0x40038238U) /**< (USBHS) Device Endpoint Interrupt Disable Register 6 */
+#define REG_USBHS_DEVEPTIDR7    (*(__O  uint32_t*)0x4003823CU) /**< (USBHS) Device Endpoint Interrupt Disable Register 7 */
+#define REG_USBHS_DEVEPTIDR8    (*(__O  uint32_t*)0x40038240U) /**< (USBHS) Device Endpoint Interrupt Disable Register 8 */
+#define REG_USBHS_DEVEPTIDR9    (*(__O  uint32_t*)0x40038244U) /**< (USBHS) Device Endpoint Interrupt Disable Register 9 */
 #define REG_USBHS_HSTCTRL       (*(__IO uint32_t*)0x40038400U) /**< (USBHS) Host General Control Register */
 #define REG_USBHS_HSTISR        (*(__I  uint32_t*)0x40038404U) /**< (USBHS) Host Global Interrupt Status Register */
 #define REG_USBHS_HSTICR        (*(__O  uint32_t*)0x40038408U) /**< (USBHS) Host Global Interrupt Clear Register */
@@ -446,105 +448,105 @@
 #define REG_USBHS_HSTADDR1      (*(__IO uint32_t*)0x40038424U) /**< (USBHS) Host Address 1 Register */
 #define REG_USBHS_HSTADDR2      (*(__IO uint32_t*)0x40038428U) /**< (USBHS) Host Address 2 Register */
 #define REG_USBHS_HSTADDR3      (*(__IO uint32_t*)0x4003842CU) /**< (USBHS) Host Address 3 Register */
-#define REG_USBHS_HSTPIPCFG     (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPCFG0    (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPCFG1    (*(__IO uint32_t*)0x40038504U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPCFG2    (*(__IO uint32_t*)0x40038508U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPCFG3    (*(__IO uint32_t*)0x4003850CU) /**< (USBHS) Host Pipe Configuration Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPCFG4    (*(__IO uint32_t*)0x40038510U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPCFG5    (*(__IO uint32_t*)0x40038514U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPCFG6    (*(__IO uint32_t*)0x40038518U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPCFG7    (*(__IO uint32_t*)0x4003851CU) /**< (USBHS) Host Pipe Configuration Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPCFG8    (*(__IO uint32_t*)0x40038520U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPCFG9    (*(__IO uint32_t*)0x40038524U) /**< (USBHS) Host Pipe Configuration Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPISR     (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPISR0    (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPISR1    (*(__I  uint32_t*)0x40038534U) /**< (USBHS) Host Pipe Status Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPISR2    (*(__I  uint32_t*)0x40038538U) /**< (USBHS) Host Pipe Status Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPISR3    (*(__I  uint32_t*)0x4003853CU) /**< (USBHS) Host Pipe Status Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPISR4    (*(__I  uint32_t*)0x40038540U) /**< (USBHS) Host Pipe Status Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPISR5    (*(__I  uint32_t*)0x40038544U) /**< (USBHS) Host Pipe Status Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPISR6    (*(__I  uint32_t*)0x40038548U) /**< (USBHS) Host Pipe Status Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPISR7    (*(__I  uint32_t*)0x4003854CU) /**< (USBHS) Host Pipe Status Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPISR8    (*(__I  uint32_t*)0x40038550U) /**< (USBHS) Host Pipe Status Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPISR9    (*(__I  uint32_t*)0x40038554U) /**< (USBHS) Host Pipe Status Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPICR     (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPICR0    (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPICR1    (*(__O  uint32_t*)0x40038564U) /**< (USBHS) Host Pipe Clear Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPICR2    (*(__O  uint32_t*)0x40038568U) /**< (USBHS) Host Pipe Clear Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPICR3    (*(__O  uint32_t*)0x4003856CU) /**< (USBHS) Host Pipe Clear Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPICR4    (*(__O  uint32_t*)0x40038570U) /**< (USBHS) Host Pipe Clear Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPICR5    (*(__O  uint32_t*)0x40038574U) /**< (USBHS) Host Pipe Clear Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPICR6    (*(__O  uint32_t*)0x40038578U) /**< (USBHS) Host Pipe Clear Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPICR7    (*(__O  uint32_t*)0x4003857CU) /**< (USBHS) Host Pipe Clear Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPICR8    (*(__O  uint32_t*)0x40038580U) /**< (USBHS) Host Pipe Clear Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPICR9    (*(__O  uint32_t*)0x40038584U) /**< (USBHS) Host Pipe Clear Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIFR     (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIFR0    (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIFR1    (*(__O  uint32_t*)0x40038594U) /**< (USBHS) Host Pipe Set Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIFR2    (*(__O  uint32_t*)0x40038598U) /**< (USBHS) Host Pipe Set Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIFR3    (*(__O  uint32_t*)0x4003859CU) /**< (USBHS) Host Pipe Set Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIFR4    (*(__O  uint32_t*)0x400385A0U) /**< (USBHS) Host Pipe Set Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIFR5    (*(__O  uint32_t*)0x400385A4U) /**< (USBHS) Host Pipe Set Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIFR6    (*(__O  uint32_t*)0x400385A8U) /**< (USBHS) Host Pipe Set Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIFR7    (*(__O  uint32_t*)0x400385ACU) /**< (USBHS) Host Pipe Set Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIFR8    (*(__O  uint32_t*)0x400385B0U) /**< (USBHS) Host Pipe Set Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIFR9    (*(__O  uint32_t*)0x400385B4U) /**< (USBHS) Host Pipe Set Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIMR     (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIMR0    (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIMR1    (*(__I  uint32_t*)0x400385C4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIMR2    (*(__I  uint32_t*)0x400385C8U) /**< (USBHS) Host Pipe Mask Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIMR3    (*(__I  uint32_t*)0x400385CCU) /**< (USBHS) Host Pipe Mask Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIMR4    (*(__I  uint32_t*)0x400385D0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIMR5    (*(__I  uint32_t*)0x400385D4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIMR6    (*(__I  uint32_t*)0x400385D8U) /**< (USBHS) Host Pipe Mask Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIMR7    (*(__I  uint32_t*)0x400385DCU) /**< (USBHS) Host Pipe Mask Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIMR8    (*(__I  uint32_t*)0x400385E0U) /**< (USBHS) Host Pipe Mask Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIMR9    (*(__I  uint32_t*)0x400385E4U) /**< (USBHS) Host Pipe Mask Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIER     (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIER0    (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIER1    (*(__O  uint32_t*)0x400385F4U) /**< (USBHS) Host Pipe Enable Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIER2    (*(__O  uint32_t*)0x400385F8U) /**< (USBHS) Host Pipe Enable Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIER3    (*(__O  uint32_t*)0x400385FCU) /**< (USBHS) Host Pipe Enable Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIER4    (*(__O  uint32_t*)0x40038600U) /**< (USBHS) Host Pipe Enable Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIER5    (*(__O  uint32_t*)0x40038604U) /**< (USBHS) Host Pipe Enable Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIER6    (*(__O  uint32_t*)0x40038608U) /**< (USBHS) Host Pipe Enable Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIER7    (*(__O  uint32_t*)0x4003860CU) /**< (USBHS) Host Pipe Enable Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIER8    (*(__O  uint32_t*)0x40038610U) /**< (USBHS) Host Pipe Enable Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIER9    (*(__O  uint32_t*)0x40038614U) /**< (USBHS) Host Pipe Enable Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPIDR     (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIDR0    (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPIDR1    (*(__O  uint32_t*)0x40038624U) /**< (USBHS) Host Pipe Disable Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPIDR2    (*(__O  uint32_t*)0x40038628U) /**< (USBHS) Host Pipe Disable Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPIDR3    (*(__O  uint32_t*)0x4003862CU) /**< (USBHS) Host Pipe Disable Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPIDR4    (*(__O  uint32_t*)0x40038630U) /**< (USBHS) Host Pipe Disable Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPIDR5    (*(__O  uint32_t*)0x40038634U) /**< (USBHS) Host Pipe Disable Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPIDR6    (*(__O  uint32_t*)0x40038638U) /**< (USBHS) Host Pipe Disable Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPIDR7    (*(__O  uint32_t*)0x4003863CU) /**< (USBHS) Host Pipe Disable Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPIDR8    (*(__O  uint32_t*)0x40038640U) /**< (USBHS) Host Pipe Disable Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPIDR9    (*(__O  uint32_t*)0x40038644U) /**< (USBHS) Host Pipe Disable Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPINRQ    (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPINRQ0   (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPINRQ1   (*(__IO uint32_t*)0x40038654U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPINRQ2   (*(__IO uint32_t*)0x40038658U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPINRQ3   (*(__IO uint32_t*)0x4003865CU) /**< (USBHS) Host Pipe IN Request Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPINRQ4   (*(__IO uint32_t*)0x40038660U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPINRQ5   (*(__IO uint32_t*)0x40038664U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPINRQ6   (*(__IO uint32_t*)0x40038668U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPINRQ7   (*(__IO uint32_t*)0x4003866CU) /**< (USBHS) Host Pipe IN Request Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPINRQ8   (*(__IO uint32_t*)0x40038670U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPINRQ9   (*(__IO uint32_t*)0x40038674U) /**< (USBHS) Host Pipe IN Request Register (n = 0) 9 */
-#define REG_USBHS_HSTPIPERR     (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPERR0    (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register (n = 0) 0 */
-#define REG_USBHS_HSTPIPERR1    (*(__IO uint32_t*)0x40038684U) /**< (USBHS) Host Pipe Error Register (n = 0) 1 */
-#define REG_USBHS_HSTPIPERR2    (*(__IO uint32_t*)0x40038688U) /**< (USBHS) Host Pipe Error Register (n = 0) 2 */
-#define REG_USBHS_HSTPIPERR3    (*(__IO uint32_t*)0x4003868CU) /**< (USBHS) Host Pipe Error Register (n = 0) 3 */
-#define REG_USBHS_HSTPIPERR4    (*(__IO uint32_t*)0x40038690U) /**< (USBHS) Host Pipe Error Register (n = 0) 4 */
-#define REG_USBHS_HSTPIPERR5    (*(__IO uint32_t*)0x40038694U) /**< (USBHS) Host Pipe Error Register (n = 0) 5 */
-#define REG_USBHS_HSTPIPERR6    (*(__IO uint32_t*)0x40038698U) /**< (USBHS) Host Pipe Error Register (n = 0) 6 */
-#define REG_USBHS_HSTPIPERR7    (*(__IO uint32_t*)0x4003869CU) /**< (USBHS) Host Pipe Error Register (n = 0) 7 */
-#define REG_USBHS_HSTPIPERR8    (*(__IO uint32_t*)0x400386A0U) /**< (USBHS) Host Pipe Error Register (n = 0) 8 */
-#define REG_USBHS_HSTPIPERR9    (*(__IO uint32_t*)0x400386A4U) /**< (USBHS) Host Pipe Error Register (n = 0) 9 */
+#define REG_USBHS_HSTPIPCFG     (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register */
+#define REG_USBHS_HSTPIPCFG0    (*(__IO uint32_t*)0x40038500U) /**< (USBHS) Host Pipe Configuration Register 0 */
+#define REG_USBHS_HSTPIPCFG1    (*(__IO uint32_t*)0x40038504U) /**< (USBHS) Host Pipe Configuration Register 1 */
+#define REG_USBHS_HSTPIPCFG2    (*(__IO uint32_t*)0x40038508U) /**< (USBHS) Host Pipe Configuration Register 2 */
+#define REG_USBHS_HSTPIPCFG3    (*(__IO uint32_t*)0x4003850CU) /**< (USBHS) Host Pipe Configuration Register 3 */
+#define REG_USBHS_HSTPIPCFG4    (*(__IO uint32_t*)0x40038510U) /**< (USBHS) Host Pipe Configuration Register 4 */
+#define REG_USBHS_HSTPIPCFG5    (*(__IO uint32_t*)0x40038514U) /**< (USBHS) Host Pipe Configuration Register 5 */
+#define REG_USBHS_HSTPIPCFG6    (*(__IO uint32_t*)0x40038518U) /**< (USBHS) Host Pipe Configuration Register 6 */
+#define REG_USBHS_HSTPIPCFG7    (*(__IO uint32_t*)0x4003851CU) /**< (USBHS) Host Pipe Configuration Register 7 */
+#define REG_USBHS_HSTPIPCFG8    (*(__IO uint32_t*)0x40038520U) /**< (USBHS) Host Pipe Configuration Register 8 */
+#define REG_USBHS_HSTPIPCFG9    (*(__IO uint32_t*)0x40038524U) /**< (USBHS) Host Pipe Configuration Register 9 */
+#define REG_USBHS_HSTPIPISR     (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register */
+#define REG_USBHS_HSTPIPISR0    (*(__I  uint32_t*)0x40038530U) /**< (USBHS) Host Pipe Status Register 0 */
+#define REG_USBHS_HSTPIPISR1    (*(__I  uint32_t*)0x40038534U) /**< (USBHS) Host Pipe Status Register 1 */
+#define REG_USBHS_HSTPIPISR2    (*(__I  uint32_t*)0x40038538U) /**< (USBHS) Host Pipe Status Register 2 */
+#define REG_USBHS_HSTPIPISR3    (*(__I  uint32_t*)0x4003853CU) /**< (USBHS) Host Pipe Status Register 3 */
+#define REG_USBHS_HSTPIPISR4    (*(__I  uint32_t*)0x40038540U) /**< (USBHS) Host Pipe Status Register 4 */
+#define REG_USBHS_HSTPIPISR5    (*(__I  uint32_t*)0x40038544U) /**< (USBHS) Host Pipe Status Register 5 */
+#define REG_USBHS_HSTPIPISR6    (*(__I  uint32_t*)0x40038548U) /**< (USBHS) Host Pipe Status Register 6 */
+#define REG_USBHS_HSTPIPISR7    (*(__I  uint32_t*)0x4003854CU) /**< (USBHS) Host Pipe Status Register 7 */
+#define REG_USBHS_HSTPIPISR8    (*(__I  uint32_t*)0x40038550U) /**< (USBHS) Host Pipe Status Register 8 */
+#define REG_USBHS_HSTPIPISR9    (*(__I  uint32_t*)0x40038554U) /**< (USBHS) Host Pipe Status Register 9 */
+#define REG_USBHS_HSTPIPICR     (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register */
+#define REG_USBHS_HSTPIPICR0    (*(__O  uint32_t*)0x40038560U) /**< (USBHS) Host Pipe Clear Register 0 */
+#define REG_USBHS_HSTPIPICR1    (*(__O  uint32_t*)0x40038564U) /**< (USBHS) Host Pipe Clear Register 1 */
+#define REG_USBHS_HSTPIPICR2    (*(__O  uint32_t*)0x40038568U) /**< (USBHS) Host Pipe Clear Register 2 */
+#define REG_USBHS_HSTPIPICR3    (*(__O  uint32_t*)0x4003856CU) /**< (USBHS) Host Pipe Clear Register 3 */
+#define REG_USBHS_HSTPIPICR4    (*(__O  uint32_t*)0x40038570U) /**< (USBHS) Host Pipe Clear Register 4 */
+#define REG_USBHS_HSTPIPICR5    (*(__O  uint32_t*)0x40038574U) /**< (USBHS) Host Pipe Clear Register 5 */
+#define REG_USBHS_HSTPIPICR6    (*(__O  uint32_t*)0x40038578U) /**< (USBHS) Host Pipe Clear Register 6 */
+#define REG_USBHS_HSTPIPICR7    (*(__O  uint32_t*)0x4003857CU) /**< (USBHS) Host Pipe Clear Register 7 */
+#define REG_USBHS_HSTPIPICR8    (*(__O  uint32_t*)0x40038580U) /**< (USBHS) Host Pipe Clear Register 8 */
+#define REG_USBHS_HSTPIPICR9    (*(__O  uint32_t*)0x40038584U) /**< (USBHS) Host Pipe Clear Register 9 */
+#define REG_USBHS_HSTPIPIFR     (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register */
+#define REG_USBHS_HSTPIPIFR0    (*(__O  uint32_t*)0x40038590U) /**< (USBHS) Host Pipe Set Register 0 */
+#define REG_USBHS_HSTPIPIFR1    (*(__O  uint32_t*)0x40038594U) /**< (USBHS) Host Pipe Set Register 1 */
+#define REG_USBHS_HSTPIPIFR2    (*(__O  uint32_t*)0x40038598U) /**< (USBHS) Host Pipe Set Register 2 */
+#define REG_USBHS_HSTPIPIFR3    (*(__O  uint32_t*)0x4003859CU) /**< (USBHS) Host Pipe Set Register 3 */
+#define REG_USBHS_HSTPIPIFR4    (*(__O  uint32_t*)0x400385A0U) /**< (USBHS) Host Pipe Set Register 4 */
+#define REG_USBHS_HSTPIPIFR5    (*(__O  uint32_t*)0x400385A4U) /**< (USBHS) Host Pipe Set Register 5 */
+#define REG_USBHS_HSTPIPIFR6    (*(__O  uint32_t*)0x400385A8U) /**< (USBHS) Host Pipe Set Register 6 */
+#define REG_USBHS_HSTPIPIFR7    (*(__O  uint32_t*)0x400385ACU) /**< (USBHS) Host Pipe Set Register 7 */
+#define REG_USBHS_HSTPIPIFR8    (*(__O  uint32_t*)0x400385B0U) /**< (USBHS) Host Pipe Set Register 8 */
+#define REG_USBHS_HSTPIPIFR9    (*(__O  uint32_t*)0x400385B4U) /**< (USBHS) Host Pipe Set Register 9 */
+#define REG_USBHS_HSTPIPIMR     (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register */
+#define REG_USBHS_HSTPIPIMR0    (*(__I  uint32_t*)0x400385C0U) /**< (USBHS) Host Pipe Mask Register 0 */
+#define REG_USBHS_HSTPIPIMR1    (*(__I  uint32_t*)0x400385C4U) /**< (USBHS) Host Pipe Mask Register 1 */
+#define REG_USBHS_HSTPIPIMR2    (*(__I  uint32_t*)0x400385C8U) /**< (USBHS) Host Pipe Mask Register 2 */
+#define REG_USBHS_HSTPIPIMR3    (*(__I  uint32_t*)0x400385CCU) /**< (USBHS) Host Pipe Mask Register 3 */
+#define REG_USBHS_HSTPIPIMR4    (*(__I  uint32_t*)0x400385D0U) /**< (USBHS) Host Pipe Mask Register 4 */
+#define REG_USBHS_HSTPIPIMR5    (*(__I  uint32_t*)0x400385D4U) /**< (USBHS) Host Pipe Mask Register 5 */
+#define REG_USBHS_HSTPIPIMR6    (*(__I  uint32_t*)0x400385D8U) /**< (USBHS) Host Pipe Mask Register 6 */
+#define REG_USBHS_HSTPIPIMR7    (*(__I  uint32_t*)0x400385DCU) /**< (USBHS) Host Pipe Mask Register 7 */
+#define REG_USBHS_HSTPIPIMR8    (*(__I  uint32_t*)0x400385E0U) /**< (USBHS) Host Pipe Mask Register 8 */
+#define REG_USBHS_HSTPIPIMR9    (*(__I  uint32_t*)0x400385E4U) /**< (USBHS) Host Pipe Mask Register 9 */
+#define REG_USBHS_HSTPIPIER     (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register */
+#define REG_USBHS_HSTPIPIER0    (*(__O  uint32_t*)0x400385F0U) /**< (USBHS) Host Pipe Enable Register 0 */
+#define REG_USBHS_HSTPIPIER1    (*(__O  uint32_t*)0x400385F4U) /**< (USBHS) Host Pipe Enable Register 1 */
+#define REG_USBHS_HSTPIPIER2    (*(__O  uint32_t*)0x400385F8U) /**< (USBHS) Host Pipe Enable Register 2 */
+#define REG_USBHS_HSTPIPIER3    (*(__O  uint32_t*)0x400385FCU) /**< (USBHS) Host Pipe Enable Register 3 */
+#define REG_USBHS_HSTPIPIER4    (*(__O  uint32_t*)0x40038600U) /**< (USBHS) Host Pipe Enable Register 4 */
+#define REG_USBHS_HSTPIPIER5    (*(__O  uint32_t*)0x40038604U) /**< (USBHS) Host Pipe Enable Register 5 */
+#define REG_USBHS_HSTPIPIER6    (*(__O  uint32_t*)0x40038608U) /**< (USBHS) Host Pipe Enable Register 6 */
+#define REG_USBHS_HSTPIPIER7    (*(__O  uint32_t*)0x4003860CU) /**< (USBHS) Host Pipe Enable Register 7 */
+#define REG_USBHS_HSTPIPIER8    (*(__O  uint32_t*)0x40038610U) /**< (USBHS) Host Pipe Enable Register 8 */
+#define REG_USBHS_HSTPIPIER9    (*(__O  uint32_t*)0x40038614U) /**< (USBHS) Host Pipe Enable Register 9 */
+#define REG_USBHS_HSTPIPIDR     (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register */
+#define REG_USBHS_HSTPIPIDR0    (*(__O  uint32_t*)0x40038620U) /**< (USBHS) Host Pipe Disable Register 0 */
+#define REG_USBHS_HSTPIPIDR1    (*(__O  uint32_t*)0x40038624U) /**< (USBHS) Host Pipe Disable Register 1 */
+#define REG_USBHS_HSTPIPIDR2    (*(__O  uint32_t*)0x40038628U) /**< (USBHS) Host Pipe Disable Register 2 */
+#define REG_USBHS_HSTPIPIDR3    (*(__O  uint32_t*)0x4003862CU) /**< (USBHS) Host Pipe Disable Register 3 */
+#define REG_USBHS_HSTPIPIDR4    (*(__O  uint32_t*)0x40038630U) /**< (USBHS) Host Pipe Disable Register 4 */
+#define REG_USBHS_HSTPIPIDR5    (*(__O  uint32_t*)0x40038634U) /**< (USBHS) Host Pipe Disable Register 5 */
+#define REG_USBHS_HSTPIPIDR6    (*(__O  uint32_t*)0x40038638U) /**< (USBHS) Host Pipe Disable Register 6 */
+#define REG_USBHS_HSTPIPIDR7    (*(__O  uint32_t*)0x4003863CU) /**< (USBHS) Host Pipe Disable Register 7 */
+#define REG_USBHS_HSTPIPIDR8    (*(__O  uint32_t*)0x40038640U) /**< (USBHS) Host Pipe Disable Register 8 */
+#define REG_USBHS_HSTPIPIDR9    (*(__O  uint32_t*)0x40038644U) /**< (USBHS) Host Pipe Disable Register 9 */
+#define REG_USBHS_HSTPIPINRQ    (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register */
+#define REG_USBHS_HSTPIPINRQ0   (*(__IO uint32_t*)0x40038650U) /**< (USBHS) Host Pipe IN Request Register 0 */
+#define REG_USBHS_HSTPIPINRQ1   (*(__IO uint32_t*)0x40038654U) /**< (USBHS) Host Pipe IN Request Register 1 */
+#define REG_USBHS_HSTPIPINRQ2   (*(__IO uint32_t*)0x40038658U) /**< (USBHS) Host Pipe IN Request Register 2 */
+#define REG_USBHS_HSTPIPINRQ3   (*(__IO uint32_t*)0x4003865CU) /**< (USBHS) Host Pipe IN Request Register 3 */
+#define REG_USBHS_HSTPIPINRQ4   (*(__IO uint32_t*)0x40038660U) /**< (USBHS) Host Pipe IN Request Register 4 */
+#define REG_USBHS_HSTPIPINRQ5   (*(__IO uint32_t*)0x40038664U) /**< (USBHS) Host Pipe IN Request Register 5 */
+#define REG_USBHS_HSTPIPINRQ6   (*(__IO uint32_t*)0x40038668U) /**< (USBHS) Host Pipe IN Request Register 6 */
+#define REG_USBHS_HSTPIPINRQ7   (*(__IO uint32_t*)0x4003866CU) /**< (USBHS) Host Pipe IN Request Register 7 */
+#define REG_USBHS_HSTPIPINRQ8   (*(__IO uint32_t*)0x40038670U) /**< (USBHS) Host Pipe IN Request Register 8 */
+#define REG_USBHS_HSTPIPINRQ9   (*(__IO uint32_t*)0x40038674U) /**< (USBHS) Host Pipe IN Request Register 9 */
+#define REG_USBHS_HSTPIPERR     (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register */
+#define REG_USBHS_HSTPIPERR0    (*(__IO uint32_t*)0x40038680U) /**< (USBHS) Host Pipe Error Register 0 */
+#define REG_USBHS_HSTPIPERR1    (*(__IO uint32_t*)0x40038684U) /**< (USBHS) Host Pipe Error Register 1 */
+#define REG_USBHS_HSTPIPERR2    (*(__IO uint32_t*)0x40038688U) /**< (USBHS) Host Pipe Error Register 2 */
+#define REG_USBHS_HSTPIPERR3    (*(__IO uint32_t*)0x4003868CU) /**< (USBHS) Host Pipe Error Register 3 */
+#define REG_USBHS_HSTPIPERR4    (*(__IO uint32_t*)0x40038690U) /**< (USBHS) Host Pipe Error Register 4 */
+#define REG_USBHS_HSTPIPERR5    (*(__IO uint32_t*)0x40038694U) /**< (USBHS) Host Pipe Error Register 5 */
+#define REG_USBHS_HSTPIPERR6    (*(__IO uint32_t*)0x40038698U) /**< (USBHS) Host Pipe Error Register 6 */
+#define REG_USBHS_HSTPIPERR7    (*(__IO uint32_t*)0x4003869CU) /**< (USBHS) Host Pipe Error Register 7 */
+#define REG_USBHS_HSTPIPERR8    (*(__IO uint32_t*)0x400386A0U) /**< (USBHS) Host Pipe Error Register 8 */
+#define REG_USBHS_HSTPIPERR9    (*(__IO uint32_t*)0x400386A4U) /**< (USBHS) Host Pipe Error Register 9 */
 #define REG_USBHS_CTRL          (*(__IO uint32_t*)0x40038800U) /**< (USBHS) General Control Register */
 #define REG_USBHS_SR            (*(__I  uint32_t*)0x40038804U) /**< (USBHS) General Status Register */
 #define REG_USBHS_SCR           (*(__O  uint32_t*)0x40038808U) /**< (USBHS) General Status Clear Register */
@@ -553,7 +555,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for USBHS peripheral ========== */
-#define USBHS_INSTANCE_ID                        34        
-#define USBHS_CLOCK_ID                           34        
+#define USBHS_INSTANCE_ID                        34         
+#define USBHS_CLOCK_ID                           34         
 
 #endif /* _SAME70_USBHS_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/utmi.h
+++ b/asf/sam/include/same70b/instance/utmi.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for UTMI
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_UTMI_INSTANCE_H_
 #define _SAME70_UTMI_INSTANCE_H_
 

--- a/asf/sam/include/same70b/instance/wdt.h
+++ b/asf/sam/include/same70b/instance/wdt.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for WDT
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_WDT_INSTANCE_H_
 #define _SAME70_WDT_INSTANCE_H_
 
@@ -45,6 +47,6 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for WDT peripheral ========== */
-#define WDT_INSTANCE_ID                          4         
+#define WDT_INSTANCE_ID                          4          
 
 #endif /* _SAME70_WDT_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/xdmac.h
+++ b/asf/sam/include/same70b/instance/xdmac.h
@@ -3,11 +3,13 @@
  *
  * \brief Instance description for XDMAC
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,349 +27,349 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70_XDMAC_INSTANCE_H_
 #define _SAME70_XDMAC_INSTANCE_H_
 
 /* ========== Register definition for XDMAC peripheral ========== */
 #if (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
 
-#define REG_XDMAC_CIE0          (0x40078050) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 0 */
-#define REG_XDMAC_CID0          (0x40078054) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 0 */
-#define REG_XDMAC_CIM0          (0x40078058) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 0 */
-#define REG_XDMAC_CIS0          (0x4007805C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 0 */
-#define REG_XDMAC_CSA0          (0x40078060) /**< (XDMAC) Channel Source Address Register (chid = 0) 0 */
-#define REG_XDMAC_CDA0          (0x40078064) /**< (XDMAC) Channel Destination Address Register (chid = 0) 0 */
-#define REG_XDMAC_CNDA0         (0x40078068) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 0 */
-#define REG_XDMAC_CNDC0         (0x4007806C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 0 */
-#define REG_XDMAC_CUBC0         (0x40078070) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 0 */
-#define REG_XDMAC_CBC0          (0x40078074) /**< (XDMAC) Channel Block Control Register (chid = 0) 0 */
-#define REG_XDMAC_CC0           (0x40078078) /**< (XDMAC) Channel Configuration Register (chid = 0) 0 */
-#define REG_XDMAC_CDS_MSP0      (0x4007807C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 0 */
-#define REG_XDMAC_CSUS0         (0x40078080) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 0 */
-#define REG_XDMAC_CDUS0         (0x40078084) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 0 */
-#define REG_XDMAC_CIE1          (0x40078090) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 1 */
-#define REG_XDMAC_CID1          (0x40078094) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 1 */
-#define REG_XDMAC_CIM1          (0x40078098) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 1 */
-#define REG_XDMAC_CIS1          (0x4007809C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 1 */
-#define REG_XDMAC_CSA1          (0x400780A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 1 */
-#define REG_XDMAC_CDA1          (0x400780A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 1 */
-#define REG_XDMAC_CNDA1         (0x400780A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 1 */
-#define REG_XDMAC_CNDC1         (0x400780AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 1 */
-#define REG_XDMAC_CUBC1         (0x400780B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 1 */
-#define REG_XDMAC_CBC1          (0x400780B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 1 */
-#define REG_XDMAC_CC1           (0x400780B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 1 */
-#define REG_XDMAC_CDS_MSP1      (0x400780BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 1 */
-#define REG_XDMAC_CSUS1         (0x400780C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 1 */
-#define REG_XDMAC_CDUS1         (0x400780C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 1 */
-#define REG_XDMAC_CIE2          (0x400780D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 2 */
-#define REG_XDMAC_CID2          (0x400780D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 2 */
-#define REG_XDMAC_CIM2          (0x400780D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 2 */
-#define REG_XDMAC_CIS2          (0x400780DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 2 */
-#define REG_XDMAC_CSA2          (0x400780E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 2 */
-#define REG_XDMAC_CDA2          (0x400780E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 2 */
-#define REG_XDMAC_CNDA2         (0x400780E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 2 */
-#define REG_XDMAC_CNDC2         (0x400780EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 2 */
-#define REG_XDMAC_CUBC2         (0x400780F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 2 */
-#define REG_XDMAC_CBC2          (0x400780F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 2 */
-#define REG_XDMAC_CC2           (0x400780F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 2 */
-#define REG_XDMAC_CDS_MSP2      (0x400780FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 2 */
-#define REG_XDMAC_CSUS2         (0x40078100) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 2 */
-#define REG_XDMAC_CDUS2         (0x40078104) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 2 */
-#define REG_XDMAC_CIE3          (0x40078110) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 3 */
-#define REG_XDMAC_CID3          (0x40078114) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 3 */
-#define REG_XDMAC_CIM3          (0x40078118) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 3 */
-#define REG_XDMAC_CIS3          (0x4007811C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 3 */
-#define REG_XDMAC_CSA3          (0x40078120) /**< (XDMAC) Channel Source Address Register (chid = 0) 3 */
-#define REG_XDMAC_CDA3          (0x40078124) /**< (XDMAC) Channel Destination Address Register (chid = 0) 3 */
-#define REG_XDMAC_CNDA3         (0x40078128) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 3 */
-#define REG_XDMAC_CNDC3         (0x4007812C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 3 */
-#define REG_XDMAC_CUBC3         (0x40078130) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 3 */
-#define REG_XDMAC_CBC3          (0x40078134) /**< (XDMAC) Channel Block Control Register (chid = 0) 3 */
-#define REG_XDMAC_CC3           (0x40078138) /**< (XDMAC) Channel Configuration Register (chid = 0) 3 */
-#define REG_XDMAC_CDS_MSP3      (0x4007813C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 3 */
-#define REG_XDMAC_CSUS3         (0x40078140) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 3 */
-#define REG_XDMAC_CDUS3         (0x40078144) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 3 */
-#define REG_XDMAC_CIE4          (0x40078150) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 4 */
-#define REG_XDMAC_CID4          (0x40078154) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 4 */
-#define REG_XDMAC_CIM4          (0x40078158) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 4 */
-#define REG_XDMAC_CIS4          (0x4007815C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 4 */
-#define REG_XDMAC_CSA4          (0x40078160) /**< (XDMAC) Channel Source Address Register (chid = 0) 4 */
-#define REG_XDMAC_CDA4          (0x40078164) /**< (XDMAC) Channel Destination Address Register (chid = 0) 4 */
-#define REG_XDMAC_CNDA4         (0x40078168) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 4 */
-#define REG_XDMAC_CNDC4         (0x4007816C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 4 */
-#define REG_XDMAC_CUBC4         (0x40078170) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 4 */
-#define REG_XDMAC_CBC4          (0x40078174) /**< (XDMAC) Channel Block Control Register (chid = 0) 4 */
-#define REG_XDMAC_CC4           (0x40078178) /**< (XDMAC) Channel Configuration Register (chid = 0) 4 */
-#define REG_XDMAC_CDS_MSP4      (0x4007817C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 4 */
-#define REG_XDMAC_CSUS4         (0x40078180) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 4 */
-#define REG_XDMAC_CDUS4         (0x40078184) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 4 */
-#define REG_XDMAC_CIE5          (0x40078190) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 5 */
-#define REG_XDMAC_CID5          (0x40078194) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 5 */
-#define REG_XDMAC_CIM5          (0x40078198) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 5 */
-#define REG_XDMAC_CIS5          (0x4007819C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 5 */
-#define REG_XDMAC_CSA5          (0x400781A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 5 */
-#define REG_XDMAC_CDA5          (0x400781A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 5 */
-#define REG_XDMAC_CNDA5         (0x400781A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 5 */
-#define REG_XDMAC_CNDC5         (0x400781AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 5 */
-#define REG_XDMAC_CUBC5         (0x400781B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 5 */
-#define REG_XDMAC_CBC5          (0x400781B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 5 */
-#define REG_XDMAC_CC5           (0x400781B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 5 */
-#define REG_XDMAC_CDS_MSP5      (0x400781BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 5 */
-#define REG_XDMAC_CSUS5         (0x400781C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 5 */
-#define REG_XDMAC_CDUS5         (0x400781C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 5 */
-#define REG_XDMAC_CIE6          (0x400781D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 6 */
-#define REG_XDMAC_CID6          (0x400781D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 6 */
-#define REG_XDMAC_CIM6          (0x400781D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 6 */
-#define REG_XDMAC_CIS6          (0x400781DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 6 */
-#define REG_XDMAC_CSA6          (0x400781E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 6 */
-#define REG_XDMAC_CDA6          (0x400781E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 6 */
-#define REG_XDMAC_CNDA6         (0x400781E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 6 */
-#define REG_XDMAC_CNDC6         (0x400781EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 6 */
-#define REG_XDMAC_CUBC6         (0x400781F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 6 */
-#define REG_XDMAC_CBC6          (0x400781F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 6 */
-#define REG_XDMAC_CC6           (0x400781F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 6 */
-#define REG_XDMAC_CDS_MSP6      (0x400781FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 6 */
-#define REG_XDMAC_CSUS6         (0x40078200) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 6 */
-#define REG_XDMAC_CDUS6         (0x40078204) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 6 */
-#define REG_XDMAC_CIE7          (0x40078210) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 7 */
-#define REG_XDMAC_CID7          (0x40078214) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 7 */
-#define REG_XDMAC_CIM7          (0x40078218) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 7 */
-#define REG_XDMAC_CIS7          (0x4007821C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 7 */
-#define REG_XDMAC_CSA7          (0x40078220) /**< (XDMAC) Channel Source Address Register (chid = 0) 7 */
-#define REG_XDMAC_CDA7          (0x40078224) /**< (XDMAC) Channel Destination Address Register (chid = 0) 7 */
-#define REG_XDMAC_CNDA7         (0x40078228) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 7 */
-#define REG_XDMAC_CNDC7         (0x4007822C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 7 */
-#define REG_XDMAC_CUBC7         (0x40078230) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 7 */
-#define REG_XDMAC_CBC7          (0x40078234) /**< (XDMAC) Channel Block Control Register (chid = 0) 7 */
-#define REG_XDMAC_CC7           (0x40078238) /**< (XDMAC) Channel Configuration Register (chid = 0) 7 */
-#define REG_XDMAC_CDS_MSP7      (0x4007823C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 7 */
-#define REG_XDMAC_CSUS7         (0x40078240) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 7 */
-#define REG_XDMAC_CDUS7         (0x40078244) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 7 */
-#define REG_XDMAC_CIE8          (0x40078250) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 8 */
-#define REG_XDMAC_CID8          (0x40078254) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 8 */
-#define REG_XDMAC_CIM8          (0x40078258) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 8 */
-#define REG_XDMAC_CIS8          (0x4007825C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 8 */
-#define REG_XDMAC_CSA8          (0x40078260) /**< (XDMAC) Channel Source Address Register (chid = 0) 8 */
-#define REG_XDMAC_CDA8          (0x40078264) /**< (XDMAC) Channel Destination Address Register (chid = 0) 8 */
-#define REG_XDMAC_CNDA8         (0x40078268) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 8 */
-#define REG_XDMAC_CNDC8         (0x4007826C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 8 */
-#define REG_XDMAC_CUBC8         (0x40078270) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 8 */
-#define REG_XDMAC_CBC8          (0x40078274) /**< (XDMAC) Channel Block Control Register (chid = 0) 8 */
-#define REG_XDMAC_CC8           (0x40078278) /**< (XDMAC) Channel Configuration Register (chid = 0) 8 */
-#define REG_XDMAC_CDS_MSP8      (0x4007827C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 8 */
-#define REG_XDMAC_CSUS8         (0x40078280) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 8 */
-#define REG_XDMAC_CDUS8         (0x40078284) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 8 */
-#define REG_XDMAC_CIE9          (0x40078290) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 9 */
-#define REG_XDMAC_CID9          (0x40078294) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 9 */
-#define REG_XDMAC_CIM9          (0x40078298) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 9 */
-#define REG_XDMAC_CIS9          (0x4007829C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 9 */
-#define REG_XDMAC_CSA9          (0x400782A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 9 */
-#define REG_XDMAC_CDA9          (0x400782A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 9 */
-#define REG_XDMAC_CNDA9         (0x400782A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 9 */
-#define REG_XDMAC_CNDC9         (0x400782AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 9 */
-#define REG_XDMAC_CUBC9         (0x400782B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 9 */
-#define REG_XDMAC_CBC9          (0x400782B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 9 */
-#define REG_XDMAC_CC9           (0x400782B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 9 */
-#define REG_XDMAC_CDS_MSP9      (0x400782BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 9 */
-#define REG_XDMAC_CSUS9         (0x400782C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 9 */
-#define REG_XDMAC_CDUS9         (0x400782C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 9 */
-#define REG_XDMAC_CIE10         (0x400782D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 10 */
-#define REG_XDMAC_CID10         (0x400782D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 10 */
-#define REG_XDMAC_CIM10         (0x400782D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 10 */
-#define REG_XDMAC_CIS10         (0x400782DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 10 */
-#define REG_XDMAC_CSA10         (0x400782E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 10 */
-#define REG_XDMAC_CDA10         (0x400782E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 10 */
-#define REG_XDMAC_CNDA10        (0x400782E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 10 */
-#define REG_XDMAC_CNDC10        (0x400782EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 10 */
-#define REG_XDMAC_CUBC10        (0x400782F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 10 */
-#define REG_XDMAC_CBC10         (0x400782F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 10 */
-#define REG_XDMAC_CC10          (0x400782F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 10 */
-#define REG_XDMAC_CDS_MSP10     (0x400782FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 10 */
-#define REG_XDMAC_CSUS10        (0x40078300) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 10 */
-#define REG_XDMAC_CDUS10        (0x40078304) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 10 */
-#define REG_XDMAC_CIE11         (0x40078310) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 11 */
-#define REG_XDMAC_CID11         (0x40078314) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 11 */
-#define REG_XDMAC_CIM11         (0x40078318) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 11 */
-#define REG_XDMAC_CIS11         (0x4007831C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 11 */
-#define REG_XDMAC_CSA11         (0x40078320) /**< (XDMAC) Channel Source Address Register (chid = 0) 11 */
-#define REG_XDMAC_CDA11         (0x40078324) /**< (XDMAC) Channel Destination Address Register (chid = 0) 11 */
-#define REG_XDMAC_CNDA11        (0x40078328) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 11 */
-#define REG_XDMAC_CNDC11        (0x4007832C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 11 */
-#define REG_XDMAC_CUBC11        (0x40078330) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 11 */
-#define REG_XDMAC_CBC11         (0x40078334) /**< (XDMAC) Channel Block Control Register (chid = 0) 11 */
-#define REG_XDMAC_CC11          (0x40078338) /**< (XDMAC) Channel Configuration Register (chid = 0) 11 */
-#define REG_XDMAC_CDS_MSP11     (0x4007833C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 11 */
-#define REG_XDMAC_CSUS11        (0x40078340) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 11 */
-#define REG_XDMAC_CDUS11        (0x40078344) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 11 */
-#define REG_XDMAC_CIE12         (0x40078350) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 12 */
-#define REG_XDMAC_CID12         (0x40078354) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 12 */
-#define REG_XDMAC_CIM12         (0x40078358) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 12 */
-#define REG_XDMAC_CIS12         (0x4007835C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 12 */
-#define REG_XDMAC_CSA12         (0x40078360) /**< (XDMAC) Channel Source Address Register (chid = 0) 12 */
-#define REG_XDMAC_CDA12         (0x40078364) /**< (XDMAC) Channel Destination Address Register (chid = 0) 12 */
-#define REG_XDMAC_CNDA12        (0x40078368) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 12 */
-#define REG_XDMAC_CNDC12        (0x4007836C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 12 */
-#define REG_XDMAC_CUBC12        (0x40078370) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 12 */
-#define REG_XDMAC_CBC12         (0x40078374) /**< (XDMAC) Channel Block Control Register (chid = 0) 12 */
-#define REG_XDMAC_CC12          (0x40078378) /**< (XDMAC) Channel Configuration Register (chid = 0) 12 */
-#define REG_XDMAC_CDS_MSP12     (0x4007837C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 12 */
-#define REG_XDMAC_CSUS12        (0x40078380) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 12 */
-#define REG_XDMAC_CDUS12        (0x40078384) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 12 */
-#define REG_XDMAC_CIE13         (0x40078390) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 13 */
-#define REG_XDMAC_CID13         (0x40078394) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 13 */
-#define REG_XDMAC_CIM13         (0x40078398) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 13 */
-#define REG_XDMAC_CIS13         (0x4007839C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 13 */
-#define REG_XDMAC_CSA13         (0x400783A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 13 */
-#define REG_XDMAC_CDA13         (0x400783A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 13 */
-#define REG_XDMAC_CNDA13        (0x400783A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 13 */
-#define REG_XDMAC_CNDC13        (0x400783AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 13 */
-#define REG_XDMAC_CUBC13        (0x400783B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 13 */
-#define REG_XDMAC_CBC13         (0x400783B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 13 */
-#define REG_XDMAC_CC13          (0x400783B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 13 */
-#define REG_XDMAC_CDS_MSP13     (0x400783BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 13 */
-#define REG_XDMAC_CSUS13        (0x400783C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 13 */
-#define REG_XDMAC_CDUS13        (0x400783C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 13 */
-#define REG_XDMAC_CIE14         (0x400783D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 14 */
-#define REG_XDMAC_CID14         (0x400783D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 14 */
-#define REG_XDMAC_CIM14         (0x400783D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 14 */
-#define REG_XDMAC_CIS14         (0x400783DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 14 */
-#define REG_XDMAC_CSA14         (0x400783E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 14 */
-#define REG_XDMAC_CDA14         (0x400783E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 14 */
-#define REG_XDMAC_CNDA14        (0x400783E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 14 */
-#define REG_XDMAC_CNDC14        (0x400783EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 14 */
-#define REG_XDMAC_CUBC14        (0x400783F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 14 */
-#define REG_XDMAC_CBC14         (0x400783F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 14 */
-#define REG_XDMAC_CC14          (0x400783F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 14 */
-#define REG_XDMAC_CDS_MSP14     (0x400783FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 14 */
-#define REG_XDMAC_CSUS14        (0x40078400) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 14 */
-#define REG_XDMAC_CDUS14        (0x40078404) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 14 */
-#define REG_XDMAC_CIE15         (0x40078410) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 15 */
-#define REG_XDMAC_CID15         (0x40078414) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 15 */
-#define REG_XDMAC_CIM15         (0x40078418) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 15 */
-#define REG_XDMAC_CIS15         (0x4007841C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 15 */
-#define REG_XDMAC_CSA15         (0x40078420) /**< (XDMAC) Channel Source Address Register (chid = 0) 15 */
-#define REG_XDMAC_CDA15         (0x40078424) /**< (XDMAC) Channel Destination Address Register (chid = 0) 15 */
-#define REG_XDMAC_CNDA15        (0x40078428) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 15 */
-#define REG_XDMAC_CNDC15        (0x4007842C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 15 */
-#define REG_XDMAC_CUBC15        (0x40078430) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 15 */
-#define REG_XDMAC_CBC15         (0x40078434) /**< (XDMAC) Channel Block Control Register (chid = 0) 15 */
-#define REG_XDMAC_CC15          (0x40078438) /**< (XDMAC) Channel Configuration Register (chid = 0) 15 */
-#define REG_XDMAC_CDS_MSP15     (0x4007843C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 15 */
-#define REG_XDMAC_CSUS15        (0x40078440) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 15 */
-#define REG_XDMAC_CDUS15        (0x40078444) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 15 */
-#define REG_XDMAC_CIE16         (0x40078450) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 16 */
-#define REG_XDMAC_CID16         (0x40078454) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 16 */
-#define REG_XDMAC_CIM16         (0x40078458) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 16 */
-#define REG_XDMAC_CIS16         (0x4007845C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 16 */
-#define REG_XDMAC_CSA16         (0x40078460) /**< (XDMAC) Channel Source Address Register (chid = 0) 16 */
-#define REG_XDMAC_CDA16         (0x40078464) /**< (XDMAC) Channel Destination Address Register (chid = 0) 16 */
-#define REG_XDMAC_CNDA16        (0x40078468) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 16 */
-#define REG_XDMAC_CNDC16        (0x4007846C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 16 */
-#define REG_XDMAC_CUBC16        (0x40078470) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 16 */
-#define REG_XDMAC_CBC16         (0x40078474) /**< (XDMAC) Channel Block Control Register (chid = 0) 16 */
-#define REG_XDMAC_CC16          (0x40078478) /**< (XDMAC) Channel Configuration Register (chid = 0) 16 */
-#define REG_XDMAC_CDS_MSP16     (0x4007847C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 16 */
-#define REG_XDMAC_CSUS16        (0x40078480) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 16 */
-#define REG_XDMAC_CDUS16        (0x40078484) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 16 */
-#define REG_XDMAC_CIE17         (0x40078490) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 17 */
-#define REG_XDMAC_CID17         (0x40078494) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 17 */
-#define REG_XDMAC_CIM17         (0x40078498) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 17 */
-#define REG_XDMAC_CIS17         (0x4007849C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 17 */
-#define REG_XDMAC_CSA17         (0x400784A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 17 */
-#define REG_XDMAC_CDA17         (0x400784A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 17 */
-#define REG_XDMAC_CNDA17        (0x400784A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 17 */
-#define REG_XDMAC_CNDC17        (0x400784AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 17 */
-#define REG_XDMAC_CUBC17        (0x400784B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 17 */
-#define REG_XDMAC_CBC17         (0x400784B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 17 */
-#define REG_XDMAC_CC17          (0x400784B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 17 */
-#define REG_XDMAC_CDS_MSP17     (0x400784BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 17 */
-#define REG_XDMAC_CSUS17        (0x400784C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 17 */
-#define REG_XDMAC_CDUS17        (0x400784C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 17 */
-#define REG_XDMAC_CIE18         (0x400784D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 18 */
-#define REG_XDMAC_CID18         (0x400784D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 18 */
-#define REG_XDMAC_CIM18         (0x400784D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 18 */
-#define REG_XDMAC_CIS18         (0x400784DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 18 */
-#define REG_XDMAC_CSA18         (0x400784E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 18 */
-#define REG_XDMAC_CDA18         (0x400784E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 18 */
-#define REG_XDMAC_CNDA18        (0x400784E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 18 */
-#define REG_XDMAC_CNDC18        (0x400784EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 18 */
-#define REG_XDMAC_CUBC18        (0x400784F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 18 */
-#define REG_XDMAC_CBC18         (0x400784F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 18 */
-#define REG_XDMAC_CC18          (0x400784F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 18 */
-#define REG_XDMAC_CDS_MSP18     (0x400784FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 18 */
-#define REG_XDMAC_CSUS18        (0x40078500) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 18 */
-#define REG_XDMAC_CDUS18        (0x40078504) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 18 */
-#define REG_XDMAC_CIE19         (0x40078510) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 19 */
-#define REG_XDMAC_CID19         (0x40078514) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 19 */
-#define REG_XDMAC_CIM19         (0x40078518) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 19 */
-#define REG_XDMAC_CIS19         (0x4007851C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 19 */
-#define REG_XDMAC_CSA19         (0x40078520) /**< (XDMAC) Channel Source Address Register (chid = 0) 19 */
-#define REG_XDMAC_CDA19         (0x40078524) /**< (XDMAC) Channel Destination Address Register (chid = 0) 19 */
-#define REG_XDMAC_CNDA19        (0x40078528) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 19 */
-#define REG_XDMAC_CNDC19        (0x4007852C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 19 */
-#define REG_XDMAC_CUBC19        (0x40078530) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 19 */
-#define REG_XDMAC_CBC19         (0x40078534) /**< (XDMAC) Channel Block Control Register (chid = 0) 19 */
-#define REG_XDMAC_CC19          (0x40078538) /**< (XDMAC) Channel Configuration Register (chid = 0) 19 */
-#define REG_XDMAC_CDS_MSP19     (0x4007853C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 19 */
-#define REG_XDMAC_CSUS19        (0x40078540) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 19 */
-#define REG_XDMAC_CDUS19        (0x40078544) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 19 */
-#define REG_XDMAC_CIE20         (0x40078550) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 20 */
-#define REG_XDMAC_CID20         (0x40078554) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 20 */
-#define REG_XDMAC_CIM20         (0x40078558) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 20 */
-#define REG_XDMAC_CIS20         (0x4007855C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 20 */
-#define REG_XDMAC_CSA20         (0x40078560) /**< (XDMAC) Channel Source Address Register (chid = 0) 20 */
-#define REG_XDMAC_CDA20         (0x40078564) /**< (XDMAC) Channel Destination Address Register (chid = 0) 20 */
-#define REG_XDMAC_CNDA20        (0x40078568) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 20 */
-#define REG_XDMAC_CNDC20        (0x4007856C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 20 */
-#define REG_XDMAC_CUBC20        (0x40078570) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 20 */
-#define REG_XDMAC_CBC20         (0x40078574) /**< (XDMAC) Channel Block Control Register (chid = 0) 20 */
-#define REG_XDMAC_CC20          (0x40078578) /**< (XDMAC) Channel Configuration Register (chid = 0) 20 */
-#define REG_XDMAC_CDS_MSP20     (0x4007857C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 20 */
-#define REG_XDMAC_CSUS20        (0x40078580) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 20 */
-#define REG_XDMAC_CDUS20        (0x40078584) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 20 */
-#define REG_XDMAC_CIE21         (0x40078590) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 21 */
-#define REG_XDMAC_CID21         (0x40078594) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 21 */
-#define REG_XDMAC_CIM21         (0x40078598) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 21 */
-#define REG_XDMAC_CIS21         (0x4007859C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 21 */
-#define REG_XDMAC_CSA21         (0x400785A0) /**< (XDMAC) Channel Source Address Register (chid = 0) 21 */
-#define REG_XDMAC_CDA21         (0x400785A4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 21 */
-#define REG_XDMAC_CNDA21        (0x400785A8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 21 */
-#define REG_XDMAC_CNDC21        (0x400785AC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 21 */
-#define REG_XDMAC_CUBC21        (0x400785B0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 21 */
-#define REG_XDMAC_CBC21         (0x400785B4) /**< (XDMAC) Channel Block Control Register (chid = 0) 21 */
-#define REG_XDMAC_CC21          (0x400785B8) /**< (XDMAC) Channel Configuration Register (chid = 0) 21 */
-#define REG_XDMAC_CDS_MSP21     (0x400785BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 21 */
-#define REG_XDMAC_CSUS21        (0x400785C0) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 21 */
-#define REG_XDMAC_CDUS21        (0x400785C4) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 21 */
-#define REG_XDMAC_CIE22         (0x400785D0) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 22 */
-#define REG_XDMAC_CID22         (0x400785D4) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 22 */
-#define REG_XDMAC_CIM22         (0x400785D8) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 22 */
-#define REG_XDMAC_CIS22         (0x400785DC) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 22 */
-#define REG_XDMAC_CSA22         (0x400785E0) /**< (XDMAC) Channel Source Address Register (chid = 0) 22 */
-#define REG_XDMAC_CDA22         (0x400785E4) /**< (XDMAC) Channel Destination Address Register (chid = 0) 22 */
-#define REG_XDMAC_CNDA22        (0x400785E8) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 22 */
-#define REG_XDMAC_CNDC22        (0x400785EC) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 22 */
-#define REG_XDMAC_CUBC22        (0x400785F0) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 22 */
-#define REG_XDMAC_CBC22         (0x400785F4) /**< (XDMAC) Channel Block Control Register (chid = 0) 22 */
-#define REG_XDMAC_CC22          (0x400785F8) /**< (XDMAC) Channel Configuration Register (chid = 0) 22 */
-#define REG_XDMAC_CDS_MSP22     (0x400785FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 22 */
-#define REG_XDMAC_CSUS22        (0x40078600) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 22 */
-#define REG_XDMAC_CDUS22        (0x40078604) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 22 */
-#define REG_XDMAC_CIE23         (0x40078610) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 23 */
-#define REG_XDMAC_CID23         (0x40078614) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 23 */
-#define REG_XDMAC_CIM23         (0x40078618) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 23 */
-#define REG_XDMAC_CIS23         (0x4007861C) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 23 */
-#define REG_XDMAC_CSA23         (0x40078620) /**< (XDMAC) Channel Source Address Register (chid = 0) 23 */
-#define REG_XDMAC_CDA23         (0x40078624) /**< (XDMAC) Channel Destination Address Register (chid = 0) 23 */
-#define REG_XDMAC_CNDA23        (0x40078628) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 23 */
-#define REG_XDMAC_CNDC23        (0x4007862C) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 23 */
-#define REG_XDMAC_CUBC23        (0x40078630) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 23 */
-#define REG_XDMAC_CBC23         (0x40078634) /**< (XDMAC) Channel Block Control Register (chid = 0) 23 */
-#define REG_XDMAC_CC23          (0x40078638) /**< (XDMAC) Channel Configuration Register (chid = 0) 23 */
-#define REG_XDMAC_CDS_MSP23     (0x4007863C) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 23 */
-#define REG_XDMAC_CSUS23        (0x40078640) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 23 */
-#define REG_XDMAC_CDUS23        (0x40078644) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_CIE0          (0x40078050) /**< (XDMAC) Channel Interrupt Enable Register 0 */
+#define REG_XDMAC_CID0          (0x40078054) /**< (XDMAC) Channel Interrupt Disable Register 0 */
+#define REG_XDMAC_CIM0          (0x40078058) /**< (XDMAC) Channel Interrupt Mask Register 0 */
+#define REG_XDMAC_CIS0          (0x4007805C) /**< (XDMAC) Channel Interrupt Status Register 0 */
+#define REG_XDMAC_CSA0          (0x40078060) /**< (XDMAC) Channel Source Address Register 0 */
+#define REG_XDMAC_CDA0          (0x40078064) /**< (XDMAC) Channel Destination Address Register 0 */
+#define REG_XDMAC_CNDA0         (0x40078068) /**< (XDMAC) Channel Next Descriptor Address Register 0 */
+#define REG_XDMAC_CNDC0         (0x4007806C) /**< (XDMAC) Channel Next Descriptor Control Register 0 */
+#define REG_XDMAC_CUBC0         (0x40078070) /**< (XDMAC) Channel Microblock Control Register 0 */
+#define REG_XDMAC_CBC0          (0x40078074) /**< (XDMAC) Channel Block Control Register 0 */
+#define REG_XDMAC_CC0           (0x40078078) /**< (XDMAC) Channel Configuration Register 0 */
+#define REG_XDMAC_CDS_MSP0      (0x4007807C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 0 */
+#define REG_XDMAC_CSUS0         (0x40078080) /**< (XDMAC) Channel Source Microblock Stride 0 */
+#define REG_XDMAC_CDUS0         (0x40078084) /**< (XDMAC) Channel Destination Microblock Stride 0 */
+#define REG_XDMAC_CIE1          (0x40078090) /**< (XDMAC) Channel Interrupt Enable Register 1 */
+#define REG_XDMAC_CID1          (0x40078094) /**< (XDMAC) Channel Interrupt Disable Register 1 */
+#define REG_XDMAC_CIM1          (0x40078098) /**< (XDMAC) Channel Interrupt Mask Register 1 */
+#define REG_XDMAC_CIS1          (0x4007809C) /**< (XDMAC) Channel Interrupt Status Register 1 */
+#define REG_XDMAC_CSA1          (0x400780A0) /**< (XDMAC) Channel Source Address Register 1 */
+#define REG_XDMAC_CDA1          (0x400780A4) /**< (XDMAC) Channel Destination Address Register 1 */
+#define REG_XDMAC_CNDA1         (0x400780A8) /**< (XDMAC) Channel Next Descriptor Address Register 1 */
+#define REG_XDMAC_CNDC1         (0x400780AC) /**< (XDMAC) Channel Next Descriptor Control Register 1 */
+#define REG_XDMAC_CUBC1         (0x400780B0) /**< (XDMAC) Channel Microblock Control Register 1 */
+#define REG_XDMAC_CBC1          (0x400780B4) /**< (XDMAC) Channel Block Control Register 1 */
+#define REG_XDMAC_CC1           (0x400780B8) /**< (XDMAC) Channel Configuration Register 1 */
+#define REG_XDMAC_CDS_MSP1      (0x400780BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 1 */
+#define REG_XDMAC_CSUS1         (0x400780C0) /**< (XDMAC) Channel Source Microblock Stride 1 */
+#define REG_XDMAC_CDUS1         (0x400780C4) /**< (XDMAC) Channel Destination Microblock Stride 1 */
+#define REG_XDMAC_CIE2          (0x400780D0) /**< (XDMAC) Channel Interrupt Enable Register 2 */
+#define REG_XDMAC_CID2          (0x400780D4) /**< (XDMAC) Channel Interrupt Disable Register 2 */
+#define REG_XDMAC_CIM2          (0x400780D8) /**< (XDMAC) Channel Interrupt Mask Register 2 */
+#define REG_XDMAC_CIS2          (0x400780DC) /**< (XDMAC) Channel Interrupt Status Register 2 */
+#define REG_XDMAC_CSA2          (0x400780E0) /**< (XDMAC) Channel Source Address Register 2 */
+#define REG_XDMAC_CDA2          (0x400780E4) /**< (XDMAC) Channel Destination Address Register 2 */
+#define REG_XDMAC_CNDA2         (0x400780E8) /**< (XDMAC) Channel Next Descriptor Address Register 2 */
+#define REG_XDMAC_CNDC2         (0x400780EC) /**< (XDMAC) Channel Next Descriptor Control Register 2 */
+#define REG_XDMAC_CUBC2         (0x400780F0) /**< (XDMAC) Channel Microblock Control Register 2 */
+#define REG_XDMAC_CBC2          (0x400780F4) /**< (XDMAC) Channel Block Control Register 2 */
+#define REG_XDMAC_CC2           (0x400780F8) /**< (XDMAC) Channel Configuration Register 2 */
+#define REG_XDMAC_CDS_MSP2      (0x400780FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 2 */
+#define REG_XDMAC_CSUS2         (0x40078100) /**< (XDMAC) Channel Source Microblock Stride 2 */
+#define REG_XDMAC_CDUS2         (0x40078104) /**< (XDMAC) Channel Destination Microblock Stride 2 */
+#define REG_XDMAC_CIE3          (0x40078110) /**< (XDMAC) Channel Interrupt Enable Register 3 */
+#define REG_XDMAC_CID3          (0x40078114) /**< (XDMAC) Channel Interrupt Disable Register 3 */
+#define REG_XDMAC_CIM3          (0x40078118) /**< (XDMAC) Channel Interrupt Mask Register 3 */
+#define REG_XDMAC_CIS3          (0x4007811C) /**< (XDMAC) Channel Interrupt Status Register 3 */
+#define REG_XDMAC_CSA3          (0x40078120) /**< (XDMAC) Channel Source Address Register 3 */
+#define REG_XDMAC_CDA3          (0x40078124) /**< (XDMAC) Channel Destination Address Register 3 */
+#define REG_XDMAC_CNDA3         (0x40078128) /**< (XDMAC) Channel Next Descriptor Address Register 3 */
+#define REG_XDMAC_CNDC3         (0x4007812C) /**< (XDMAC) Channel Next Descriptor Control Register 3 */
+#define REG_XDMAC_CUBC3         (0x40078130) /**< (XDMAC) Channel Microblock Control Register 3 */
+#define REG_XDMAC_CBC3          (0x40078134) /**< (XDMAC) Channel Block Control Register 3 */
+#define REG_XDMAC_CC3           (0x40078138) /**< (XDMAC) Channel Configuration Register 3 */
+#define REG_XDMAC_CDS_MSP3      (0x4007813C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 3 */
+#define REG_XDMAC_CSUS3         (0x40078140) /**< (XDMAC) Channel Source Microblock Stride 3 */
+#define REG_XDMAC_CDUS3         (0x40078144) /**< (XDMAC) Channel Destination Microblock Stride 3 */
+#define REG_XDMAC_CIE4          (0x40078150) /**< (XDMAC) Channel Interrupt Enable Register 4 */
+#define REG_XDMAC_CID4          (0x40078154) /**< (XDMAC) Channel Interrupt Disable Register 4 */
+#define REG_XDMAC_CIM4          (0x40078158) /**< (XDMAC) Channel Interrupt Mask Register 4 */
+#define REG_XDMAC_CIS4          (0x4007815C) /**< (XDMAC) Channel Interrupt Status Register 4 */
+#define REG_XDMAC_CSA4          (0x40078160) /**< (XDMAC) Channel Source Address Register 4 */
+#define REG_XDMAC_CDA4          (0x40078164) /**< (XDMAC) Channel Destination Address Register 4 */
+#define REG_XDMAC_CNDA4         (0x40078168) /**< (XDMAC) Channel Next Descriptor Address Register 4 */
+#define REG_XDMAC_CNDC4         (0x4007816C) /**< (XDMAC) Channel Next Descriptor Control Register 4 */
+#define REG_XDMAC_CUBC4         (0x40078170) /**< (XDMAC) Channel Microblock Control Register 4 */
+#define REG_XDMAC_CBC4          (0x40078174) /**< (XDMAC) Channel Block Control Register 4 */
+#define REG_XDMAC_CC4           (0x40078178) /**< (XDMAC) Channel Configuration Register 4 */
+#define REG_XDMAC_CDS_MSP4      (0x4007817C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 4 */
+#define REG_XDMAC_CSUS4         (0x40078180) /**< (XDMAC) Channel Source Microblock Stride 4 */
+#define REG_XDMAC_CDUS4         (0x40078184) /**< (XDMAC) Channel Destination Microblock Stride 4 */
+#define REG_XDMAC_CIE5          (0x40078190) /**< (XDMAC) Channel Interrupt Enable Register 5 */
+#define REG_XDMAC_CID5          (0x40078194) /**< (XDMAC) Channel Interrupt Disable Register 5 */
+#define REG_XDMAC_CIM5          (0x40078198) /**< (XDMAC) Channel Interrupt Mask Register 5 */
+#define REG_XDMAC_CIS5          (0x4007819C) /**< (XDMAC) Channel Interrupt Status Register 5 */
+#define REG_XDMAC_CSA5          (0x400781A0) /**< (XDMAC) Channel Source Address Register 5 */
+#define REG_XDMAC_CDA5          (0x400781A4) /**< (XDMAC) Channel Destination Address Register 5 */
+#define REG_XDMAC_CNDA5         (0x400781A8) /**< (XDMAC) Channel Next Descriptor Address Register 5 */
+#define REG_XDMAC_CNDC5         (0x400781AC) /**< (XDMAC) Channel Next Descriptor Control Register 5 */
+#define REG_XDMAC_CUBC5         (0x400781B0) /**< (XDMAC) Channel Microblock Control Register 5 */
+#define REG_XDMAC_CBC5          (0x400781B4) /**< (XDMAC) Channel Block Control Register 5 */
+#define REG_XDMAC_CC5           (0x400781B8) /**< (XDMAC) Channel Configuration Register 5 */
+#define REG_XDMAC_CDS_MSP5      (0x400781BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 5 */
+#define REG_XDMAC_CSUS5         (0x400781C0) /**< (XDMAC) Channel Source Microblock Stride 5 */
+#define REG_XDMAC_CDUS5         (0x400781C4) /**< (XDMAC) Channel Destination Microblock Stride 5 */
+#define REG_XDMAC_CIE6          (0x400781D0) /**< (XDMAC) Channel Interrupt Enable Register 6 */
+#define REG_XDMAC_CID6          (0x400781D4) /**< (XDMAC) Channel Interrupt Disable Register 6 */
+#define REG_XDMAC_CIM6          (0x400781D8) /**< (XDMAC) Channel Interrupt Mask Register 6 */
+#define REG_XDMAC_CIS6          (0x400781DC) /**< (XDMAC) Channel Interrupt Status Register 6 */
+#define REG_XDMAC_CSA6          (0x400781E0) /**< (XDMAC) Channel Source Address Register 6 */
+#define REG_XDMAC_CDA6          (0x400781E4) /**< (XDMAC) Channel Destination Address Register 6 */
+#define REG_XDMAC_CNDA6         (0x400781E8) /**< (XDMAC) Channel Next Descriptor Address Register 6 */
+#define REG_XDMAC_CNDC6         (0x400781EC) /**< (XDMAC) Channel Next Descriptor Control Register 6 */
+#define REG_XDMAC_CUBC6         (0x400781F0) /**< (XDMAC) Channel Microblock Control Register 6 */
+#define REG_XDMAC_CBC6          (0x400781F4) /**< (XDMAC) Channel Block Control Register 6 */
+#define REG_XDMAC_CC6           (0x400781F8) /**< (XDMAC) Channel Configuration Register 6 */
+#define REG_XDMAC_CDS_MSP6      (0x400781FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 6 */
+#define REG_XDMAC_CSUS6         (0x40078200) /**< (XDMAC) Channel Source Microblock Stride 6 */
+#define REG_XDMAC_CDUS6         (0x40078204) /**< (XDMAC) Channel Destination Microblock Stride 6 */
+#define REG_XDMAC_CIE7          (0x40078210) /**< (XDMAC) Channel Interrupt Enable Register 7 */
+#define REG_XDMAC_CID7          (0x40078214) /**< (XDMAC) Channel Interrupt Disable Register 7 */
+#define REG_XDMAC_CIM7          (0x40078218) /**< (XDMAC) Channel Interrupt Mask Register 7 */
+#define REG_XDMAC_CIS7          (0x4007821C) /**< (XDMAC) Channel Interrupt Status Register 7 */
+#define REG_XDMAC_CSA7          (0x40078220) /**< (XDMAC) Channel Source Address Register 7 */
+#define REG_XDMAC_CDA7          (0x40078224) /**< (XDMAC) Channel Destination Address Register 7 */
+#define REG_XDMAC_CNDA7         (0x40078228) /**< (XDMAC) Channel Next Descriptor Address Register 7 */
+#define REG_XDMAC_CNDC7         (0x4007822C) /**< (XDMAC) Channel Next Descriptor Control Register 7 */
+#define REG_XDMAC_CUBC7         (0x40078230) /**< (XDMAC) Channel Microblock Control Register 7 */
+#define REG_XDMAC_CBC7          (0x40078234) /**< (XDMAC) Channel Block Control Register 7 */
+#define REG_XDMAC_CC7           (0x40078238) /**< (XDMAC) Channel Configuration Register 7 */
+#define REG_XDMAC_CDS_MSP7      (0x4007823C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 7 */
+#define REG_XDMAC_CSUS7         (0x40078240) /**< (XDMAC) Channel Source Microblock Stride 7 */
+#define REG_XDMAC_CDUS7         (0x40078244) /**< (XDMAC) Channel Destination Microblock Stride 7 */
+#define REG_XDMAC_CIE8          (0x40078250) /**< (XDMAC) Channel Interrupt Enable Register 8 */
+#define REG_XDMAC_CID8          (0x40078254) /**< (XDMAC) Channel Interrupt Disable Register 8 */
+#define REG_XDMAC_CIM8          (0x40078258) /**< (XDMAC) Channel Interrupt Mask Register 8 */
+#define REG_XDMAC_CIS8          (0x4007825C) /**< (XDMAC) Channel Interrupt Status Register 8 */
+#define REG_XDMAC_CSA8          (0x40078260) /**< (XDMAC) Channel Source Address Register 8 */
+#define REG_XDMAC_CDA8          (0x40078264) /**< (XDMAC) Channel Destination Address Register 8 */
+#define REG_XDMAC_CNDA8         (0x40078268) /**< (XDMAC) Channel Next Descriptor Address Register 8 */
+#define REG_XDMAC_CNDC8         (0x4007826C) /**< (XDMAC) Channel Next Descriptor Control Register 8 */
+#define REG_XDMAC_CUBC8         (0x40078270) /**< (XDMAC) Channel Microblock Control Register 8 */
+#define REG_XDMAC_CBC8          (0x40078274) /**< (XDMAC) Channel Block Control Register 8 */
+#define REG_XDMAC_CC8           (0x40078278) /**< (XDMAC) Channel Configuration Register 8 */
+#define REG_XDMAC_CDS_MSP8      (0x4007827C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 8 */
+#define REG_XDMAC_CSUS8         (0x40078280) /**< (XDMAC) Channel Source Microblock Stride 8 */
+#define REG_XDMAC_CDUS8         (0x40078284) /**< (XDMAC) Channel Destination Microblock Stride 8 */
+#define REG_XDMAC_CIE9          (0x40078290) /**< (XDMAC) Channel Interrupt Enable Register 9 */
+#define REG_XDMAC_CID9          (0x40078294) /**< (XDMAC) Channel Interrupt Disable Register 9 */
+#define REG_XDMAC_CIM9          (0x40078298) /**< (XDMAC) Channel Interrupt Mask Register 9 */
+#define REG_XDMAC_CIS9          (0x4007829C) /**< (XDMAC) Channel Interrupt Status Register 9 */
+#define REG_XDMAC_CSA9          (0x400782A0) /**< (XDMAC) Channel Source Address Register 9 */
+#define REG_XDMAC_CDA9          (0x400782A4) /**< (XDMAC) Channel Destination Address Register 9 */
+#define REG_XDMAC_CNDA9         (0x400782A8) /**< (XDMAC) Channel Next Descriptor Address Register 9 */
+#define REG_XDMAC_CNDC9         (0x400782AC) /**< (XDMAC) Channel Next Descriptor Control Register 9 */
+#define REG_XDMAC_CUBC9         (0x400782B0) /**< (XDMAC) Channel Microblock Control Register 9 */
+#define REG_XDMAC_CBC9          (0x400782B4) /**< (XDMAC) Channel Block Control Register 9 */
+#define REG_XDMAC_CC9           (0x400782B8) /**< (XDMAC) Channel Configuration Register 9 */
+#define REG_XDMAC_CDS_MSP9      (0x400782BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 9 */
+#define REG_XDMAC_CSUS9         (0x400782C0) /**< (XDMAC) Channel Source Microblock Stride 9 */
+#define REG_XDMAC_CDUS9         (0x400782C4) /**< (XDMAC) Channel Destination Microblock Stride 9 */
+#define REG_XDMAC_CIE10         (0x400782D0) /**< (XDMAC) Channel Interrupt Enable Register 10 */
+#define REG_XDMAC_CID10         (0x400782D4) /**< (XDMAC) Channel Interrupt Disable Register 10 */
+#define REG_XDMAC_CIM10         (0x400782D8) /**< (XDMAC) Channel Interrupt Mask Register 10 */
+#define REG_XDMAC_CIS10         (0x400782DC) /**< (XDMAC) Channel Interrupt Status Register 10 */
+#define REG_XDMAC_CSA10         (0x400782E0) /**< (XDMAC) Channel Source Address Register 10 */
+#define REG_XDMAC_CDA10         (0x400782E4) /**< (XDMAC) Channel Destination Address Register 10 */
+#define REG_XDMAC_CNDA10        (0x400782E8) /**< (XDMAC) Channel Next Descriptor Address Register 10 */
+#define REG_XDMAC_CNDC10        (0x400782EC) /**< (XDMAC) Channel Next Descriptor Control Register 10 */
+#define REG_XDMAC_CUBC10        (0x400782F0) /**< (XDMAC) Channel Microblock Control Register 10 */
+#define REG_XDMAC_CBC10         (0x400782F4) /**< (XDMAC) Channel Block Control Register 10 */
+#define REG_XDMAC_CC10          (0x400782F8) /**< (XDMAC) Channel Configuration Register 10 */
+#define REG_XDMAC_CDS_MSP10     (0x400782FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 10 */
+#define REG_XDMAC_CSUS10        (0x40078300) /**< (XDMAC) Channel Source Microblock Stride 10 */
+#define REG_XDMAC_CDUS10        (0x40078304) /**< (XDMAC) Channel Destination Microblock Stride 10 */
+#define REG_XDMAC_CIE11         (0x40078310) /**< (XDMAC) Channel Interrupt Enable Register 11 */
+#define REG_XDMAC_CID11         (0x40078314) /**< (XDMAC) Channel Interrupt Disable Register 11 */
+#define REG_XDMAC_CIM11         (0x40078318) /**< (XDMAC) Channel Interrupt Mask Register 11 */
+#define REG_XDMAC_CIS11         (0x4007831C) /**< (XDMAC) Channel Interrupt Status Register 11 */
+#define REG_XDMAC_CSA11         (0x40078320) /**< (XDMAC) Channel Source Address Register 11 */
+#define REG_XDMAC_CDA11         (0x40078324) /**< (XDMAC) Channel Destination Address Register 11 */
+#define REG_XDMAC_CNDA11        (0x40078328) /**< (XDMAC) Channel Next Descriptor Address Register 11 */
+#define REG_XDMAC_CNDC11        (0x4007832C) /**< (XDMAC) Channel Next Descriptor Control Register 11 */
+#define REG_XDMAC_CUBC11        (0x40078330) /**< (XDMAC) Channel Microblock Control Register 11 */
+#define REG_XDMAC_CBC11         (0x40078334) /**< (XDMAC) Channel Block Control Register 11 */
+#define REG_XDMAC_CC11          (0x40078338) /**< (XDMAC) Channel Configuration Register 11 */
+#define REG_XDMAC_CDS_MSP11     (0x4007833C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 11 */
+#define REG_XDMAC_CSUS11        (0x40078340) /**< (XDMAC) Channel Source Microblock Stride 11 */
+#define REG_XDMAC_CDUS11        (0x40078344) /**< (XDMAC) Channel Destination Microblock Stride 11 */
+#define REG_XDMAC_CIE12         (0x40078350) /**< (XDMAC) Channel Interrupt Enable Register 12 */
+#define REG_XDMAC_CID12         (0x40078354) /**< (XDMAC) Channel Interrupt Disable Register 12 */
+#define REG_XDMAC_CIM12         (0x40078358) /**< (XDMAC) Channel Interrupt Mask Register 12 */
+#define REG_XDMAC_CIS12         (0x4007835C) /**< (XDMAC) Channel Interrupt Status Register 12 */
+#define REG_XDMAC_CSA12         (0x40078360) /**< (XDMAC) Channel Source Address Register 12 */
+#define REG_XDMAC_CDA12         (0x40078364) /**< (XDMAC) Channel Destination Address Register 12 */
+#define REG_XDMAC_CNDA12        (0x40078368) /**< (XDMAC) Channel Next Descriptor Address Register 12 */
+#define REG_XDMAC_CNDC12        (0x4007836C) /**< (XDMAC) Channel Next Descriptor Control Register 12 */
+#define REG_XDMAC_CUBC12        (0x40078370) /**< (XDMAC) Channel Microblock Control Register 12 */
+#define REG_XDMAC_CBC12         (0x40078374) /**< (XDMAC) Channel Block Control Register 12 */
+#define REG_XDMAC_CC12          (0x40078378) /**< (XDMAC) Channel Configuration Register 12 */
+#define REG_XDMAC_CDS_MSP12     (0x4007837C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 12 */
+#define REG_XDMAC_CSUS12        (0x40078380) /**< (XDMAC) Channel Source Microblock Stride 12 */
+#define REG_XDMAC_CDUS12        (0x40078384) /**< (XDMAC) Channel Destination Microblock Stride 12 */
+#define REG_XDMAC_CIE13         (0x40078390) /**< (XDMAC) Channel Interrupt Enable Register 13 */
+#define REG_XDMAC_CID13         (0x40078394) /**< (XDMAC) Channel Interrupt Disable Register 13 */
+#define REG_XDMAC_CIM13         (0x40078398) /**< (XDMAC) Channel Interrupt Mask Register 13 */
+#define REG_XDMAC_CIS13         (0x4007839C) /**< (XDMAC) Channel Interrupt Status Register 13 */
+#define REG_XDMAC_CSA13         (0x400783A0) /**< (XDMAC) Channel Source Address Register 13 */
+#define REG_XDMAC_CDA13         (0x400783A4) /**< (XDMAC) Channel Destination Address Register 13 */
+#define REG_XDMAC_CNDA13        (0x400783A8) /**< (XDMAC) Channel Next Descriptor Address Register 13 */
+#define REG_XDMAC_CNDC13        (0x400783AC) /**< (XDMAC) Channel Next Descriptor Control Register 13 */
+#define REG_XDMAC_CUBC13        (0x400783B0) /**< (XDMAC) Channel Microblock Control Register 13 */
+#define REG_XDMAC_CBC13         (0x400783B4) /**< (XDMAC) Channel Block Control Register 13 */
+#define REG_XDMAC_CC13          (0x400783B8) /**< (XDMAC) Channel Configuration Register 13 */
+#define REG_XDMAC_CDS_MSP13     (0x400783BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 13 */
+#define REG_XDMAC_CSUS13        (0x400783C0) /**< (XDMAC) Channel Source Microblock Stride 13 */
+#define REG_XDMAC_CDUS13        (0x400783C4) /**< (XDMAC) Channel Destination Microblock Stride 13 */
+#define REG_XDMAC_CIE14         (0x400783D0) /**< (XDMAC) Channel Interrupt Enable Register 14 */
+#define REG_XDMAC_CID14         (0x400783D4) /**< (XDMAC) Channel Interrupt Disable Register 14 */
+#define REG_XDMAC_CIM14         (0x400783D8) /**< (XDMAC) Channel Interrupt Mask Register 14 */
+#define REG_XDMAC_CIS14         (0x400783DC) /**< (XDMAC) Channel Interrupt Status Register 14 */
+#define REG_XDMAC_CSA14         (0x400783E0) /**< (XDMAC) Channel Source Address Register 14 */
+#define REG_XDMAC_CDA14         (0x400783E4) /**< (XDMAC) Channel Destination Address Register 14 */
+#define REG_XDMAC_CNDA14        (0x400783E8) /**< (XDMAC) Channel Next Descriptor Address Register 14 */
+#define REG_XDMAC_CNDC14        (0x400783EC) /**< (XDMAC) Channel Next Descriptor Control Register 14 */
+#define REG_XDMAC_CUBC14        (0x400783F0) /**< (XDMAC) Channel Microblock Control Register 14 */
+#define REG_XDMAC_CBC14         (0x400783F4) /**< (XDMAC) Channel Block Control Register 14 */
+#define REG_XDMAC_CC14          (0x400783F8) /**< (XDMAC) Channel Configuration Register 14 */
+#define REG_XDMAC_CDS_MSP14     (0x400783FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 14 */
+#define REG_XDMAC_CSUS14        (0x40078400) /**< (XDMAC) Channel Source Microblock Stride 14 */
+#define REG_XDMAC_CDUS14        (0x40078404) /**< (XDMAC) Channel Destination Microblock Stride 14 */
+#define REG_XDMAC_CIE15         (0x40078410) /**< (XDMAC) Channel Interrupt Enable Register 15 */
+#define REG_XDMAC_CID15         (0x40078414) /**< (XDMAC) Channel Interrupt Disable Register 15 */
+#define REG_XDMAC_CIM15         (0x40078418) /**< (XDMAC) Channel Interrupt Mask Register 15 */
+#define REG_XDMAC_CIS15         (0x4007841C) /**< (XDMAC) Channel Interrupt Status Register 15 */
+#define REG_XDMAC_CSA15         (0x40078420) /**< (XDMAC) Channel Source Address Register 15 */
+#define REG_XDMAC_CDA15         (0x40078424) /**< (XDMAC) Channel Destination Address Register 15 */
+#define REG_XDMAC_CNDA15        (0x40078428) /**< (XDMAC) Channel Next Descriptor Address Register 15 */
+#define REG_XDMAC_CNDC15        (0x4007842C) /**< (XDMAC) Channel Next Descriptor Control Register 15 */
+#define REG_XDMAC_CUBC15        (0x40078430) /**< (XDMAC) Channel Microblock Control Register 15 */
+#define REG_XDMAC_CBC15         (0x40078434) /**< (XDMAC) Channel Block Control Register 15 */
+#define REG_XDMAC_CC15          (0x40078438) /**< (XDMAC) Channel Configuration Register 15 */
+#define REG_XDMAC_CDS_MSP15     (0x4007843C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 15 */
+#define REG_XDMAC_CSUS15        (0x40078440) /**< (XDMAC) Channel Source Microblock Stride 15 */
+#define REG_XDMAC_CDUS15        (0x40078444) /**< (XDMAC) Channel Destination Microblock Stride 15 */
+#define REG_XDMAC_CIE16         (0x40078450) /**< (XDMAC) Channel Interrupt Enable Register 16 */
+#define REG_XDMAC_CID16         (0x40078454) /**< (XDMAC) Channel Interrupt Disable Register 16 */
+#define REG_XDMAC_CIM16         (0x40078458) /**< (XDMAC) Channel Interrupt Mask Register 16 */
+#define REG_XDMAC_CIS16         (0x4007845C) /**< (XDMAC) Channel Interrupt Status Register 16 */
+#define REG_XDMAC_CSA16         (0x40078460) /**< (XDMAC) Channel Source Address Register 16 */
+#define REG_XDMAC_CDA16         (0x40078464) /**< (XDMAC) Channel Destination Address Register 16 */
+#define REG_XDMAC_CNDA16        (0x40078468) /**< (XDMAC) Channel Next Descriptor Address Register 16 */
+#define REG_XDMAC_CNDC16        (0x4007846C) /**< (XDMAC) Channel Next Descriptor Control Register 16 */
+#define REG_XDMAC_CUBC16        (0x40078470) /**< (XDMAC) Channel Microblock Control Register 16 */
+#define REG_XDMAC_CBC16         (0x40078474) /**< (XDMAC) Channel Block Control Register 16 */
+#define REG_XDMAC_CC16          (0x40078478) /**< (XDMAC) Channel Configuration Register 16 */
+#define REG_XDMAC_CDS_MSP16     (0x4007847C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 16 */
+#define REG_XDMAC_CSUS16        (0x40078480) /**< (XDMAC) Channel Source Microblock Stride 16 */
+#define REG_XDMAC_CDUS16        (0x40078484) /**< (XDMAC) Channel Destination Microblock Stride 16 */
+#define REG_XDMAC_CIE17         (0x40078490) /**< (XDMAC) Channel Interrupt Enable Register 17 */
+#define REG_XDMAC_CID17         (0x40078494) /**< (XDMAC) Channel Interrupt Disable Register 17 */
+#define REG_XDMAC_CIM17         (0x40078498) /**< (XDMAC) Channel Interrupt Mask Register 17 */
+#define REG_XDMAC_CIS17         (0x4007849C) /**< (XDMAC) Channel Interrupt Status Register 17 */
+#define REG_XDMAC_CSA17         (0x400784A0) /**< (XDMAC) Channel Source Address Register 17 */
+#define REG_XDMAC_CDA17         (0x400784A4) /**< (XDMAC) Channel Destination Address Register 17 */
+#define REG_XDMAC_CNDA17        (0x400784A8) /**< (XDMAC) Channel Next Descriptor Address Register 17 */
+#define REG_XDMAC_CNDC17        (0x400784AC) /**< (XDMAC) Channel Next Descriptor Control Register 17 */
+#define REG_XDMAC_CUBC17        (0x400784B0) /**< (XDMAC) Channel Microblock Control Register 17 */
+#define REG_XDMAC_CBC17         (0x400784B4) /**< (XDMAC) Channel Block Control Register 17 */
+#define REG_XDMAC_CC17          (0x400784B8) /**< (XDMAC) Channel Configuration Register 17 */
+#define REG_XDMAC_CDS_MSP17     (0x400784BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 17 */
+#define REG_XDMAC_CSUS17        (0x400784C0) /**< (XDMAC) Channel Source Microblock Stride 17 */
+#define REG_XDMAC_CDUS17        (0x400784C4) /**< (XDMAC) Channel Destination Microblock Stride 17 */
+#define REG_XDMAC_CIE18         (0x400784D0) /**< (XDMAC) Channel Interrupt Enable Register 18 */
+#define REG_XDMAC_CID18         (0x400784D4) /**< (XDMAC) Channel Interrupt Disable Register 18 */
+#define REG_XDMAC_CIM18         (0x400784D8) /**< (XDMAC) Channel Interrupt Mask Register 18 */
+#define REG_XDMAC_CIS18         (0x400784DC) /**< (XDMAC) Channel Interrupt Status Register 18 */
+#define REG_XDMAC_CSA18         (0x400784E0) /**< (XDMAC) Channel Source Address Register 18 */
+#define REG_XDMAC_CDA18         (0x400784E4) /**< (XDMAC) Channel Destination Address Register 18 */
+#define REG_XDMAC_CNDA18        (0x400784E8) /**< (XDMAC) Channel Next Descriptor Address Register 18 */
+#define REG_XDMAC_CNDC18        (0x400784EC) /**< (XDMAC) Channel Next Descriptor Control Register 18 */
+#define REG_XDMAC_CUBC18        (0x400784F0) /**< (XDMAC) Channel Microblock Control Register 18 */
+#define REG_XDMAC_CBC18         (0x400784F4) /**< (XDMAC) Channel Block Control Register 18 */
+#define REG_XDMAC_CC18          (0x400784F8) /**< (XDMAC) Channel Configuration Register 18 */
+#define REG_XDMAC_CDS_MSP18     (0x400784FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 18 */
+#define REG_XDMAC_CSUS18        (0x40078500) /**< (XDMAC) Channel Source Microblock Stride 18 */
+#define REG_XDMAC_CDUS18        (0x40078504) /**< (XDMAC) Channel Destination Microblock Stride 18 */
+#define REG_XDMAC_CIE19         (0x40078510) /**< (XDMAC) Channel Interrupt Enable Register 19 */
+#define REG_XDMAC_CID19         (0x40078514) /**< (XDMAC) Channel Interrupt Disable Register 19 */
+#define REG_XDMAC_CIM19         (0x40078518) /**< (XDMAC) Channel Interrupt Mask Register 19 */
+#define REG_XDMAC_CIS19         (0x4007851C) /**< (XDMAC) Channel Interrupt Status Register 19 */
+#define REG_XDMAC_CSA19         (0x40078520) /**< (XDMAC) Channel Source Address Register 19 */
+#define REG_XDMAC_CDA19         (0x40078524) /**< (XDMAC) Channel Destination Address Register 19 */
+#define REG_XDMAC_CNDA19        (0x40078528) /**< (XDMAC) Channel Next Descriptor Address Register 19 */
+#define REG_XDMAC_CNDC19        (0x4007852C) /**< (XDMAC) Channel Next Descriptor Control Register 19 */
+#define REG_XDMAC_CUBC19        (0x40078530) /**< (XDMAC) Channel Microblock Control Register 19 */
+#define REG_XDMAC_CBC19         (0x40078534) /**< (XDMAC) Channel Block Control Register 19 */
+#define REG_XDMAC_CC19          (0x40078538) /**< (XDMAC) Channel Configuration Register 19 */
+#define REG_XDMAC_CDS_MSP19     (0x4007853C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 19 */
+#define REG_XDMAC_CSUS19        (0x40078540) /**< (XDMAC) Channel Source Microblock Stride 19 */
+#define REG_XDMAC_CDUS19        (0x40078544) /**< (XDMAC) Channel Destination Microblock Stride 19 */
+#define REG_XDMAC_CIE20         (0x40078550) /**< (XDMAC) Channel Interrupt Enable Register 20 */
+#define REG_XDMAC_CID20         (0x40078554) /**< (XDMAC) Channel Interrupt Disable Register 20 */
+#define REG_XDMAC_CIM20         (0x40078558) /**< (XDMAC) Channel Interrupt Mask Register 20 */
+#define REG_XDMAC_CIS20         (0x4007855C) /**< (XDMAC) Channel Interrupt Status Register 20 */
+#define REG_XDMAC_CSA20         (0x40078560) /**< (XDMAC) Channel Source Address Register 20 */
+#define REG_XDMAC_CDA20         (0x40078564) /**< (XDMAC) Channel Destination Address Register 20 */
+#define REG_XDMAC_CNDA20        (0x40078568) /**< (XDMAC) Channel Next Descriptor Address Register 20 */
+#define REG_XDMAC_CNDC20        (0x4007856C) /**< (XDMAC) Channel Next Descriptor Control Register 20 */
+#define REG_XDMAC_CUBC20        (0x40078570) /**< (XDMAC) Channel Microblock Control Register 20 */
+#define REG_XDMAC_CBC20         (0x40078574) /**< (XDMAC) Channel Block Control Register 20 */
+#define REG_XDMAC_CC20          (0x40078578) /**< (XDMAC) Channel Configuration Register 20 */
+#define REG_XDMAC_CDS_MSP20     (0x4007857C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 20 */
+#define REG_XDMAC_CSUS20        (0x40078580) /**< (XDMAC) Channel Source Microblock Stride 20 */
+#define REG_XDMAC_CDUS20        (0x40078584) /**< (XDMAC) Channel Destination Microblock Stride 20 */
+#define REG_XDMAC_CIE21         (0x40078590) /**< (XDMAC) Channel Interrupt Enable Register 21 */
+#define REG_XDMAC_CID21         (0x40078594) /**< (XDMAC) Channel Interrupt Disable Register 21 */
+#define REG_XDMAC_CIM21         (0x40078598) /**< (XDMAC) Channel Interrupt Mask Register 21 */
+#define REG_XDMAC_CIS21         (0x4007859C) /**< (XDMAC) Channel Interrupt Status Register 21 */
+#define REG_XDMAC_CSA21         (0x400785A0) /**< (XDMAC) Channel Source Address Register 21 */
+#define REG_XDMAC_CDA21         (0x400785A4) /**< (XDMAC) Channel Destination Address Register 21 */
+#define REG_XDMAC_CNDA21        (0x400785A8) /**< (XDMAC) Channel Next Descriptor Address Register 21 */
+#define REG_XDMAC_CNDC21        (0x400785AC) /**< (XDMAC) Channel Next Descriptor Control Register 21 */
+#define REG_XDMAC_CUBC21        (0x400785B0) /**< (XDMAC) Channel Microblock Control Register 21 */
+#define REG_XDMAC_CBC21         (0x400785B4) /**< (XDMAC) Channel Block Control Register 21 */
+#define REG_XDMAC_CC21          (0x400785B8) /**< (XDMAC) Channel Configuration Register 21 */
+#define REG_XDMAC_CDS_MSP21     (0x400785BC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 21 */
+#define REG_XDMAC_CSUS21        (0x400785C0) /**< (XDMAC) Channel Source Microblock Stride 21 */
+#define REG_XDMAC_CDUS21        (0x400785C4) /**< (XDMAC) Channel Destination Microblock Stride 21 */
+#define REG_XDMAC_CIE22         (0x400785D0) /**< (XDMAC) Channel Interrupt Enable Register 22 */
+#define REG_XDMAC_CID22         (0x400785D4) /**< (XDMAC) Channel Interrupt Disable Register 22 */
+#define REG_XDMAC_CIM22         (0x400785D8) /**< (XDMAC) Channel Interrupt Mask Register 22 */
+#define REG_XDMAC_CIS22         (0x400785DC) /**< (XDMAC) Channel Interrupt Status Register 22 */
+#define REG_XDMAC_CSA22         (0x400785E0) /**< (XDMAC) Channel Source Address Register 22 */
+#define REG_XDMAC_CDA22         (0x400785E4) /**< (XDMAC) Channel Destination Address Register 22 */
+#define REG_XDMAC_CNDA22        (0x400785E8) /**< (XDMAC) Channel Next Descriptor Address Register 22 */
+#define REG_XDMAC_CNDC22        (0x400785EC) /**< (XDMAC) Channel Next Descriptor Control Register 22 */
+#define REG_XDMAC_CUBC22        (0x400785F0) /**< (XDMAC) Channel Microblock Control Register 22 */
+#define REG_XDMAC_CBC22         (0x400785F4) /**< (XDMAC) Channel Block Control Register 22 */
+#define REG_XDMAC_CC22          (0x400785F8) /**< (XDMAC) Channel Configuration Register 22 */
+#define REG_XDMAC_CDS_MSP22     (0x400785FC) /**< (XDMAC) Channel Data Stride Memory Set Pattern 22 */
+#define REG_XDMAC_CSUS22        (0x40078600) /**< (XDMAC) Channel Source Microblock Stride 22 */
+#define REG_XDMAC_CDUS22        (0x40078604) /**< (XDMAC) Channel Destination Microblock Stride 22 */
+#define REG_XDMAC_CIE23         (0x40078610) /**< (XDMAC) Channel Interrupt Enable Register 23 */
+#define REG_XDMAC_CID23         (0x40078614) /**< (XDMAC) Channel Interrupt Disable Register 23 */
+#define REG_XDMAC_CIM23         (0x40078618) /**< (XDMAC) Channel Interrupt Mask Register 23 */
+#define REG_XDMAC_CIS23         (0x4007861C) /**< (XDMAC) Channel Interrupt Status Register 23 */
+#define REG_XDMAC_CSA23         (0x40078620) /**< (XDMAC) Channel Source Address Register 23 */
+#define REG_XDMAC_CDA23         (0x40078624) /**< (XDMAC) Channel Destination Address Register 23 */
+#define REG_XDMAC_CNDA23        (0x40078628) /**< (XDMAC) Channel Next Descriptor Address Register 23 */
+#define REG_XDMAC_CNDC23        (0x4007862C) /**< (XDMAC) Channel Next Descriptor Control Register 23 */
+#define REG_XDMAC_CUBC23        (0x40078630) /**< (XDMAC) Channel Microblock Control Register 23 */
+#define REG_XDMAC_CBC23         (0x40078634) /**< (XDMAC) Channel Block Control Register 23 */
+#define REG_XDMAC_CC23          (0x40078638) /**< (XDMAC) Channel Configuration Register 23 */
+#define REG_XDMAC_CDS_MSP23     (0x4007863C) /**< (XDMAC) Channel Data Stride Memory Set Pattern 23 */
+#define REG_XDMAC_CSUS23        (0x40078640) /**< (XDMAC) Channel Source Microblock Stride 23 */
+#define REG_XDMAC_CDUS23        (0x40078644) /**< (XDMAC) Channel Destination Microblock Stride 23 */
 #define REG_XDMAC_GTYPE         (0x40078000) /**< (XDMAC) Global Type Register */
 #define REG_XDMAC_GCFG          (0x40078004) /**< (XDMAC) Global Configuration Register */
 #define REG_XDMAC_GWAC          (0x40078008) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
@@ -388,342 +390,342 @@
 
 #else
 
-#define REG_XDMAC_CIE0          (*(__O  uint32_t*)0x40078050U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 0 */
-#define REG_XDMAC_CID0          (*(__O  uint32_t*)0x40078054U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 0 */
-#define REG_XDMAC_CIM0          (*(__I  uint32_t*)0x40078058U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 0 */
-#define REG_XDMAC_CIS0          (*(__I  uint32_t*)0x4007805CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 0 */
-#define REG_XDMAC_CSA0          (*(__IO uint32_t*)0x40078060U) /**< (XDMAC) Channel Source Address Register (chid = 0) 0 */
-#define REG_XDMAC_CDA0          (*(__IO uint32_t*)0x40078064U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 0 */
-#define REG_XDMAC_CNDA0         (*(__IO uint32_t*)0x40078068U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 0 */
-#define REG_XDMAC_CNDC0         (*(__IO uint32_t*)0x4007806CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 0 */
-#define REG_XDMAC_CUBC0         (*(__IO uint32_t*)0x40078070U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 0 */
-#define REG_XDMAC_CBC0          (*(__IO uint32_t*)0x40078074U) /**< (XDMAC) Channel Block Control Register (chid = 0) 0 */
-#define REG_XDMAC_CC0           (*(__IO uint32_t*)0x40078078U) /**< (XDMAC) Channel Configuration Register (chid = 0) 0 */
-#define REG_XDMAC_CDS_MSP0      (*(__IO uint32_t*)0x4007807CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 0 */
-#define REG_XDMAC_CSUS0         (*(__IO uint32_t*)0x40078080U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 0 */
-#define REG_XDMAC_CDUS0         (*(__IO uint32_t*)0x40078084U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 0 */
-#define REG_XDMAC_CIE1          (*(__O  uint32_t*)0x40078090U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 1 */
-#define REG_XDMAC_CID1          (*(__O  uint32_t*)0x40078094U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 1 */
-#define REG_XDMAC_CIM1          (*(__I  uint32_t*)0x40078098U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 1 */
-#define REG_XDMAC_CIS1          (*(__I  uint32_t*)0x4007809CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 1 */
-#define REG_XDMAC_CSA1          (*(__IO uint32_t*)0x400780A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 1 */
-#define REG_XDMAC_CDA1          (*(__IO uint32_t*)0x400780A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 1 */
-#define REG_XDMAC_CNDA1         (*(__IO uint32_t*)0x400780A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 1 */
-#define REG_XDMAC_CNDC1         (*(__IO uint32_t*)0x400780ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 1 */
-#define REG_XDMAC_CUBC1         (*(__IO uint32_t*)0x400780B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 1 */
-#define REG_XDMAC_CBC1          (*(__IO uint32_t*)0x400780B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 1 */
-#define REG_XDMAC_CC1           (*(__IO uint32_t*)0x400780B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 1 */
-#define REG_XDMAC_CDS_MSP1      (*(__IO uint32_t*)0x400780BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 1 */
-#define REG_XDMAC_CSUS1         (*(__IO uint32_t*)0x400780C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 1 */
-#define REG_XDMAC_CDUS1         (*(__IO uint32_t*)0x400780C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 1 */
-#define REG_XDMAC_CIE2          (*(__O  uint32_t*)0x400780D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 2 */
-#define REG_XDMAC_CID2          (*(__O  uint32_t*)0x400780D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 2 */
-#define REG_XDMAC_CIM2          (*(__I  uint32_t*)0x400780D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 2 */
-#define REG_XDMAC_CIS2          (*(__I  uint32_t*)0x400780DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 2 */
-#define REG_XDMAC_CSA2          (*(__IO uint32_t*)0x400780E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 2 */
-#define REG_XDMAC_CDA2          (*(__IO uint32_t*)0x400780E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 2 */
-#define REG_XDMAC_CNDA2         (*(__IO uint32_t*)0x400780E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 2 */
-#define REG_XDMAC_CNDC2         (*(__IO uint32_t*)0x400780ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 2 */
-#define REG_XDMAC_CUBC2         (*(__IO uint32_t*)0x400780F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 2 */
-#define REG_XDMAC_CBC2          (*(__IO uint32_t*)0x400780F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 2 */
-#define REG_XDMAC_CC2           (*(__IO uint32_t*)0x400780F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 2 */
-#define REG_XDMAC_CDS_MSP2      (*(__IO uint32_t*)0x400780FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 2 */
-#define REG_XDMAC_CSUS2         (*(__IO uint32_t*)0x40078100U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 2 */
-#define REG_XDMAC_CDUS2         (*(__IO uint32_t*)0x40078104U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 2 */
-#define REG_XDMAC_CIE3          (*(__O  uint32_t*)0x40078110U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 3 */
-#define REG_XDMAC_CID3          (*(__O  uint32_t*)0x40078114U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 3 */
-#define REG_XDMAC_CIM3          (*(__I  uint32_t*)0x40078118U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 3 */
-#define REG_XDMAC_CIS3          (*(__I  uint32_t*)0x4007811CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 3 */
-#define REG_XDMAC_CSA3          (*(__IO uint32_t*)0x40078120U) /**< (XDMAC) Channel Source Address Register (chid = 0) 3 */
-#define REG_XDMAC_CDA3          (*(__IO uint32_t*)0x40078124U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 3 */
-#define REG_XDMAC_CNDA3         (*(__IO uint32_t*)0x40078128U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 3 */
-#define REG_XDMAC_CNDC3         (*(__IO uint32_t*)0x4007812CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 3 */
-#define REG_XDMAC_CUBC3         (*(__IO uint32_t*)0x40078130U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 3 */
-#define REG_XDMAC_CBC3          (*(__IO uint32_t*)0x40078134U) /**< (XDMAC) Channel Block Control Register (chid = 0) 3 */
-#define REG_XDMAC_CC3           (*(__IO uint32_t*)0x40078138U) /**< (XDMAC) Channel Configuration Register (chid = 0) 3 */
-#define REG_XDMAC_CDS_MSP3      (*(__IO uint32_t*)0x4007813CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 3 */
-#define REG_XDMAC_CSUS3         (*(__IO uint32_t*)0x40078140U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 3 */
-#define REG_XDMAC_CDUS3         (*(__IO uint32_t*)0x40078144U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 3 */
-#define REG_XDMAC_CIE4          (*(__O  uint32_t*)0x40078150U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 4 */
-#define REG_XDMAC_CID4          (*(__O  uint32_t*)0x40078154U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 4 */
-#define REG_XDMAC_CIM4          (*(__I  uint32_t*)0x40078158U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 4 */
-#define REG_XDMAC_CIS4          (*(__I  uint32_t*)0x4007815CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 4 */
-#define REG_XDMAC_CSA4          (*(__IO uint32_t*)0x40078160U) /**< (XDMAC) Channel Source Address Register (chid = 0) 4 */
-#define REG_XDMAC_CDA4          (*(__IO uint32_t*)0x40078164U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 4 */
-#define REG_XDMAC_CNDA4         (*(__IO uint32_t*)0x40078168U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 4 */
-#define REG_XDMAC_CNDC4         (*(__IO uint32_t*)0x4007816CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 4 */
-#define REG_XDMAC_CUBC4         (*(__IO uint32_t*)0x40078170U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 4 */
-#define REG_XDMAC_CBC4          (*(__IO uint32_t*)0x40078174U) /**< (XDMAC) Channel Block Control Register (chid = 0) 4 */
-#define REG_XDMAC_CC4           (*(__IO uint32_t*)0x40078178U) /**< (XDMAC) Channel Configuration Register (chid = 0) 4 */
-#define REG_XDMAC_CDS_MSP4      (*(__IO uint32_t*)0x4007817CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 4 */
-#define REG_XDMAC_CSUS4         (*(__IO uint32_t*)0x40078180U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 4 */
-#define REG_XDMAC_CDUS4         (*(__IO uint32_t*)0x40078184U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 4 */
-#define REG_XDMAC_CIE5          (*(__O  uint32_t*)0x40078190U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 5 */
-#define REG_XDMAC_CID5          (*(__O  uint32_t*)0x40078194U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 5 */
-#define REG_XDMAC_CIM5          (*(__I  uint32_t*)0x40078198U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 5 */
-#define REG_XDMAC_CIS5          (*(__I  uint32_t*)0x4007819CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 5 */
-#define REG_XDMAC_CSA5          (*(__IO uint32_t*)0x400781A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 5 */
-#define REG_XDMAC_CDA5          (*(__IO uint32_t*)0x400781A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 5 */
-#define REG_XDMAC_CNDA5         (*(__IO uint32_t*)0x400781A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 5 */
-#define REG_XDMAC_CNDC5         (*(__IO uint32_t*)0x400781ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 5 */
-#define REG_XDMAC_CUBC5         (*(__IO uint32_t*)0x400781B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 5 */
-#define REG_XDMAC_CBC5          (*(__IO uint32_t*)0x400781B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 5 */
-#define REG_XDMAC_CC5           (*(__IO uint32_t*)0x400781B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 5 */
-#define REG_XDMAC_CDS_MSP5      (*(__IO uint32_t*)0x400781BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 5 */
-#define REG_XDMAC_CSUS5         (*(__IO uint32_t*)0x400781C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 5 */
-#define REG_XDMAC_CDUS5         (*(__IO uint32_t*)0x400781C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 5 */
-#define REG_XDMAC_CIE6          (*(__O  uint32_t*)0x400781D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 6 */
-#define REG_XDMAC_CID6          (*(__O  uint32_t*)0x400781D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 6 */
-#define REG_XDMAC_CIM6          (*(__I  uint32_t*)0x400781D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 6 */
-#define REG_XDMAC_CIS6          (*(__I  uint32_t*)0x400781DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 6 */
-#define REG_XDMAC_CSA6          (*(__IO uint32_t*)0x400781E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 6 */
-#define REG_XDMAC_CDA6          (*(__IO uint32_t*)0x400781E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 6 */
-#define REG_XDMAC_CNDA6         (*(__IO uint32_t*)0x400781E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 6 */
-#define REG_XDMAC_CNDC6         (*(__IO uint32_t*)0x400781ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 6 */
-#define REG_XDMAC_CUBC6         (*(__IO uint32_t*)0x400781F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 6 */
-#define REG_XDMAC_CBC6          (*(__IO uint32_t*)0x400781F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 6 */
-#define REG_XDMAC_CC6           (*(__IO uint32_t*)0x400781F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 6 */
-#define REG_XDMAC_CDS_MSP6      (*(__IO uint32_t*)0x400781FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 6 */
-#define REG_XDMAC_CSUS6         (*(__IO uint32_t*)0x40078200U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 6 */
-#define REG_XDMAC_CDUS6         (*(__IO uint32_t*)0x40078204U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 6 */
-#define REG_XDMAC_CIE7          (*(__O  uint32_t*)0x40078210U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 7 */
-#define REG_XDMAC_CID7          (*(__O  uint32_t*)0x40078214U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 7 */
-#define REG_XDMAC_CIM7          (*(__I  uint32_t*)0x40078218U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 7 */
-#define REG_XDMAC_CIS7          (*(__I  uint32_t*)0x4007821CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 7 */
-#define REG_XDMAC_CSA7          (*(__IO uint32_t*)0x40078220U) /**< (XDMAC) Channel Source Address Register (chid = 0) 7 */
-#define REG_XDMAC_CDA7          (*(__IO uint32_t*)0x40078224U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 7 */
-#define REG_XDMAC_CNDA7         (*(__IO uint32_t*)0x40078228U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 7 */
-#define REG_XDMAC_CNDC7         (*(__IO uint32_t*)0x4007822CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 7 */
-#define REG_XDMAC_CUBC7         (*(__IO uint32_t*)0x40078230U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 7 */
-#define REG_XDMAC_CBC7          (*(__IO uint32_t*)0x40078234U) /**< (XDMAC) Channel Block Control Register (chid = 0) 7 */
-#define REG_XDMAC_CC7           (*(__IO uint32_t*)0x40078238U) /**< (XDMAC) Channel Configuration Register (chid = 0) 7 */
-#define REG_XDMAC_CDS_MSP7      (*(__IO uint32_t*)0x4007823CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 7 */
-#define REG_XDMAC_CSUS7         (*(__IO uint32_t*)0x40078240U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 7 */
-#define REG_XDMAC_CDUS7         (*(__IO uint32_t*)0x40078244U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 7 */
-#define REG_XDMAC_CIE8          (*(__O  uint32_t*)0x40078250U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 8 */
-#define REG_XDMAC_CID8          (*(__O  uint32_t*)0x40078254U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 8 */
-#define REG_XDMAC_CIM8          (*(__I  uint32_t*)0x40078258U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 8 */
-#define REG_XDMAC_CIS8          (*(__I  uint32_t*)0x4007825CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 8 */
-#define REG_XDMAC_CSA8          (*(__IO uint32_t*)0x40078260U) /**< (XDMAC) Channel Source Address Register (chid = 0) 8 */
-#define REG_XDMAC_CDA8          (*(__IO uint32_t*)0x40078264U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 8 */
-#define REG_XDMAC_CNDA8         (*(__IO uint32_t*)0x40078268U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 8 */
-#define REG_XDMAC_CNDC8         (*(__IO uint32_t*)0x4007826CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 8 */
-#define REG_XDMAC_CUBC8         (*(__IO uint32_t*)0x40078270U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 8 */
-#define REG_XDMAC_CBC8          (*(__IO uint32_t*)0x40078274U) /**< (XDMAC) Channel Block Control Register (chid = 0) 8 */
-#define REG_XDMAC_CC8           (*(__IO uint32_t*)0x40078278U) /**< (XDMAC) Channel Configuration Register (chid = 0) 8 */
-#define REG_XDMAC_CDS_MSP8      (*(__IO uint32_t*)0x4007827CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 8 */
-#define REG_XDMAC_CSUS8         (*(__IO uint32_t*)0x40078280U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 8 */
-#define REG_XDMAC_CDUS8         (*(__IO uint32_t*)0x40078284U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 8 */
-#define REG_XDMAC_CIE9          (*(__O  uint32_t*)0x40078290U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 9 */
-#define REG_XDMAC_CID9          (*(__O  uint32_t*)0x40078294U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 9 */
-#define REG_XDMAC_CIM9          (*(__I  uint32_t*)0x40078298U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 9 */
-#define REG_XDMAC_CIS9          (*(__I  uint32_t*)0x4007829CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 9 */
-#define REG_XDMAC_CSA9          (*(__IO uint32_t*)0x400782A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 9 */
-#define REG_XDMAC_CDA9          (*(__IO uint32_t*)0x400782A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 9 */
-#define REG_XDMAC_CNDA9         (*(__IO uint32_t*)0x400782A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 9 */
-#define REG_XDMAC_CNDC9         (*(__IO uint32_t*)0x400782ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 9 */
-#define REG_XDMAC_CUBC9         (*(__IO uint32_t*)0x400782B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 9 */
-#define REG_XDMAC_CBC9          (*(__IO uint32_t*)0x400782B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 9 */
-#define REG_XDMAC_CC9           (*(__IO uint32_t*)0x400782B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 9 */
-#define REG_XDMAC_CDS_MSP9      (*(__IO uint32_t*)0x400782BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 9 */
-#define REG_XDMAC_CSUS9         (*(__IO uint32_t*)0x400782C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 9 */
-#define REG_XDMAC_CDUS9         (*(__IO uint32_t*)0x400782C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 9 */
-#define REG_XDMAC_CIE10         (*(__O  uint32_t*)0x400782D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 10 */
-#define REG_XDMAC_CID10         (*(__O  uint32_t*)0x400782D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 10 */
-#define REG_XDMAC_CIM10         (*(__I  uint32_t*)0x400782D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 10 */
-#define REG_XDMAC_CIS10         (*(__I  uint32_t*)0x400782DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 10 */
-#define REG_XDMAC_CSA10         (*(__IO uint32_t*)0x400782E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 10 */
-#define REG_XDMAC_CDA10         (*(__IO uint32_t*)0x400782E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 10 */
-#define REG_XDMAC_CNDA10        (*(__IO uint32_t*)0x400782E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 10 */
-#define REG_XDMAC_CNDC10        (*(__IO uint32_t*)0x400782ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 10 */
-#define REG_XDMAC_CUBC10        (*(__IO uint32_t*)0x400782F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 10 */
-#define REG_XDMAC_CBC10         (*(__IO uint32_t*)0x400782F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 10 */
-#define REG_XDMAC_CC10          (*(__IO uint32_t*)0x400782F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 10 */
-#define REG_XDMAC_CDS_MSP10     (*(__IO uint32_t*)0x400782FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 10 */
-#define REG_XDMAC_CSUS10        (*(__IO uint32_t*)0x40078300U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 10 */
-#define REG_XDMAC_CDUS10        (*(__IO uint32_t*)0x40078304U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 10 */
-#define REG_XDMAC_CIE11         (*(__O  uint32_t*)0x40078310U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 11 */
-#define REG_XDMAC_CID11         (*(__O  uint32_t*)0x40078314U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 11 */
-#define REG_XDMAC_CIM11         (*(__I  uint32_t*)0x40078318U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 11 */
-#define REG_XDMAC_CIS11         (*(__I  uint32_t*)0x4007831CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 11 */
-#define REG_XDMAC_CSA11         (*(__IO uint32_t*)0x40078320U) /**< (XDMAC) Channel Source Address Register (chid = 0) 11 */
-#define REG_XDMAC_CDA11         (*(__IO uint32_t*)0x40078324U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 11 */
-#define REG_XDMAC_CNDA11        (*(__IO uint32_t*)0x40078328U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 11 */
-#define REG_XDMAC_CNDC11        (*(__IO uint32_t*)0x4007832CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 11 */
-#define REG_XDMAC_CUBC11        (*(__IO uint32_t*)0x40078330U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 11 */
-#define REG_XDMAC_CBC11         (*(__IO uint32_t*)0x40078334U) /**< (XDMAC) Channel Block Control Register (chid = 0) 11 */
-#define REG_XDMAC_CC11          (*(__IO uint32_t*)0x40078338U) /**< (XDMAC) Channel Configuration Register (chid = 0) 11 */
-#define REG_XDMAC_CDS_MSP11     (*(__IO uint32_t*)0x4007833CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 11 */
-#define REG_XDMAC_CSUS11        (*(__IO uint32_t*)0x40078340U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 11 */
-#define REG_XDMAC_CDUS11        (*(__IO uint32_t*)0x40078344U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 11 */
-#define REG_XDMAC_CIE12         (*(__O  uint32_t*)0x40078350U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 12 */
-#define REG_XDMAC_CID12         (*(__O  uint32_t*)0x40078354U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 12 */
-#define REG_XDMAC_CIM12         (*(__I  uint32_t*)0x40078358U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 12 */
-#define REG_XDMAC_CIS12         (*(__I  uint32_t*)0x4007835CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 12 */
-#define REG_XDMAC_CSA12         (*(__IO uint32_t*)0x40078360U) /**< (XDMAC) Channel Source Address Register (chid = 0) 12 */
-#define REG_XDMAC_CDA12         (*(__IO uint32_t*)0x40078364U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 12 */
-#define REG_XDMAC_CNDA12        (*(__IO uint32_t*)0x40078368U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 12 */
-#define REG_XDMAC_CNDC12        (*(__IO uint32_t*)0x4007836CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 12 */
-#define REG_XDMAC_CUBC12        (*(__IO uint32_t*)0x40078370U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 12 */
-#define REG_XDMAC_CBC12         (*(__IO uint32_t*)0x40078374U) /**< (XDMAC) Channel Block Control Register (chid = 0) 12 */
-#define REG_XDMAC_CC12          (*(__IO uint32_t*)0x40078378U) /**< (XDMAC) Channel Configuration Register (chid = 0) 12 */
-#define REG_XDMAC_CDS_MSP12     (*(__IO uint32_t*)0x4007837CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 12 */
-#define REG_XDMAC_CSUS12        (*(__IO uint32_t*)0x40078380U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 12 */
-#define REG_XDMAC_CDUS12        (*(__IO uint32_t*)0x40078384U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 12 */
-#define REG_XDMAC_CIE13         (*(__O  uint32_t*)0x40078390U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 13 */
-#define REG_XDMAC_CID13         (*(__O  uint32_t*)0x40078394U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 13 */
-#define REG_XDMAC_CIM13         (*(__I  uint32_t*)0x40078398U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 13 */
-#define REG_XDMAC_CIS13         (*(__I  uint32_t*)0x4007839CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 13 */
-#define REG_XDMAC_CSA13         (*(__IO uint32_t*)0x400783A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 13 */
-#define REG_XDMAC_CDA13         (*(__IO uint32_t*)0x400783A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 13 */
-#define REG_XDMAC_CNDA13        (*(__IO uint32_t*)0x400783A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 13 */
-#define REG_XDMAC_CNDC13        (*(__IO uint32_t*)0x400783ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 13 */
-#define REG_XDMAC_CUBC13        (*(__IO uint32_t*)0x400783B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 13 */
-#define REG_XDMAC_CBC13         (*(__IO uint32_t*)0x400783B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 13 */
-#define REG_XDMAC_CC13          (*(__IO uint32_t*)0x400783B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 13 */
-#define REG_XDMAC_CDS_MSP13     (*(__IO uint32_t*)0x400783BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 13 */
-#define REG_XDMAC_CSUS13        (*(__IO uint32_t*)0x400783C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 13 */
-#define REG_XDMAC_CDUS13        (*(__IO uint32_t*)0x400783C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 13 */
-#define REG_XDMAC_CIE14         (*(__O  uint32_t*)0x400783D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 14 */
-#define REG_XDMAC_CID14         (*(__O  uint32_t*)0x400783D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 14 */
-#define REG_XDMAC_CIM14         (*(__I  uint32_t*)0x400783D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 14 */
-#define REG_XDMAC_CIS14         (*(__I  uint32_t*)0x400783DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 14 */
-#define REG_XDMAC_CSA14         (*(__IO uint32_t*)0x400783E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 14 */
-#define REG_XDMAC_CDA14         (*(__IO uint32_t*)0x400783E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 14 */
-#define REG_XDMAC_CNDA14        (*(__IO uint32_t*)0x400783E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 14 */
-#define REG_XDMAC_CNDC14        (*(__IO uint32_t*)0x400783ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 14 */
-#define REG_XDMAC_CUBC14        (*(__IO uint32_t*)0x400783F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 14 */
-#define REG_XDMAC_CBC14         (*(__IO uint32_t*)0x400783F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 14 */
-#define REG_XDMAC_CC14          (*(__IO uint32_t*)0x400783F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 14 */
-#define REG_XDMAC_CDS_MSP14     (*(__IO uint32_t*)0x400783FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 14 */
-#define REG_XDMAC_CSUS14        (*(__IO uint32_t*)0x40078400U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 14 */
-#define REG_XDMAC_CDUS14        (*(__IO uint32_t*)0x40078404U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 14 */
-#define REG_XDMAC_CIE15         (*(__O  uint32_t*)0x40078410U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 15 */
-#define REG_XDMAC_CID15         (*(__O  uint32_t*)0x40078414U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 15 */
-#define REG_XDMAC_CIM15         (*(__I  uint32_t*)0x40078418U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 15 */
-#define REG_XDMAC_CIS15         (*(__I  uint32_t*)0x4007841CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 15 */
-#define REG_XDMAC_CSA15         (*(__IO uint32_t*)0x40078420U) /**< (XDMAC) Channel Source Address Register (chid = 0) 15 */
-#define REG_XDMAC_CDA15         (*(__IO uint32_t*)0x40078424U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 15 */
-#define REG_XDMAC_CNDA15        (*(__IO uint32_t*)0x40078428U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 15 */
-#define REG_XDMAC_CNDC15        (*(__IO uint32_t*)0x4007842CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 15 */
-#define REG_XDMAC_CUBC15        (*(__IO uint32_t*)0x40078430U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 15 */
-#define REG_XDMAC_CBC15         (*(__IO uint32_t*)0x40078434U) /**< (XDMAC) Channel Block Control Register (chid = 0) 15 */
-#define REG_XDMAC_CC15          (*(__IO uint32_t*)0x40078438U) /**< (XDMAC) Channel Configuration Register (chid = 0) 15 */
-#define REG_XDMAC_CDS_MSP15     (*(__IO uint32_t*)0x4007843CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 15 */
-#define REG_XDMAC_CSUS15        (*(__IO uint32_t*)0x40078440U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 15 */
-#define REG_XDMAC_CDUS15        (*(__IO uint32_t*)0x40078444U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 15 */
-#define REG_XDMAC_CIE16         (*(__O  uint32_t*)0x40078450U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 16 */
-#define REG_XDMAC_CID16         (*(__O  uint32_t*)0x40078454U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 16 */
-#define REG_XDMAC_CIM16         (*(__I  uint32_t*)0x40078458U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 16 */
-#define REG_XDMAC_CIS16         (*(__I  uint32_t*)0x4007845CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 16 */
-#define REG_XDMAC_CSA16         (*(__IO uint32_t*)0x40078460U) /**< (XDMAC) Channel Source Address Register (chid = 0) 16 */
-#define REG_XDMAC_CDA16         (*(__IO uint32_t*)0x40078464U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 16 */
-#define REG_XDMAC_CNDA16        (*(__IO uint32_t*)0x40078468U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 16 */
-#define REG_XDMAC_CNDC16        (*(__IO uint32_t*)0x4007846CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 16 */
-#define REG_XDMAC_CUBC16        (*(__IO uint32_t*)0x40078470U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 16 */
-#define REG_XDMAC_CBC16         (*(__IO uint32_t*)0x40078474U) /**< (XDMAC) Channel Block Control Register (chid = 0) 16 */
-#define REG_XDMAC_CC16          (*(__IO uint32_t*)0x40078478U) /**< (XDMAC) Channel Configuration Register (chid = 0) 16 */
-#define REG_XDMAC_CDS_MSP16     (*(__IO uint32_t*)0x4007847CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 16 */
-#define REG_XDMAC_CSUS16        (*(__IO uint32_t*)0x40078480U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 16 */
-#define REG_XDMAC_CDUS16        (*(__IO uint32_t*)0x40078484U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 16 */
-#define REG_XDMAC_CIE17         (*(__O  uint32_t*)0x40078490U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 17 */
-#define REG_XDMAC_CID17         (*(__O  uint32_t*)0x40078494U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 17 */
-#define REG_XDMAC_CIM17         (*(__I  uint32_t*)0x40078498U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 17 */
-#define REG_XDMAC_CIS17         (*(__I  uint32_t*)0x4007849CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 17 */
-#define REG_XDMAC_CSA17         (*(__IO uint32_t*)0x400784A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 17 */
-#define REG_XDMAC_CDA17         (*(__IO uint32_t*)0x400784A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 17 */
-#define REG_XDMAC_CNDA17        (*(__IO uint32_t*)0x400784A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 17 */
-#define REG_XDMAC_CNDC17        (*(__IO uint32_t*)0x400784ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 17 */
-#define REG_XDMAC_CUBC17        (*(__IO uint32_t*)0x400784B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 17 */
-#define REG_XDMAC_CBC17         (*(__IO uint32_t*)0x400784B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 17 */
-#define REG_XDMAC_CC17          (*(__IO uint32_t*)0x400784B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 17 */
-#define REG_XDMAC_CDS_MSP17     (*(__IO uint32_t*)0x400784BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 17 */
-#define REG_XDMAC_CSUS17        (*(__IO uint32_t*)0x400784C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 17 */
-#define REG_XDMAC_CDUS17        (*(__IO uint32_t*)0x400784C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 17 */
-#define REG_XDMAC_CIE18         (*(__O  uint32_t*)0x400784D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 18 */
-#define REG_XDMAC_CID18         (*(__O  uint32_t*)0x400784D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 18 */
-#define REG_XDMAC_CIM18         (*(__I  uint32_t*)0x400784D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 18 */
-#define REG_XDMAC_CIS18         (*(__I  uint32_t*)0x400784DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 18 */
-#define REG_XDMAC_CSA18         (*(__IO uint32_t*)0x400784E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 18 */
-#define REG_XDMAC_CDA18         (*(__IO uint32_t*)0x400784E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 18 */
-#define REG_XDMAC_CNDA18        (*(__IO uint32_t*)0x400784E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 18 */
-#define REG_XDMAC_CNDC18        (*(__IO uint32_t*)0x400784ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 18 */
-#define REG_XDMAC_CUBC18        (*(__IO uint32_t*)0x400784F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 18 */
-#define REG_XDMAC_CBC18         (*(__IO uint32_t*)0x400784F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 18 */
-#define REG_XDMAC_CC18          (*(__IO uint32_t*)0x400784F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 18 */
-#define REG_XDMAC_CDS_MSP18     (*(__IO uint32_t*)0x400784FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 18 */
-#define REG_XDMAC_CSUS18        (*(__IO uint32_t*)0x40078500U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 18 */
-#define REG_XDMAC_CDUS18        (*(__IO uint32_t*)0x40078504U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 18 */
-#define REG_XDMAC_CIE19         (*(__O  uint32_t*)0x40078510U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 19 */
-#define REG_XDMAC_CID19         (*(__O  uint32_t*)0x40078514U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 19 */
-#define REG_XDMAC_CIM19         (*(__I  uint32_t*)0x40078518U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 19 */
-#define REG_XDMAC_CIS19         (*(__I  uint32_t*)0x4007851CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 19 */
-#define REG_XDMAC_CSA19         (*(__IO uint32_t*)0x40078520U) /**< (XDMAC) Channel Source Address Register (chid = 0) 19 */
-#define REG_XDMAC_CDA19         (*(__IO uint32_t*)0x40078524U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 19 */
-#define REG_XDMAC_CNDA19        (*(__IO uint32_t*)0x40078528U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 19 */
-#define REG_XDMAC_CNDC19        (*(__IO uint32_t*)0x4007852CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 19 */
-#define REG_XDMAC_CUBC19        (*(__IO uint32_t*)0x40078530U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 19 */
-#define REG_XDMAC_CBC19         (*(__IO uint32_t*)0x40078534U) /**< (XDMAC) Channel Block Control Register (chid = 0) 19 */
-#define REG_XDMAC_CC19          (*(__IO uint32_t*)0x40078538U) /**< (XDMAC) Channel Configuration Register (chid = 0) 19 */
-#define REG_XDMAC_CDS_MSP19     (*(__IO uint32_t*)0x4007853CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 19 */
-#define REG_XDMAC_CSUS19        (*(__IO uint32_t*)0x40078540U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 19 */
-#define REG_XDMAC_CDUS19        (*(__IO uint32_t*)0x40078544U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 19 */
-#define REG_XDMAC_CIE20         (*(__O  uint32_t*)0x40078550U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 20 */
-#define REG_XDMAC_CID20         (*(__O  uint32_t*)0x40078554U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 20 */
-#define REG_XDMAC_CIM20         (*(__I  uint32_t*)0x40078558U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 20 */
-#define REG_XDMAC_CIS20         (*(__I  uint32_t*)0x4007855CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 20 */
-#define REG_XDMAC_CSA20         (*(__IO uint32_t*)0x40078560U) /**< (XDMAC) Channel Source Address Register (chid = 0) 20 */
-#define REG_XDMAC_CDA20         (*(__IO uint32_t*)0x40078564U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 20 */
-#define REG_XDMAC_CNDA20        (*(__IO uint32_t*)0x40078568U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 20 */
-#define REG_XDMAC_CNDC20        (*(__IO uint32_t*)0x4007856CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 20 */
-#define REG_XDMAC_CUBC20        (*(__IO uint32_t*)0x40078570U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 20 */
-#define REG_XDMAC_CBC20         (*(__IO uint32_t*)0x40078574U) /**< (XDMAC) Channel Block Control Register (chid = 0) 20 */
-#define REG_XDMAC_CC20          (*(__IO uint32_t*)0x40078578U) /**< (XDMAC) Channel Configuration Register (chid = 0) 20 */
-#define REG_XDMAC_CDS_MSP20     (*(__IO uint32_t*)0x4007857CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 20 */
-#define REG_XDMAC_CSUS20        (*(__IO uint32_t*)0x40078580U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 20 */
-#define REG_XDMAC_CDUS20        (*(__IO uint32_t*)0x40078584U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 20 */
-#define REG_XDMAC_CIE21         (*(__O  uint32_t*)0x40078590U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 21 */
-#define REG_XDMAC_CID21         (*(__O  uint32_t*)0x40078594U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 21 */
-#define REG_XDMAC_CIM21         (*(__I  uint32_t*)0x40078598U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 21 */
-#define REG_XDMAC_CIS21         (*(__I  uint32_t*)0x4007859CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 21 */
-#define REG_XDMAC_CSA21         (*(__IO uint32_t*)0x400785A0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 21 */
-#define REG_XDMAC_CDA21         (*(__IO uint32_t*)0x400785A4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 21 */
-#define REG_XDMAC_CNDA21        (*(__IO uint32_t*)0x400785A8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 21 */
-#define REG_XDMAC_CNDC21        (*(__IO uint32_t*)0x400785ACU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 21 */
-#define REG_XDMAC_CUBC21        (*(__IO uint32_t*)0x400785B0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 21 */
-#define REG_XDMAC_CBC21         (*(__IO uint32_t*)0x400785B4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 21 */
-#define REG_XDMAC_CC21          (*(__IO uint32_t*)0x400785B8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 21 */
-#define REG_XDMAC_CDS_MSP21     (*(__IO uint32_t*)0x400785BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 21 */
-#define REG_XDMAC_CSUS21        (*(__IO uint32_t*)0x400785C0U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 21 */
-#define REG_XDMAC_CDUS21        (*(__IO uint32_t*)0x400785C4U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 21 */
-#define REG_XDMAC_CIE22         (*(__O  uint32_t*)0x400785D0U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 22 */
-#define REG_XDMAC_CID22         (*(__O  uint32_t*)0x400785D4U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 22 */
-#define REG_XDMAC_CIM22         (*(__I  uint32_t*)0x400785D8U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 22 */
-#define REG_XDMAC_CIS22         (*(__I  uint32_t*)0x400785DCU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 22 */
-#define REG_XDMAC_CSA22         (*(__IO uint32_t*)0x400785E0U) /**< (XDMAC) Channel Source Address Register (chid = 0) 22 */
-#define REG_XDMAC_CDA22         (*(__IO uint32_t*)0x400785E4U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 22 */
-#define REG_XDMAC_CNDA22        (*(__IO uint32_t*)0x400785E8U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 22 */
-#define REG_XDMAC_CNDC22        (*(__IO uint32_t*)0x400785ECU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 22 */
-#define REG_XDMAC_CUBC22        (*(__IO uint32_t*)0x400785F0U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 22 */
-#define REG_XDMAC_CBC22         (*(__IO uint32_t*)0x400785F4U) /**< (XDMAC) Channel Block Control Register (chid = 0) 22 */
-#define REG_XDMAC_CC22          (*(__IO uint32_t*)0x400785F8U) /**< (XDMAC) Channel Configuration Register (chid = 0) 22 */
-#define REG_XDMAC_CDS_MSP22     (*(__IO uint32_t*)0x400785FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 22 */
-#define REG_XDMAC_CSUS22        (*(__IO uint32_t*)0x40078600U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 22 */
-#define REG_XDMAC_CDUS22        (*(__IO uint32_t*)0x40078604U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 22 */
-#define REG_XDMAC_CIE23         (*(__O  uint32_t*)0x40078610U) /**< (XDMAC) Channel Interrupt Enable Register (chid = 0) 23 */
-#define REG_XDMAC_CID23         (*(__O  uint32_t*)0x40078614U) /**< (XDMAC) Channel Interrupt Disable Register (chid = 0) 23 */
-#define REG_XDMAC_CIM23         (*(__I  uint32_t*)0x40078618U) /**< (XDMAC) Channel Interrupt Mask Register (chid = 0) 23 */
-#define REG_XDMAC_CIS23         (*(__I  uint32_t*)0x4007861CU) /**< (XDMAC) Channel Interrupt Status Register (chid = 0) 23 */
-#define REG_XDMAC_CSA23         (*(__IO uint32_t*)0x40078620U) /**< (XDMAC) Channel Source Address Register (chid = 0) 23 */
-#define REG_XDMAC_CDA23         (*(__IO uint32_t*)0x40078624U) /**< (XDMAC) Channel Destination Address Register (chid = 0) 23 */
-#define REG_XDMAC_CNDA23        (*(__IO uint32_t*)0x40078628U) /**< (XDMAC) Channel Next Descriptor Address Register (chid = 0) 23 */
-#define REG_XDMAC_CNDC23        (*(__IO uint32_t*)0x4007862CU) /**< (XDMAC) Channel Next Descriptor Control Register (chid = 0) 23 */
-#define REG_XDMAC_CUBC23        (*(__IO uint32_t*)0x40078630U) /**< (XDMAC) Channel Microblock Control Register (chid = 0) 23 */
-#define REG_XDMAC_CBC23         (*(__IO uint32_t*)0x40078634U) /**< (XDMAC) Channel Block Control Register (chid = 0) 23 */
-#define REG_XDMAC_CC23          (*(__IO uint32_t*)0x40078638U) /**< (XDMAC) Channel Configuration Register (chid = 0) 23 */
-#define REG_XDMAC_CDS_MSP23     (*(__IO uint32_t*)0x4007863CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern (chid = 0) 23 */
-#define REG_XDMAC_CSUS23        (*(__IO uint32_t*)0x40078640U) /**< (XDMAC) Channel Source Microblock Stride (chid = 0) 23 */
-#define REG_XDMAC_CDUS23        (*(__IO uint32_t*)0x40078644U) /**< (XDMAC) Channel Destination Microblock Stride (chid = 0) 23 */
+#define REG_XDMAC_CIE0          (*(__O  uint32_t*)0x40078050U) /**< (XDMAC) Channel Interrupt Enable Register 0 */
+#define REG_XDMAC_CID0          (*(__O  uint32_t*)0x40078054U) /**< (XDMAC) Channel Interrupt Disable Register 0 */
+#define REG_XDMAC_CIM0          (*(__I  uint32_t*)0x40078058U) /**< (XDMAC) Channel Interrupt Mask Register 0 */
+#define REG_XDMAC_CIS0          (*(__I  uint32_t*)0x4007805CU) /**< (XDMAC) Channel Interrupt Status Register 0 */
+#define REG_XDMAC_CSA0          (*(__IO uint32_t*)0x40078060U) /**< (XDMAC) Channel Source Address Register 0 */
+#define REG_XDMAC_CDA0          (*(__IO uint32_t*)0x40078064U) /**< (XDMAC) Channel Destination Address Register 0 */
+#define REG_XDMAC_CNDA0         (*(__IO uint32_t*)0x40078068U) /**< (XDMAC) Channel Next Descriptor Address Register 0 */
+#define REG_XDMAC_CNDC0         (*(__IO uint32_t*)0x4007806CU) /**< (XDMAC) Channel Next Descriptor Control Register 0 */
+#define REG_XDMAC_CUBC0         (*(__IO uint32_t*)0x40078070U) /**< (XDMAC) Channel Microblock Control Register 0 */
+#define REG_XDMAC_CBC0          (*(__IO uint32_t*)0x40078074U) /**< (XDMAC) Channel Block Control Register 0 */
+#define REG_XDMAC_CC0           (*(__IO uint32_t*)0x40078078U) /**< (XDMAC) Channel Configuration Register 0 */
+#define REG_XDMAC_CDS_MSP0      (*(__IO uint32_t*)0x4007807CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 0 */
+#define REG_XDMAC_CSUS0         (*(__IO uint32_t*)0x40078080U) /**< (XDMAC) Channel Source Microblock Stride 0 */
+#define REG_XDMAC_CDUS0         (*(__IO uint32_t*)0x40078084U) /**< (XDMAC) Channel Destination Microblock Stride 0 */
+#define REG_XDMAC_CIE1          (*(__O  uint32_t*)0x40078090U) /**< (XDMAC) Channel Interrupt Enable Register 1 */
+#define REG_XDMAC_CID1          (*(__O  uint32_t*)0x40078094U) /**< (XDMAC) Channel Interrupt Disable Register 1 */
+#define REG_XDMAC_CIM1          (*(__I  uint32_t*)0x40078098U) /**< (XDMAC) Channel Interrupt Mask Register 1 */
+#define REG_XDMAC_CIS1          (*(__I  uint32_t*)0x4007809CU) /**< (XDMAC) Channel Interrupt Status Register 1 */
+#define REG_XDMAC_CSA1          (*(__IO uint32_t*)0x400780A0U) /**< (XDMAC) Channel Source Address Register 1 */
+#define REG_XDMAC_CDA1          (*(__IO uint32_t*)0x400780A4U) /**< (XDMAC) Channel Destination Address Register 1 */
+#define REG_XDMAC_CNDA1         (*(__IO uint32_t*)0x400780A8U) /**< (XDMAC) Channel Next Descriptor Address Register 1 */
+#define REG_XDMAC_CNDC1         (*(__IO uint32_t*)0x400780ACU) /**< (XDMAC) Channel Next Descriptor Control Register 1 */
+#define REG_XDMAC_CUBC1         (*(__IO uint32_t*)0x400780B0U) /**< (XDMAC) Channel Microblock Control Register 1 */
+#define REG_XDMAC_CBC1          (*(__IO uint32_t*)0x400780B4U) /**< (XDMAC) Channel Block Control Register 1 */
+#define REG_XDMAC_CC1           (*(__IO uint32_t*)0x400780B8U) /**< (XDMAC) Channel Configuration Register 1 */
+#define REG_XDMAC_CDS_MSP1      (*(__IO uint32_t*)0x400780BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 1 */
+#define REG_XDMAC_CSUS1         (*(__IO uint32_t*)0x400780C0U) /**< (XDMAC) Channel Source Microblock Stride 1 */
+#define REG_XDMAC_CDUS1         (*(__IO uint32_t*)0x400780C4U) /**< (XDMAC) Channel Destination Microblock Stride 1 */
+#define REG_XDMAC_CIE2          (*(__O  uint32_t*)0x400780D0U) /**< (XDMAC) Channel Interrupt Enable Register 2 */
+#define REG_XDMAC_CID2          (*(__O  uint32_t*)0x400780D4U) /**< (XDMAC) Channel Interrupt Disable Register 2 */
+#define REG_XDMAC_CIM2          (*(__I  uint32_t*)0x400780D8U) /**< (XDMAC) Channel Interrupt Mask Register 2 */
+#define REG_XDMAC_CIS2          (*(__I  uint32_t*)0x400780DCU) /**< (XDMAC) Channel Interrupt Status Register 2 */
+#define REG_XDMAC_CSA2          (*(__IO uint32_t*)0x400780E0U) /**< (XDMAC) Channel Source Address Register 2 */
+#define REG_XDMAC_CDA2          (*(__IO uint32_t*)0x400780E4U) /**< (XDMAC) Channel Destination Address Register 2 */
+#define REG_XDMAC_CNDA2         (*(__IO uint32_t*)0x400780E8U) /**< (XDMAC) Channel Next Descriptor Address Register 2 */
+#define REG_XDMAC_CNDC2         (*(__IO uint32_t*)0x400780ECU) /**< (XDMAC) Channel Next Descriptor Control Register 2 */
+#define REG_XDMAC_CUBC2         (*(__IO uint32_t*)0x400780F0U) /**< (XDMAC) Channel Microblock Control Register 2 */
+#define REG_XDMAC_CBC2          (*(__IO uint32_t*)0x400780F4U) /**< (XDMAC) Channel Block Control Register 2 */
+#define REG_XDMAC_CC2           (*(__IO uint32_t*)0x400780F8U) /**< (XDMAC) Channel Configuration Register 2 */
+#define REG_XDMAC_CDS_MSP2      (*(__IO uint32_t*)0x400780FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 2 */
+#define REG_XDMAC_CSUS2         (*(__IO uint32_t*)0x40078100U) /**< (XDMAC) Channel Source Microblock Stride 2 */
+#define REG_XDMAC_CDUS2         (*(__IO uint32_t*)0x40078104U) /**< (XDMAC) Channel Destination Microblock Stride 2 */
+#define REG_XDMAC_CIE3          (*(__O  uint32_t*)0x40078110U) /**< (XDMAC) Channel Interrupt Enable Register 3 */
+#define REG_XDMAC_CID3          (*(__O  uint32_t*)0x40078114U) /**< (XDMAC) Channel Interrupt Disable Register 3 */
+#define REG_XDMAC_CIM3          (*(__I  uint32_t*)0x40078118U) /**< (XDMAC) Channel Interrupt Mask Register 3 */
+#define REG_XDMAC_CIS3          (*(__I  uint32_t*)0x4007811CU) /**< (XDMAC) Channel Interrupt Status Register 3 */
+#define REG_XDMAC_CSA3          (*(__IO uint32_t*)0x40078120U) /**< (XDMAC) Channel Source Address Register 3 */
+#define REG_XDMAC_CDA3          (*(__IO uint32_t*)0x40078124U) /**< (XDMAC) Channel Destination Address Register 3 */
+#define REG_XDMAC_CNDA3         (*(__IO uint32_t*)0x40078128U) /**< (XDMAC) Channel Next Descriptor Address Register 3 */
+#define REG_XDMAC_CNDC3         (*(__IO uint32_t*)0x4007812CU) /**< (XDMAC) Channel Next Descriptor Control Register 3 */
+#define REG_XDMAC_CUBC3         (*(__IO uint32_t*)0x40078130U) /**< (XDMAC) Channel Microblock Control Register 3 */
+#define REG_XDMAC_CBC3          (*(__IO uint32_t*)0x40078134U) /**< (XDMAC) Channel Block Control Register 3 */
+#define REG_XDMAC_CC3           (*(__IO uint32_t*)0x40078138U) /**< (XDMAC) Channel Configuration Register 3 */
+#define REG_XDMAC_CDS_MSP3      (*(__IO uint32_t*)0x4007813CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 3 */
+#define REG_XDMAC_CSUS3         (*(__IO uint32_t*)0x40078140U) /**< (XDMAC) Channel Source Microblock Stride 3 */
+#define REG_XDMAC_CDUS3         (*(__IO uint32_t*)0x40078144U) /**< (XDMAC) Channel Destination Microblock Stride 3 */
+#define REG_XDMAC_CIE4          (*(__O  uint32_t*)0x40078150U) /**< (XDMAC) Channel Interrupt Enable Register 4 */
+#define REG_XDMAC_CID4          (*(__O  uint32_t*)0x40078154U) /**< (XDMAC) Channel Interrupt Disable Register 4 */
+#define REG_XDMAC_CIM4          (*(__I  uint32_t*)0x40078158U) /**< (XDMAC) Channel Interrupt Mask Register 4 */
+#define REG_XDMAC_CIS4          (*(__I  uint32_t*)0x4007815CU) /**< (XDMAC) Channel Interrupt Status Register 4 */
+#define REG_XDMAC_CSA4          (*(__IO uint32_t*)0x40078160U) /**< (XDMAC) Channel Source Address Register 4 */
+#define REG_XDMAC_CDA4          (*(__IO uint32_t*)0x40078164U) /**< (XDMAC) Channel Destination Address Register 4 */
+#define REG_XDMAC_CNDA4         (*(__IO uint32_t*)0x40078168U) /**< (XDMAC) Channel Next Descriptor Address Register 4 */
+#define REG_XDMAC_CNDC4         (*(__IO uint32_t*)0x4007816CU) /**< (XDMAC) Channel Next Descriptor Control Register 4 */
+#define REG_XDMAC_CUBC4         (*(__IO uint32_t*)0x40078170U) /**< (XDMAC) Channel Microblock Control Register 4 */
+#define REG_XDMAC_CBC4          (*(__IO uint32_t*)0x40078174U) /**< (XDMAC) Channel Block Control Register 4 */
+#define REG_XDMAC_CC4           (*(__IO uint32_t*)0x40078178U) /**< (XDMAC) Channel Configuration Register 4 */
+#define REG_XDMAC_CDS_MSP4      (*(__IO uint32_t*)0x4007817CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 4 */
+#define REG_XDMAC_CSUS4         (*(__IO uint32_t*)0x40078180U) /**< (XDMAC) Channel Source Microblock Stride 4 */
+#define REG_XDMAC_CDUS4         (*(__IO uint32_t*)0x40078184U) /**< (XDMAC) Channel Destination Microblock Stride 4 */
+#define REG_XDMAC_CIE5          (*(__O  uint32_t*)0x40078190U) /**< (XDMAC) Channel Interrupt Enable Register 5 */
+#define REG_XDMAC_CID5          (*(__O  uint32_t*)0x40078194U) /**< (XDMAC) Channel Interrupt Disable Register 5 */
+#define REG_XDMAC_CIM5          (*(__I  uint32_t*)0x40078198U) /**< (XDMAC) Channel Interrupt Mask Register 5 */
+#define REG_XDMAC_CIS5          (*(__I  uint32_t*)0x4007819CU) /**< (XDMAC) Channel Interrupt Status Register 5 */
+#define REG_XDMAC_CSA5          (*(__IO uint32_t*)0x400781A0U) /**< (XDMAC) Channel Source Address Register 5 */
+#define REG_XDMAC_CDA5          (*(__IO uint32_t*)0x400781A4U) /**< (XDMAC) Channel Destination Address Register 5 */
+#define REG_XDMAC_CNDA5         (*(__IO uint32_t*)0x400781A8U) /**< (XDMAC) Channel Next Descriptor Address Register 5 */
+#define REG_XDMAC_CNDC5         (*(__IO uint32_t*)0x400781ACU) /**< (XDMAC) Channel Next Descriptor Control Register 5 */
+#define REG_XDMAC_CUBC5         (*(__IO uint32_t*)0x400781B0U) /**< (XDMAC) Channel Microblock Control Register 5 */
+#define REG_XDMAC_CBC5          (*(__IO uint32_t*)0x400781B4U) /**< (XDMAC) Channel Block Control Register 5 */
+#define REG_XDMAC_CC5           (*(__IO uint32_t*)0x400781B8U) /**< (XDMAC) Channel Configuration Register 5 */
+#define REG_XDMAC_CDS_MSP5      (*(__IO uint32_t*)0x400781BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 5 */
+#define REG_XDMAC_CSUS5         (*(__IO uint32_t*)0x400781C0U) /**< (XDMAC) Channel Source Microblock Stride 5 */
+#define REG_XDMAC_CDUS5         (*(__IO uint32_t*)0x400781C4U) /**< (XDMAC) Channel Destination Microblock Stride 5 */
+#define REG_XDMAC_CIE6          (*(__O  uint32_t*)0x400781D0U) /**< (XDMAC) Channel Interrupt Enable Register 6 */
+#define REG_XDMAC_CID6          (*(__O  uint32_t*)0x400781D4U) /**< (XDMAC) Channel Interrupt Disable Register 6 */
+#define REG_XDMAC_CIM6          (*(__I  uint32_t*)0x400781D8U) /**< (XDMAC) Channel Interrupt Mask Register 6 */
+#define REG_XDMAC_CIS6          (*(__I  uint32_t*)0x400781DCU) /**< (XDMAC) Channel Interrupt Status Register 6 */
+#define REG_XDMAC_CSA6          (*(__IO uint32_t*)0x400781E0U) /**< (XDMAC) Channel Source Address Register 6 */
+#define REG_XDMAC_CDA6          (*(__IO uint32_t*)0x400781E4U) /**< (XDMAC) Channel Destination Address Register 6 */
+#define REG_XDMAC_CNDA6         (*(__IO uint32_t*)0x400781E8U) /**< (XDMAC) Channel Next Descriptor Address Register 6 */
+#define REG_XDMAC_CNDC6         (*(__IO uint32_t*)0x400781ECU) /**< (XDMAC) Channel Next Descriptor Control Register 6 */
+#define REG_XDMAC_CUBC6         (*(__IO uint32_t*)0x400781F0U) /**< (XDMAC) Channel Microblock Control Register 6 */
+#define REG_XDMAC_CBC6          (*(__IO uint32_t*)0x400781F4U) /**< (XDMAC) Channel Block Control Register 6 */
+#define REG_XDMAC_CC6           (*(__IO uint32_t*)0x400781F8U) /**< (XDMAC) Channel Configuration Register 6 */
+#define REG_XDMAC_CDS_MSP6      (*(__IO uint32_t*)0x400781FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 6 */
+#define REG_XDMAC_CSUS6         (*(__IO uint32_t*)0x40078200U) /**< (XDMAC) Channel Source Microblock Stride 6 */
+#define REG_XDMAC_CDUS6         (*(__IO uint32_t*)0x40078204U) /**< (XDMAC) Channel Destination Microblock Stride 6 */
+#define REG_XDMAC_CIE7          (*(__O  uint32_t*)0x40078210U) /**< (XDMAC) Channel Interrupt Enable Register 7 */
+#define REG_XDMAC_CID7          (*(__O  uint32_t*)0x40078214U) /**< (XDMAC) Channel Interrupt Disable Register 7 */
+#define REG_XDMAC_CIM7          (*(__I  uint32_t*)0x40078218U) /**< (XDMAC) Channel Interrupt Mask Register 7 */
+#define REG_XDMAC_CIS7          (*(__I  uint32_t*)0x4007821CU) /**< (XDMAC) Channel Interrupt Status Register 7 */
+#define REG_XDMAC_CSA7          (*(__IO uint32_t*)0x40078220U) /**< (XDMAC) Channel Source Address Register 7 */
+#define REG_XDMAC_CDA7          (*(__IO uint32_t*)0x40078224U) /**< (XDMAC) Channel Destination Address Register 7 */
+#define REG_XDMAC_CNDA7         (*(__IO uint32_t*)0x40078228U) /**< (XDMAC) Channel Next Descriptor Address Register 7 */
+#define REG_XDMAC_CNDC7         (*(__IO uint32_t*)0x4007822CU) /**< (XDMAC) Channel Next Descriptor Control Register 7 */
+#define REG_XDMAC_CUBC7         (*(__IO uint32_t*)0x40078230U) /**< (XDMAC) Channel Microblock Control Register 7 */
+#define REG_XDMAC_CBC7          (*(__IO uint32_t*)0x40078234U) /**< (XDMAC) Channel Block Control Register 7 */
+#define REG_XDMAC_CC7           (*(__IO uint32_t*)0x40078238U) /**< (XDMAC) Channel Configuration Register 7 */
+#define REG_XDMAC_CDS_MSP7      (*(__IO uint32_t*)0x4007823CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 7 */
+#define REG_XDMAC_CSUS7         (*(__IO uint32_t*)0x40078240U) /**< (XDMAC) Channel Source Microblock Stride 7 */
+#define REG_XDMAC_CDUS7         (*(__IO uint32_t*)0x40078244U) /**< (XDMAC) Channel Destination Microblock Stride 7 */
+#define REG_XDMAC_CIE8          (*(__O  uint32_t*)0x40078250U) /**< (XDMAC) Channel Interrupt Enable Register 8 */
+#define REG_XDMAC_CID8          (*(__O  uint32_t*)0x40078254U) /**< (XDMAC) Channel Interrupt Disable Register 8 */
+#define REG_XDMAC_CIM8          (*(__I  uint32_t*)0x40078258U) /**< (XDMAC) Channel Interrupt Mask Register 8 */
+#define REG_XDMAC_CIS8          (*(__I  uint32_t*)0x4007825CU) /**< (XDMAC) Channel Interrupt Status Register 8 */
+#define REG_XDMAC_CSA8          (*(__IO uint32_t*)0x40078260U) /**< (XDMAC) Channel Source Address Register 8 */
+#define REG_XDMAC_CDA8          (*(__IO uint32_t*)0x40078264U) /**< (XDMAC) Channel Destination Address Register 8 */
+#define REG_XDMAC_CNDA8         (*(__IO uint32_t*)0x40078268U) /**< (XDMAC) Channel Next Descriptor Address Register 8 */
+#define REG_XDMAC_CNDC8         (*(__IO uint32_t*)0x4007826CU) /**< (XDMAC) Channel Next Descriptor Control Register 8 */
+#define REG_XDMAC_CUBC8         (*(__IO uint32_t*)0x40078270U) /**< (XDMAC) Channel Microblock Control Register 8 */
+#define REG_XDMAC_CBC8          (*(__IO uint32_t*)0x40078274U) /**< (XDMAC) Channel Block Control Register 8 */
+#define REG_XDMAC_CC8           (*(__IO uint32_t*)0x40078278U) /**< (XDMAC) Channel Configuration Register 8 */
+#define REG_XDMAC_CDS_MSP8      (*(__IO uint32_t*)0x4007827CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 8 */
+#define REG_XDMAC_CSUS8         (*(__IO uint32_t*)0x40078280U) /**< (XDMAC) Channel Source Microblock Stride 8 */
+#define REG_XDMAC_CDUS8         (*(__IO uint32_t*)0x40078284U) /**< (XDMAC) Channel Destination Microblock Stride 8 */
+#define REG_XDMAC_CIE9          (*(__O  uint32_t*)0x40078290U) /**< (XDMAC) Channel Interrupt Enable Register 9 */
+#define REG_XDMAC_CID9          (*(__O  uint32_t*)0x40078294U) /**< (XDMAC) Channel Interrupt Disable Register 9 */
+#define REG_XDMAC_CIM9          (*(__I  uint32_t*)0x40078298U) /**< (XDMAC) Channel Interrupt Mask Register 9 */
+#define REG_XDMAC_CIS9          (*(__I  uint32_t*)0x4007829CU) /**< (XDMAC) Channel Interrupt Status Register 9 */
+#define REG_XDMAC_CSA9          (*(__IO uint32_t*)0x400782A0U) /**< (XDMAC) Channel Source Address Register 9 */
+#define REG_XDMAC_CDA9          (*(__IO uint32_t*)0x400782A4U) /**< (XDMAC) Channel Destination Address Register 9 */
+#define REG_XDMAC_CNDA9         (*(__IO uint32_t*)0x400782A8U) /**< (XDMAC) Channel Next Descriptor Address Register 9 */
+#define REG_XDMAC_CNDC9         (*(__IO uint32_t*)0x400782ACU) /**< (XDMAC) Channel Next Descriptor Control Register 9 */
+#define REG_XDMAC_CUBC9         (*(__IO uint32_t*)0x400782B0U) /**< (XDMAC) Channel Microblock Control Register 9 */
+#define REG_XDMAC_CBC9          (*(__IO uint32_t*)0x400782B4U) /**< (XDMAC) Channel Block Control Register 9 */
+#define REG_XDMAC_CC9           (*(__IO uint32_t*)0x400782B8U) /**< (XDMAC) Channel Configuration Register 9 */
+#define REG_XDMAC_CDS_MSP9      (*(__IO uint32_t*)0x400782BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 9 */
+#define REG_XDMAC_CSUS9         (*(__IO uint32_t*)0x400782C0U) /**< (XDMAC) Channel Source Microblock Stride 9 */
+#define REG_XDMAC_CDUS9         (*(__IO uint32_t*)0x400782C4U) /**< (XDMAC) Channel Destination Microblock Stride 9 */
+#define REG_XDMAC_CIE10         (*(__O  uint32_t*)0x400782D0U) /**< (XDMAC) Channel Interrupt Enable Register 10 */
+#define REG_XDMAC_CID10         (*(__O  uint32_t*)0x400782D4U) /**< (XDMAC) Channel Interrupt Disable Register 10 */
+#define REG_XDMAC_CIM10         (*(__I  uint32_t*)0x400782D8U) /**< (XDMAC) Channel Interrupt Mask Register 10 */
+#define REG_XDMAC_CIS10         (*(__I  uint32_t*)0x400782DCU) /**< (XDMAC) Channel Interrupt Status Register 10 */
+#define REG_XDMAC_CSA10         (*(__IO uint32_t*)0x400782E0U) /**< (XDMAC) Channel Source Address Register 10 */
+#define REG_XDMAC_CDA10         (*(__IO uint32_t*)0x400782E4U) /**< (XDMAC) Channel Destination Address Register 10 */
+#define REG_XDMAC_CNDA10        (*(__IO uint32_t*)0x400782E8U) /**< (XDMAC) Channel Next Descriptor Address Register 10 */
+#define REG_XDMAC_CNDC10        (*(__IO uint32_t*)0x400782ECU) /**< (XDMAC) Channel Next Descriptor Control Register 10 */
+#define REG_XDMAC_CUBC10        (*(__IO uint32_t*)0x400782F0U) /**< (XDMAC) Channel Microblock Control Register 10 */
+#define REG_XDMAC_CBC10         (*(__IO uint32_t*)0x400782F4U) /**< (XDMAC) Channel Block Control Register 10 */
+#define REG_XDMAC_CC10          (*(__IO uint32_t*)0x400782F8U) /**< (XDMAC) Channel Configuration Register 10 */
+#define REG_XDMAC_CDS_MSP10     (*(__IO uint32_t*)0x400782FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 10 */
+#define REG_XDMAC_CSUS10        (*(__IO uint32_t*)0x40078300U) /**< (XDMAC) Channel Source Microblock Stride 10 */
+#define REG_XDMAC_CDUS10        (*(__IO uint32_t*)0x40078304U) /**< (XDMAC) Channel Destination Microblock Stride 10 */
+#define REG_XDMAC_CIE11         (*(__O  uint32_t*)0x40078310U) /**< (XDMAC) Channel Interrupt Enable Register 11 */
+#define REG_XDMAC_CID11         (*(__O  uint32_t*)0x40078314U) /**< (XDMAC) Channel Interrupt Disable Register 11 */
+#define REG_XDMAC_CIM11         (*(__I  uint32_t*)0x40078318U) /**< (XDMAC) Channel Interrupt Mask Register 11 */
+#define REG_XDMAC_CIS11         (*(__I  uint32_t*)0x4007831CU) /**< (XDMAC) Channel Interrupt Status Register 11 */
+#define REG_XDMAC_CSA11         (*(__IO uint32_t*)0x40078320U) /**< (XDMAC) Channel Source Address Register 11 */
+#define REG_XDMAC_CDA11         (*(__IO uint32_t*)0x40078324U) /**< (XDMAC) Channel Destination Address Register 11 */
+#define REG_XDMAC_CNDA11        (*(__IO uint32_t*)0x40078328U) /**< (XDMAC) Channel Next Descriptor Address Register 11 */
+#define REG_XDMAC_CNDC11        (*(__IO uint32_t*)0x4007832CU) /**< (XDMAC) Channel Next Descriptor Control Register 11 */
+#define REG_XDMAC_CUBC11        (*(__IO uint32_t*)0x40078330U) /**< (XDMAC) Channel Microblock Control Register 11 */
+#define REG_XDMAC_CBC11         (*(__IO uint32_t*)0x40078334U) /**< (XDMAC) Channel Block Control Register 11 */
+#define REG_XDMAC_CC11          (*(__IO uint32_t*)0x40078338U) /**< (XDMAC) Channel Configuration Register 11 */
+#define REG_XDMAC_CDS_MSP11     (*(__IO uint32_t*)0x4007833CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 11 */
+#define REG_XDMAC_CSUS11        (*(__IO uint32_t*)0x40078340U) /**< (XDMAC) Channel Source Microblock Stride 11 */
+#define REG_XDMAC_CDUS11        (*(__IO uint32_t*)0x40078344U) /**< (XDMAC) Channel Destination Microblock Stride 11 */
+#define REG_XDMAC_CIE12         (*(__O  uint32_t*)0x40078350U) /**< (XDMAC) Channel Interrupt Enable Register 12 */
+#define REG_XDMAC_CID12         (*(__O  uint32_t*)0x40078354U) /**< (XDMAC) Channel Interrupt Disable Register 12 */
+#define REG_XDMAC_CIM12         (*(__I  uint32_t*)0x40078358U) /**< (XDMAC) Channel Interrupt Mask Register 12 */
+#define REG_XDMAC_CIS12         (*(__I  uint32_t*)0x4007835CU) /**< (XDMAC) Channel Interrupt Status Register 12 */
+#define REG_XDMAC_CSA12         (*(__IO uint32_t*)0x40078360U) /**< (XDMAC) Channel Source Address Register 12 */
+#define REG_XDMAC_CDA12         (*(__IO uint32_t*)0x40078364U) /**< (XDMAC) Channel Destination Address Register 12 */
+#define REG_XDMAC_CNDA12        (*(__IO uint32_t*)0x40078368U) /**< (XDMAC) Channel Next Descriptor Address Register 12 */
+#define REG_XDMAC_CNDC12        (*(__IO uint32_t*)0x4007836CU) /**< (XDMAC) Channel Next Descriptor Control Register 12 */
+#define REG_XDMAC_CUBC12        (*(__IO uint32_t*)0x40078370U) /**< (XDMAC) Channel Microblock Control Register 12 */
+#define REG_XDMAC_CBC12         (*(__IO uint32_t*)0x40078374U) /**< (XDMAC) Channel Block Control Register 12 */
+#define REG_XDMAC_CC12          (*(__IO uint32_t*)0x40078378U) /**< (XDMAC) Channel Configuration Register 12 */
+#define REG_XDMAC_CDS_MSP12     (*(__IO uint32_t*)0x4007837CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 12 */
+#define REG_XDMAC_CSUS12        (*(__IO uint32_t*)0x40078380U) /**< (XDMAC) Channel Source Microblock Stride 12 */
+#define REG_XDMAC_CDUS12        (*(__IO uint32_t*)0x40078384U) /**< (XDMAC) Channel Destination Microblock Stride 12 */
+#define REG_XDMAC_CIE13         (*(__O  uint32_t*)0x40078390U) /**< (XDMAC) Channel Interrupt Enable Register 13 */
+#define REG_XDMAC_CID13         (*(__O  uint32_t*)0x40078394U) /**< (XDMAC) Channel Interrupt Disable Register 13 */
+#define REG_XDMAC_CIM13         (*(__I  uint32_t*)0x40078398U) /**< (XDMAC) Channel Interrupt Mask Register 13 */
+#define REG_XDMAC_CIS13         (*(__I  uint32_t*)0x4007839CU) /**< (XDMAC) Channel Interrupt Status Register 13 */
+#define REG_XDMAC_CSA13         (*(__IO uint32_t*)0x400783A0U) /**< (XDMAC) Channel Source Address Register 13 */
+#define REG_XDMAC_CDA13         (*(__IO uint32_t*)0x400783A4U) /**< (XDMAC) Channel Destination Address Register 13 */
+#define REG_XDMAC_CNDA13        (*(__IO uint32_t*)0x400783A8U) /**< (XDMAC) Channel Next Descriptor Address Register 13 */
+#define REG_XDMAC_CNDC13        (*(__IO uint32_t*)0x400783ACU) /**< (XDMAC) Channel Next Descriptor Control Register 13 */
+#define REG_XDMAC_CUBC13        (*(__IO uint32_t*)0x400783B0U) /**< (XDMAC) Channel Microblock Control Register 13 */
+#define REG_XDMAC_CBC13         (*(__IO uint32_t*)0x400783B4U) /**< (XDMAC) Channel Block Control Register 13 */
+#define REG_XDMAC_CC13          (*(__IO uint32_t*)0x400783B8U) /**< (XDMAC) Channel Configuration Register 13 */
+#define REG_XDMAC_CDS_MSP13     (*(__IO uint32_t*)0x400783BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 13 */
+#define REG_XDMAC_CSUS13        (*(__IO uint32_t*)0x400783C0U) /**< (XDMAC) Channel Source Microblock Stride 13 */
+#define REG_XDMAC_CDUS13        (*(__IO uint32_t*)0x400783C4U) /**< (XDMAC) Channel Destination Microblock Stride 13 */
+#define REG_XDMAC_CIE14         (*(__O  uint32_t*)0x400783D0U) /**< (XDMAC) Channel Interrupt Enable Register 14 */
+#define REG_XDMAC_CID14         (*(__O  uint32_t*)0x400783D4U) /**< (XDMAC) Channel Interrupt Disable Register 14 */
+#define REG_XDMAC_CIM14         (*(__I  uint32_t*)0x400783D8U) /**< (XDMAC) Channel Interrupt Mask Register 14 */
+#define REG_XDMAC_CIS14         (*(__I  uint32_t*)0x400783DCU) /**< (XDMAC) Channel Interrupt Status Register 14 */
+#define REG_XDMAC_CSA14         (*(__IO uint32_t*)0x400783E0U) /**< (XDMAC) Channel Source Address Register 14 */
+#define REG_XDMAC_CDA14         (*(__IO uint32_t*)0x400783E4U) /**< (XDMAC) Channel Destination Address Register 14 */
+#define REG_XDMAC_CNDA14        (*(__IO uint32_t*)0x400783E8U) /**< (XDMAC) Channel Next Descriptor Address Register 14 */
+#define REG_XDMAC_CNDC14        (*(__IO uint32_t*)0x400783ECU) /**< (XDMAC) Channel Next Descriptor Control Register 14 */
+#define REG_XDMAC_CUBC14        (*(__IO uint32_t*)0x400783F0U) /**< (XDMAC) Channel Microblock Control Register 14 */
+#define REG_XDMAC_CBC14         (*(__IO uint32_t*)0x400783F4U) /**< (XDMAC) Channel Block Control Register 14 */
+#define REG_XDMAC_CC14          (*(__IO uint32_t*)0x400783F8U) /**< (XDMAC) Channel Configuration Register 14 */
+#define REG_XDMAC_CDS_MSP14     (*(__IO uint32_t*)0x400783FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 14 */
+#define REG_XDMAC_CSUS14        (*(__IO uint32_t*)0x40078400U) /**< (XDMAC) Channel Source Microblock Stride 14 */
+#define REG_XDMAC_CDUS14        (*(__IO uint32_t*)0x40078404U) /**< (XDMAC) Channel Destination Microblock Stride 14 */
+#define REG_XDMAC_CIE15         (*(__O  uint32_t*)0x40078410U) /**< (XDMAC) Channel Interrupt Enable Register 15 */
+#define REG_XDMAC_CID15         (*(__O  uint32_t*)0x40078414U) /**< (XDMAC) Channel Interrupt Disable Register 15 */
+#define REG_XDMAC_CIM15         (*(__I  uint32_t*)0x40078418U) /**< (XDMAC) Channel Interrupt Mask Register 15 */
+#define REG_XDMAC_CIS15         (*(__I  uint32_t*)0x4007841CU) /**< (XDMAC) Channel Interrupt Status Register 15 */
+#define REG_XDMAC_CSA15         (*(__IO uint32_t*)0x40078420U) /**< (XDMAC) Channel Source Address Register 15 */
+#define REG_XDMAC_CDA15         (*(__IO uint32_t*)0x40078424U) /**< (XDMAC) Channel Destination Address Register 15 */
+#define REG_XDMAC_CNDA15        (*(__IO uint32_t*)0x40078428U) /**< (XDMAC) Channel Next Descriptor Address Register 15 */
+#define REG_XDMAC_CNDC15        (*(__IO uint32_t*)0x4007842CU) /**< (XDMAC) Channel Next Descriptor Control Register 15 */
+#define REG_XDMAC_CUBC15        (*(__IO uint32_t*)0x40078430U) /**< (XDMAC) Channel Microblock Control Register 15 */
+#define REG_XDMAC_CBC15         (*(__IO uint32_t*)0x40078434U) /**< (XDMAC) Channel Block Control Register 15 */
+#define REG_XDMAC_CC15          (*(__IO uint32_t*)0x40078438U) /**< (XDMAC) Channel Configuration Register 15 */
+#define REG_XDMAC_CDS_MSP15     (*(__IO uint32_t*)0x4007843CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 15 */
+#define REG_XDMAC_CSUS15        (*(__IO uint32_t*)0x40078440U) /**< (XDMAC) Channel Source Microblock Stride 15 */
+#define REG_XDMAC_CDUS15        (*(__IO uint32_t*)0x40078444U) /**< (XDMAC) Channel Destination Microblock Stride 15 */
+#define REG_XDMAC_CIE16         (*(__O  uint32_t*)0x40078450U) /**< (XDMAC) Channel Interrupt Enable Register 16 */
+#define REG_XDMAC_CID16         (*(__O  uint32_t*)0x40078454U) /**< (XDMAC) Channel Interrupt Disable Register 16 */
+#define REG_XDMAC_CIM16         (*(__I  uint32_t*)0x40078458U) /**< (XDMAC) Channel Interrupt Mask Register 16 */
+#define REG_XDMAC_CIS16         (*(__I  uint32_t*)0x4007845CU) /**< (XDMAC) Channel Interrupt Status Register 16 */
+#define REG_XDMAC_CSA16         (*(__IO uint32_t*)0x40078460U) /**< (XDMAC) Channel Source Address Register 16 */
+#define REG_XDMAC_CDA16         (*(__IO uint32_t*)0x40078464U) /**< (XDMAC) Channel Destination Address Register 16 */
+#define REG_XDMAC_CNDA16        (*(__IO uint32_t*)0x40078468U) /**< (XDMAC) Channel Next Descriptor Address Register 16 */
+#define REG_XDMAC_CNDC16        (*(__IO uint32_t*)0x4007846CU) /**< (XDMAC) Channel Next Descriptor Control Register 16 */
+#define REG_XDMAC_CUBC16        (*(__IO uint32_t*)0x40078470U) /**< (XDMAC) Channel Microblock Control Register 16 */
+#define REG_XDMAC_CBC16         (*(__IO uint32_t*)0x40078474U) /**< (XDMAC) Channel Block Control Register 16 */
+#define REG_XDMAC_CC16          (*(__IO uint32_t*)0x40078478U) /**< (XDMAC) Channel Configuration Register 16 */
+#define REG_XDMAC_CDS_MSP16     (*(__IO uint32_t*)0x4007847CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 16 */
+#define REG_XDMAC_CSUS16        (*(__IO uint32_t*)0x40078480U) /**< (XDMAC) Channel Source Microblock Stride 16 */
+#define REG_XDMAC_CDUS16        (*(__IO uint32_t*)0x40078484U) /**< (XDMAC) Channel Destination Microblock Stride 16 */
+#define REG_XDMAC_CIE17         (*(__O  uint32_t*)0x40078490U) /**< (XDMAC) Channel Interrupt Enable Register 17 */
+#define REG_XDMAC_CID17         (*(__O  uint32_t*)0x40078494U) /**< (XDMAC) Channel Interrupt Disable Register 17 */
+#define REG_XDMAC_CIM17         (*(__I  uint32_t*)0x40078498U) /**< (XDMAC) Channel Interrupt Mask Register 17 */
+#define REG_XDMAC_CIS17         (*(__I  uint32_t*)0x4007849CU) /**< (XDMAC) Channel Interrupt Status Register 17 */
+#define REG_XDMAC_CSA17         (*(__IO uint32_t*)0x400784A0U) /**< (XDMAC) Channel Source Address Register 17 */
+#define REG_XDMAC_CDA17         (*(__IO uint32_t*)0x400784A4U) /**< (XDMAC) Channel Destination Address Register 17 */
+#define REG_XDMAC_CNDA17        (*(__IO uint32_t*)0x400784A8U) /**< (XDMAC) Channel Next Descriptor Address Register 17 */
+#define REG_XDMAC_CNDC17        (*(__IO uint32_t*)0x400784ACU) /**< (XDMAC) Channel Next Descriptor Control Register 17 */
+#define REG_XDMAC_CUBC17        (*(__IO uint32_t*)0x400784B0U) /**< (XDMAC) Channel Microblock Control Register 17 */
+#define REG_XDMAC_CBC17         (*(__IO uint32_t*)0x400784B4U) /**< (XDMAC) Channel Block Control Register 17 */
+#define REG_XDMAC_CC17          (*(__IO uint32_t*)0x400784B8U) /**< (XDMAC) Channel Configuration Register 17 */
+#define REG_XDMAC_CDS_MSP17     (*(__IO uint32_t*)0x400784BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 17 */
+#define REG_XDMAC_CSUS17        (*(__IO uint32_t*)0x400784C0U) /**< (XDMAC) Channel Source Microblock Stride 17 */
+#define REG_XDMAC_CDUS17        (*(__IO uint32_t*)0x400784C4U) /**< (XDMAC) Channel Destination Microblock Stride 17 */
+#define REG_XDMAC_CIE18         (*(__O  uint32_t*)0x400784D0U) /**< (XDMAC) Channel Interrupt Enable Register 18 */
+#define REG_XDMAC_CID18         (*(__O  uint32_t*)0x400784D4U) /**< (XDMAC) Channel Interrupt Disable Register 18 */
+#define REG_XDMAC_CIM18         (*(__I  uint32_t*)0x400784D8U) /**< (XDMAC) Channel Interrupt Mask Register 18 */
+#define REG_XDMAC_CIS18         (*(__I  uint32_t*)0x400784DCU) /**< (XDMAC) Channel Interrupt Status Register 18 */
+#define REG_XDMAC_CSA18         (*(__IO uint32_t*)0x400784E0U) /**< (XDMAC) Channel Source Address Register 18 */
+#define REG_XDMAC_CDA18         (*(__IO uint32_t*)0x400784E4U) /**< (XDMAC) Channel Destination Address Register 18 */
+#define REG_XDMAC_CNDA18        (*(__IO uint32_t*)0x400784E8U) /**< (XDMAC) Channel Next Descriptor Address Register 18 */
+#define REG_XDMAC_CNDC18        (*(__IO uint32_t*)0x400784ECU) /**< (XDMAC) Channel Next Descriptor Control Register 18 */
+#define REG_XDMAC_CUBC18        (*(__IO uint32_t*)0x400784F0U) /**< (XDMAC) Channel Microblock Control Register 18 */
+#define REG_XDMAC_CBC18         (*(__IO uint32_t*)0x400784F4U) /**< (XDMAC) Channel Block Control Register 18 */
+#define REG_XDMAC_CC18          (*(__IO uint32_t*)0x400784F8U) /**< (XDMAC) Channel Configuration Register 18 */
+#define REG_XDMAC_CDS_MSP18     (*(__IO uint32_t*)0x400784FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 18 */
+#define REG_XDMAC_CSUS18        (*(__IO uint32_t*)0x40078500U) /**< (XDMAC) Channel Source Microblock Stride 18 */
+#define REG_XDMAC_CDUS18        (*(__IO uint32_t*)0x40078504U) /**< (XDMAC) Channel Destination Microblock Stride 18 */
+#define REG_XDMAC_CIE19         (*(__O  uint32_t*)0x40078510U) /**< (XDMAC) Channel Interrupt Enable Register 19 */
+#define REG_XDMAC_CID19         (*(__O  uint32_t*)0x40078514U) /**< (XDMAC) Channel Interrupt Disable Register 19 */
+#define REG_XDMAC_CIM19         (*(__I  uint32_t*)0x40078518U) /**< (XDMAC) Channel Interrupt Mask Register 19 */
+#define REG_XDMAC_CIS19         (*(__I  uint32_t*)0x4007851CU) /**< (XDMAC) Channel Interrupt Status Register 19 */
+#define REG_XDMAC_CSA19         (*(__IO uint32_t*)0x40078520U) /**< (XDMAC) Channel Source Address Register 19 */
+#define REG_XDMAC_CDA19         (*(__IO uint32_t*)0x40078524U) /**< (XDMAC) Channel Destination Address Register 19 */
+#define REG_XDMAC_CNDA19        (*(__IO uint32_t*)0x40078528U) /**< (XDMAC) Channel Next Descriptor Address Register 19 */
+#define REG_XDMAC_CNDC19        (*(__IO uint32_t*)0x4007852CU) /**< (XDMAC) Channel Next Descriptor Control Register 19 */
+#define REG_XDMAC_CUBC19        (*(__IO uint32_t*)0x40078530U) /**< (XDMAC) Channel Microblock Control Register 19 */
+#define REG_XDMAC_CBC19         (*(__IO uint32_t*)0x40078534U) /**< (XDMAC) Channel Block Control Register 19 */
+#define REG_XDMAC_CC19          (*(__IO uint32_t*)0x40078538U) /**< (XDMAC) Channel Configuration Register 19 */
+#define REG_XDMAC_CDS_MSP19     (*(__IO uint32_t*)0x4007853CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 19 */
+#define REG_XDMAC_CSUS19        (*(__IO uint32_t*)0x40078540U) /**< (XDMAC) Channel Source Microblock Stride 19 */
+#define REG_XDMAC_CDUS19        (*(__IO uint32_t*)0x40078544U) /**< (XDMAC) Channel Destination Microblock Stride 19 */
+#define REG_XDMAC_CIE20         (*(__O  uint32_t*)0x40078550U) /**< (XDMAC) Channel Interrupt Enable Register 20 */
+#define REG_XDMAC_CID20         (*(__O  uint32_t*)0x40078554U) /**< (XDMAC) Channel Interrupt Disable Register 20 */
+#define REG_XDMAC_CIM20         (*(__I  uint32_t*)0x40078558U) /**< (XDMAC) Channel Interrupt Mask Register 20 */
+#define REG_XDMAC_CIS20         (*(__I  uint32_t*)0x4007855CU) /**< (XDMAC) Channel Interrupt Status Register 20 */
+#define REG_XDMAC_CSA20         (*(__IO uint32_t*)0x40078560U) /**< (XDMAC) Channel Source Address Register 20 */
+#define REG_XDMAC_CDA20         (*(__IO uint32_t*)0x40078564U) /**< (XDMAC) Channel Destination Address Register 20 */
+#define REG_XDMAC_CNDA20        (*(__IO uint32_t*)0x40078568U) /**< (XDMAC) Channel Next Descriptor Address Register 20 */
+#define REG_XDMAC_CNDC20        (*(__IO uint32_t*)0x4007856CU) /**< (XDMAC) Channel Next Descriptor Control Register 20 */
+#define REG_XDMAC_CUBC20        (*(__IO uint32_t*)0x40078570U) /**< (XDMAC) Channel Microblock Control Register 20 */
+#define REG_XDMAC_CBC20         (*(__IO uint32_t*)0x40078574U) /**< (XDMAC) Channel Block Control Register 20 */
+#define REG_XDMAC_CC20          (*(__IO uint32_t*)0x40078578U) /**< (XDMAC) Channel Configuration Register 20 */
+#define REG_XDMAC_CDS_MSP20     (*(__IO uint32_t*)0x4007857CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 20 */
+#define REG_XDMAC_CSUS20        (*(__IO uint32_t*)0x40078580U) /**< (XDMAC) Channel Source Microblock Stride 20 */
+#define REG_XDMAC_CDUS20        (*(__IO uint32_t*)0x40078584U) /**< (XDMAC) Channel Destination Microblock Stride 20 */
+#define REG_XDMAC_CIE21         (*(__O  uint32_t*)0x40078590U) /**< (XDMAC) Channel Interrupt Enable Register 21 */
+#define REG_XDMAC_CID21         (*(__O  uint32_t*)0x40078594U) /**< (XDMAC) Channel Interrupt Disable Register 21 */
+#define REG_XDMAC_CIM21         (*(__I  uint32_t*)0x40078598U) /**< (XDMAC) Channel Interrupt Mask Register 21 */
+#define REG_XDMAC_CIS21         (*(__I  uint32_t*)0x4007859CU) /**< (XDMAC) Channel Interrupt Status Register 21 */
+#define REG_XDMAC_CSA21         (*(__IO uint32_t*)0x400785A0U) /**< (XDMAC) Channel Source Address Register 21 */
+#define REG_XDMAC_CDA21         (*(__IO uint32_t*)0x400785A4U) /**< (XDMAC) Channel Destination Address Register 21 */
+#define REG_XDMAC_CNDA21        (*(__IO uint32_t*)0x400785A8U) /**< (XDMAC) Channel Next Descriptor Address Register 21 */
+#define REG_XDMAC_CNDC21        (*(__IO uint32_t*)0x400785ACU) /**< (XDMAC) Channel Next Descriptor Control Register 21 */
+#define REG_XDMAC_CUBC21        (*(__IO uint32_t*)0x400785B0U) /**< (XDMAC) Channel Microblock Control Register 21 */
+#define REG_XDMAC_CBC21         (*(__IO uint32_t*)0x400785B4U) /**< (XDMAC) Channel Block Control Register 21 */
+#define REG_XDMAC_CC21          (*(__IO uint32_t*)0x400785B8U) /**< (XDMAC) Channel Configuration Register 21 */
+#define REG_XDMAC_CDS_MSP21     (*(__IO uint32_t*)0x400785BCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 21 */
+#define REG_XDMAC_CSUS21        (*(__IO uint32_t*)0x400785C0U) /**< (XDMAC) Channel Source Microblock Stride 21 */
+#define REG_XDMAC_CDUS21        (*(__IO uint32_t*)0x400785C4U) /**< (XDMAC) Channel Destination Microblock Stride 21 */
+#define REG_XDMAC_CIE22         (*(__O  uint32_t*)0x400785D0U) /**< (XDMAC) Channel Interrupt Enable Register 22 */
+#define REG_XDMAC_CID22         (*(__O  uint32_t*)0x400785D4U) /**< (XDMAC) Channel Interrupt Disable Register 22 */
+#define REG_XDMAC_CIM22         (*(__I  uint32_t*)0x400785D8U) /**< (XDMAC) Channel Interrupt Mask Register 22 */
+#define REG_XDMAC_CIS22         (*(__I  uint32_t*)0x400785DCU) /**< (XDMAC) Channel Interrupt Status Register 22 */
+#define REG_XDMAC_CSA22         (*(__IO uint32_t*)0x400785E0U) /**< (XDMAC) Channel Source Address Register 22 */
+#define REG_XDMAC_CDA22         (*(__IO uint32_t*)0x400785E4U) /**< (XDMAC) Channel Destination Address Register 22 */
+#define REG_XDMAC_CNDA22        (*(__IO uint32_t*)0x400785E8U) /**< (XDMAC) Channel Next Descriptor Address Register 22 */
+#define REG_XDMAC_CNDC22        (*(__IO uint32_t*)0x400785ECU) /**< (XDMAC) Channel Next Descriptor Control Register 22 */
+#define REG_XDMAC_CUBC22        (*(__IO uint32_t*)0x400785F0U) /**< (XDMAC) Channel Microblock Control Register 22 */
+#define REG_XDMAC_CBC22         (*(__IO uint32_t*)0x400785F4U) /**< (XDMAC) Channel Block Control Register 22 */
+#define REG_XDMAC_CC22          (*(__IO uint32_t*)0x400785F8U) /**< (XDMAC) Channel Configuration Register 22 */
+#define REG_XDMAC_CDS_MSP22     (*(__IO uint32_t*)0x400785FCU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 22 */
+#define REG_XDMAC_CSUS22        (*(__IO uint32_t*)0x40078600U) /**< (XDMAC) Channel Source Microblock Stride 22 */
+#define REG_XDMAC_CDUS22        (*(__IO uint32_t*)0x40078604U) /**< (XDMAC) Channel Destination Microblock Stride 22 */
+#define REG_XDMAC_CIE23         (*(__O  uint32_t*)0x40078610U) /**< (XDMAC) Channel Interrupt Enable Register 23 */
+#define REG_XDMAC_CID23         (*(__O  uint32_t*)0x40078614U) /**< (XDMAC) Channel Interrupt Disable Register 23 */
+#define REG_XDMAC_CIM23         (*(__I  uint32_t*)0x40078618U) /**< (XDMAC) Channel Interrupt Mask Register 23 */
+#define REG_XDMAC_CIS23         (*(__I  uint32_t*)0x4007861CU) /**< (XDMAC) Channel Interrupt Status Register 23 */
+#define REG_XDMAC_CSA23         (*(__IO uint32_t*)0x40078620U) /**< (XDMAC) Channel Source Address Register 23 */
+#define REG_XDMAC_CDA23         (*(__IO uint32_t*)0x40078624U) /**< (XDMAC) Channel Destination Address Register 23 */
+#define REG_XDMAC_CNDA23        (*(__IO uint32_t*)0x40078628U) /**< (XDMAC) Channel Next Descriptor Address Register 23 */
+#define REG_XDMAC_CNDC23        (*(__IO uint32_t*)0x4007862CU) /**< (XDMAC) Channel Next Descriptor Control Register 23 */
+#define REG_XDMAC_CUBC23        (*(__IO uint32_t*)0x40078630U) /**< (XDMAC) Channel Microblock Control Register 23 */
+#define REG_XDMAC_CBC23         (*(__IO uint32_t*)0x40078634U) /**< (XDMAC) Channel Block Control Register 23 */
+#define REG_XDMAC_CC23          (*(__IO uint32_t*)0x40078638U) /**< (XDMAC) Channel Configuration Register 23 */
+#define REG_XDMAC_CDS_MSP23     (*(__IO uint32_t*)0x4007863CU) /**< (XDMAC) Channel Data Stride Memory Set Pattern 23 */
+#define REG_XDMAC_CSUS23        (*(__IO uint32_t*)0x40078640U) /**< (XDMAC) Channel Source Microblock Stride 23 */
+#define REG_XDMAC_CDUS23        (*(__IO uint32_t*)0x40078644U) /**< (XDMAC) Channel Destination Microblock Stride 23 */
 #define REG_XDMAC_GTYPE         (*(__I  uint32_t*)0x40078000U) /**< (XDMAC) Global Type Register */
 #define REG_XDMAC_GCFG          (*(__IO uint32_t*)0x40078004U) /**< (XDMAC) Global Configuration Register */
 #define REG_XDMAC_GWAC          (*(__IO uint32_t*)0x40078008U) /**< (XDMAC) Global Weighted Arbiter Configuration Register */
@@ -745,7 +747,7 @@
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for XDMAC peripheral ========== */
-#define XDMAC_INSTANCE_ID                        58        
-#define XDMAC_CLOCK_ID                           58        
+#define XDMAC_INSTANCE_ID                        58         
+#define XDMAC_CLOCK_ID                           58         
 
 #endif /* _SAME70_XDMAC_INSTANCE_ */

--- a/asf/sam/include/same70b/pio/same70j19b.h
+++ b/asf/sam/include/same70b/pio/same70j19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:37Z */
 #ifndef _SAME70J19B_PIO_H_
 #define _SAME70J19B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -533,6 +521,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -797,6 +797,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SSC peripheral ========== */
 #define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
 #define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
@@ -829,6 +836,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1010,6 +1060,49 @@
 #define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
 #define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
 #define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70J19B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70j20b.h
+++ b/asf/sam/include/same70b/pio/same70j20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:41Z */
 #ifndef _SAME70J20B_PIO_H_
 #define _SAME70J20B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -533,6 +521,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -797,6 +797,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SSC peripheral ========== */
 #define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
 #define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
@@ -829,6 +836,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1010,6 +1060,49 @@
 #define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
 #define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
 #define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70J20B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70j21b.h
+++ b/asf/sam/include/same70b/pio/same70j21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70J21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:46Z */
 #ifndef _SAME70J21B_PIO_H_
 #define _SAME70J21B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -533,6 +521,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -797,6 +797,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SSC peripheral ========== */
 #define PIN_PA10C_SSC_RD                           _L_(10)      /**< SSC signal: RD on PA10 mux C*/
 #define MUX_PA10C_SSC_RD                           _L_(2)       /**< SSC signal line function value: RD */
@@ -829,6 +836,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1010,6 +1060,49 @@
 #define PIN_PB4D_USART1_TXD1                       _L_(36)      /**< USART1 signal: TXD1 on PB4 mux D*/
 #define MUX_PB4D_USART1_TXD1                       _L_(3)       /**< USART1 signal line function value: TXD1 */
 #define PIO_PB4D_USART1_TXD1                       (_UL_(1) << 4)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70J21B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70n19b.h
+++ b/asf/sam/include/same70b/pio/same70n19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:48Z */
 #ifndef _SAME70N19B_PIO_H_
 #define _SAME70N19B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -588,6 +576,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -852,6 +852,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
 #define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
@@ -917,6 +924,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1170,6 +1220,49 @@
 #define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70N19B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70n20b.h
+++ b/asf/sam/include/same70b/pio/same70n20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:51Z */
 #ifndef _SAME70N20B_PIO_H_
 #define _SAME70N20B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -588,6 +576,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -852,6 +852,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
 #define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
@@ -917,6 +924,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1170,6 +1220,49 @@
 #define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70N20B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70n21b.h
+++ b/asf/sam/include/same70b/pio/same70n21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70N21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:53Z */
 #ifndef _SAME70N21B_PIO_H_
 #define _SAME70N21B_PIO_H_
 
@@ -276,14 +278,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PB2X1_AFEC0_AD5                        _L_(34)      /**< AFEC0 signal: AD5 on PB2 mux X1*/
 #define PIO_PB2X1_AFEC0_AD5                        (_UL_(1) << 2)
@@ -297,20 +293,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -319,9 +306,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 /* ========== PIO definition for DACC peripheral ========== */
 #define PIN_PB13X1_DACC_DAC0                       _L_(45)      /**< DACC signal: DAC0 on PB13 mux X1*/
@@ -333,6 +317,10 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -588,6 +576,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -852,6 +852,13 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
+
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
 #define MUX_PD20B_SPI0_MISO                        _L_(1)       /**< SPI0 signal line function value: MISO */
@@ -917,6 +924,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -1170,6 +1220,49 @@
 #define PIN_PD16B_USART2_TXD2                      _L_(112)     /**< USART2 signal: TXD2 on PD16 mux B*/
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
+
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
+
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
+
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
+
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
+
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
+
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
+
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
+
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
+
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
+
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
+
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
+
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70N21B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70q19b.h
+++ b/asf/sam/include/same70b/pio/same70q19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:55Z */
 #ifndef _SAME70Q19B_PIO_H_
 #define _SAME70Q19B_PIO_H_
 
@@ -390,14 +392,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
 #define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
@@ -417,20 +413,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -439,9 +426,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 #define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
 #define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
@@ -486,6 +470,343 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -718,10 +1039,6 @@
 #define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
 #define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
 
-#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
-#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
-#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
-
 #define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
 #define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
 #define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
@@ -770,6 +1087,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -1078,551 +1407,12 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
-/* ========== PIO definition for SDRAMC peripheral ========== */
-#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
-#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
-
-#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
-#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
-
-#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
-#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
-
-#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
-#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
-
-#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
-#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
-
-#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
-#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
-
-#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
-#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
-
-#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
-#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
-
-#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
-#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
-
-#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
-#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
-
-#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
-#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
-
-#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
-#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
-
-#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
-#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
-
-#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
-#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
-
-#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
-#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
-
-#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
-#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
-
-#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
-#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
-
-#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
-#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
-
-#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
-#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
-
-#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
-#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
-
-#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
-#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
-
-#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
-#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
-
-#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
-#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
-
-#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
-#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
-
-#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
-#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
-
-#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
-#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
-
-#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
-#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
-
-#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
-#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
-
-#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
-#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
-
-#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
-#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
-
-#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
-#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
-
-#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
-#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
-
-#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
-#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
-
-#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
-#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
-
-#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
-#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
-
-#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
-#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
-
-#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
-#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
-
-#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
-#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
-
-#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
-#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
-
-#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
-#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
-
-#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
-#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
-
-#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
-#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
-
-#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
-#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
-
-#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
-#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
-
-#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
-#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
-
-#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
-#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
-
-#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
-#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
-
-#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
-#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
-
-#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
-#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
-
-#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
-
-#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
-
-#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
-
-#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
-
-#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
-#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
-
-#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
-
-#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
-
-#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
-#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
-
-#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
-#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
-
-#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
-#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
-
-#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
-#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
-
-#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
-#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
-
-#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
-#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
-
-#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
-#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
-
-#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
-#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
-
-#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
-#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
-
-#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
-#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
-
-/* ========== PIO definition for SMC peripheral ========== */
-#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
-#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
-
-#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
-#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
-
-#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
-#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
-
-#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
-#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
-
-#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
-#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
-
-#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
-#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
-
-#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
-#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
-
-#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
-#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
-
-#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
-#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
-
-#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
-#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
-
-#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
-#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
-
-#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
-#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
-#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
-#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
-#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
-#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
-#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
-#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
-#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
-#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
-#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
-#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
-#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
-#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
-#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
-#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
-#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
-#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
-#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
-#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
-#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
-#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
-#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
-#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
-#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
-#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
-#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
-#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
-#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
-#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
-#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
-#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
-#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
-#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
-#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
-#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
-#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
-#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
-#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
-#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
-#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
-#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
-#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
-#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
-#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
-#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
-#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
-#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
-#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
-#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
 
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
@@ -1730,6 +1520,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -2082,278 +1915,48 @@
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
 
-/* ========== PIO definition for EBI peripheral ========== */
-#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
-#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
-#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
 
-#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
-#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
 
-#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
-#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
-#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
 
-#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
-#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
-#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
 
-#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
-#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
-#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
 
-#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
-#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
-#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
 
-#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
-#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
-#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
 
-#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
-#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
-#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
 
-#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
-#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
-#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
 
-#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
-#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
-#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
 
-#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
-#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
-#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
 
-#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
-#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
-#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
-#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
-#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
-#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
-#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
-#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
-#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
-#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
-#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
-#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
-#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
-#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
-#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
-#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
-#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
-#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
-#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
-#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
-#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
-#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
-#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
-#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
-#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
-#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
-#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
-#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
-#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
-#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
-#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
-#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
-#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
-#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
-#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
-#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
-#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
-#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
-#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
-#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
-#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
-#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
-#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
-#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
-#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
-#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
-#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
-#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
-#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
-#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
-#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
-#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
-#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
-#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
-#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
-#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
-#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
-#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
-#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
-#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
-#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
-#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
-#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
-#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
-#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
-#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
-#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
-#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
-#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
-#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
-#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
-#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
-#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
-#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
-#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
-#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
-#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
-#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
-#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
-#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
-#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
-#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
-#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
-#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70Q19B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70q20b.h
+++ b/asf/sam/include/same70b/pio/same70q20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:57Z */
 #ifndef _SAME70Q20B_PIO_H_
 #define _SAME70Q20B_PIO_H_
 
@@ -390,14 +392,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
 #define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
@@ -417,20 +413,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -439,9 +426,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 #define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
 #define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
@@ -486,6 +470,343 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -718,10 +1039,6 @@
 #define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
 #define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
 
-#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
-#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
-#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
-
 #define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
 #define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
 #define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
@@ -770,6 +1087,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -1078,551 +1407,12 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
-/* ========== PIO definition for SDRAMC peripheral ========== */
-#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
-#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
-
-#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
-#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
-
-#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
-#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
-
-#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
-#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
-
-#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
-#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
-
-#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
-#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
-
-#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
-#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
-
-#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
-#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
-
-#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
-#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
-
-#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
-#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
-
-#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
-#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
-
-#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
-#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
-
-#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
-#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
-
-#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
-#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
-
-#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
-#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
-
-#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
-#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
-
-#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
-#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
-
-#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
-#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
-
-#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
-#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
-
-#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
-#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
-
-#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
-#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
-
-#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
-#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
-
-#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
-#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
-
-#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
-#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
-
-#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
-#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
-
-#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
-#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
-
-#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
-#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
-
-#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
-#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
-
-#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
-#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
-
-#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
-#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
-
-#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
-#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
-
-#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
-#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
-
-#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
-#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
-
-#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
-#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
-
-#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
-#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
-
-#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
-#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
-
-#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
-#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
-
-#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
-#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
-
-#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
-#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
-
-#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
-#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
-
-#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
-#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
-
-#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
-#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
-
-#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
-#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
-
-#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
-#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
-
-#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
-#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
-
-#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
-#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
-
-#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
-#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
-
-#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
-#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
-
-#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
-#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
-
-#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
-
-#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
-
-#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
-
-#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
-
-#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
-#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
-
-#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
-
-#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
-
-#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
-#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
-
-#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
-#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
-
-#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
-#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
-
-#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
-#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
-
-#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
-#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
-
-#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
-#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
-
-#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
-#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
-
-#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
-#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
-
-#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
-#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
-
-#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
-#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
-
-/* ========== PIO definition for SMC peripheral ========== */
-#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
-#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
-
-#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
-#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
-
-#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
-#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
-
-#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
-#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
-
-#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
-#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
-
-#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
-#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
-
-#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
-#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
-
-#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
-#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
-
-#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
-#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
-
-#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
-#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
-
-#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
-#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
-
-#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
-#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
-#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
-#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
-#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
-#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
-#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
-#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
-#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
-#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
-#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
-#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
-#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
-#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
-#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
-#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
-#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
-#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
-#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
-#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
-#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
-#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
-#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
-#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
-#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
-#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
-#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
-#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
-#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
-#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
-#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
-#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
-#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
-#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
-#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
-#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
-#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
-#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
-#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
-#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
-#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
-#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
-#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
-#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
-#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
-#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
-#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
-#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
-#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
-#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
 
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
@@ -1730,6 +1520,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -2082,278 +1915,48 @@
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
 
-/* ========== PIO definition for EBI peripheral ========== */
-#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
-#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
-#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
 
-#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
-#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
 
-#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
-#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
-#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
 
-#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
-#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
-#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
 
-#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
-#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
-#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
 
-#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
-#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
-#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
 
-#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
-#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
-#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
 
-#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
-#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
-#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
 
-#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
-#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
-#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
 
-#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
-#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
-#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
 
-#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
-#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
-#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
 
-#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
-#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
-#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
-#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
-#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
-#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
-#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
-#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
-#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
-#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
-#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
-#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
-#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
-#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
-#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
-#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
-#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
-#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
-#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
-#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
-#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
-#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
-#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
-#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
-#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
-#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
-#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
-#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
-#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
-#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
-#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
-#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
-#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
-#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
-#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
-#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
-#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
-#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
-#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
-#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
-#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
-#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
-#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
-#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
-#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
-#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
-#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
-#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
-#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
-#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
-#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
-#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
-#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
-#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
-#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
-#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
-#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
-#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
-#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
-#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
-#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
-#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
-#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
-#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
-#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
-#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
-#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
-#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
-#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
-#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
-#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
-#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
-#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
-#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
-#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
-#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
-#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
-#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
-#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
-#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
-#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
-#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
-#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
-#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70Q20B_PIO_H_ */

--- a/asf/sam/include/same70b/pio/same70q21b.h
+++ b/asf/sam/include/same70b/pio/same70q21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Peripheral I/O description for SAME70Q21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70Q21B_PIO_H_
 #define _SAME70Q21B_PIO_H_
 
@@ -390,14 +392,8 @@
 #define PIN_PA21X1_AFEC0_AD1                       _L_(21)      /**< AFEC0 signal: AD1 on PA21 mux X1*/
 #define PIO_PA21X1_AFEC0_AD1                       (_UL_(1) << 21)
 
-#define PIN_PA21X1_AFEC0_PIODCEN2                  _L_(21)      /**< AFEC0 signal: PIODCEN2 on PA21 mux X1*/
-#define PIO_PA21X1_AFEC0_PIODCEN2                  (_UL_(1) << 21)
-
 #define PIN_PB3X1_AFEC0_AD2                        _L_(35)      /**< AFEC0 signal: AD2 on PB3 mux X1*/
 #define PIO_PB3X1_AFEC0_AD2                        (_UL_(1) << 3)
-
-#define PIN_PB3X1_AFEC0_WKUP12                     _L_(35)      /**< AFEC0 signal: WKUP12 on PB3 mux X1*/
-#define PIO_PB3X1_AFEC0_WKUP12                     (_UL_(1) << 3)
 
 #define PIN_PE5X1_AFEC0_AD3                        _L_(133)     /**< AFEC0 signal: AD3 on PE5 mux X1*/
 #define PIO_PE5X1_AFEC0_AD3                        (_UL_(1) << 5)
@@ -417,20 +413,11 @@
 #define PIN_PA19X1_AFEC0_AD8                       _L_(19)      /**< AFEC0 signal: AD8 on PA19 mux X1*/
 #define PIO_PA19X1_AFEC0_AD8                       (_UL_(1) << 19)
 
-#define PIN_PA19X1_AFEC0_WKUP9                     _L_(19)      /**< AFEC0 signal: WKUP9 on PA19 mux X1*/
-#define PIO_PA19X1_AFEC0_WKUP9                     (_UL_(1) << 19)
-
 #define PIN_PA20X1_AFEC0_AD9                       _L_(20)      /**< AFEC0 signal: AD9 on PA20 mux X1*/
 #define PIO_PA20X1_AFEC0_AD9                       (_UL_(1) << 20)
 
-#define PIN_PA20X1_AFEC0_WKUP10                    _L_(20)      /**< AFEC0 signal: WKUP10 on PA20 mux X1*/
-#define PIO_PA20X1_AFEC0_WKUP10                    (_UL_(1) << 20)
-
 #define PIN_PB0X1_AFEC0_AD10                       _L_(32)      /**< AFEC0 signal: AD10 on PB0 mux X1*/
 #define PIO_PB0X1_AFEC0_AD10                       (_UL_(1) << 0)
-
-#define PIN_PB0X1_AFEC0_RTCOUT0                    _L_(32)      /**< AFEC0 signal: RTCOUT0 on PB0 mux X1*/
-#define PIO_PB0X1_AFEC0_RTCOUT0                    (_UL_(1) << 0)
 
 /* ========== PIO definition for AFEC1 peripheral ========== */
 #define PIN_PD9C_AFEC1_ADTRG                       _L_(105)     /**< AFEC1 signal: ADTRG on PD9 mux C*/
@@ -439,9 +426,6 @@
 
 #define PIN_PB1X1_AFEC1_AD0                        _L_(33)      /**< AFEC1 signal: AD0 on PB1 mux X1*/
 #define PIO_PB1X1_AFEC1_AD0                        (_UL_(1) << 1)
-
-#define PIN_PB1X1_AFEC1_RTCOUT1                    _L_(33)      /**< AFEC1 signal: RTCOUT1 on PB1 mux X1*/
-#define PIO_PB1X1_AFEC1_RTCOUT1                    (_UL_(1) << 1)
 
 #define PIN_PC13X1_AFEC1_AD1                       _L_(77)      /**< AFEC1 signal: AD1 on PC13 mux X1*/
 #define PIO_PC13X1_AFEC1_AD1                       (_UL_(1) << 13)
@@ -486,6 +470,343 @@
 #define PIN_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal: DATRG on PA2 mux C*/
 #define MUX_PA2C_DACC_DATRG                        _L_(2)       /**< DACC signal line function value: DATRG */
 #define PIO_PA2C_DACC_DATRG                        (_UL_(1) << 2)
+
+/* ========== PIO definition for EBI peripheral ========== */
+#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
+#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
+#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+
+#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
+#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
+#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+
+#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
+#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
+#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
+#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
+#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
+#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
+#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
+#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
+#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
+#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
+#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
+#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
+#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
+#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
+#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
+#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
+#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
+#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
+#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
+#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
+#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
+
+#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
+#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
+#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
+
+#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
+#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
+#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
+#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
+#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
+#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
+#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
+
+#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
+#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
+#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
+#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
+#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
+
+#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
+#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
+#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
+
+#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
+#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
+#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
+
+#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
+#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
+#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
+
+#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
+#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
+#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
+#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
+#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
+
+#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
+#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
+#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
+
+#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
+#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
+#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
+
+#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
+#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
+#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
+
+#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
+#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
+#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
+
+#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
+#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
+#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
+
+#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
+#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
+#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
+
+#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
+#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
+#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
+
+#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
+#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
+#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
+
+#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
+#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
+#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
+
+#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
+#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
+#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
+
+#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
+#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
+#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
+
+#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
+#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
+#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
+
+#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
+#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
+#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
+
+#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
+#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
+#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
+
+#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
+#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
+#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
+
+#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
+#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
+#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
+
+#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
+#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
+#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
+
+#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
+#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
+#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
+
+#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
+#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
+#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
+#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
+#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
+#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
+
+#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
+#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
+#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
+
+#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
+#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
+
+#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
+#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
+#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
+
+#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
+#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
+#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
+
+#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
+#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
+
+#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
+#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
+#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
+
+#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
+#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
+#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
+
+#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
+#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
+#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
+#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
+#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
+
+#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
+#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
+#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
+
+#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
+#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
+#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
+
+#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
+#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
+#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
+
+#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
+#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
+#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
+
+#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
+#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
+#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
+
+#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
+#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
+#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
+
+#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
+#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
+
+#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
+#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
+#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
+
+#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
+#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
+#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
+
+#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
+#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
+#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
+
+#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
+#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
+#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+
+#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
+#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
+#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
+
+#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
+#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
+#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
+
+#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
+#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
+#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
+#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
+
+#define PIN_PC20A_EBI_SDA0                         _L_(84)      /**< EBI signal: SDA0 on PC20 mux A*/
+#define MUX_PC20A_EBI_SDA0                         _L_(0)       /**< EBI signal line function value: SDA0 */
+#define PIO_PC20A_EBI_SDA0                         (_UL_(1) << 20)
+
+#define PIN_PC21A_EBI_SDA1                         _L_(85)      /**< EBI signal: SDA1 on PC21 mux A*/
+#define MUX_PC21A_EBI_SDA1                         _L_(0)       /**< EBI signal line function value: SDA1 */
+#define PIO_PC21A_EBI_SDA1                         (_UL_(1) << 21)
+
+#define PIN_PC22A_EBI_SDA2                         _L_(86)      /**< EBI signal: SDA2 on PC22 mux A*/
+#define MUX_PC22A_EBI_SDA2                         _L_(0)       /**< EBI signal line function value: SDA2 */
+#define PIO_PC22A_EBI_SDA2                         (_UL_(1) << 22)
+
+#define PIN_PC23A_EBI_SDA3                         _L_(87)      /**< EBI signal: SDA3 on PC23 mux A*/
+#define MUX_PC23A_EBI_SDA3                         _L_(0)       /**< EBI signal line function value: SDA3 */
+#define PIO_PC23A_EBI_SDA3                         (_UL_(1) << 23)
+
+#define PIN_PC24A_EBI_SDA4                         _L_(88)      /**< EBI signal: SDA4 on PC24 mux A*/
+#define MUX_PC24A_EBI_SDA4                         _L_(0)       /**< EBI signal line function value: SDA4 */
+#define PIO_PC24A_EBI_SDA4                         (_UL_(1) << 24)
+
+#define PIN_PC25A_EBI_SDA5                         _L_(89)      /**< EBI signal: SDA5 on PC25 mux A*/
+#define MUX_PC25A_EBI_SDA5                         _L_(0)       /**< EBI signal line function value: SDA5 */
+#define PIO_PC25A_EBI_SDA5                         (_UL_(1) << 25)
+
+#define PIN_PC26A_EBI_SDA6                         _L_(90)      /**< EBI signal: SDA6 on PC26 mux A*/
+#define MUX_PC26A_EBI_SDA6                         _L_(0)       /**< EBI signal line function value: SDA6 */
+#define PIO_PC26A_EBI_SDA6                         (_UL_(1) << 26)
+
+#define PIN_PC27A_EBI_SDA7                         _L_(91)      /**< EBI signal: SDA7 on PC27 mux A*/
+#define MUX_PC27A_EBI_SDA7                         _L_(0)       /**< EBI signal line function value: SDA7 */
+#define PIO_PC27A_EBI_SDA7                         (_UL_(1) << 27)
+
+#define PIN_PC28A_EBI_SDA8                         _L_(92)      /**< EBI signal: SDA8 on PC28 mux A*/
+#define MUX_PC28A_EBI_SDA8                         _L_(0)       /**< EBI signal line function value: SDA8 */
+#define PIO_PC28A_EBI_SDA8                         (_UL_(1) << 28)
+
+#define PIN_PC29A_EBI_SDA9                         _L_(93)      /**< EBI signal: SDA9 on PC29 mux A*/
+#define MUX_PC29A_EBI_SDA9                         _L_(0)       /**< EBI signal line function value: SDA9 */
+#define PIO_PC29A_EBI_SDA9                         (_UL_(1) << 29)
+
+#define PIN_PC31A_EBI_SDA11                        _L_(95)      /**< EBI signal: SDA11 on PC31 mux A*/
+#define MUX_PC31A_EBI_SDA11                        _L_(0)       /**< EBI signal line function value: SDA11 */
+#define PIO_PC31A_EBI_SDA11                        (_UL_(1) << 31)
+
+#define PIN_PA18C_EBI_SDA12                        _L_(18)      /**< EBI signal: SDA12 on PA18 mux C*/
+#define MUX_PA18C_EBI_SDA12                        _L_(2)       /**< EBI signal line function value: SDA12 */
+#define PIO_PA18C_EBI_SDA12                        (_UL_(1) << 18)
+
+#define PIN_PA19C_EBI_SDA13                        _L_(19)      /**< EBI signal: SDA13 on PA19 mux C*/
+#define MUX_PA19C_EBI_SDA13                        _L_(2)       /**< EBI signal line function value: SDA13 */
+#define PIO_PA19C_EBI_SDA13                        (_UL_(1) << 19)
+
+#define PIN_PC18A_EBI_DQM0                         _L_(82)      /**< EBI signal: DQM0 on PC18 mux A*/
+#define MUX_PC18A_EBI_DQM0                         _L_(0)       /**< EBI signal line function value: DQM0 */
+#define PIO_PC18A_EBI_DQM0                         (_UL_(1) << 18)
+
+#define PIN_PD15C_EBI_DQM1                         _L_(111)     /**< EBI signal: DQM1 on PD15 mux C*/
+#define MUX_PD15C_EBI_DQM1                         _L_(2)       /**< EBI signal line function value: DQM1 */
+#define PIO_PD15C_EBI_DQM1                         (_UL_(1) << 15)
+
+/* ========== PIO definition for EFC peripheral ========== */
+#define PIN_PB12X1_EFC_ERASE                       _L_(44)      /**< EFC signal: ERASE on PB12 mux X1*/
+#define PIO_PB12X1_EFC_ERASE                       (_UL_(1) << 12)
 
 /* ========== PIO definition for GMAC peripheral ========== */
 #define PIN_PD13A_GMAC_GCOL                        _L_(109)     /**< GMAC signal: GCOL on PD13 mux A*/
@@ -718,10 +1039,6 @@
 #define MUX_PC12C_MCAN1_CANRX1                     _L_(2)       /**< MCAN1 signal line function value: CANRX1 */
 #define PIO_PC12C_MCAN1_CANRX1                     (_UL_(1) << 12)
 
-#define PIN_PD28B_MCAN1_CANRX1                     _L_(124)     /**< MCAN1 signal: CANRX1 on PD28 mux B*/
-#define MUX_PD28B_MCAN1_CANRX1                     _L_(1)       /**< MCAN1 signal line function value: CANRX1 */
-#define PIO_PD28B_MCAN1_CANRX1                     (_UL_(1) << 28)
-
 #define PIN_PC14C_MCAN1_CANTX1                     _L_(78)      /**< MCAN1 signal: CANTX1 on PC14 mux C*/
 #define MUX_PC14C_MCAN1_CANTX1                     _L_(2)       /**< MCAN1 signal line function value: CANTX1 */
 #define PIO_PC14C_MCAN1_CANTX1                     (_UL_(1) << 14)
@@ -770,6 +1087,18 @@
 #define PIN_PD31C_PMC_PCK2                         _L_(127)     /**< PMC signal: PCK2 on PD31 mux C*/
 #define MUX_PD31C_PMC_PCK2                         _L_(2)       /**< PMC signal line function value: PCK2 */
 #define PIO_PD31C_PMC_PCK2                         (_UL_(1) << 31)
+
+#define PIN_PB9X1_PMC_XIN                          _L_(41)      /**< PMC signal: XIN on PB9 mux X1*/
+#define PIO_PB9X1_PMC_XIN                          (_UL_(1) << 9)
+
+#define PIN_PB8X1_PMC_XOUT                         _L_(40)      /**< PMC signal: XOUT on PB8 mux X1*/
+#define PIO_PB8X1_PMC_XOUT                         (_UL_(1) << 8)
+
+#define PIN_PA7X1_PMC_XIN32                        _L_(7)       /**< PMC signal: XIN32 on PA7 mux X1*/
+#define PIO_PA7X1_PMC_XIN32                        (_UL_(1) << 7)
+
+#define PIN_PA8X1_PMC_XOUT32                       _L_(8)       /**< PMC signal: XOUT32 on PA8 mux X1*/
+#define PIO_PA8X1_PMC_XOUT32                       (_UL_(1) << 8)
 
 /* ========== PIO definition for PWM0 peripheral ========== */
 #define PIN_PA10B_PWM0_PWMEXTRG0                   _L_(10)      /**< PWM0 signal: PWMEXTRG0 on PA10 mux B*/
@@ -1078,551 +1407,12 @@
 #define MUX_PA14A_QSPI_QSCK                        _L_(0)       /**< QSPI signal line function value: QSCK */
 #define PIO_PA14A_QSPI_QSCK                        (_UL_(1) << 14)
 
-/* ========== PIO definition for SDRAMC peripheral ========== */
-#define PIN_PC18A_SDRAMC_A0                        _L_(82)      /**< SDRAMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_A0                        _L_(0)       /**< SDRAMC signal line function value: A0 */
-#define PIO_PC18A_SDRAMC_A0                        (_UL_(1) << 18)
-
-#define PIN_PC18A_SDRAMC_NBS0                      _L_(82)      /**< SDRAMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SDRAMC_NBS0                      _L_(0)       /**< SDRAMC signal line function value: NBS0 */
-#define PIO_PC18A_SDRAMC_NBS0                      (_UL_(1) << 18)
-
-#define PIN_PC19A_SDRAMC_A1                        _L_(83)      /**< SDRAMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SDRAMC_A1                        _L_(0)       /**< SDRAMC signal line function value: A1 */
-#define PIO_PC19A_SDRAMC_A1                        (_UL_(1) << 19)
-
-#define PIN_PC20A_SDRAMC_A2                        _L_(84)      /**< SDRAMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SDRAMC_A2                        _L_(0)       /**< SDRAMC signal line function value: A2 */
-#define PIO_PC20A_SDRAMC_A2                        (_UL_(1) << 20)
-
-#define PIN_PC21A_SDRAMC_A3                        _L_(85)      /**< SDRAMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SDRAMC_A3                        _L_(0)       /**< SDRAMC signal line function value: A3 */
-#define PIO_PC21A_SDRAMC_A3                        (_UL_(1) << 21)
-
-#define PIN_PC22A_SDRAMC_A4                        _L_(86)      /**< SDRAMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SDRAMC_A4                        _L_(0)       /**< SDRAMC signal line function value: A4 */
-#define PIO_PC22A_SDRAMC_A4                        (_UL_(1) << 22)
-
-#define PIN_PC23A_SDRAMC_A5                        _L_(87)      /**< SDRAMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SDRAMC_A5                        _L_(0)       /**< SDRAMC signal line function value: A5 */
-#define PIO_PC23A_SDRAMC_A5                        (_UL_(1) << 23)
-
-#define PIN_PC24A_SDRAMC_A6                        _L_(88)      /**< SDRAMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SDRAMC_A6                        _L_(0)       /**< SDRAMC signal line function value: A6 */
-#define PIO_PC24A_SDRAMC_A6                        (_UL_(1) << 24)
-
-#define PIN_PC25A_SDRAMC_A7                        _L_(89)      /**< SDRAMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SDRAMC_A7                        _L_(0)       /**< SDRAMC signal line function value: A7 */
-#define PIO_PC25A_SDRAMC_A7                        (_UL_(1) << 25)
-
-#define PIN_PC26A_SDRAMC_A8                        _L_(90)      /**< SDRAMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SDRAMC_A8                        _L_(0)       /**< SDRAMC signal line function value: A8 */
-#define PIO_PC26A_SDRAMC_A8                        (_UL_(1) << 26)
-
-#define PIN_PC27A_SDRAMC_A9                        _L_(91)      /**< SDRAMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SDRAMC_A9                        _L_(0)       /**< SDRAMC signal line function value: A9 */
-#define PIO_PC27A_SDRAMC_A9                        (_UL_(1) << 27)
-
-#define PIN_PC28A_SDRAMC_A10                       _L_(92)      /**< SDRAMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SDRAMC_A10                       _L_(0)       /**< SDRAMC signal line function value: A10 */
-#define PIO_PC28A_SDRAMC_A10                       (_UL_(1) << 28)
-
-#define PIN_PC29A_SDRAMC_A11                       _L_(93)      /**< SDRAMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SDRAMC_A11                       _L_(0)       /**< SDRAMC signal line function value: A11 */
-#define PIO_PC29A_SDRAMC_A11                       (_UL_(1) << 29)
-
-#define PIN_PC30A_SDRAMC_A12                       _L_(94)      /**< SDRAMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SDRAMC_A12                       _L_(0)       /**< SDRAMC signal line function value: A12 */
-#define PIO_PC30A_SDRAMC_A12                       (_UL_(1) << 30)
-
-#define PIN_PC31A_SDRAMC_A13                       _L_(95)      /**< SDRAMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SDRAMC_A13                       _L_(0)       /**< SDRAMC signal line function value: A13 */
-#define PIO_PC31A_SDRAMC_A13                       (_UL_(1) << 31)
-
-#define PIN_PA18C_SDRAMC_A14                       _L_(18)      /**< SDRAMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SDRAMC_A14                       _L_(2)       /**< SDRAMC signal line function value: A14 */
-#define PIO_PA18C_SDRAMC_A14                       (_UL_(1) << 18)
-
-#define PIN_PA19C_SDRAMC_A15                       _L_(19)      /**< SDRAMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SDRAMC_A15                       _L_(2)       /**< SDRAMC signal line function value: A15 */
-#define PIO_PA19C_SDRAMC_A15                       (_UL_(1) << 19)
-
-#define PIN_PA20C_SDRAMC_A16                       _L_(20)      /**< SDRAMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_A16                       _L_(2)       /**< SDRAMC signal line function value: A16 */
-#define PIO_PA20C_SDRAMC_A16                       (_UL_(1) << 20)
-
-#define PIN_PA20C_SDRAMC_BA0                       _L_(20)      /**< SDRAMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SDRAMC_BA0                       _L_(2)       /**< SDRAMC signal line function value: BA0 */
-#define PIO_PA20C_SDRAMC_BA0                       (_UL_(1) << 20)
-
-#define PIN_PA0C_SDRAMC_A17                        _L_(0)       /**< SDRAMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_A17                        _L_(2)       /**< SDRAMC signal line function value: A17 */
-#define PIO_PA0C_SDRAMC_A17                        (_UL_(1) << 0)
-
-#define PIN_PA0C_SDRAMC_BA1                        _L_(0)       /**< SDRAMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SDRAMC_BA1                        _L_(2)       /**< SDRAMC signal line function value: BA1 */
-#define PIO_PA0C_SDRAMC_BA1                        (_UL_(1) << 0)
-
-#define PIN_PA1C_SDRAMC_A18                        _L_(1)       /**< SDRAMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SDRAMC_A18                        _L_(2)       /**< SDRAMC signal line function value: A18 */
-#define PIO_PA1C_SDRAMC_A18                        (_UL_(1) << 1)
-
-#define PIN_PA23C_SDRAMC_A19                       _L_(23)      /**< SDRAMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SDRAMC_A19                       _L_(2)       /**< SDRAMC signal line function value: A19 */
-#define PIO_PA23C_SDRAMC_A19                       (_UL_(1) << 23)
-
-#define PIN_PA24C_SDRAMC_A20                       _L_(24)      /**< SDRAMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SDRAMC_A20                       _L_(2)       /**< SDRAMC signal line function value: A20 */
-#define PIO_PA24C_SDRAMC_A20                       (_UL_(1) << 24)
-
-#define PIN_PC16A_SDRAMC_A21                       _L_(80)      /**< SDRAMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_A21                       _L_(0)       /**< SDRAMC signal line function value: A21 */
-#define PIO_PC16A_SDRAMC_A21                       (_UL_(1) << 16)
-
-#define PIN_PC16A_SDRAMC_NANDALE                   _L_(80)      /**< SDRAMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SDRAMC_NANDALE                   _L_(0)       /**< SDRAMC signal line function value: NANDALE */
-#define PIO_PC16A_SDRAMC_NANDALE                   (_UL_(1) << 16)
-
-#define PIN_PC17A_SDRAMC_A22                       _L_(81)      /**< SDRAMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_A22                       _L_(0)       /**< SDRAMC signal line function value: A22 */
-#define PIO_PC17A_SDRAMC_A22                       (_UL_(1) << 17)
-
-#define PIN_PC17A_SDRAMC_NANDCLE                   _L_(81)      /**< SDRAMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SDRAMC_NANDCLE                   _L_(0)       /**< SDRAMC signal line function value: NANDCLE */
-#define PIO_PC17A_SDRAMC_NANDCLE                   (_UL_(1) << 17)
-
-#define PIN_PA25C_SDRAMC_A23                       _L_(25)      /**< SDRAMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SDRAMC_A23                       _L_(2)       /**< SDRAMC signal line function value: A23 */
-#define PIO_PA25C_SDRAMC_A23                       (_UL_(1) << 25)
-
-#define PIN_PD17C_SDRAMC_CAS                       _L_(113)     /**< SDRAMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SDRAMC_CAS                       _L_(2)       /**< SDRAMC signal line function value: CAS */
-#define PIO_PD17C_SDRAMC_CAS                       (_UL_(1) << 17)
-
-#define PIN_PC0A_SDRAMC_D0                         _L_(64)      /**< SDRAMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SDRAMC_D0                         _L_(0)       /**< SDRAMC signal line function value: D0 */
-#define PIO_PC0A_SDRAMC_D0                         (_UL_(1) << 0)
-
-#define PIN_PC1A_SDRAMC_D1                         _L_(65)      /**< SDRAMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SDRAMC_D1                         _L_(0)       /**< SDRAMC signal line function value: D1 */
-#define PIO_PC1A_SDRAMC_D1                         (_UL_(1) << 1)
-
-#define PIN_PC2A_SDRAMC_D2                         _L_(66)      /**< SDRAMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SDRAMC_D2                         _L_(0)       /**< SDRAMC signal line function value: D2 */
-#define PIO_PC2A_SDRAMC_D2                         (_UL_(1) << 2)
-
-#define PIN_PC3A_SDRAMC_D3                         _L_(67)      /**< SDRAMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SDRAMC_D3                         _L_(0)       /**< SDRAMC signal line function value: D3 */
-#define PIO_PC3A_SDRAMC_D3                         (_UL_(1) << 3)
-
-#define PIN_PC4A_SDRAMC_D4                         _L_(68)      /**< SDRAMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SDRAMC_D4                         _L_(0)       /**< SDRAMC signal line function value: D4 */
-#define PIO_PC4A_SDRAMC_D4                         (_UL_(1) << 4)
-
-#define PIN_PC5A_SDRAMC_D5                         _L_(69)      /**< SDRAMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SDRAMC_D5                         _L_(0)       /**< SDRAMC signal line function value: D5 */
-#define PIO_PC5A_SDRAMC_D5                         (_UL_(1) << 5)
-
-#define PIN_PC6A_SDRAMC_D6                         _L_(70)      /**< SDRAMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SDRAMC_D6                         _L_(0)       /**< SDRAMC signal line function value: D6 */
-#define PIO_PC6A_SDRAMC_D6                         (_UL_(1) << 6)
-
-#define PIN_PC7A_SDRAMC_D7                         _L_(71)      /**< SDRAMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SDRAMC_D7                         _L_(0)       /**< SDRAMC signal line function value: D7 */
-#define PIO_PC7A_SDRAMC_D7                         (_UL_(1) << 7)
-
-#define PIN_PE0A_SDRAMC_D8                         _L_(128)     /**< SDRAMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SDRAMC_D8                         _L_(0)       /**< SDRAMC signal line function value: D8 */
-#define PIO_PE0A_SDRAMC_D8                         (_UL_(1) << 0)
-
-#define PIN_PE1A_SDRAMC_D9                         _L_(129)     /**< SDRAMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SDRAMC_D9                         _L_(0)       /**< SDRAMC signal line function value: D9 */
-#define PIO_PE1A_SDRAMC_D9                         (_UL_(1) << 1)
-
-#define PIN_PE2A_SDRAMC_D10                        _L_(130)     /**< SDRAMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SDRAMC_D10                        _L_(0)       /**< SDRAMC signal line function value: D10 */
-#define PIO_PE2A_SDRAMC_D10                        (_UL_(1) << 2)
-
-#define PIN_PE3A_SDRAMC_D11                        _L_(131)     /**< SDRAMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SDRAMC_D11                        _L_(0)       /**< SDRAMC signal line function value: D11 */
-#define PIO_PE3A_SDRAMC_D11                        (_UL_(1) << 3)
-
-#define PIN_PE4A_SDRAMC_D12                        _L_(132)     /**< SDRAMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SDRAMC_D12                        _L_(0)       /**< SDRAMC signal line function value: D12 */
-#define PIO_PE4A_SDRAMC_D12                        (_UL_(1) << 4)
-
-#define PIN_PE5A_SDRAMC_D13                        _L_(133)     /**< SDRAMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SDRAMC_D13                        _L_(0)       /**< SDRAMC signal line function value: D13 */
-#define PIO_PE5A_SDRAMC_D13                        (_UL_(1) << 5)
-
-#define PIN_PA15A_SDRAMC_D14                       _L_(15)      /**< SDRAMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SDRAMC_D14                       _L_(0)       /**< SDRAMC signal line function value: D14 */
-#define PIO_PA15A_SDRAMC_D14                       (_UL_(1) << 15)
-
-#define PIN_PA16A_SDRAMC_D15                       _L_(16)      /**< SDRAMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SDRAMC_D15                       _L_(0)       /**< SDRAMC signal line function value: D15 */
-#define PIO_PA16A_SDRAMC_D15                       (_UL_(1) << 16)
-
-#define PIN_PC9A_SDRAMC_NANDOE                     _L_(73)      /**< SDRAMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SDRAMC_NANDOE                     _L_(0)       /**< SDRAMC signal line function value: NANDOE */
-#define PIO_PC9A_SDRAMC_NANDOE                     (_UL_(1) << 9)
-
-#define PIN_PC10A_SDRAMC_NANDWE                    _L_(74)      /**< SDRAMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SDRAMC_NANDWE                    _L_(0)       /**< SDRAMC signal line function value: NANDWE */
-#define PIO_PC10A_SDRAMC_NANDWE                    (_UL_(1) << 10)
-
-#define PIN_PC14A_SDRAMC_NCS0                      _L_(78)      /**< SDRAMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SDRAMC_NCS0                      _L_(0)       /**< SDRAMC signal line function value: NCS0 */
-#define PIO_PC14A_SDRAMC_NCS0                      (_UL_(1) << 14)
-
-#define PIN_PC15A_SDRAMC_NCS1                      _L_(79)      /**< SDRAMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PC15A_SDRAMC_NCS1                      (_UL_(1) << 15)
-
-#define PIN_PC15A_SDRAMC_SDCS                      _L_(79)      /**< SDRAMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PC15A_SDRAMC_SDCS                      (_UL_(1) << 15)
-
-#define PIN_PD18A_SDRAMC_NCS1                      _L_(114)     /**< SDRAMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_NCS1                      _L_(0)       /**< SDRAMC signal line function value: NCS1 */
-#define PIO_PD18A_SDRAMC_NCS1                      (_UL_(1) << 18)
-
-#define PIN_PD18A_SDRAMC_SDCS                      _L_(114)     /**< SDRAMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SDRAMC_SDCS                      _L_(0)       /**< SDRAMC signal line function value: SDCS */
-#define PIO_PD18A_SDRAMC_SDCS                      (_UL_(1) << 18)
-
-#define PIN_PA22C_SDRAMC_NCS2                      _L_(22)      /**< SDRAMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SDRAMC_NCS2                      _L_(2)       /**< SDRAMC signal line function value: NCS2 */
-#define PIO_PA22C_SDRAMC_NCS2                      (_UL_(1) << 22)
-
-#define PIN_PC12A_SDRAMC_NCS3                      _L_(76)      /**< SDRAMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PC12A_SDRAMC_NCS3                      (_UL_(1) << 12)
-
-#define PIN_PD19A_SDRAMC_NCS3                      _L_(115)     /**< SDRAMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SDRAMC_NCS3                      _L_(0)       /**< SDRAMC signal line function value: NCS3 */
-#define PIO_PD19A_SDRAMC_NCS3                      (_UL_(1) << 19)
-
-#define PIN_PC11A_SDRAMC_NRD                       _L_(75)      /**< SDRAMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SDRAMC_NRD                       _L_(0)       /**< SDRAMC signal line function value: NRD */
-#define PIO_PC11A_SDRAMC_NRD                       (_UL_(1) << 11)
-
-#define PIN_PC13A_SDRAMC_NWAIT                     _L_(77)      /**< SDRAMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SDRAMC_NWAIT                     _L_(0)       /**< SDRAMC signal line function value: NWAIT */
-#define PIO_PC13A_SDRAMC_NWAIT                     (_UL_(1) << 13)
-
-#define PIN_PC8A_SDRAMC_NWR0                       _L_(72)      /**< SDRAMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWR0                       _L_(0)       /**< SDRAMC signal line function value: NWR0 */
-#define PIO_PC8A_SDRAMC_NWR0                       (_UL_(1) << 8)
-
-#define PIN_PC8A_SDRAMC_NWE                        _L_(72)      /**< SDRAMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SDRAMC_NWE                        _L_(0)       /**< SDRAMC signal line function value: NWE */
-#define PIO_PC8A_SDRAMC_NWE                        (_UL_(1) << 8)
-
-#define PIN_PD15C_SDRAMC_NWR1                      _L_(111)     /**< SDRAMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NWR1                      _L_(2)       /**< SDRAMC signal line function value: NWR1 */
-#define PIO_PD15C_SDRAMC_NWR1                      (_UL_(1) << 15)
-
-#define PIN_PD15C_SDRAMC_NBS1                      _L_(111)     /**< SDRAMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SDRAMC_NBS1                      _L_(2)       /**< SDRAMC signal line function value: NBS1 */
-#define PIO_PD15C_SDRAMC_NBS1                      (_UL_(1) << 15)
-
-#define PIN_PD16C_SDRAMC_RAS                       _L_(112)     /**< SDRAMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SDRAMC_RAS                       _L_(2)       /**< SDRAMC signal line function value: RAS */
-#define PIO_PD16C_SDRAMC_RAS                       (_UL_(1) << 16)
-
-#define PIN_PC13C_SDRAMC_SDA10                     _L_(77)      /**< SDRAMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PC13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD13C_SDRAMC_SDA10                     _L_(109)     /**< SDRAMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SDRAMC_SDA10                     _L_(2)       /**< SDRAMC signal line function value: SDA10 */
-#define PIO_PD13C_SDRAMC_SDA10                     (_UL_(1) << 13)
-
-#define PIN_PD23C_SDRAMC_SDCK                      _L_(119)     /**< SDRAMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SDRAMC_SDCK                      _L_(2)       /**< SDRAMC signal line function value: SDCK */
-#define PIO_PD23C_SDRAMC_SDCK                      (_UL_(1) << 23)
-
-#define PIN_PD14C_SDRAMC_SDCKE                     _L_(110)     /**< SDRAMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SDRAMC_SDCKE                     _L_(2)       /**< SDRAMC signal line function value: SDCKE */
-#define PIO_PD14C_SDRAMC_SDCKE                     (_UL_(1) << 14)
-
-#define PIN_PD29C_SDRAMC_SDWE                      _L_(125)     /**< SDRAMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SDRAMC_SDWE                      _L_(2)       /**< SDRAMC signal line function value: SDWE */
-#define PIO_PD29C_SDRAMC_SDWE                      (_UL_(1) << 29)
-
-/* ========== PIO definition for SMC peripheral ========== */
-#define PIN_PC18A_SMC_A0                           _L_(82)      /**< SMC signal: A0 on PC18 mux A*/
-#define MUX_PC18A_SMC_A0                           _L_(0)       /**< SMC signal line function value: A0 */
-#define PIO_PC18A_SMC_A0                           (_UL_(1) << 18)
-
-#define PIN_PC18A_SMC_NBS0                         _L_(82)      /**< SMC signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_SMC_NBS0                         _L_(0)       /**< SMC signal line function value: NBS0 */
-#define PIO_PC18A_SMC_NBS0                         (_UL_(1) << 18)
-
-#define PIN_PC19A_SMC_A1                           _L_(83)      /**< SMC signal: A1 on PC19 mux A*/
-#define MUX_PC19A_SMC_A1                           _L_(0)       /**< SMC signal line function value: A1 */
-#define PIO_PC19A_SMC_A1                           (_UL_(1) << 19)
-
-#define PIN_PC20A_SMC_A2                           _L_(84)      /**< SMC signal: A2 on PC20 mux A*/
-#define MUX_PC20A_SMC_A2                           _L_(0)       /**< SMC signal line function value: A2 */
-#define PIO_PC20A_SMC_A2                           (_UL_(1) << 20)
-
-#define PIN_PC21A_SMC_A3                           _L_(85)      /**< SMC signal: A3 on PC21 mux A*/
-#define MUX_PC21A_SMC_A3                           _L_(0)       /**< SMC signal line function value: A3 */
-#define PIO_PC21A_SMC_A3                           (_UL_(1) << 21)
-
-#define PIN_PC22A_SMC_A4                           _L_(86)      /**< SMC signal: A4 on PC22 mux A*/
-#define MUX_PC22A_SMC_A4                           _L_(0)       /**< SMC signal line function value: A4 */
-#define PIO_PC22A_SMC_A4                           (_UL_(1) << 22)
-
-#define PIN_PC23A_SMC_A5                           _L_(87)      /**< SMC signal: A5 on PC23 mux A*/
-#define MUX_PC23A_SMC_A5                           _L_(0)       /**< SMC signal line function value: A5 */
-#define PIO_PC23A_SMC_A5                           (_UL_(1) << 23)
-
-#define PIN_PC24A_SMC_A6                           _L_(88)      /**< SMC signal: A6 on PC24 mux A*/
-#define MUX_PC24A_SMC_A6                           _L_(0)       /**< SMC signal line function value: A6 */
-#define PIO_PC24A_SMC_A6                           (_UL_(1) << 24)
-
-#define PIN_PC25A_SMC_A7                           _L_(89)      /**< SMC signal: A7 on PC25 mux A*/
-#define MUX_PC25A_SMC_A7                           _L_(0)       /**< SMC signal line function value: A7 */
-#define PIO_PC25A_SMC_A7                           (_UL_(1) << 25)
-
-#define PIN_PC26A_SMC_A8                           _L_(90)      /**< SMC signal: A8 on PC26 mux A*/
-#define MUX_PC26A_SMC_A8                           _L_(0)       /**< SMC signal line function value: A8 */
-#define PIO_PC26A_SMC_A8                           (_UL_(1) << 26)
-
-#define PIN_PC27A_SMC_A9                           _L_(91)      /**< SMC signal: A9 on PC27 mux A*/
-#define MUX_PC27A_SMC_A9                           _L_(0)       /**< SMC signal line function value: A9 */
-#define PIO_PC27A_SMC_A9                           (_UL_(1) << 27)
-
-#define PIN_PC28A_SMC_A10                          _L_(92)      /**< SMC signal: A10 on PC28 mux A*/
-#define MUX_PC28A_SMC_A10                          _L_(0)       /**< SMC signal line function value: A10 */
-#define PIO_PC28A_SMC_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_SMC_A11                          _L_(93)      /**< SMC signal: A11 on PC29 mux A*/
-#define MUX_PC29A_SMC_A11                          _L_(0)       /**< SMC signal line function value: A11 */
-#define PIO_PC29A_SMC_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_SMC_A12                          _L_(94)      /**< SMC signal: A12 on PC30 mux A*/
-#define MUX_PC30A_SMC_A12                          _L_(0)       /**< SMC signal line function value: A12 */
-#define PIO_PC30A_SMC_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_SMC_A13                          _L_(95)      /**< SMC signal: A13 on PC31 mux A*/
-#define MUX_PC31A_SMC_A13                          _L_(0)       /**< SMC signal line function value: A13 */
-#define PIO_PC31A_SMC_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_SMC_A14                          _L_(18)      /**< SMC signal: A14 on PA18 mux C*/
-#define MUX_PA18C_SMC_A14                          _L_(2)       /**< SMC signal line function value: A14 */
-#define PIO_PA18C_SMC_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_SMC_A15                          _L_(19)      /**< SMC signal: A15 on PA19 mux C*/
-#define MUX_PA19C_SMC_A15                          _L_(2)       /**< SMC signal line function value: A15 */
-#define PIO_PA19C_SMC_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_SMC_A16                          _L_(20)      /**< SMC signal: A16 on PA20 mux C*/
-#define MUX_PA20C_SMC_A16                          _L_(2)       /**< SMC signal line function value: A16 */
-#define PIO_PA20C_SMC_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_SMC_BA0                          _L_(20)      /**< SMC signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_SMC_BA0                          _L_(2)       /**< SMC signal line function value: BA0 */
-#define PIO_PA20C_SMC_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_SMC_A17                           _L_(0)       /**< SMC signal: A17 on PA0 mux C*/
-#define MUX_PA0C_SMC_A17                           _L_(2)       /**< SMC signal line function value: A17 */
-#define PIO_PA0C_SMC_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_SMC_BA1                           _L_(0)       /**< SMC signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_SMC_BA1                           _L_(2)       /**< SMC signal line function value: BA1 */
-#define PIO_PA0C_SMC_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_SMC_A18                           _L_(1)       /**< SMC signal: A18 on PA1 mux C*/
-#define MUX_PA1C_SMC_A18                           _L_(2)       /**< SMC signal line function value: A18 */
-#define PIO_PA1C_SMC_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_SMC_A19                          _L_(23)      /**< SMC signal: A19 on PA23 mux C*/
-#define MUX_PA23C_SMC_A19                          _L_(2)       /**< SMC signal line function value: A19 */
-#define PIO_PA23C_SMC_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_SMC_A20                          _L_(24)      /**< SMC signal: A20 on PA24 mux C*/
-#define MUX_PA24C_SMC_A20                          _L_(2)       /**< SMC signal line function value: A20 */
-#define PIO_PA24C_SMC_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_SMC_A21                          _L_(80)      /**< SMC signal: A21 on PC16 mux A*/
-#define MUX_PC16A_SMC_A21                          _L_(0)       /**< SMC signal line function value: A21 */
-#define PIO_PC16A_SMC_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_SMC_NANDALE                      _L_(80)      /**< SMC signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_SMC_NANDALE                      _L_(0)       /**< SMC signal line function value: NANDALE */
-#define PIO_PC16A_SMC_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_SMC_A22                          _L_(81)      /**< SMC signal: A22 on PC17 mux A*/
-#define MUX_PC17A_SMC_A22                          _L_(0)       /**< SMC signal line function value: A22 */
-#define PIO_PC17A_SMC_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_SMC_NANDCLE                      _L_(81)      /**< SMC signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_SMC_NANDCLE                      _L_(0)       /**< SMC signal line function value: NANDCLE */
-#define PIO_PC17A_SMC_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_SMC_A23                          _L_(25)      /**< SMC signal: A23 on PA25 mux C*/
-#define MUX_PA25C_SMC_A23                          _L_(2)       /**< SMC signal line function value: A23 */
-#define PIO_PA25C_SMC_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_SMC_CAS                          _L_(113)     /**< SMC signal: CAS on PD17 mux C*/
-#define MUX_PD17C_SMC_CAS                          _L_(2)       /**< SMC signal line function value: CAS */
-#define PIO_PD17C_SMC_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_SMC_D0                            _L_(64)      /**< SMC signal: D0 on PC0 mux A*/
-#define MUX_PC0A_SMC_D0                            _L_(0)       /**< SMC signal line function value: D0 */
-#define PIO_PC0A_SMC_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_SMC_D1                            _L_(65)      /**< SMC signal: D1 on PC1 mux A*/
-#define MUX_PC1A_SMC_D1                            _L_(0)       /**< SMC signal line function value: D1 */
-#define PIO_PC1A_SMC_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_SMC_D2                            _L_(66)      /**< SMC signal: D2 on PC2 mux A*/
-#define MUX_PC2A_SMC_D2                            _L_(0)       /**< SMC signal line function value: D2 */
-#define PIO_PC2A_SMC_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_SMC_D3                            _L_(67)      /**< SMC signal: D3 on PC3 mux A*/
-#define MUX_PC3A_SMC_D3                            _L_(0)       /**< SMC signal line function value: D3 */
-#define PIO_PC3A_SMC_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_SMC_D4                            _L_(68)      /**< SMC signal: D4 on PC4 mux A*/
-#define MUX_PC4A_SMC_D4                            _L_(0)       /**< SMC signal line function value: D4 */
-#define PIO_PC4A_SMC_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_SMC_D5                            _L_(69)      /**< SMC signal: D5 on PC5 mux A*/
-#define MUX_PC5A_SMC_D5                            _L_(0)       /**< SMC signal line function value: D5 */
-#define PIO_PC5A_SMC_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_SMC_D6                            _L_(70)      /**< SMC signal: D6 on PC6 mux A*/
-#define MUX_PC6A_SMC_D6                            _L_(0)       /**< SMC signal line function value: D6 */
-#define PIO_PC6A_SMC_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_SMC_D7                            _L_(71)      /**< SMC signal: D7 on PC7 mux A*/
-#define MUX_PC7A_SMC_D7                            _L_(0)       /**< SMC signal line function value: D7 */
-#define PIO_PC7A_SMC_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_SMC_D8                            _L_(128)     /**< SMC signal: D8 on PE0 mux A*/
-#define MUX_PE0A_SMC_D8                            _L_(0)       /**< SMC signal line function value: D8 */
-#define PIO_PE0A_SMC_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_SMC_D9                            _L_(129)     /**< SMC signal: D9 on PE1 mux A*/
-#define MUX_PE1A_SMC_D9                            _L_(0)       /**< SMC signal line function value: D9 */
-#define PIO_PE1A_SMC_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_SMC_D10                           _L_(130)     /**< SMC signal: D10 on PE2 mux A*/
-#define MUX_PE2A_SMC_D10                           _L_(0)       /**< SMC signal line function value: D10 */
-#define PIO_PE2A_SMC_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_SMC_D11                           _L_(131)     /**< SMC signal: D11 on PE3 mux A*/
-#define MUX_PE3A_SMC_D11                           _L_(0)       /**< SMC signal line function value: D11 */
-#define PIO_PE3A_SMC_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_SMC_D12                           _L_(132)     /**< SMC signal: D12 on PE4 mux A*/
-#define MUX_PE4A_SMC_D12                           _L_(0)       /**< SMC signal line function value: D12 */
-#define PIO_PE4A_SMC_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_SMC_D13                           _L_(133)     /**< SMC signal: D13 on PE5 mux A*/
-#define MUX_PE5A_SMC_D13                           _L_(0)       /**< SMC signal line function value: D13 */
-#define PIO_PE5A_SMC_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_SMC_D14                          _L_(15)      /**< SMC signal: D14 on PA15 mux A*/
-#define MUX_PA15A_SMC_D14                          _L_(0)       /**< SMC signal line function value: D14 */
-#define PIO_PA15A_SMC_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_SMC_D15                          _L_(16)      /**< SMC signal: D15 on PA16 mux A*/
-#define MUX_PA16A_SMC_D15                          _L_(0)       /**< SMC signal line function value: D15 */
-#define PIO_PA16A_SMC_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_SMC_NANDOE                        _L_(73)      /**< SMC signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_SMC_NANDOE                        _L_(0)       /**< SMC signal line function value: NANDOE */
-#define PIO_PC9A_SMC_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_SMC_NANDWE                       _L_(74)      /**< SMC signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_SMC_NANDWE                       _L_(0)       /**< SMC signal line function value: NANDWE */
-#define PIO_PC10A_SMC_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_SMC_NCS0                         _L_(78)      /**< SMC signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_SMC_NCS0                         _L_(0)       /**< SMC signal line function value: NCS0 */
-#define PIO_PC14A_SMC_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_SMC_NCS1                         _L_(79)      /**< SMC signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PC15A_SMC_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_SMC_SDCS                         _L_(79)      /**< SMC signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PC15A_SMC_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_SMC_NCS1                         _L_(114)     /**< SMC signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_SMC_NCS1                         _L_(0)       /**< SMC signal line function value: NCS1 */
-#define PIO_PD18A_SMC_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_SMC_SDCS                         _L_(114)     /**< SMC signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_SMC_SDCS                         _L_(0)       /**< SMC signal line function value: SDCS */
-#define PIO_PD18A_SMC_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_SMC_NCS2                         _L_(22)      /**< SMC signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_SMC_NCS2                         _L_(2)       /**< SMC signal line function value: NCS2 */
-#define PIO_PA22C_SMC_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_SMC_NCS3                         _L_(76)      /**< SMC signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PC12A_SMC_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_SMC_NCS3                         _L_(115)     /**< SMC signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_SMC_NCS3                         _L_(0)       /**< SMC signal line function value: NCS3 */
-#define PIO_PD19A_SMC_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_SMC_NRD                          _L_(75)      /**< SMC signal: NRD on PC11 mux A*/
-#define MUX_PC11A_SMC_NRD                          _L_(0)       /**< SMC signal line function value: NRD */
-#define PIO_PC11A_SMC_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_SMC_NWAIT                        _L_(77)      /**< SMC signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_SMC_NWAIT                        _L_(0)       /**< SMC signal line function value: NWAIT */
-#define PIO_PC13A_SMC_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_SMC_NWR0                          _L_(72)      /**< SMC signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_SMC_NWR0                          _L_(0)       /**< SMC signal line function value: NWR0 */
-#define PIO_PC8A_SMC_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_SMC_NWE                           _L_(72)      /**< SMC signal: NWE on PC8 mux A*/
-#define MUX_PC8A_SMC_NWE                           _L_(0)       /**< SMC signal line function value: NWE */
-#define PIO_PC8A_SMC_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_SMC_NWR1                         _L_(111)     /**< SMC signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NWR1                         _L_(2)       /**< SMC signal line function value: NWR1 */
-#define PIO_PD15C_SMC_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_SMC_NBS1                         _L_(111)     /**< SMC signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_SMC_NBS1                         _L_(2)       /**< SMC signal line function value: NBS1 */
-#define PIO_PD15C_SMC_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_SMC_RAS                          _L_(112)     /**< SMC signal: RAS on PD16 mux C*/
-#define MUX_PD16C_SMC_RAS                          _L_(2)       /**< SMC signal line function value: RAS */
-#define PIO_PD16C_SMC_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_SMC_SDA10                        _L_(77)      /**< SMC signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PC13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_SMC_SDA10                        _L_(109)     /**< SMC signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_SMC_SDA10                        _L_(2)       /**< SMC signal line function value: SDA10 */
-#define PIO_PD13C_SMC_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_SMC_SDCK                         _L_(119)     /**< SMC signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_SMC_SDCK                         _L_(2)       /**< SMC signal line function value: SDCK */
-#define PIO_PD23C_SMC_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_SMC_SDCKE                        _L_(110)     /**< SMC signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_SMC_SDCKE                        _L_(2)       /**< SMC signal line function value: SDCKE */
-#define PIO_PD14C_SMC_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_SMC_SDWE                         _L_(125)     /**< SMC signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_SMC_SDWE                         _L_(2)       /**< SMC signal line function value: SDWE */
-#define PIO_PD29C_SMC_SDWE                         (_UL_(1) << 29)
+/* ========== PIO definition for RTC peripheral ========== */
+#define PIN_PB0X1_RTC_RTCOUT0                      _L_(32)      /**< RTC signal: RTCOUT0 on PB0 mux X1*/
+#define PIO_PB0X1_RTC_RTCOUT0                      (_UL_(1) << 0)
+
+#define PIN_PB1X1_RTC_RTCOUT1                      _L_(33)      /**< RTC signal: RTCOUT1 on PB1 mux X1*/
+#define PIO_PB1X1_RTC_RTCOUT1                      (_UL_(1) << 1)
 
 /* ========== PIO definition for SPI0 peripheral ========== */
 #define PIN_PD20B_SPI0_MISO                        _L_(116)     /**< SPI0 signal: MISO on PD20 mux B*/
@@ -1730,6 +1520,49 @@
 #define PIN_PB1D_SSC_TK                            _L_(33)      /**< SSC signal: TK on PB1 mux D*/
 #define MUX_PB1D_SSC_TK                            _L_(3)       /**< SSC signal line function value: TK */
 #define PIO_PB1D_SSC_TK                            (_UL_(1) << 1)
+
+/* ========== PIO definition for SUPC peripheral ========== */
+#define PIN_PA0X1_SUPC_WKUP0                       _L_(0)       /**< SUPC signal: WKUP0 on PA0 mux X1*/
+#define PIO_PA0X1_SUPC_WKUP0                       (_UL_(1) << 0)
+
+#define PIN_PA1X1_SUPC_WKUP1                       _L_(1)       /**< SUPC signal: WKUP1 on PA1 mux X1*/
+#define PIO_PA1X1_SUPC_WKUP1                       (_UL_(1) << 1)
+
+#define PIN_PA2X1_SUPC_WKUP2                       _L_(2)       /**< SUPC signal: WKUP2 on PA2 mux X1*/
+#define PIO_PA2X1_SUPC_WKUP2                       (_UL_(1) << 2)
+
+#define PIN_PA4X1_SUPC_WKUP3                       _L_(4)       /**< SUPC signal: WKUP3 on PA4 mux X1*/
+#define PIO_PA4X1_SUPC_WKUP3                       (_UL_(1) << 4)
+
+#define PIN_PA5X1_SUPC_WKUP4                       _L_(5)       /**< SUPC signal: WKUP4 on PA5 mux X1*/
+#define PIO_PA5X1_SUPC_WKUP4                       (_UL_(1) << 5)
+
+#define PIN_PA9X1_SUPC_WKUP6                       _L_(9)       /**< SUPC signal: WKUP6 on PA9 mux X1*/
+#define PIO_PA9X1_SUPC_WKUP6                       (_UL_(1) << 9)
+
+#define PIN_PA11X1_SUPC_WKUP7                      _L_(11)      /**< SUPC signal: WKUP7 on PA11 mux X1*/
+#define PIO_PA11X1_SUPC_WKUP7                      (_UL_(1) << 11)
+
+#define PIN_PA14X1_SUPC_WKUP8                      _L_(14)      /**< SUPC signal: WKUP8 on PA14 mux X1*/
+#define PIO_PA14X1_SUPC_WKUP8                      (_UL_(1) << 14)
+
+#define PIN_PA19X1_SUPC_WKUP9                      _L_(19)      /**< SUPC signal: WKUP9 on PA19 mux X1*/
+#define PIO_PA19X1_SUPC_WKUP9                      (_UL_(1) << 19)
+
+#define PIN_PA20X1_SUPC_WKUP10                     _L_(20)      /**< SUPC signal: WKUP10 on PA20 mux X1*/
+#define PIO_PA20X1_SUPC_WKUP10                     (_UL_(1) << 20)
+
+#define PIN_PA30X1_SUPC_WKUP11                     _L_(30)      /**< SUPC signal: WKUP11 on PA30 mux X1*/
+#define PIO_PA30X1_SUPC_WKUP11                     (_UL_(1) << 30)
+
+#define PIN_PB3X1_SUPC_WKUP12                      _L_(35)      /**< SUPC signal: WKUP12 on PB3 mux X1*/
+#define PIO_PB3X1_SUPC_WKUP12                      (_UL_(1) << 3)
+
+#define PIN_PB5X1_SUPC_WKUP13                      _L_(37)      /**< SUPC signal: WKUP13 on PB5 mux X1*/
+#define PIO_PB5X1_SUPC_WKUP13                      (_UL_(1) << 5)
+
+#define PIN_PD28X1_SUPC_WKUP5                      _L_(124)     /**< SUPC signal: WKUP5 on PD28 mux X1*/
+#define PIO_PD28X1_SUPC_WKUP5                      (_UL_(1) << 28)
 
 /* ========== PIO definition for TC0 peripheral ========== */
 #define PIN_PA4B_TC0_TCLK0                         _L_(4)       /**< TC0 signal: TCLK0 on PA4 mux B*/
@@ -2082,278 +1915,48 @@
 #define MUX_PD16B_USART2_TXD2                      _L_(1)       /**< USART2 signal line function value: TXD2 */
 #define PIO_PD16B_USART2_TXD2                      (_UL_(1) << 16)
 
-/* ========== PIO definition for EBI peripheral ========== */
-#define PIN_PC18A_EBI_A0                           _L_(82)      /**< EBI signal: A0 on PC18 mux A*/
-#define MUX_PC18A_EBI_A0                           _L_(0)       /**< EBI signal line function value: A0 */
-#define PIO_PC18A_EBI_A0                           (_UL_(1) << 18)
+/* ========== PIO definition for ICE peripheral ========== */
+#define PIN_PB4X1_ICE_TDI                          _L_(36)      /**< ICE signal: TDI on PB4 mux X1*/
+#define PIO_PB4X1_ICE_TDI                          (_UL_(1) << 4)
 
-#define PIN_PC18A_EBI_NBS0                         _L_(82)      /**< EBI signal: NBS0 on PC18 mux A*/
-#define MUX_PC18A_EBI_NBS0                         _L_(0)       /**< EBI signal line function value: NBS0 */
-#define PIO_PC18A_EBI_NBS0                         (_UL_(1) << 18)
+#define PIN_PB5X1_ICE_TDO                          _L_(37)      /**< ICE signal: TDO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TDO                          (_UL_(1) << 5)
 
-#define PIN_PC19A_EBI_A1                           _L_(83)      /**< EBI signal: A1 on PC19 mux A*/
-#define MUX_PC19A_EBI_A1                           _L_(0)       /**< EBI signal line function value: A1 */
-#define PIO_PC19A_EBI_A1                           (_UL_(1) << 19)
+#define PIN_PB5X1_ICE_TRACESWO                     _L_(37)      /**< ICE signal: TRACESWO on PB5 mux X1*/
+#define PIO_PB5X1_ICE_TRACESWO                     (_UL_(1) << 5)
 
-#define PIN_PC20A_EBI_A2                           _L_(84)      /**< EBI signal: A2 on PC20 mux A*/
-#define MUX_PC20A_EBI_A2                           _L_(0)       /**< EBI signal line function value: A2 */
-#define PIO_PC20A_EBI_A2                           (_UL_(1) << 20)
+#define PIN_PB6X1_ICE_TMS                          _L_(38)      /**< ICE signal: TMS on PB6 mux X1*/
+#define PIO_PB6X1_ICE_TMS                          (_UL_(1) << 6)
 
-#define PIN_PC21A_EBI_A3                           _L_(85)      /**< EBI signal: A3 on PC21 mux A*/
-#define MUX_PC21A_EBI_A3                           _L_(0)       /**< EBI signal line function value: A3 */
-#define PIO_PC21A_EBI_A3                           (_UL_(1) << 21)
+#define PIN_PB6X1_ICE_SWDIO                        _L_(38)      /**< ICE signal: SWDIO on PB6 mux X1*/
+#define PIO_PB6X1_ICE_SWDIO                        (_UL_(1) << 6)
 
-#define PIN_PC22A_EBI_A4                           _L_(86)      /**< EBI signal: A4 on PC22 mux A*/
-#define MUX_PC22A_EBI_A4                           _L_(0)       /**< EBI signal line function value: A4 */
-#define PIO_PC22A_EBI_A4                           (_UL_(1) << 22)
+#define PIN_PB7X1_ICE_TCK                          _L_(39)      /**< ICE signal: TCK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_TCK                          (_UL_(1) << 7)
 
-#define PIN_PC23A_EBI_A5                           _L_(87)      /**< EBI signal: A5 on PC23 mux A*/
-#define MUX_PC23A_EBI_A5                           _L_(0)       /**< EBI signal line function value: A5 */
-#define PIO_PC23A_EBI_A5                           (_UL_(1) << 23)
+#define PIN_PB7X1_ICE_SWDCLK                       _L_(39)      /**< ICE signal: SWDCLK on PB7 mux X1*/
+#define PIO_PB7X1_ICE_SWDCLK                       (_UL_(1) << 7)
 
-#define PIN_PC24A_EBI_A6                           _L_(88)      /**< EBI signal: A6 on PC24 mux A*/
-#define MUX_PC24A_EBI_A6                           _L_(0)       /**< EBI signal line function value: A6 */
-#define PIO_PC24A_EBI_A6                           (_UL_(1) << 24)
+/* ========== PIO definition for TPIU peripheral ========== */
+#define PIN_PD8D_TPIU_TRACECLK                     _L_(104)     /**< TPIU signal: TRACECLK on PD8 mux D*/
+#define MUX_PD8D_TPIU_TRACECLK                     _L_(3)       /**< TPIU signal line function value: TRACECLK */
+#define PIO_PD8D_TPIU_TRACECLK                     (_UL_(1) << 8)
 
-#define PIN_PC25A_EBI_A7                           _L_(89)      /**< EBI signal: A7 on PC25 mux A*/
-#define MUX_PC25A_EBI_A7                           _L_(0)       /**< EBI signal line function value: A7 */
-#define PIO_PC25A_EBI_A7                           (_UL_(1) << 25)
+#define PIN_PD4C_TPIU_TRACED0                      _L_(100)     /**< TPIU signal: TRACED0 on PD4 mux C*/
+#define MUX_PD4C_TPIU_TRACED0                      _L_(2)       /**< TPIU signal line function value: TRACED0 */
+#define PIO_PD4C_TPIU_TRACED0                      (_UL_(1) << 4)
 
-#define PIN_PC26A_EBI_A8                           _L_(90)      /**< EBI signal: A8 on PC26 mux A*/
-#define MUX_PC26A_EBI_A8                           _L_(0)       /**< EBI signal line function value: A8 */
-#define PIO_PC26A_EBI_A8                           (_UL_(1) << 26)
+#define PIN_PD5C_TPIU_TRACED1                      _L_(101)     /**< TPIU signal: TRACED1 on PD5 mux C*/
+#define MUX_PD5C_TPIU_TRACED1                      _L_(2)       /**< TPIU signal line function value: TRACED1 */
+#define PIO_PD5C_TPIU_TRACED1                      (_UL_(1) << 5)
 
-#define PIN_PC27A_EBI_A9                           _L_(91)      /**< EBI signal: A9 on PC27 mux A*/
-#define MUX_PC27A_EBI_A9                           _L_(0)       /**< EBI signal line function value: A9 */
-#define PIO_PC27A_EBI_A9                           (_UL_(1) << 27)
+#define PIN_PD6C_TPIU_TRACED2                      _L_(102)     /**< TPIU signal: TRACED2 on PD6 mux C*/
+#define MUX_PD6C_TPIU_TRACED2                      _L_(2)       /**< TPIU signal line function value: TRACED2 */
+#define PIO_PD6C_TPIU_TRACED2                      (_UL_(1) << 6)
 
-#define PIN_PC28A_EBI_A10                          _L_(92)      /**< EBI signal: A10 on PC28 mux A*/
-#define MUX_PC28A_EBI_A10                          _L_(0)       /**< EBI signal line function value: A10 */
-#define PIO_PC28A_EBI_A10                          (_UL_(1) << 28)
-
-#define PIN_PC29A_EBI_A11                          _L_(93)      /**< EBI signal: A11 on PC29 mux A*/
-#define MUX_PC29A_EBI_A11                          _L_(0)       /**< EBI signal line function value: A11 */
-#define PIO_PC29A_EBI_A11                          (_UL_(1) << 29)
-
-#define PIN_PC30A_EBI_A12                          _L_(94)      /**< EBI signal: A12 on PC30 mux A*/
-#define MUX_PC30A_EBI_A12                          _L_(0)       /**< EBI signal line function value: A12 */
-#define PIO_PC30A_EBI_A12                          (_UL_(1) << 30)
-
-#define PIN_PC31A_EBI_A13                          _L_(95)      /**< EBI signal: A13 on PC31 mux A*/
-#define MUX_PC31A_EBI_A13                          _L_(0)       /**< EBI signal line function value: A13 */
-#define PIO_PC31A_EBI_A13                          (_UL_(1) << 31)
-
-#define PIN_PA18C_EBI_A14                          _L_(18)      /**< EBI signal: A14 on PA18 mux C*/
-#define MUX_PA18C_EBI_A14                          _L_(2)       /**< EBI signal line function value: A14 */
-#define PIO_PA18C_EBI_A14                          (_UL_(1) << 18)
-
-#define PIN_PA19C_EBI_A15                          _L_(19)      /**< EBI signal: A15 on PA19 mux C*/
-#define MUX_PA19C_EBI_A15                          _L_(2)       /**< EBI signal line function value: A15 */
-#define PIO_PA19C_EBI_A15                          (_UL_(1) << 19)
-
-#define PIN_PA20C_EBI_A16                          _L_(20)      /**< EBI signal: A16 on PA20 mux C*/
-#define MUX_PA20C_EBI_A16                          _L_(2)       /**< EBI signal line function value: A16 */
-#define PIO_PA20C_EBI_A16                          (_UL_(1) << 20)
-
-#define PIN_PA20C_EBI_BA0                          _L_(20)      /**< EBI signal: BA0 on PA20 mux C*/
-#define MUX_PA20C_EBI_BA0                          _L_(2)       /**< EBI signal line function value: BA0 */
-#define PIO_PA20C_EBI_BA0                          (_UL_(1) << 20)
-
-#define PIN_PA0C_EBI_A17                           _L_(0)       /**< EBI signal: A17 on PA0 mux C*/
-#define MUX_PA0C_EBI_A17                           _L_(2)       /**< EBI signal line function value: A17 */
-#define PIO_PA0C_EBI_A17                           (_UL_(1) << 0)
-
-#define PIN_PA0C_EBI_BA1                           _L_(0)       /**< EBI signal: BA1 on PA0 mux C*/
-#define MUX_PA0C_EBI_BA1                           _L_(2)       /**< EBI signal line function value: BA1 */
-#define PIO_PA0C_EBI_BA1                           (_UL_(1) << 0)
-
-#define PIN_PA1C_EBI_A18                           _L_(1)       /**< EBI signal: A18 on PA1 mux C*/
-#define MUX_PA1C_EBI_A18                           _L_(2)       /**< EBI signal line function value: A18 */
-#define PIO_PA1C_EBI_A18                           (_UL_(1) << 1)
-
-#define PIN_PA23C_EBI_A19                          _L_(23)      /**< EBI signal: A19 on PA23 mux C*/
-#define MUX_PA23C_EBI_A19                          _L_(2)       /**< EBI signal line function value: A19 */
-#define PIO_PA23C_EBI_A19                          (_UL_(1) << 23)
-
-#define PIN_PA24C_EBI_A20                          _L_(24)      /**< EBI signal: A20 on PA24 mux C*/
-#define MUX_PA24C_EBI_A20                          _L_(2)       /**< EBI signal line function value: A20 */
-#define PIO_PA24C_EBI_A20                          (_UL_(1) << 24)
-
-#define PIN_PC16A_EBI_A21                          _L_(80)      /**< EBI signal: A21 on PC16 mux A*/
-#define MUX_PC16A_EBI_A21                          _L_(0)       /**< EBI signal line function value: A21 */
-#define PIO_PC16A_EBI_A21                          (_UL_(1) << 16)
-
-#define PIN_PC16A_EBI_NANDALE                      _L_(80)      /**< EBI signal: NANDALE on PC16 mux A*/
-#define MUX_PC16A_EBI_NANDALE                      _L_(0)       /**< EBI signal line function value: NANDALE */
-#define PIO_PC16A_EBI_NANDALE                      (_UL_(1) << 16)
-
-#define PIN_PC17A_EBI_A22                          _L_(81)      /**< EBI signal: A22 on PC17 mux A*/
-#define MUX_PC17A_EBI_A22                          _L_(0)       /**< EBI signal line function value: A22 */
-#define PIO_PC17A_EBI_A22                          (_UL_(1) << 17)
-
-#define PIN_PC17A_EBI_NANDCLE                      _L_(81)      /**< EBI signal: NANDCLE on PC17 mux A*/
-#define MUX_PC17A_EBI_NANDCLE                      _L_(0)       /**< EBI signal line function value: NANDCLE */
-#define PIO_PC17A_EBI_NANDCLE                      (_UL_(1) << 17)
-
-#define PIN_PA25C_EBI_A23                          _L_(25)      /**< EBI signal: A23 on PA25 mux C*/
-#define MUX_PA25C_EBI_A23                          _L_(2)       /**< EBI signal line function value: A23 */
-#define PIO_PA25C_EBI_A23                          (_UL_(1) << 25)
-
-#define PIN_PD17C_EBI_CAS                          _L_(113)     /**< EBI signal: CAS on PD17 mux C*/
-#define MUX_PD17C_EBI_CAS                          _L_(2)       /**< EBI signal line function value: CAS */
-#define PIO_PD17C_EBI_CAS                          (_UL_(1) << 17)
-
-#define PIN_PC0A_EBI_D0                            _L_(64)      /**< EBI signal: D0 on PC0 mux A*/
-#define MUX_PC0A_EBI_D0                            _L_(0)       /**< EBI signal line function value: D0 */
-#define PIO_PC0A_EBI_D0                            (_UL_(1) << 0)
-
-#define PIN_PC1A_EBI_D1                            _L_(65)      /**< EBI signal: D1 on PC1 mux A*/
-#define MUX_PC1A_EBI_D1                            _L_(0)       /**< EBI signal line function value: D1 */
-#define PIO_PC1A_EBI_D1                            (_UL_(1) << 1)
-
-#define PIN_PC2A_EBI_D2                            _L_(66)      /**< EBI signal: D2 on PC2 mux A*/
-#define MUX_PC2A_EBI_D2                            _L_(0)       /**< EBI signal line function value: D2 */
-#define PIO_PC2A_EBI_D2                            (_UL_(1) << 2)
-
-#define PIN_PC3A_EBI_D3                            _L_(67)      /**< EBI signal: D3 on PC3 mux A*/
-#define MUX_PC3A_EBI_D3                            _L_(0)       /**< EBI signal line function value: D3 */
-#define PIO_PC3A_EBI_D3                            (_UL_(1) << 3)
-
-#define PIN_PC4A_EBI_D4                            _L_(68)      /**< EBI signal: D4 on PC4 mux A*/
-#define MUX_PC4A_EBI_D4                            _L_(0)       /**< EBI signal line function value: D4 */
-#define PIO_PC4A_EBI_D4                            (_UL_(1) << 4)
-
-#define PIN_PC5A_EBI_D5                            _L_(69)      /**< EBI signal: D5 on PC5 mux A*/
-#define MUX_PC5A_EBI_D5                            _L_(0)       /**< EBI signal line function value: D5 */
-#define PIO_PC5A_EBI_D5                            (_UL_(1) << 5)
-
-#define PIN_PC6A_EBI_D6                            _L_(70)      /**< EBI signal: D6 on PC6 mux A*/
-#define MUX_PC6A_EBI_D6                            _L_(0)       /**< EBI signal line function value: D6 */
-#define PIO_PC6A_EBI_D6                            (_UL_(1) << 6)
-
-#define PIN_PC7A_EBI_D7                            _L_(71)      /**< EBI signal: D7 on PC7 mux A*/
-#define MUX_PC7A_EBI_D7                            _L_(0)       /**< EBI signal line function value: D7 */
-#define PIO_PC7A_EBI_D7                            (_UL_(1) << 7)
-
-#define PIN_PE0A_EBI_D8                            _L_(128)     /**< EBI signal: D8 on PE0 mux A*/
-#define MUX_PE0A_EBI_D8                            _L_(0)       /**< EBI signal line function value: D8 */
-#define PIO_PE0A_EBI_D8                            (_UL_(1) << 0)
-
-#define PIN_PE1A_EBI_D9                            _L_(129)     /**< EBI signal: D9 on PE1 mux A*/
-#define MUX_PE1A_EBI_D9                            _L_(0)       /**< EBI signal line function value: D9 */
-#define PIO_PE1A_EBI_D9                            (_UL_(1) << 1)
-
-#define PIN_PE2A_EBI_D10                           _L_(130)     /**< EBI signal: D10 on PE2 mux A*/
-#define MUX_PE2A_EBI_D10                           _L_(0)       /**< EBI signal line function value: D10 */
-#define PIO_PE2A_EBI_D10                           (_UL_(1) << 2)
-
-#define PIN_PE3A_EBI_D11                           _L_(131)     /**< EBI signal: D11 on PE3 mux A*/
-#define MUX_PE3A_EBI_D11                           _L_(0)       /**< EBI signal line function value: D11 */
-#define PIO_PE3A_EBI_D11                           (_UL_(1) << 3)
-
-#define PIN_PE4A_EBI_D12                           _L_(132)     /**< EBI signal: D12 on PE4 mux A*/
-#define MUX_PE4A_EBI_D12                           _L_(0)       /**< EBI signal line function value: D12 */
-#define PIO_PE4A_EBI_D12                           (_UL_(1) << 4)
-
-#define PIN_PE5A_EBI_D13                           _L_(133)     /**< EBI signal: D13 on PE5 mux A*/
-#define MUX_PE5A_EBI_D13                           _L_(0)       /**< EBI signal line function value: D13 */
-#define PIO_PE5A_EBI_D13                           (_UL_(1) << 5)
-
-#define PIN_PA15A_EBI_D14                          _L_(15)      /**< EBI signal: D14 on PA15 mux A*/
-#define MUX_PA15A_EBI_D14                          _L_(0)       /**< EBI signal line function value: D14 */
-#define PIO_PA15A_EBI_D14                          (_UL_(1) << 15)
-
-#define PIN_PA16A_EBI_D15                          _L_(16)      /**< EBI signal: D15 on PA16 mux A*/
-#define MUX_PA16A_EBI_D15                          _L_(0)       /**< EBI signal line function value: D15 */
-#define PIO_PA16A_EBI_D15                          (_UL_(1) << 16)
-
-#define PIN_PC9A_EBI_NANDOE                        _L_(73)      /**< EBI signal: NANDOE on PC9 mux A*/
-#define MUX_PC9A_EBI_NANDOE                        _L_(0)       /**< EBI signal line function value: NANDOE */
-#define PIO_PC9A_EBI_NANDOE                        (_UL_(1) << 9)
-
-#define PIN_PC10A_EBI_NANDWE                       _L_(74)      /**< EBI signal: NANDWE on PC10 mux A*/
-#define MUX_PC10A_EBI_NANDWE                       _L_(0)       /**< EBI signal line function value: NANDWE */
-#define PIO_PC10A_EBI_NANDWE                       (_UL_(1) << 10)
-
-#define PIN_PC14A_EBI_NCS0                         _L_(78)      /**< EBI signal: NCS0 on PC14 mux A*/
-#define MUX_PC14A_EBI_NCS0                         _L_(0)       /**< EBI signal line function value: NCS0 */
-#define PIO_PC14A_EBI_NCS0                         (_UL_(1) << 14)
-
-#define PIN_PC15A_EBI_NCS1                         _L_(79)      /**< EBI signal: NCS1 on PC15 mux A*/
-#define MUX_PC15A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PC15A_EBI_NCS1                         (_UL_(1) << 15)
-
-#define PIN_PC15A_EBI_SDCS                         _L_(79)      /**< EBI signal: SDCS on PC15 mux A*/
-#define MUX_PC15A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PC15A_EBI_SDCS                         (_UL_(1) << 15)
-
-#define PIN_PD18A_EBI_NCS1                         _L_(114)     /**< EBI signal: NCS1 on PD18 mux A*/
-#define MUX_PD18A_EBI_NCS1                         _L_(0)       /**< EBI signal line function value: NCS1 */
-#define PIO_PD18A_EBI_NCS1                         (_UL_(1) << 18)
-
-#define PIN_PD18A_EBI_SDCS                         _L_(114)     /**< EBI signal: SDCS on PD18 mux A*/
-#define MUX_PD18A_EBI_SDCS                         _L_(0)       /**< EBI signal line function value: SDCS */
-#define PIO_PD18A_EBI_SDCS                         (_UL_(1) << 18)
-
-#define PIN_PA22C_EBI_NCS2                         _L_(22)      /**< EBI signal: NCS2 on PA22 mux C*/
-#define MUX_PA22C_EBI_NCS2                         _L_(2)       /**< EBI signal line function value: NCS2 */
-#define PIO_PA22C_EBI_NCS2                         (_UL_(1) << 22)
-
-#define PIN_PC12A_EBI_NCS3                         _L_(76)      /**< EBI signal: NCS3 on PC12 mux A*/
-#define MUX_PC12A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PC12A_EBI_NCS3                         (_UL_(1) << 12)
-
-#define PIN_PD19A_EBI_NCS3                         _L_(115)     /**< EBI signal: NCS3 on PD19 mux A*/
-#define MUX_PD19A_EBI_NCS3                         _L_(0)       /**< EBI signal line function value: NCS3 */
-#define PIO_PD19A_EBI_NCS3                         (_UL_(1) << 19)
-
-#define PIN_PC11A_EBI_NRD                          _L_(75)      /**< EBI signal: NRD on PC11 mux A*/
-#define MUX_PC11A_EBI_NRD                          _L_(0)       /**< EBI signal line function value: NRD */
-#define PIO_PC11A_EBI_NRD                          (_UL_(1) << 11)
-
-#define PIN_PC13A_EBI_NWAIT                        _L_(77)      /**< EBI signal: NWAIT on PC13 mux A*/
-#define MUX_PC13A_EBI_NWAIT                        _L_(0)       /**< EBI signal line function value: NWAIT */
-#define PIO_PC13A_EBI_NWAIT                        (_UL_(1) << 13)
-
-#define PIN_PC8A_EBI_NWR0                          _L_(72)      /**< EBI signal: NWR0 on PC8 mux A*/
-#define MUX_PC8A_EBI_NWR0                          _L_(0)       /**< EBI signal line function value: NWR0 */
-#define PIO_PC8A_EBI_NWR0                          (_UL_(1) << 8)
-
-#define PIN_PC8A_EBI_NWE                           _L_(72)      /**< EBI signal: NWE on PC8 mux A*/
-#define MUX_PC8A_EBI_NWE                           _L_(0)       /**< EBI signal line function value: NWE */
-#define PIO_PC8A_EBI_NWE                           (_UL_(1) << 8)
-
-#define PIN_PD15C_EBI_NWR1                         _L_(111)     /**< EBI signal: NWR1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NWR1                         _L_(2)       /**< EBI signal line function value: NWR1 */
-#define PIO_PD15C_EBI_NWR1                         (_UL_(1) << 15)
-
-#define PIN_PD15C_EBI_NBS1                         _L_(111)     /**< EBI signal: NBS1 on PD15 mux C*/
-#define MUX_PD15C_EBI_NBS1                         _L_(2)       /**< EBI signal line function value: NBS1 */
-#define PIO_PD15C_EBI_NBS1                         (_UL_(1) << 15)
-
-#define PIN_PD16C_EBI_RAS                          _L_(112)     /**< EBI signal: RAS on PD16 mux C*/
-#define MUX_PD16C_EBI_RAS                          _L_(2)       /**< EBI signal line function value: RAS */
-#define PIO_PD16C_EBI_RAS                          (_UL_(1) << 16)
-
-#define PIN_PC13C_EBI_SDA10                        _L_(77)      /**< EBI signal: SDA10 on PC13 mux C*/
-#define MUX_PC13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PC13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD13C_EBI_SDA10                        _L_(109)     /**< EBI signal: SDA10 on PD13 mux C*/
-#define MUX_PD13C_EBI_SDA10                        _L_(2)       /**< EBI signal line function value: SDA10 */
-#define PIO_PD13C_EBI_SDA10                        (_UL_(1) << 13)
-
-#define PIN_PD23C_EBI_SDCK                         _L_(119)     /**< EBI signal: SDCK on PD23 mux C*/
-#define MUX_PD23C_EBI_SDCK                         _L_(2)       /**< EBI signal line function value: SDCK */
-#define PIO_PD23C_EBI_SDCK                         (_UL_(1) << 23)
-
-#define PIN_PD14C_EBI_SDCKE                        _L_(110)     /**< EBI signal: SDCKE on PD14 mux C*/
-#define MUX_PD14C_EBI_SDCKE                        _L_(2)       /**< EBI signal line function value: SDCKE */
-#define PIO_PD14C_EBI_SDCKE                        (_UL_(1) << 14)
-
-#define PIN_PD29C_EBI_SDWE                         _L_(125)     /**< EBI signal: SDWE on PD29 mux C*/
-#define MUX_PD29C_EBI_SDWE                         _L_(2)       /**< EBI signal line function value: SDWE */
-#define PIO_PD29C_EBI_SDWE                         (_UL_(1) << 29)
+#define PIN_PD7C_TPIU_TRACED3                      _L_(103)     /**< TPIU signal: TRACED3 on PD7 mux C*/
+#define MUX_PD7C_TPIU_TRACED3                      _L_(2)       /**< TPIU signal line function value: TRACED3 */
+#define PIO_PD7C_TPIU_TRACED3                      (_UL_(1) << 7)
 
 
 #endif /* _SAME70Q21B_PIO_H_ */

--- a/asf/sam/include/same70b/same70j19b.h
+++ b/asf/sam/include/same70b/same70j19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:37Z */
 #ifndef _SAME70J19B_H_
 #define _SAME70J19B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J19B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70J19B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70J19B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J19B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J19B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J19B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J19B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J19B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J19B Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J19B Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J19B Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J19B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J19B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J19B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J19B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70J19B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70J19B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70J19B Timer Counter (TC3)      */
@@ -165,13 +173,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J19B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J19B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J19B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J19B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J19B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J19B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J19B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J19B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70J19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70J19B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J19B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J19B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J19B Floating Point Unit (FPU) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q5_IRQn              = 73 , /**< 73  SAME70J19B Gigabit Ethernet MAC (GMAC) */
@@ -202,6 +210,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J19B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70J19B Reset Controller (RSTC) */
@@ -229,9 +238,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J19B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70J19B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70J19B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J19B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70J19B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70J19B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J19B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J19B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J19B Pulse Width Modulation Controller (PWM0) */
@@ -250,9 +259,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J19B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J19B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70J19B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70J19B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70J19B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70J19B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70J19B Timer Counter (TC3) */
@@ -264,20 +273,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J19B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J19B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J19B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J19B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J19B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J19B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J19B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J19B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70J19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70J19B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J19B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J19B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J19B Floating Point Unit (FPU) */
   void* pvReserved69;
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70J19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70J19B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -337,6 +353,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -350,6 +372,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -370,7 +400,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -459,6 +489,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -501,6 +533,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -512,6 +547,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -581,6 +619,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -690,9 +730,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -759,7 +801,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
 #define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
 #define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
-#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
 
 #define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
 #define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
@@ -770,7 +811,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
 #define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
 #define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
-#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
 
 /* ************************************************************************** */
 /**  DEVICE SIGNATURES FOR SAME70J19B */
@@ -800,6 +840,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70j20b.h
+++ b/asf/sam/include/same70b/same70j20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:41Z */
 #ifndef _SAME70J20B_H_
 #define _SAME70J20B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J20B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70J20B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70J20B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J20B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J20B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J20B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J20B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J20B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J20B Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J20B Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J20B Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J20B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J20B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J20B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J20B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70J20B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70J20B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70J20B Timer Counter (TC3)      */
@@ -165,13 +173,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J20B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J20B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J20B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J20B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J20B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J20B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J20B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J20B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70J20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70J20B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J20B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J20B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J20B Floating Point Unit (FPU) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q5_IRQn              = 73 , /**< 73  SAME70J20B Gigabit Ethernet MAC (GMAC) */
@@ -202,6 +210,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J20B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70J20B Reset Controller (RSTC) */
@@ -229,9 +238,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J20B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70J20B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70J20B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J20B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70J20B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70J20B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J20B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J20B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J20B Pulse Width Modulation Controller (PWM0) */
@@ -250,9 +259,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J20B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J20B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70J20B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70J20B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70J20B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70J20B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70J20B Timer Counter (TC3) */
@@ -264,20 +273,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J20B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J20B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J20B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J20B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J20B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J20B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J20B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J20B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70J20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70J20B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J20B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J20B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J20B Floating Point Unit (FPU) */
   void* pvReserved69;
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70J20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70J20B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -337,6 +353,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -350,6 +372,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -370,7 +400,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -459,6 +489,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -501,6 +533,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -512,6 +547,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -581,6 +619,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -690,9 +730,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -759,7 +801,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
 #define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
 #define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
-#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
 
 #define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
 #define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
@@ -770,7 +811,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
 #define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
 #define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
-#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
 
 /* ************************************************************************** */
 /**  DEVICE SIGNATURES FOR SAME70J20B */
@@ -800,6 +840,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70j21b.h
+++ b/asf/sam/include/same70b/same70j21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70J21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:46Z */
 #ifndef _SAME70J21B_H_
 #define _SAME70J21B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -145,6 +147,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70J21B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70J21B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70J21B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70J21B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70J21B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70J21B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70J21B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70J21B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70J21B Pulse Width Modulation Controller (PWM0) */
@@ -157,6 +162,9 @@ typedef enum IRQn
   AFEC1_IRQn                = 40 , /**< 40  SAME70J21B Analog Front-End Controller (AFEC1) */
   QSPI_IRQn                 = 43 , /**< 43  SAME70J21B Quad Serial Peripheral Interface (QSPI) */
   UART2_IRQn                = 44 , /**< 44  SAME70J21B Universal Asynchronous Receiver Transmitter (UART2) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70J21B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70J21B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70J21B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70J21B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70J21B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70J21B Timer Counter (TC3)      */
@@ -165,13 +173,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70J21B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70J21B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70J21B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70J21B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70J21B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70J21B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70J21B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70J21B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70J21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70J21B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70J21B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70J21B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70J21B Floating Point Unit (FPU) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q5_IRQn              = 73 , /**< 73  SAME70J21B Gigabit Ethernet MAC (GMAC) */
@@ -202,6 +210,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70J21B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70J21B Reset Controller (RSTC) */
@@ -229,9 +238,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70J21B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70J21B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70J21B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70J21B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70J21B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70J21B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70J21B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70J21B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70J21B Pulse Width Modulation Controller (PWM0) */
@@ -250,9 +259,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70J21B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pvReserved45;
   void* pvReserved46;
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70J21B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70J21B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70J21B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70J21B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70J21B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70J21B Timer Counter (TC3) */
@@ -264,20 +273,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70J21B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70J21B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70J21B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70J21B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70J21B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70J21B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70J21B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70J21B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70J21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70J21B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70J21B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70J21B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70J21B Floating Point Unit (FPU) */
   void* pvReserved69;
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70J21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70J21B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -337,6 +353,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -350,6 +372,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -370,7 +400,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -459,6 +489,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -501,6 +533,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -512,6 +547,9 @@ void XDMAC_Handler                 ( void );
 #define ID_AFEC1        ( 40) /**< \brief Analog Front-End Controller (AFEC1) */
 #define ID_QSPI         ( 43) /**< \brief Quad Serial Peripheral Interface (QSPI) */
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -581,6 +619,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -690,9 +730,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -798,6 +840,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70n19b.h
+++ b/asf/sam/include/same70b/same70n19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:48Z */
 #ifndef _SAME70N19B_H_
 #define _SAME70N19B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N19B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70N19B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70N19B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N19B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N19B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N19B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N19B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N19B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N19B Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N19B Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N19B Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N19B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N19B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N19B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N19B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70N19B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70N19B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70N19B Timer Counter (TC3)      */
@@ -173,13 +181,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N19B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N19B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N19B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N19B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N19B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N19B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N19B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N19B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70N19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70N19B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N19B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N19B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N19B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70N19B Inter-IC Sound Controller (I2SC0) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70N19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70N19B Gigabit Ethernet MAC (GMAC) */
@@ -211,6 +219,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N19B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70N19B Reset Controller (RSTC) */
@@ -238,9 +247,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N19B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70N19B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70N19B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N19B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70N19B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70N19B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N19B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N19B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N19B Pulse Width Modulation Controller (PWM0) */
@@ -259,9 +268,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N19B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N19B Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N19B Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N19B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70N19B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70N19B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70N19B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70N19B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70N19B Timer Counter (TC3) */
@@ -273,20 +282,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N19B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N19B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N19B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N19B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N19B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N19B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N19B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N19B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70N19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70N19B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N19B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N19B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N19B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70N19B Inter-IC Sound Controller (I2SC0) */
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70N19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70N19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70N19B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -351,6 +367,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -368,6 +390,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -388,7 +418,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -484,6 +514,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -533,6 +565,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -548,6 +583,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -622,6 +660,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -748,9 +788,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -821,7 +863,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
 #define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
 #define IRAM_SIZE                _U_(0x00040000)       /*  256kB Memory segment type: ram */
-#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
 
 #define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
 #define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
@@ -832,7 +873,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
 #define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
 #define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
-#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
 
 /* ************************************************************************** */
 /**  DEVICE SIGNATURES FOR SAME70N19B */
@@ -862,6 +902,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70n20b.h
+++ b/asf/sam/include/same70b/same70n20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:51Z */
 #ifndef _SAME70N20B_H_
 #define _SAME70N20B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N20B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70N20B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70N20B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N20B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N20B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N20B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N20B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N20B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N20B Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N20B Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N20B Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N20B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N20B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N20B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N20B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70N20B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70N20B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70N20B Timer Counter (TC3)      */
@@ -173,13 +181,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N20B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N20B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N20B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N20B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N20B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N20B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N20B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N20B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70N20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70N20B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N20B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N20B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N20B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70N20B Inter-IC Sound Controller (I2SC0) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70N20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70N20B Gigabit Ethernet MAC (GMAC) */
@@ -211,6 +219,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N20B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70N20B Reset Controller (RSTC) */
@@ -238,9 +247,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N20B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70N20B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70N20B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N20B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70N20B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70N20B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N20B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N20B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N20B Pulse Width Modulation Controller (PWM0) */
@@ -259,9 +268,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N20B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N20B Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N20B Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N20B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70N20B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70N20B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70N20B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70N20B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70N20B Timer Counter (TC3) */
@@ -273,20 +282,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N20B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N20B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N20B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N20B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N20B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N20B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N20B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N20B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70N20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70N20B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N20B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N20B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N20B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70N20B Inter-IC Sound Controller (I2SC0) */
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70N20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70N20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70N20B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -351,6 +367,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -368,6 +390,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -388,7 +418,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -484,6 +514,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -533,6 +565,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -548,6 +583,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -622,6 +660,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -748,9 +788,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -821,7 +863,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
 #define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
 #define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
-#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
 
 #define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
 #define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
@@ -832,7 +873,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
 #define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
 #define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
-#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
 
 /* ************************************************************************** */
 /**  DEVICE SIGNATURES FOR SAME70N20B */
@@ -862,6 +902,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70n21b.h
+++ b/asf/sam/include/same70b/same70n21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70N21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2018-01-24T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:53Z */
 #ifndef _SAME70N21B_H_
 #define _SAME70N21B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -148,6 +150,9 @@ typedef enum IRQn
   TC0_IRQn                  = 23 , /**< 23  SAME70N21B Timer Counter (TC0)      */
   TC1_IRQn                  = 24 , /**< 24  SAME70N21B Timer Counter (TC0)      */
   TC2_IRQn                  = 25 , /**< 25  SAME70N21B Timer Counter (TC0)      */
+  TC3_IRQn                  = 26 , /**< 26  SAME70N21B Timer Counter (TC1)      */
+  TC4_IRQn                  = 27 , /**< 27  SAME70N21B Timer Counter (TC1)      */
+  TC5_IRQn                  = 28 , /**< 28  SAME70N21B Timer Counter (TC1)      */
   AFEC0_IRQn                = 29 , /**< 29  SAME70N21B Analog Front-End Controller (AFEC0) */
   DACC_IRQn                 = 30 , /**< 30  SAME70N21B Digital-to-Analog Converter Controller (DACC) */
   PWM0_IRQn                 = 31 , /**< 31  SAME70N21B Pulse Width Modulation Controller (PWM0) */
@@ -165,6 +170,9 @@ typedef enum IRQn
   UART2_IRQn                = 44 , /**< 44  SAME70N21B Universal Asynchronous Receiver Transmitter (UART2) */
   UART3_IRQn                = 45 , /**< 45  SAME70N21B Universal Asynchronous Receiver Transmitter (UART3) */
   UART4_IRQn                = 46 , /**< 46  SAME70N21B Universal Asynchronous Receiver Transmitter (UART4) */
+  TC6_IRQn                  = 47 , /**< 47  SAME70N21B Timer Counter (TC2)      */
+  TC7_IRQn                  = 48 , /**< 48  SAME70N21B Timer Counter (TC2)      */
+  TC8_IRQn                  = 49 , /**< 49  SAME70N21B Timer Counter (TC2)      */
   TC9_IRQn                  = 50 , /**< 50  SAME70N21B Timer Counter (TC3)      */
   TC10_IRQn                 = 51 , /**< 51  SAME70N21B Timer Counter (TC3)      */
   TC11_IRQn                 = 52 , /**< 52  SAME70N21B Timer Counter (TC3)      */
@@ -173,13 +181,13 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70N21B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70N21B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70N21B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70N21B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70N21B Floating Point Unit (FPU) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70N21B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70N21B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70N21B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70N21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70N21B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70N21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70N21B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70N21B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70N21B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70N21B Inter-IC Sound Controller (I2SC0) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70N21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q4_IRQn              = 72 , /**< 72  SAME70N21B Gigabit Ethernet MAC (GMAC) */
@@ -211,6 +219,7 @@ typedef struct _DeviceVectors
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
 
+
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70N21B Supply Controller (SUPC) */
   void* pfnRSTC_Handler;                         /* 1   SAME70N21B Reset Controller (RSTC) */
@@ -238,9 +247,9 @@ typedef struct _DeviceVectors
   void* pfnTC0_Handler;                          /* 23  SAME70N21B Timer Counter (TC0) */
   void* pfnTC1_Handler;                          /* 24  SAME70N21B Timer Counter (TC0) */
   void* pfnTC2_Handler;                          /* 25  SAME70N21B Timer Counter (TC0) */
-  void* pvReserved26;
-  void* pvReserved27;
-  void* pvReserved28;
+  void* pfnTC3_Handler;                          /* 26  SAME70N21B Timer Counter (TC1) */
+  void* pfnTC4_Handler;                          /* 27  SAME70N21B Timer Counter (TC1) */
+  void* pfnTC5_Handler;                          /* 28  SAME70N21B Timer Counter (TC1) */
   void* pfnAFEC0_Handler;                        /* 29  SAME70N21B Analog Front-End Controller (AFEC0) */
   void* pfnDACC_Handler;                         /* 30  SAME70N21B Digital-to-Analog Converter Controller (DACC) */
   void* pfnPWM0_Handler;                         /* 31  SAME70N21B Pulse Width Modulation Controller (PWM0) */
@@ -259,9 +268,9 @@ typedef struct _DeviceVectors
   void* pfnUART2_Handler;                        /* 44  SAME70N21B Universal Asynchronous Receiver Transmitter (UART2) */
   void* pfnUART3_Handler;                        /* 45  SAME70N21B Universal Asynchronous Receiver Transmitter (UART3) */
   void* pfnUART4_Handler;                        /* 46  SAME70N21B Universal Asynchronous Receiver Transmitter (UART4) */
-  void* pvReserved47;
-  void* pvReserved48;
-  void* pvReserved49;
+  void* pfnTC6_Handler;                          /* 47  SAME70N21B Timer Counter (TC2) */
+  void* pfnTC7_Handler;                          /* 48  SAME70N21B Timer Counter (TC2) */
+  void* pfnTC8_Handler;                          /* 49  SAME70N21B Timer Counter (TC2) */
   void* pfnTC9_Handler;                          /* 50  SAME70N21B Timer Counter (TC3) */
   void* pfnTC10_Handler;                         /* 51  SAME70N21B Timer Counter (TC3) */
   void* pfnTC11_Handler;                         /* 52  SAME70N21B Timer Counter (TC3) */
@@ -273,20 +282,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70N21B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70N21B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70N21B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70N21B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70N21B Floating Point Unit (FPU) */
   void* pvReserved62;
   void* pfnRSWDT_Handler;                        /* 63  SAME70N21B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70N21B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70N21B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70N21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70N21B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70N21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70N21B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70N21B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70N21B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70N21B Inter-IC Sound Controller (I2SC0) */
   void* pvReserved70;
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70N21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70N21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70N21B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -351,6 +367,12 @@ void TC10_Handler                  ( void );
 void TC11_Handler                  ( void );
 void TC1_Handler                   ( void );
 void TC2_Handler                   ( void );
+void TC3_Handler                   ( void );
+void TC4_Handler                   ( void );
+void TC5_Handler                   ( void );
+void TC6_Handler                   ( void );
+void TC7_Handler                   ( void );
+void TC8_Handler                   ( void );
 void TC9_Handler                   ( void );
 void TRNG_Handler                  ( void );
 void TWIHS0_Handler                ( void );
@@ -368,6 +390,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -388,7 +418,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -484,6 +514,8 @@ void XDMAC_Handler                 ( void );
 #include "instance/ssc.h"
 #include "instance/supc.h"
 #include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
 #include "instance/tc3.h"
 #include "instance/trng.h"
 #include "instance/twihs0.h"
@@ -533,6 +565,9 @@ void XDMAC_Handler                 ( void );
 #define ID_TC0_CHANNEL0 ( 23) /**< \brief Timer Counter (TC0_CHANNEL0) */
 #define ID_TC0_CHANNEL1 ( 24) /**< \brief Timer Counter (TC0_CHANNEL1) */
 #define ID_TC0_CHANNEL2 ( 25) /**< \brief Timer Counter (TC0_CHANNEL2) */
+#define ID_TC1_CHANNEL0 ( 26) /**< \brief Timer Counter (TC1_CHANNEL0) */
+#define ID_TC1_CHANNEL1 ( 27) /**< \brief Timer Counter (TC1_CHANNEL1) */
+#define ID_TC1_CHANNEL2 ( 28) /**< \brief Timer Counter (TC1_CHANNEL2) */
 #define ID_AFEC0        ( 29) /**< \brief Analog Front-End Controller (AFEC0) */
 #define ID_DACC         ( 30) /**< \brief Digital-to-Analog Converter Controller (DACC) */
 #define ID_PWM0         ( 31) /**< \brief Pulse Width Modulation Controller (PWM0) */
@@ -548,6 +583,9 @@ void XDMAC_Handler                 ( void );
 #define ID_UART2        ( 44) /**< \brief Universal Asynchronous Receiver Transmitter (UART2) */
 #define ID_UART3        ( 45) /**< \brief Universal Asynchronous Receiver Transmitter (UART3) */
 #define ID_UART4        ( 46) /**< \brief Universal Asynchronous Receiver Transmitter (UART4) */
+#define ID_TC2_CHANNEL0 ( 47) /**< \brief Timer Counter (TC2_CHANNEL0) */
+#define ID_TC2_CHANNEL1 ( 48) /**< \brief Timer Counter (TC2_CHANNEL1) */
+#define ID_TC2_CHANNEL2 ( 49) /**< \brief Timer Counter (TC2_CHANNEL2) */
 #define ID_TC3_CHANNEL0 ( 50) /**< \brief Timer Counter (TC3_CHANNEL0) */
 #define ID_TC3_CHANNEL1 ( 51) /**< \brief Timer Counter (TC3_CHANNEL1) */
 #define ID_TC3_CHANNEL2 ( 52) /**< \brief Timer Counter (TC3_CHANNEL2) */
@@ -622,6 +660,8 @@ void XDMAC_Handler                 ( void );
 #define SSC                    (0x40004000)                   /**< \brief (SSC       ) Base Address */
 #define SUPC                   (0x400E1810)                   /**< \brief (SUPC      ) Base Address */
 #define TC0                    (0x4000C000)                   /**< \brief (TC0       ) Base Address */
+#define TC1                    (0x40010000)                   /**< \brief (TC1       ) Base Address */
+#define TC2                    (0x40014000)                   /**< \brief (TC2       ) Base Address */
 #define TC3                    (0x40054000)                   /**< \brief (TC3       ) Base Address */
 #define TRNG                   (0x40070000)                   /**< \brief (TRNG      ) Base Address */
 #define TWIHS0                 (0x40018000)                   /**< \brief (TWIHS0    ) Base Address */
@@ -748,9 +788,11 @@ void XDMAC_Handler                 ( void );
 #define SUPC_INSTS             { SUPC }                       /**< \brief (SUPC      ) Instances List */
 
 #define TC0                    ((Tc *)0x4000C000U)            /**< \brief (TC0       ) Base Address */
+#define TC1                    ((Tc *)0x40010000U)            /**< \brief (TC1       ) Base Address */
+#define TC2                    ((Tc *)0x40014000U)            /**< \brief (TC2       ) Base Address */
 #define TC3                    ((Tc *)0x40054000U)            /**< \brief (TC3       ) Base Address */
-#define TC_INST_NUM            2                              /**< \brief (TC        ) Number of instances */
-#define TC_INSTS               { TC0, TC3 }                   /**< \brief (TC        ) Instances List */
+#define TC_INST_NUM            4                              /**< \brief (TC        ) Number of instances */
+#define TC_INSTS               { TC0, TC1, TC2, TC3 }         /**< \brief (TC        ) Instances List */
 
 #define TRNG                   ((Trng *)0x40070000U)          /**< \brief (TRNG      ) Base Address */
 #define TRNG_INST_NUM          1                              /**< \brief (TRNG      ) Number of instances */
@@ -821,7 +863,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_SIZE                _U_(0x00004000)       /*   16kB Memory segment type: rom */
 #define DTCM_SIZE                _U_(0x00020000)       /*  128kB Memory segment type: other */
 #define IRAM_SIZE                _U_(0x00060000)       /*  384kB Memory segment type: ram */
-#define SDRAM_CS_SIZE            _U_(0x10000000)       /* 262144kB Memory segment type: other */
 
 #define PERIPHERALS_ADDR         _U_(0x40000000)       /**< PERIPHERALS base address (type: io)*/
 #define SYSTEM_ADDR              _U_(0xe0000000)       /**< SYSTEM base address (type: io)*/
@@ -832,7 +873,6 @@ void XDMAC_Handler                 ( void );
 #define IROM_ADDR                _U_(0x00800000)       /**< IROM base address (type: rom)*/
 #define DTCM_ADDR                _U_(0x20000000)       /**< DTCM base address (type: other)*/
 #define IRAM_ADDR                _U_(0x20400000)       /**< IRAM base address (type: ram)*/
-#define SDRAM_CS_ADDR            _U_(0x70000000)       /**< SDRAM_CS base address (type: other)*/
 
 /* ************************************************************************** */
 /**  DEVICE SIGNATURES FOR SAME70N21B */
@@ -862,6 +902,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70q19b.h
+++ b/asf/sam/include/same70b/same70q19b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q19B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:55Z */
 #ifndef _SAME70Q19B_H_
 #define _SAME70Q19B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,14 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q19B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q19B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q19B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q19B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q19B Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q19B SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q19B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q19B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q19B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70Q19B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70Q19B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q19B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q19B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70Q19B Inter-IC Sound Controller (I2SC0) */
   I2SC1_IRQn                = 70 , /**< 70  SAME70Q19B Inter-IC Sound Controller (I2SC1) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
@@ -221,6 +223,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q19B Supply Controller (SUPC) */
@@ -284,20 +287,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q19B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q19B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q19B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q19B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q19B Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q19B SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q19B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q19B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q19B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70Q19B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70Q19B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q19B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q19B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70Q19B Inter-IC Sound Controller (I2SC0) */
   void* pfnI2SC1_Handler;                        /* 70  SAME70Q19B Inter-IC Sound Controller (I2SC1) */
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70Q19B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -390,6 +400,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -410,7 +428,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -936,6 +954,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70q20b.h
+++ b/asf/sam/include/same70b/same70q20b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q20B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:57Z */
 #ifndef _SAME70Q20B_H_
 #define _SAME70Q20B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,14 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q20B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q20B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q20B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q20B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q20B Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q20B SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q20B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q20B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q20B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70Q20B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70Q20B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q20B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q20B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70Q20B Inter-IC Sound Controller (I2SC0) */
   I2SC1_IRQn                = 70 , /**< 70  SAME70Q20B Inter-IC Sound Controller (I2SC1) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
@@ -221,6 +223,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q20B Supply Controller (SUPC) */
@@ -284,20 +287,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q20B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q20B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q20B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q20B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q20B Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q20B SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q20B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q20B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q20B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70Q20B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70Q20B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q20B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q20B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70Q20B Inter-IC Sound Controller (I2SC0) */
   void* pfnI2SC1_Handler;                        /* 70  SAME70Q20B Inter-IC Sound Controller (I2SC1) */
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70Q20B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -390,6 +400,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -410,7 +428,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -936,6 +954,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }

--- a/asf/sam/include/same70b/same70q21b.h
+++ b/asf/sam/include/same70b/same70q21b.h
@@ -3,11 +3,13 @@
  *
  * \brief Header file for ATSAME70Q21B
  *
- * Copyright (c) 2018 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ * Copyright (c) 2019 Microchip Technology Inc.
  *
  * \license_start
  *
  * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +27,7 @@
  *
  */
 
-/* file generated from device description version 2017-09-13T14:00:00Z */
+/* file generated from device description version 2019-01-18T21:19:59Z */
 #ifndef _SAME70Q21B_H_
 #define _SAME70Q21B_H_
 
@@ -69,7 +71,7 @@ typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatil
 #endif
 typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
-typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
@@ -182,14 +184,14 @@ typedef enum IRQn
   XDMAC_IRQn                = 58 , /**< 58  SAME70Q21B Extensible DMA Controller (XDMAC) */
   ISI_IRQn                  = 59 , /**< 59  SAME70Q21B Image Sensor Interface (ISI) */
   PWM1_IRQn                 = 60 , /**< 60  SAME70Q21B Pulse Width Modulation Controller (PWM1) */
-  FPU_IRQn                  = 61 , /**< 61  SAME70Q21B Floating Point Unit Registers (FPU) */
+  FPU_IRQn                  = 61 , /**< 61  SAME70Q21B Floating Point Unit (FPU) */
   SDRAMC_IRQn               = 62 , /**< 62  SAME70Q21B SDRAM Controller (SDRAMC) */
   RSWDT_IRQn                = 63 , /**< 63  SAME70Q21B Reinforced Safety Watchdog Timer (RSWDT) */
-  CCW_IRQn                  = 64 , /**< 64  SAME70Q21B System Control Registers (SystemControl) */
-  CCF_IRQn                  = 65 , /**< 65  SAME70Q21B System Control Registers (SystemControl) */
+  CCW_IRQn                  = 64 , /**< 64  SAME70Q21B System Control Block (SCB) */
+  CCF_IRQn                  = 65 , /**< 65  SAME70Q21B System Control Block (SCB) */
   GMAC_Q1_IRQn              = 66 , /**< 66  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
   GMAC_Q2_IRQn              = 67 , /**< 67  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
-  IXC_IRQn                  = 68 , /**< 68  SAME70Q21B Floating Point Unit Registers (FPU) */
+  IXC_IRQn                  = 68 , /**< 68  SAME70Q21B Floating Point Unit (FPU) */
   I2SC0_IRQn                = 69 , /**< 69  SAME70Q21B Inter-IC Sound Controller (I2SC0) */
   I2SC1_IRQn                = 70 , /**< 70  SAME70Q21B Inter-IC Sound Controller (I2SC1) */
   GMAC_Q3_IRQn              = 71 , /**< 71  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
@@ -221,6 +223,7 @@ typedef struct _DeviceVectors
   void* pvReservedC3;
   void* pfnPendSV_Handler;                       /*  -2 Pendable request for system service  */
   void* pfnSysTick_Handler;                      /*  -1 System Tick Timer                    */
+
 
   /* Peripheral handlers */
   void* pfnSUPC_Handler;                         /* 0   SAME70Q21B Supply Controller (SUPC) */
@@ -284,20 +287,27 @@ typedef struct _DeviceVectors
   void* pfnXDMAC_Handler;                        /* 58  SAME70Q21B Extensible DMA Controller (XDMAC) */
   void* pfnISI_Handler;                          /* 59  SAME70Q21B Image Sensor Interface (ISI) */
   void* pfnPWM1_Handler;                         /* 60  SAME70Q21B Pulse Width Modulation Controller (PWM1) */
-  void* pfnFPU_Handler;                          /* 61  SAME70Q21B Floating Point Unit Registers (FPU) */
+  void* pfnFPU_Handler;                          /* 61  SAME70Q21B Floating Point Unit (FPU) */
   void* pfnSDRAMC_Handler;                       /* 62  SAME70Q21B SDRAM Controller (SDRAMC) */
   void* pfnRSWDT_Handler;                        /* 63  SAME70Q21B Reinforced Safety Watchdog Timer (RSWDT) */
-  void* pfnCCW_Handler;                          /* 64  SAME70Q21B System Control Registers (SystemControl) */
-  void* pfnCCF_Handler;                          /* 65  SAME70Q21B System Control Registers (SystemControl) */
+  void* pfnCCW_Handler;                          /* 64  SAME70Q21B System Control Block (SCB) */
+  void* pfnCCF_Handler;                          /* 65  SAME70Q21B System Control Block (SCB) */
   void* pfnGMAC_Q1_Handler;                      /* 66  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q2_Handler;                      /* 67  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
-  void* pfnIXC_Handler;                          /* 68  SAME70Q21B Floating Point Unit Registers (FPU) */
+  void* pfnIXC_Handler;                          /* 68  SAME70Q21B Floating Point Unit (FPU) */
   void* pfnI2SC0_Handler;                        /* 69  SAME70Q21B Inter-IC Sound Controller (I2SC0) */
   void* pfnI2SC1_Handler;                        /* 70  SAME70Q21B Inter-IC Sound Controller (I2SC1) */
   void* pfnGMAC_Q3_Handler;                      /* 71  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q4_Handler;                      /* 72  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
   void* pfnGMAC_Q5_Handler;                      /* 73  SAME70Q21B Gigabit Ethernet MAC (GMAC) */
 } DeviceVectors;
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define pfnMemManage_Handler      pfnMemoryManagement_Handler     /**< \deprecated  Backward compatibility for ASF */
+#define pfnDebugMon_Handler       pfnDebugMonitor_Handler         /**< \deprecated  Backward compatibility for ASF */
+#define pfnNMI_Handler            pfnNonMaskableInt_Handler       /**< \deprecated  Backward compatibility for ASF */
+#define pfnSVC_Handler            pfnSVCall_Handler               /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #if !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__))
@@ -390,6 +400,14 @@ void USBHS_Handler                 ( void );
 void WDT_Handler                   ( void );
 void XDMAC_Handler                 ( void );
 #endif /* DONT_USE_PREDEFINED_PERIPHERALS_HANDLERS */
+
+
+/* Defines for Deprecated Interrupt and Exceptions handler names */
+#define MemManage_Handler         MemoryManagement_Handler        /**< \deprecated  Backward compatibility for ASF */
+#define DebugMon_Handler          DebugMonitor_Handler            /**< \deprecated  Backward compatibility for ASF */
+#define NMI_Handler               NonMaskableInt_Handler          /**< \deprecated  Backward compatibility for ASF */
+#define SVC_Handler               SVCall_Handler                  /**< \deprecated  Backward compatibility for ASF */
+
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 
@@ -410,7 +428,7 @@ void XDMAC_Handler                 ( void );
 #define __DTCM_PRESENT                 1 /**< Data TCM present                                                          */
 #define __DEBUG_LVL                    1
 #define __TRACE_LVL                    1
-#define LITTLE_ENDIAN                  1
+#define __LITTLE_ENDIAN                1
 #define __ARCH_ARM                     1
 #define __ARCH_ARM_CORTEX_M            1
 #define __DEVICE_IS_SAM                1
@@ -613,18 +631,18 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 /*  LEGACY PERIPHERAL ID DEFINITIONS FOR SAME70Q21B */
 /* ************************************************************************** */
-#define ID_TC0                   ID_TC0_CHANNEL0
-#define ID_TC1                   ID_TC0_CHANNEL1
-#define ID_TC2                   ID_TC0_CHANNEL2
-#define ID_TC3                   ID_TC1_CHANNEL0
-#define ID_TC4                   ID_TC1_CHANNEL1
-#define ID_TC5                   ID_TC1_CHANNEL2
-#define ID_TC6                   ID_TC2_CHANNEL0
-#define ID_TC7                   ID_TC2_CHANNEL1
-#define ID_TC8                   ID_TC2_CHANNEL2
-#define ID_TC9                   ID_TC3_CHANNEL0
-#define ID_TC10                  ID_TC3_CHANNEL1
-#define ID_TC11                  ID_TC3_CHANNEL2
+#define ID_TC0                   TC0_INSTANCE_ID_CHANNEL0
+#define ID_TC1                   TC0_INSTANCE_ID_CHANNEL1
+#define ID_TC2                   TC0_INSTANCE_ID_CHANNEL2
+#define ID_TC3                   TC1_INSTANCE_ID_CHANNEL0
+#define ID_TC4                   TC1_INSTANCE_ID_CHANNEL1
+#define ID_TC5                   TC1_INSTANCE_ID_CHANNEL2
+#define ID_TC6                   TC2_INSTANCE_ID_CHANNEL0
+#define ID_TC7                   TC2_INSTANCE_ID_CHANNEL1
+#define ID_TC8                   TC2_INSTANCE_ID_CHANNEL2
+#define ID_TC9                   TC3_INSTANCE_ID_CHANNEL0
+#define ID_TC10                  TC3_INSTANCE_ID_CHANNEL1
+#define ID_TC11                  TC3_INSTANCE_ID_CHANNEL2
 /** @}  end of Legacy Peripheral Ids Definitions */
 
 /** \addtogroup SAME70Q21B_base Peripheral Base Address Definitions
@@ -936,6 +954,8 @@ void XDMAC_Handler                 ( void );
 #define CHIP_FREQ_FWS_5                _UL_(138000000) /**< \brief Maximum operating frequency when FWS is 5*/
 #define CHIP_FREQ_FWS_6                _UL_(150000000) /**< \brief Maximum operating frequency when FWS is 6*/
 #define CHIP_FREQ_FWS_NUMBER           _UL_(7)         /**< \brief Number of FWS ranges*/
+
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Import SAME70 DFP version 2.4.166 for SAM E70 and SAM E70B.

NOTE: The "PATCH: Fix GMAC priority queue register offsets" was not applied to `same70b` because this is already fixed in the upstream.

Supersedes #7.