### PR TITLE
ext: hal: atmel: sam4e: Fix wrong __MPU_PRESENT definition

### DIFF
--- a/asf/sam/include/sam4e/sam4e16c.h
+++ b/asf/sam/include/sam4e/sam4e16c.h
@@ -250,7 +250,7 @@ void WDT_Handler        ( void );
  */
 
 #define __CM4_REV              0x0000 /**< SAM4E16C core revision number ([15:8] revision number, [7:0] patch number) */
-#define __MPU_PRESENT          0      /**< SAM4E16C does not provide a MPU */
+#define __MPU_PRESENT          1      /**< SAM4E16C does provide a MPU */
 #define __FPU_PRESENT          1      /**< SAM4E16C does provide a FPU */
 #define __NVIC_PRIO_BITS       4      /**< SAM4E16C uses 4 Bits for the Priority Levels */
 #define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */

--- a/asf/sam/include/sam4e/sam4e16e.h
+++ b/asf/sam/include/sam4e/sam4e16e.h
@@ -250,7 +250,7 @@ void WDT_Handler        ( void );
  */
 
 #define __CM4_REV              0x0000 /**< SAM4E16E core revision number ([15:8] revision number, [7:0] patch number) */
-#define __MPU_PRESENT          0      /**< SAM4E16E does not provide a MPU */
+#define __MPU_PRESENT          1      /**< SAM4E16E does provide a MPU */
 #define __FPU_PRESENT          1      /**< SAM4E16E does provide a FPU */
 #define __NVIC_PRIO_BITS       4      /**< SAM4E16E uses 4 Bits for the Priority Levels */
 #define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */

--- a/asf/sam/include/sam4e/sam4e8c.h
+++ b/asf/sam/include/sam4e/sam4e8c.h
@@ -250,7 +250,7 @@ void WDT_Handler        ( void );
  */
 
 #define __CM4_REV              0x0000 /**< SAM4E8C core revision number ([15:8] revision number, [7:0] patch number) */
-#define __MPU_PRESENT          0      /**< SAM4E8C does not provide a MPU */
+#define __MPU_PRESENT          1      /**< SAM4E8C does provide a MPU */
 #define __FPU_PRESENT          1      /**< SAM4E8C does provide a FPU */
 #define __NVIC_PRIO_BITS       4      /**< SAM4E8C uses 4 Bits for the Priority Levels */
 #define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */

--- a/asf/sam/include/sam4e/sam4e8e.h
+++ b/asf/sam/include/sam4e/sam4e8e.h
@@ -250,7 +250,7 @@ void WDT_Handler        ( void );
  */
 
 #define __CM4_REV              0x0000 /**< SAM4E8E core revision number ([15:8] revision number, [7:0] patch number) */
-#define __MPU_PRESENT          0      /**< SAM4E8E does not provide a MPU */
+#define __MPU_PRESENT          1      /**< SAM4E8E does provide a MPU */
 #define __FPU_PRESENT          1      /**< SAM4E8E does provide a FPU */
 #define __NVIC_PRIO_BITS       4      /**< SAM4E8E uses 4 Bits for the Priority Levels */
 #define __Vendor_SysTickConfig 0      /**< Set to 1 if different SysTick Config is used */


### PR DESCRIPTION
The SAM4E have MPU on SoC but __MPU_PRESENT definition don't reflects on header files. This fixes __MPU_PRESENT definition setting to value 1 (enabled).

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>