### PR TITLE
patch: samd21: Correct missing underscore in defines for variants

### DIFF
--- a/asf/sam0/include/samd21/samd21e15a.h
+++ b/asf/sam0/include/samd21/samd21e15a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21e16a.h
+++ b/asf/sam0/include/samd21/samd21e16a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21e17a.h
+++ b/asf/sam0/include/samd21/samd21e17a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21e18a.h
+++ b/asf/sam0/include/samd21/samd21e18a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
+#if !defined(__UL)
 #define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
 #define __L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g15a.h
+++ b/asf/sam0/include/samd21/samd21g15a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g16a.h
+++ b/asf/sam0/include/samd21/samd21g16a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g17a.h
+++ b/asf/sam0/include/samd21/samd21g17a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g17au.h
+++ b/asf/sam0/include/samd21/samd21g17au.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g18a.h
+++ b/asf/sam0/include/samd21/samd21g18a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
+#if !defined(__UL)
 #define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
 #define __L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21g18au.h
+++ b/asf/sam0/include/samd21/samd21g18au.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21j15a.h
+++ b/asf/sam0/include/samd21/samd21j15a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21j16a.h
+++ b/asf/sam0/include/samd21/samd21j16a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21j17a.h
+++ b/asf/sam0/include/samd21/samd21j17a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
-#define _U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
-#define _L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
+#define __L(x)          x ## L            /**< C code: Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 

--- a/asf/sam0/include/samd21/samd21j18a.h
+++ b/asf/sam0/include/samd21/samd21j18a.h
@@ -61,16 +61,16 @@ typedef volatile       uint32_t WoReg8;  /**< Write only  8-bit register (volati
 typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
 typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
 typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
-#if !defined(_UL)
+#if !defined(__UL)
 #define __U(x)          x ## U            /**< C code: Unsigned integer literal constant value */
 #define __L(x)          x ## L            /**< C code: Long integer literal constant value */
-#define _UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#define __UL(x)         x ## UL           /**< C code: Unsigned Long integer literal constant value */
 #endif
 #else
-#if !defined(_UL)
-#define _U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
-#define _L(x)          x                 /**< Assembler: Long integer literal constant value */
-#define _UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
+#if !defined(__UL)
+#define __U(x)          x                 /**< Assembler: Unsigned integer literal constant value */
+#define __L(x)          x                 /**< Assembler: Long integer literal constant value */
+#define __UL(x)         x                 /**< Assembler: Unsigned Long integer literal constant value */
 #endif
 #endif
 


### PR DESCRIPTION
Propagate fix for atsamd21j18a in a1a4c018074727620799ac526f4a26ce7b518ba3 to all samd21 variants.