### PR TITLE
winc1500: nmspi: Fix compiler warning

### DIFF
--- a/asf/common/components/wifi/winc1500/driver/source/nmspi.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmspi.c
@@ -743,6 +743,7 @@ _error_:
 	return result;
 }
 #endif
+#if defined USE_OLD_SPI_SW
 static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 {
 	sint16 retry, ix, nbytes;
@@ -811,6 +812,7 @@ static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 
 	return result;
 }
+#endif
 
 static sint8 spi_data_write(uint8 *b, uint16 sz)
 {


### PR DESCRIPTION
Now that we don't set USE_OLD_SPI_SW because of this commit:

commit d17b7dd92d209b20bc1e15431d068edc29bf438d
Author: Raja D.Singh <rdsingh@iotwizards.com>
Date:   Tue Jul 21 16:06:05 2020 -0700

    winc1500: nmspi: Don't force definition of USE_OLD_SPI_SW

We get a compiler warning about spi_data_read being unused.  Add
ifdef protection around spi_data_read() to fix the compiler warning.

Signed-off-by: Kumar Gala <galak@kernel.org>