### PR TITLE
Add missing register definitions for SAM series chips

### DIFF
--- a/asf/sam/include/sam4e/component/supc.h
+++ b/asf/sam/include/sam4e/component/supc.h
@@ -57,6 +57,7 @@ typedef struct {
 #define SUPC_CR_KEY_Pos 24
 #define SUPC_CR_KEY_Msk (0xffu << SUPC_CR_KEY_Pos) /**< \brief (SUPC_CR) Password */
 #define SUPC_CR_KEY(value) ((SUPC_CR_KEY_Msk & ((value) << SUPC_CR_KEY_Pos)))
+#define   SUPC_CR_KEY_PASSWD (0xA5u << 24) /**< \brief (SUPC_CR) Writing any other value in this field aborts the write operation. */
 /* -------- SUPC_SMMR : (SUPC Offset: 0x04) Supply Controller Supply Monitor Mode Register -------- */
 #define SUPC_SMMR_SMTH_Pos 0
 #define SUPC_SMMR_SMTH_Msk (0xfu << SUPC_SMMR_SMTH_Pos) /**< \brief (SUPC_SMMR) Supply Monitor Threshold */

--- a/asf/sam/include/sam4e/instance/rtc.h
+++ b/asf/sam/include/sam4e/instance/rtc.h
@@ -44,6 +44,7 @@
 #define REG_RTC_IDR             (0x400E1884U) /**< \brief (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888U) /**< \brief (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188CU) /**< \brief (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (0x400E18E4U) /**< \brief (RTC) Write Protect Mode Register */
 #else
 #define REG_RTC_CR     (*(RwReg*)0x400E1860U) /**< \brief (RTC) Control Register */
 #define REG_RTC_MR     (*(RwReg*)0x400E1864U) /**< \brief (RTC) Mode Register */
@@ -57,6 +58,8 @@
 #define REG_RTC_IDR    (*(WoReg*)0x400E1884U) /**< \brief (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR    (*(RoReg*)0x400E1888U) /**< \brief (RTC) Interrupt Mask Register */
 #define REG_RTC_VER    (*(RoReg*)0x400E188CU) /**< \brief (RTC) Valid Entry Register */
+#define REG_RTC_WPMR   (*(WoReg*)0x400E18E4U) /**< \brief (RTC) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #endif /* _SAM4E_RTC_INSTANCE_ */
+

--- a/asf/sam/include/sam4s/instance/rtc.h
+++ b/asf/sam/include/sam4s/instance/rtc.h
@@ -44,6 +44,7 @@
   #define REG_RTC_IDR                     (0x400E1484U) /**< \brief (RTC) Interrupt Disable Register */
   #define REG_RTC_IMR                     (0x400E1488U) /**< \brief (RTC) Interrupt Mask Register */
   #define REG_RTC_VER                     (0x400E148CU) /**< \brief (RTC) Valid Entry Register */
+  #define REG_RTC_WPMR                    (0x400E14E4U) /**< \brief (RTC) Write Protect Mode Register */
 #else
   #define REG_RTC_CR     (*(__IO uint32_t*)0x400E1460U) /**< \brief (RTC) Control Register */
   #define REG_RTC_MR     (*(__IO uint32_t*)0x400E1464U) /**< \brief (RTC) Mode Register */
@@ -57,6 +58,7 @@
   #define REG_RTC_IDR    (*(__O  uint32_t*)0x400E1484U) /**< \brief (RTC) Interrupt Disable Register */
   #define REG_RTC_IMR    (*(__I  uint32_t*)0x400E1488U) /**< \brief (RTC) Interrupt Mask Register */
   #define REG_RTC_VER    (*(__I  uint32_t*)0x400E148CU) /**< \brief (RTC) Valid Entry Register */
+  #define REG_RTC_WPMR   (*(__O  uint32_t*)0x400E14E4U) /**< \brief (RTC) Write Protect Mode Register */
 #endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 #endif /* _SAM4S_RTC_INSTANCE_ */

--- a/asf/sam/include/same70/instance/rtc.h
+++ b/asf/sam/include/same70/instance/rtc.h
@@ -46,6 +46,7 @@
 #define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (0x400E18E4) /**< (RTC) Write Protect Mode Register */
 
 #else
 
@@ -61,10 +62,11 @@
 #define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (*(__O  uint32_t*)0x400E18E4U) /**< (RTC) Write Protect Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2          
+#define RTC_INSTANCE_ID                          2
 
 #endif /* _SAME70_RTC_INSTANCE_ */

--- a/asf/sam/include/same70b/instance/rtc.h
+++ b/asf/sam/include/same70b/instance/rtc.h
@@ -46,6 +46,7 @@
 #define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (0x400E18E4) /**< (RTC) Write Protect Mode Register */
 
 #else
 
@@ -61,10 +62,11 @@
 #define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (*(__O  uint32_t*)0x400E18E4U) /**< (RTC) Write Protect Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2          
+#define RTC_INSTANCE_ID                          2
 
 #endif /* _SAME70_RTC_INSTANCE_ */

--- a/asf/sam/include/samv71/instance/rtc.h
+++ b/asf/sam/include/samv71/instance/rtc.h
@@ -47,6 +47,7 @@
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
 #define REG_RTC_VERSION         (0x400E195C) /**< (RTC) Version Register */
+#define REG_RTC_WPMR            (0x400E18E4) /**< (RTC) Write Protect Mode Register */
 
 #else
 
@@ -63,10 +64,11 @@
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
 #define REG_RTC_VERSION         (*(__I  uint32_t*)0x400E195CU) /**< (RTC) Version Register */
+#define REG_RTC_WPMR            (*(__O  uint32_t*)0x400E18E4U) /**< (RTC) Write Protect Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2          
+#define RTC_INSTANCE_ID                          2
 
 #endif /* _SAMV71_RTC_INSTANCE_ */

--- a/asf/sam/include/samv71b/instance/rtc.h
+++ b/asf/sam/include/samv71b/instance/rtc.h
@@ -46,6 +46,7 @@
 #define REG_RTC_IDR             (0x400E1884) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (0x400E1888) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (0x400E188C) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (0x400E18E4) /**< (RTC) Write Protect Mode Register */
 
 #else
 
@@ -61,10 +62,11 @@
 #define REG_RTC_IDR             (*(__O  uint32_t*)0x400E1884U) /**< (RTC) Interrupt Disable Register */
 #define REG_RTC_IMR             (*(__I  uint32_t*)0x400E1888U) /**< (RTC) Interrupt Mask Register */
 #define REG_RTC_VER             (*(__I  uint32_t*)0x400E188CU) /**< (RTC) Valid Entry Register */
+#define REG_RTC_WPMR            (*(__O  uint32_t*)0x400E18E4U) /**< (RTC) Write Protect Mode Register */
 
 #endif /* (defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 
 /* ========== Instance Parameter definitions for RTC peripheral ========== */
-#define RTC_INSTANCE_ID                          2          
+#define RTC_INSTANCE_ID                          2
 
 #endif /* _SAMV71_RTC_INSTANCE_ */


### PR DESCRIPTION
This PR contains two commits, adding a missing instance of `SUPC_CR_KEY_PASSWORD` to `component/sam4e.h`, and missing instances of
`REG_RTC_WPMR` to all but the `instance/sam3x.h` header