### PR TITLE
CMakeLists.txt: Add include directory only for atmel devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,2 @@
-zephyr_include_directories(include)
+zephyr_include_directories_ifdef(CONFIG_ASF include)
 add_subdirectory(asf)


### PR DESCRIPTION
The main CMakeLists.txt for this repository adds an include directory
without checking that the module is enabled. This causes ALL Zephyr
builds to have modules/hal/atmel/include in their included
directories. This commit adds a conditional to this addition, to
address this problem.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>