### PR TITLE
Fix include path and function name

### DIFF
--- a/asf/common/components/wifi/winc1500/bsp/include/nm_bsp_internal.h
+++ b/asf/common/components/wifi/winc1500/bsp/include/nm_bsp_internal.h
@@ -8,7 +8,7 @@
 #define _NM_BSP_INTERNAL_H_
 
 #if defined(CONFIG_WIFI_WINC1500)
-#include <wifi_winc1500_nm_bsp_internal.h>
+#include <wifi/winc1500/wifi_winc1500_nm_bsp_internal.h>
 #endif /* CONFIG_WIFI_WINC1500 */
 
 #endif //_NM_BSP_INTERNAL_H_

--- a/asf/common/components/wifi/winc1500/socket/include/socket.h
+++ b/asf/common/components/wifi/winc1500/socket/include/socket.h
@@ -1834,7 +1834,7 @@ NMI_API sint16 sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uin
 @return		
 	The function returned @ref SOCK_ERR_NO_ERROR for successful operation and a negative value (indicating the error) otherwise. 
 */
-NMI_API sint8 close(SOCKET sock);
+NMI_API sint8 winc1500_close(SOCKET sock);
 
 
 /** @} */

--- a/asf/common/components/wifi/winc1500/socket/source/socket.c
+++ b/asf/common/components/wifi/winc1500/socket/source/socket.c
@@ -905,7 +905,7 @@ Version
 Date
 		4 June 2012
 *********************************************************************/
-sint8 close(SOCKET sock)
+sint8 winc1500_close(SOCKET sock)
 {
 	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
     M2M_INFO("Sock to delete <%d>\n", sock);


### PR DESCRIPTION
When using the WINC1500 module in a project a while ago, we needed to make two changes to hal_atmel to make things build, which I think would make sense to get merged upstream. 