### PR TITLE
sam4l: Add US_MR_CHRL_{n}_BIT Register Aliases for USART Driver

### DIFF
--- a/asf/sam/include/sam4l/sam4lc2a.h
+++ b/asf/sam/include/sam4l/sam4lc2a.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc2b.h
+++ b/asf/sam/include/sam4l/sam4lc2b.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc2c.h
+++ b/asf/sam/include/sam4l/sam4lc2c.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc4a.h
+++ b/asf/sam/include/sam4l/sam4lc4a.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc4b.h
+++ b/asf/sam/include/sam4l/sam4lc4b.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc4c.h
+++ b/asf/sam/include/sam4l/sam4lc4c.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc8a.h
+++ b/asf/sam/include/sam4l/sam4lc8a.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc8b.h
+++ b/asf/sam/include/sam4l/sam4lc8b.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4lc8c.h
+++ b/asf/sam/include/sam4l/sam4lc8c.h
@@ -832,6 +832,9 @@ void LCDCA_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls2a.h
+++ b/asf/sam/include/sam4l/sam4ls2a.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls2b.h
+++ b/asf/sam/include/sam4l/sam4ls2b.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls2c.h
+++ b/asf/sam/include/sam4l/sam4ls2c.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls4a.h
+++ b/asf/sam/include/sam4l/sam4ls4a.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls4b.h
+++ b/asf/sam/include/sam4l/sam4ls4b.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls4c.h
+++ b/asf/sam/include/sam4l/sam4ls4c.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls8a.h
+++ b/asf/sam/include/sam4l/sam4ls8a.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls8b.h
+++ b/asf/sam/include/sam4l/sam4ls8b.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI

--- a/asf/sam/include/sam4l/sam4ls8c.h
+++ b/asf/sam/include/sam4l/sam4ls8c.h
@@ -808,6 +808,9 @@ void TWIM3_Handler               ( void );
 #define US_MR_NBSTOP_2_BIT    US_MR_NBSTOP_2
 #define US_MR_NBSTOP_1_5_BIT  US_MR_NBSTOP_1_5
 #define US_MR_NBSTOP_1_BIT    US_MR_NBSTOP_1
+#define US_MR_CHRL_5_BIT      US_MR_CHRL_5
+#define US_MR_CHRL_6_BIT      US_MR_CHRL_6
+#define US_MR_CHRL_7_BIT      US_MR_CHRL_7
 #define US_MR_CHRL_8_BIT      US_MR_CHRL_8
 #define US_MR_PAR_NO          US_MR_PAR_NONE
 #define US_MR_PAR_MULTIDROP   US_MR_PAR_MULTI


### PR DESCRIPTION
Adds an alias from the US_MR_CHRL_{n} register define in the saml4 usart component to the US_MR_CHRL_{n}_BIT register name used in the zephyr usart driver

Signed-off-by: Nick Kraus <nick@nckraus.com>