### PR TITLE
winc: Remove offending #define

### DIFF
--- a/asf/common/components/wifi/winc1500/driver/source/nmspi.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmspi.c
@@ -42,7 +42,9 @@
 
 #ifdef CONF_WINC_USE_SPI
 
+/* Don't force USE_OLD_SPI_SW, instead we will pass it from Zephyr side
 #define USE_OLD_SPI_SW
+*/
 
 #include "bus_wrapper/include/nm_bus_wrapper.h"
 #include "nmspi.h"


### PR DESCRIPTION
If this offending #define is in place,

winc1500 driver will not work with

 nrf52840 DK or nrf52832 DK boards.

This definition should come from project Kconfig instead

Signed-off-by: Raja D.Singh <rdsingh@iotwizards.com>