### PR TITLE
samv71b: Fix CIDR for V71 Revision B Silicon

### DIFF
--- a/asf/sam/include/samv71b/samv71j19b.h
+++ b/asf/sam/include/samv71b/samv71j19b.h
@@ -827,7 +827,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_CIDR                _UL_(0XA12D0A01)
 #define CHIP_EXID                _UL_(0X00000000)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71j20b.h
+++ b/asf/sam/include/samv71b/samv71j20b.h
@@ -827,7 +827,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_CIDR                _UL_(0XA1220C01)
 #define CHIP_EXID                _UL_(0X00000000)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71j21b.h
+++ b/asf/sam/include/samv71b/samv71j21b.h
@@ -827,7 +827,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_CIDR                _UL_(0XA1220E01)
 #define CHIP_EXID                _UL_(0X00000000)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71n19b.h
+++ b/asf/sam/include/samv71b/samv71n19b.h
@@ -889,7 +889,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_CIDR                _UL_(0XA12D0A01)
 #define CHIP_EXID                _UL_(0X00000001)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71n20b.h
+++ b/asf/sam/include/samv71b/samv71n20b.h
@@ -889,7 +889,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_CIDR                _UL_(0XA1220C01)
 #define CHIP_EXID                _UL_(0X00000001)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71n21b.h
+++ b/asf/sam/include/samv71b/samv71n21b.h
@@ -889,7 +889,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_CIDR                _UL_(0XA1220E01)
 #define CHIP_EXID                _UL_(0X00000001)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71q19b.h
+++ b/asf/sam/include/samv71b/samv71q19b.h
@@ -941,7 +941,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA12D0A00)
+#define CHIP_CIDR                _UL_(0XA12D0A01)
 #define CHIP_EXID                _UL_(0X00000002)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71q20b.h
+++ b/asf/sam/include/samv71b/samv71q20b.h
@@ -941,7 +941,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220C00)
+#define CHIP_CIDR                _UL_(0XA1220C01)
 #define CHIP_EXID                _UL_(0X00000002)
 
 /* ************************************************************************** */

--- a/asf/sam/include/samv71b/samv71q21b.h
+++ b/asf/sam/include/samv71b/samv71q21b.h
@@ -941,7 +941,7 @@ void XDMAC_Handler                 ( void );
 /* ************************************************************************** */
 #define JTAGID                   _UL_(0X05B3D03F)
 #define CHIP_JTAGID              _UL_(0X05B3D03F)
-#define CHIP_CIDR                _UL_(0XA1220E00)
+#define CHIP_CIDR                _UL_(0XA1220E01)
 #define CHIP_EXID                _UL_(0X00000002)
 
 /* ************************************************************************** */


### PR DESCRIPTION
For all V71 rev B silicon this changes the last CIDR byte to '1' instead
of '0', as described in the V71 Family Datasheet, page 129-130.

This fixes the warning '<wrn> soc: CIDR mismatch: chip = 0xa1220e01 vs
HAL = 0xa1220e00' seen during boot up for these silicon devices.

Signed-off-by: Nick Kraus <nick@nckraus.com>