### PR TITLE
pinctrl: Add wake-up sources generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python

--- a/include/dt-bindings/pinctrl/atmel_sam_pinctrl.h
+++ b/include/dt-bindings/pinctrl/atmel_sam_pinctrl.h
@@ -11,22 +11,22 @@
  * @{
  */
 
-#define SAM_PINMUX_PORT_a	0U
-#define SAM_PINMUX_PORT_b	1U
-#define SAM_PINMUX_PORT_c	2U
-#define SAM_PINMUX_PORT_d	3U
-#define SAM_PINMUX_PORT_e	4U
-#define SAM_PINMUX_PORT_f	5U
-#define SAM_PINMUX_PORT_g	6U
-#define SAM_PINMUX_PORT_h	7U
-#define SAM_PINMUX_PORT_i	8U
-#define SAM_PINMUX_PORT_j	9U
-#define SAM_PINMUX_PORT_k	10U
-#define SAM_PINMUX_PORT_l	11U
-#define SAM_PINMUX_PORT_m	12U
-#define SAM_PINMUX_PORT_n	13U
-#define SAM_PINMUX_PORT_o	14U
-#define SAM_PINMUX_PORT_p	15U
+#define SAM_PINMUX_PORT_a		0U
+#define SAM_PINMUX_PORT_b		1U
+#define SAM_PINMUX_PORT_c		2U
+#define SAM_PINMUX_PORT_d		3U
+#define SAM_PINMUX_PORT_e		4U
+#define SAM_PINMUX_PORT_f		5U
+#define SAM_PINMUX_PORT_g		6U
+#define SAM_PINMUX_PORT_h		7U
+#define SAM_PINMUX_PORT_i		8U
+#define SAM_PINMUX_PORT_j		9U
+#define SAM_PINMUX_PORT_k		10U
+#define SAM_PINMUX_PORT_l		11U
+#define SAM_PINMUX_PORT_m		12U
+#define SAM_PINMUX_PORT_n		13U
+#define SAM_PINMUX_PORT_o		14U
+#define SAM_PINMUX_PORT_p		15U
 
 /** @} */
 
@@ -36,29 +36,45 @@
  */
 
 /** GPIO */
-#define SAM_PINMUX_PERIPH_gpio	0U
+#define SAM_PINMUX_PERIPH_gpio		0U
 /** Peripherals */
-#define SAM_PINMUX_PERIPH_a	0U
-#define SAM_PINMUX_PERIPH_b	1U
-#define SAM_PINMUX_PERIPH_c	2U
-#define SAM_PINMUX_PERIPH_d	3U
-#define SAM_PINMUX_PERIPH_e	4U
-#define SAM_PINMUX_PERIPH_f	5U
-#define SAM_PINMUX_PERIPH_g	6U
-#define SAM_PINMUX_PERIPH_h	7U
-#define SAM_PINMUX_PERIPH_i	8U
-#define SAM_PINMUX_PERIPH_j	9U
-#define SAM_PINMUX_PERIPH_k	10U
-#define SAM_PINMUX_PERIPH_l	11U
-#define SAM_PINMUX_PERIPH_m	12U
-#define SAM_PINMUX_PERIPH_n	13U
+#define SAM_PINMUX_PERIPH_a		0U
+#define SAM_PINMUX_PERIPH_b		1U
+#define SAM_PINMUX_PERIPH_c		2U
+#define SAM_PINMUX_PERIPH_d		3U
+#define SAM_PINMUX_PERIPH_e		4U
+#define SAM_PINMUX_PERIPH_f		5U
+#define SAM_PINMUX_PERIPH_g		6U
+#define SAM_PINMUX_PERIPH_h		7U
+#define SAM_PINMUX_PERIPH_i		8U
+#define SAM_PINMUX_PERIPH_j		9U
+#define SAM_PINMUX_PERIPH_k		10U
+#define SAM_PINMUX_PERIPH_l		11U
+#define SAM_PINMUX_PERIPH_m		12U
+#define SAM_PINMUX_PERIPH_n		13U
 /** Extra */
-#define SAM_PINMUX_PERIPH_x	0U
+#define SAM_PINMUX_PERIPH_x		0U
 /** System */
-#define SAM_PINMUX_PERIPH_s	0U
+#define SAM_PINMUX_PERIPH_s		0U
 /** LPM */
-#define SAM_PINMUX_PERIPH_lpm	0U
-
+#define SAM_PINMUX_PERIPH_lpm		0U
+/** Wake-up pin sources */
+#define SAM_PINMUX_PERIPH_wkup0		0U
+#define SAM_PINMUX_PERIPH_wkup1		1U
+#define SAM_PINMUX_PERIPH_wkup2		2U
+#define SAM_PINMUX_PERIPH_wkup3		3U
+#define SAM_PINMUX_PERIPH_wkup4		4U
+#define SAM_PINMUX_PERIPH_wkup5		5U
+#define SAM_PINMUX_PERIPH_wkup6		6U
+#define SAM_PINMUX_PERIPH_wkup7		7U
+#define SAM_PINMUX_PERIPH_wkup8		8U
+#define SAM_PINMUX_PERIPH_wkup9		9U
+#define SAM_PINMUX_PERIPH_wkup10	10U
+#define SAM_PINMUX_PERIPH_wkup11	11U
+#define SAM_PINMUX_PERIPH_wkup12	12U
+#define SAM_PINMUX_PERIPH_wkup13	13U
+#define SAM_PINMUX_PERIPH_wkup14	14U
+#define SAM_PINMUX_PERIPH_wkup15	15U
 /** @} */
 
 /**
@@ -67,15 +83,17 @@
  */
 
 /** Selects pin to be used as GPIO */
-#define SAM_PINMUX_FUNC_gpio	0U
+#define SAM_PINMUX_FUNC_gpio		0U
 /** Selects pin to be used as by some peripheral */
-#define SAM_PINMUX_FUNC_periph	1U
+#define SAM_PINMUX_FUNC_periph		1U
 /** Selects pin to be used as extra function */
-#define SAM_PINMUX_FUNC_extra	2U
+#define SAM_PINMUX_FUNC_extra		2U
 /** Selects pin to be used as system function */
-#define SAM_PINMUX_FUNC_system	3U
+#define SAM_PINMUX_FUNC_system		3U
 /** Selects and configure pin to be used in Low Power Mode */
-#define SAM_PINMUX_FUNC_lpm	4U
+#define SAM_PINMUX_FUNC_lpm		4U
+/** Selects and configure wake-up pin sources Low Power Mode */
+#define SAM_PINMUX_FUNC_wakeup		5U
 
 /** @} */
 
@@ -85,26 +103,26 @@
  */
 
 /** Pinmux bit field position. */
-#define SAM_PINCTRL_PINMUX_POS  (16U)
+#define SAM_PINCTRL_PINMUX_POS  	(16U)
 /** Pinmux bit field mask. */
-#define SAM_PINCTRL_PINMUX_MASK (0xFFFF)
+#define SAM_PINCTRL_PINMUX_MASK 	(0xFFFF)
 
 /** Port field mask. */
-#define SAM_PINMUX_PORT_MSK	(0xFU)
+#define SAM_PINMUX_PORT_MSK		(0xFU)
 /** Port field position. */
-#define SAM_PINMUX_PORT_POS	(0U)
+#define SAM_PINMUX_PORT_POS		(0U)
 /** Pin field mask. */
-#define SAM_PINMUX_PIN_MSK	(0x1FU)
+#define SAM_PINMUX_PIN_MSK		(0x1FU)
 /** Pin field position. */
-#define SAM_PINMUX_PIN_POS	(SAM_PINMUX_PORT_POS + 4U)
+#define SAM_PINMUX_PIN_POS		(SAM_PINMUX_PORT_POS + 4U)
 /** Function field mask. */
-#define SAM_PINMUX_FUNC_MSK	(0x7U)
+#define SAM_PINMUX_FUNC_MSK		(0x7U)
 /** Function field position. */
-#define SAM_PINMUX_FUNC_POS	(SAM_PINMUX_PIN_POS + 5U)
+#define SAM_PINMUX_FUNC_POS		(SAM_PINMUX_PIN_POS + 5U)
 /** Peripheral field mask. */
-#define SAM_PINMUX_PERIPH_MSK	(0xFU)
+#define SAM_PINMUX_PERIPH_MSK		(0xFU)
 /** Peripheral field position. */
-#define SAM_PINMUX_PERIPH_POS	(SAM_PINMUX_FUNC_POS + 3U)
+#define SAM_PINMUX_PERIPH_POS		(SAM_PINMUX_FUNC_POS + 3U)
 
 /** @} */
 

--- a/include/dt-bindings/pinctrl/sam3AXc-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam3AXc-pinctrl.h
@@ -32,7 +32,7 @@
 
 /* pa1x_supc_wkup0 */
 #define PA1X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup0, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -64,7 +64,7 @@
 
 /* pa3x_supc_wkup1 */
 #define PA3X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 3, x, extra)
+	SAM_PINMUX(a, 3, wkup1, wakeup)
 
 /* pa4_gpio */
 #define PA4_GPIO \
@@ -92,7 +92,7 @@
 
 /* pa5x_supc_wkup2 */
 #define PA5X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup2, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -116,7 +116,7 @@
 
 /* pa7x_supc_wkup3 */
 #define PA7X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 7, x, extra)
+	SAM_PINMUX(a, 7, wkup3, wakeup)
 
 /* pa8_gpio */
 #define PA8_GPIO \
@@ -132,7 +132,7 @@
 
 /* pa8x_supc_wkup4 */
 #define PA8X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 8, x, extra)
+	SAM_PINMUX(a, 8, wkup4, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -160,7 +160,7 @@
 
 /* pa10x_supc_wkup5 */
 #define PA10X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 10, x, extra)
+	SAM_PINMUX(a, 10, wkup5, wakeup)
 
 /* pa11_gpio */
 #define PA11_GPIO \
@@ -176,7 +176,7 @@
 
 /* pa11x_supc_wkup6 */
 #define PA11X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup6, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa12x_supc_wkup7 */
 #define PA12X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 12, x, extra)
+	SAM_PINMUX(a, 12, wkup7, wakeup)
 
 /* pa13_gpio */
 #define PA13_GPIO \
@@ -232,7 +232,7 @@
 
 /* pa15x_supc_wkup8 */
 #define PA15X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup8, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -272,7 +272,7 @@
 
 /* pa18x_supc_wkup9 */
 #define PA18X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 18, x, extra)
+	SAM_PINMUX(a, 18, wkup9, wakeup)
 
 /* pa19_gpio */
 #define PA19_GPIO \
@@ -384,7 +384,7 @@
 
 /* pa27x_supc_wkup10 */
 #define PA27X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 27, x, extra)
+	SAM_PINMUX(a, 27, wkup10, wakeup)
 
 /* pa28_gpio */
 #define PA28_GPIO \
@@ -400,7 +400,7 @@
 
 /* pa28x_supc_wkup11 */
 #define PA28X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 28, x, extra)
+	SAM_PINMUX(a, 28, wkup11, wakeup)
 
 /* pa29_gpio */
 #define PA29_GPIO \
@@ -568,7 +568,7 @@
 
 /* pb15x_supc_wkup10 */
 #define PB15X_SUPC_WKUP10 \
-	SAM_PINMUX(b, 15, x, extra)
+	SAM_PINMUX(b, 15, wkup10, wakeup)
 
 /* pb16_gpio */
 #define PB16_GPIO \
@@ -668,7 +668,7 @@
 
 /* pb21x_supc_wkup13 */
 #define PB21X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 21, x, extra)
+	SAM_PINMUX(b, 21, wkup13, wakeup)
 
 /* pb22_gpio */
 #define PB22_GPIO \
@@ -696,7 +696,7 @@
 
 /* pb23x_supc_wkup14 */
 #define PB23X_SUPC_WKUP14 \
-	SAM_PINMUX(b, 23, x, extra)
+	SAM_PINMUX(b, 23, wkup14, wakeup)
 
 /* pb24_gpio */
 #define PB24_GPIO \
@@ -732,7 +732,7 @@
 
 /* pb26x_supc_wkup15 */
 #define PB26X_SUPC_WKUP15 \
-	SAM_PINMUX(b, 26, x, extra)
+	SAM_PINMUX(b, 26, wkup15, wakeup)
 
 /* pb27_gpio */
 #define PB27_GPIO \

--- a/include/dt-bindings/pinctrl/sam3XXc-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam3XXc-pinctrl.h
@@ -32,7 +32,7 @@
 
 /* pa1x_supc_wkup0 */
 #define PA1X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup0, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -64,7 +64,7 @@
 
 /* pa3x_supc_wkup1 */
 #define PA3X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 3, x, extra)
+	SAM_PINMUX(a, 3, wkup1, wakeup)
 
 /* pa4_gpio */
 #define PA4_GPIO \
@@ -92,7 +92,7 @@
 
 /* pa5x_supc_wkup2 */
 #define PA5X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup2, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -116,7 +116,7 @@
 
 /* pa7x_supc_wkup3 */
 #define PA7X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 7, x, extra)
+	SAM_PINMUX(a, 7, wkup3, wakeup)
 
 /* pa8_gpio */
 #define PA8_GPIO \
@@ -132,7 +132,7 @@
 
 /* pa8x_supc_wkup4 */
 #define PA8X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 8, x, extra)
+	SAM_PINMUX(a, 8, wkup4, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -160,7 +160,7 @@
 
 /* pa10x_supc_wkup5 */
 #define PA10X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 10, x, extra)
+	SAM_PINMUX(a, 10, wkup5, wakeup)
 
 /* pa11_gpio */
 #define PA11_GPIO \
@@ -176,7 +176,7 @@
 
 /* pa11x_supc_wkup6 */
 #define PA11X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup6, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa12x_supc_wkup7 */
 #define PA12X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 12, x, extra)
+	SAM_PINMUX(a, 12, wkup7, wakeup)
 
 /* pa13_gpio */
 #define PA13_GPIO \
@@ -232,7 +232,7 @@
 
 /* pa15x_supc_wkup8 */
 #define PA15X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup8, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -272,7 +272,7 @@
 
 /* pa18x_supc_wkup9 */
 #define PA18X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 18, x, extra)
+	SAM_PINMUX(a, 18, wkup9, wakeup)
 
 /* pa19_gpio */
 #define PA19_GPIO \
@@ -384,7 +384,7 @@
 
 /* pa27x_supc_wkup10 */
 #define PA27X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 27, x, extra)
+	SAM_PINMUX(a, 27, wkup10, wakeup)
 
 /* pa28_gpio */
 #define PA28_GPIO \
@@ -400,7 +400,7 @@
 
 /* pa28x_supc_wkup11 */
 #define PA28X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 28, x, extra)
+	SAM_PINMUX(a, 28, wkup11, wakeup)
 
 /* pa29_gpio */
 #define PA29_GPIO \
@@ -608,7 +608,7 @@
 
 /* pb15x_supc_wkup10 */
 #define PB15X_SUPC_WKUP10 \
-	SAM_PINMUX(b, 15, x, extra)
+	SAM_PINMUX(b, 15, wkup10, wakeup)
 
 /* pb16_gpio */
 #define PB16_GPIO \
@@ -708,7 +708,7 @@
 
 /* pb21x_supc_wkup13 */
 #define PB21X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 21, x, extra)
+	SAM_PINMUX(b, 21, wkup13, wakeup)
 
 /* pb22_gpio */
 #define PB22_GPIO \
@@ -736,7 +736,7 @@
 
 /* pb23x_supc_wkup14 */
 #define PB23X_SUPC_WKUP14 \
-	SAM_PINMUX(b, 23, x, extra)
+	SAM_PINMUX(b, 23, wkup14, wakeup)
 
 /* pb24_gpio */
 #define PB24_GPIO \
@@ -772,7 +772,7 @@
 
 /* pb26x_supc_wkup15 */
 #define PB26X_SUPC_WKUP15 \
-	SAM_PINMUX(b, 26, x, extra)
+	SAM_PINMUX(b, 26, wkup15, wakeup)
 
 /* pb27_gpio */
 #define PB27_GPIO \

--- a/include/dt-bindings/pinctrl/sam3XXe-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam3XXe-pinctrl.h
@@ -32,7 +32,7 @@
 
 /* pa1x_supc_wkup0 */
 #define PA1X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup0, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa3x_supc_wkup1 */
 #define PA3X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 3, x, extra)
+	SAM_PINMUX(a, 3, wkup1, wakeup)
 
 /* pa4_gpio */
 #define PA4_GPIO \
@@ -100,7 +100,7 @@
 
 /* pa5x_supc_wkup2 */
 #define PA5X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup2, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -132,7 +132,7 @@
 
 /* pa7x_supc_wkup3 */
 #define PA7X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 7, x, extra)
+	SAM_PINMUX(a, 7, wkup3, wakeup)
 
 /* pa8_gpio */
 #define PA8_GPIO \
@@ -148,7 +148,7 @@
 
 /* pa8x_supc_wkup4 */
 #define PA8X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 8, x, extra)
+	SAM_PINMUX(a, 8, wkup4, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -176,7 +176,7 @@
 
 /* pa10x_supc_wkup5 */
 #define PA10X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 10, x, extra)
+	SAM_PINMUX(a, 10, wkup5, wakeup)
 
 /* pa11_gpio */
 #define PA11_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa11x_supc_wkup6 */
 #define PA11X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup6, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -208,7 +208,7 @@
 
 /* pa12x_supc_wkup7 */
 #define PA12X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 12, x, extra)
+	SAM_PINMUX(a, 12, wkup7, wakeup)
 
 /* pa13_gpio */
 #define PA13_GPIO \
@@ -248,7 +248,7 @@
 
 /* pa15x_supc_wkup8 */
 #define PA15X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup8, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -292,7 +292,7 @@
 
 /* pa18x_supc_wkup9 */
 #define PA18X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 18, x, extra)
+	SAM_PINMUX(a, 18, wkup9, wakeup)
 
 /* pa19_gpio */
 #define PA19_GPIO \
@@ -416,7 +416,7 @@
 
 /* pa27x_supc_wkup10 */
 #define PA27X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 27, x, extra)
+	SAM_PINMUX(a, 27, wkup10, wakeup)
 
 /* pa28_gpio */
 #define PA28_GPIO \
@@ -432,7 +432,7 @@
 
 /* pa28x_supc_wkup11 */
 #define PA28X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 28, x, extra)
+	SAM_PINMUX(a, 28, wkup11, wakeup)
 
 /* pa29_gpio */
 #define PA29_GPIO \
@@ -652,7 +652,7 @@
 
 /* pb15x_supc_wkup10 */
 #define PB15X_SUPC_WKUP10 \
-	SAM_PINMUX(b, 15, x, extra)
+	SAM_PINMUX(b, 15, wkup10, wakeup)
 
 /* pb16_gpio */
 #define PB16_GPIO \
@@ -752,7 +752,7 @@
 
 /* pb21x_supc_wkup13 */
 #define PB21X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 21, x, extra)
+	SAM_PINMUX(b, 21, wkup13, wakeup)
 
 /* pb22_gpio */
 #define PB22_GPIO \
@@ -780,7 +780,7 @@
 
 /* pb23x_supc_wkup14 */
 #define PB23X_SUPC_WKUP14 \
-	SAM_PINMUX(b, 23, x, extra)
+	SAM_PINMUX(b, 23, wkup14, wakeup)
 
 /* pb24_gpio */
 #define PB24_GPIO \
@@ -820,7 +820,7 @@
 
 /* pb26x_supc_wkup15 */
 #define PB26X_SUPC_WKUP15 \
-	SAM_PINMUX(b, 26, x, extra)
+	SAM_PINMUX(b, 26, wkup15, wakeup)
 
 /* pb27_gpio */
 #define PB27_GPIO \

--- a/include/dt-bindings/pinctrl/sam3XXh-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam3XXh-pinctrl.h
@@ -32,7 +32,7 @@
 
 /* pa1x_supc_wkup0 */
 #define PA1X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup0, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa3x_supc_wkup1 */
 #define PA3X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 3, x, extra)
+	SAM_PINMUX(a, 3, wkup1, wakeup)
 
 /* pa4_gpio */
 #define PA4_GPIO \
@@ -100,7 +100,7 @@
 
 /* pa5x_supc_wkup2 */
 #define PA5X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup2, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -132,7 +132,7 @@
 
 /* pa7x_supc_wkup3 */
 #define PA7X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 7, x, extra)
+	SAM_PINMUX(a, 7, wkup3, wakeup)
 
 /* pa8_gpio */
 #define PA8_GPIO \
@@ -148,7 +148,7 @@
 
 /* pa8x_supc_wkup4 */
 #define PA8X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 8, x, extra)
+	SAM_PINMUX(a, 8, wkup4, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -176,7 +176,7 @@
 
 /* pa10x_supc_wkup5 */
 #define PA10X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 10, x, extra)
+	SAM_PINMUX(a, 10, wkup5, wakeup)
 
 /* pa11_gpio */
 #define PA11_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa11x_supc_wkup6 */
 #define PA11X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup6, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -208,7 +208,7 @@
 
 /* pa12x_supc_wkup7 */
 #define PA12X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 12, x, extra)
+	SAM_PINMUX(a, 12, wkup7, wakeup)
 
 /* pa13_gpio */
 #define PA13_GPIO \
@@ -248,7 +248,7 @@
 
 /* pa15x_supc_wkup8 */
 #define PA15X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup8, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -292,7 +292,7 @@
 
 /* pa18x_supc_wkup9 */
 #define PA18X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 18, x, extra)
+	SAM_PINMUX(a, 18, wkup9, wakeup)
 
 /* pa19_gpio */
 #define PA19_GPIO \
@@ -416,7 +416,7 @@
 
 /* pa27x_supc_wkup10 */
 #define PA27X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 27, x, extra)
+	SAM_PINMUX(a, 27, wkup10, wakeup)
 
 /* pa28_gpio */
 #define PA28_GPIO \
@@ -432,7 +432,7 @@
 
 /* pa28x_supc_wkup11 */
 #define PA28X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 28, x, extra)
+	SAM_PINMUX(a, 28, wkup11, wakeup)
 
 /* pa29_gpio */
 #define PA29_GPIO \
@@ -676,7 +676,7 @@
 
 /* pb15x_supc_wkup10 */
 #define PB15X_SUPC_WKUP10 \
-	SAM_PINMUX(b, 15, x, extra)
+	SAM_PINMUX(b, 15, wkup10, wakeup)
 
 /* pb16_gpio */
 #define PB16_GPIO \
@@ -776,7 +776,7 @@
 
 /* pb21x_supc_wkup13 */
 #define PB21X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 21, x, extra)
+	SAM_PINMUX(b, 21, wkup13, wakeup)
 
 /* pb22_gpio */
 #define PB22_GPIO \
@@ -804,7 +804,7 @@
 
 /* pb23x_supc_wkup14 */
 #define PB23X_SUPC_WKUP14 \
-	SAM_PINMUX(b, 23, x, extra)
+	SAM_PINMUX(b, 23, wkup14, wakeup)
 
 /* pb24_gpio */
 #define PB24_GPIO \
@@ -844,7 +844,7 @@
 
 /* pb26x_supc_wkup15 */
 #define PB26X_SUPC_WKUP15 \
-	SAM_PINMUX(b, 26, x, extra)
+	SAM_PINMUX(b, 26, wkup15, wakeup)
 
 /* pb27_gpio */
 #define PB27_GPIO \

--- a/include/dt-bindings/pinctrl/sam4eXc-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam4eXc-pinctrl.h
@@ -20,7 +20,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -36,7 +36,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -52,7 +52,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -80,7 +80,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -96,7 +96,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -130,13 +130,13 @@
 #define PA8B_AFEC0_ADTRG \
 	SAM_PINMUX(a, 8, b, periph)
 
-/* pa8x_supc_wkup5 */
-#define PA8X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 8, x, extra)
-
 /* pa8s_supc_xout32 */
 #define PA8S_SUPC_XOUT32 \
 	SAM_PINMUX(a, 8, s, system)
+
+/* pa8x_supc_wkup5 */
+#define PA8X_SUPC_WKUP5 \
+	SAM_PINMUX(a, 8, wkup5, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -156,7 +156,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -184,7 +184,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -224,7 +224,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -244,7 +244,7 @@
 
 /* pa15x_supc_wkup14 */
 #define PA15X_SUPC_WKUP14 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup14, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -264,7 +264,7 @@
 
 /* pa16x_supc_wkup15 */
 #define PA16X_SUPC_WKUP15 \
-	SAM_PINMUX(a, 16, x, extra)
+	SAM_PINMUX(a, 16, wkup15, wakeup)
 
 /* pa17_gpio */
 #define PA17_GPIO \
@@ -308,7 +308,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -324,7 +324,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -508,7 +508,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -592,7 +592,7 @@
 
 /* pb2x_supc_wkup12 */
 #define PB2X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 2, x, extra)
+	SAM_PINMUX(b, 2, wkup12, wakeup)
 
 /* pb3_gpio */
 #define PB3_GPIO \
@@ -642,10 +642,6 @@
 #define PB5B_PWM_PWML0 \
 	SAM_PINMUX(b, 5, b, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -653,6 +649,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/sam4eXe-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam4eXe-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -60,7 +60,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -88,7 +88,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -104,7 +104,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -138,13 +138,13 @@
 #define PA8B_AFEC0_ADTRG \
 	SAM_PINMUX(a, 8, b, periph)
 
-/* pa8x_supc_wkup5 */
-#define PA8X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 8, x, extra)
-
 /* pa8s_supc_xout32 */
 #define PA8S_SUPC_XOUT32 \
 	SAM_PINMUX(a, 8, s, system)
+
+/* pa8x_supc_wkup5 */
+#define PA8X_SUPC_WKUP5 \
+	SAM_PINMUX(a, 8, wkup5, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -164,7 +164,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -232,7 +232,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -252,7 +252,7 @@
 
 /* pa15x_supc_wkup14 */
 #define PA15X_SUPC_WKUP14 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup14, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -272,7 +272,7 @@
 
 /* pa16x_supc_wkup15 */
 #define PA16X_SUPC_WKUP15 \
-	SAM_PINMUX(a, 16, x, extra)
+	SAM_PINMUX(a, 16, wkup15, wakeup)
 
 /* pa17_gpio */
 #define PA17_GPIO \
@@ -324,7 +324,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -344,7 +344,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -544,7 +544,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -628,7 +628,7 @@
 
 /* pb2x_supc_wkup12 */
 #define PB2X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 2, x, extra)
+	SAM_PINMUX(b, 2, wkup12, wakeup)
 
 /* pb3_gpio */
 #define PB3_GPIO \
@@ -678,10 +678,6 @@
 #define PB5B_PWM_PWML0 \
 	SAM_PINMUX(b, 5, b, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -689,6 +685,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/sam4sXa-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam4sXa-pinctrl.h
@@ -27,7 +27,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -43,7 +43,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -63,7 +63,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -91,7 +91,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -107,7 +107,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -149,13 +149,13 @@
 #define PA8B_ADC_ADTRG \
 	SAM_PINMUX(a, 8, b, periph)
 
-/* pa8x_supc_wkup5 */
-#define PA8X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 8, x, extra)
-
 /* pa8s_supc_xout32 */
 #define PA8S_SUPC_XOUT32 \
 	SAM_PINMUX(a, 8, s, system)
+
+/* pa8x_supc_wkup5 */
+#define PA8X_SUPC_WKUP5 \
+	SAM_PINMUX(a, 8, wkup5, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -175,7 +175,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -207,7 +207,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -247,7 +247,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -271,7 +271,7 @@
 
 /* pa15x_supc_wkup14 */
 #define PA15X_SUPC_WKUP14 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup14, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -295,7 +295,7 @@
 
 /* pa16x_supc_wkup15 */
 #define PA16X_SUPC_WKUP15 \
-	SAM_PINMUX(a, 16, x, extra)
+	SAM_PINMUX(a, 16, wkup15, wakeup)
 
 /* pa17_gpio */
 #define PA17_GPIO \
@@ -355,7 +355,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -375,7 +375,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pb0_gpio */
 #define PB0_GPIO \
@@ -427,7 +427,7 @@
 
 /* pb2x_supc_wkup12 */
 #define PB2X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 2, x, extra)
+	SAM_PINMUX(b, 2, wkup12, wakeup)
 
 /* pb3_gpio */
 #define PB3_GPIO \
@@ -473,10 +473,6 @@
 #define PB5B_PWM_PWML0 \
 	SAM_PINMUX(b, 5, b, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -484,6 +480,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/sam4sXb-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam4sXb-pinctrl.h
@@ -20,7 +20,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -36,7 +36,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -56,7 +56,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -84,7 +84,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -100,7 +100,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -142,13 +142,13 @@
 #define PA8B_ADC_ADTRG \
 	SAM_PINMUX(a, 8, b, periph)
 
-/* pa8x_supc_wkup5 */
-#define PA8X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 8, x, extra)
-
 /* pa8s_supc_xout32 */
 #define PA8S_SUPC_XOUT32 \
 	SAM_PINMUX(a, 8, s, system)
+
+/* pa8x_supc_wkup5 */
+#define PA8X_SUPC_WKUP5 \
+	SAM_PINMUX(a, 8, wkup5, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -168,7 +168,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -200,7 +200,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -240,7 +240,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -264,7 +264,7 @@
 
 /* pa15x_supc_wkup14 */
 #define PA15X_SUPC_WKUP14 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup14, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -288,7 +288,7 @@
 
 /* pa16x_supc_wkup15 */
 #define PA16X_SUPC_WKUP15 \
-	SAM_PINMUX(a, 16, x, extra)
+	SAM_PINMUX(a, 16, wkup15, wakeup)
 
 /* pa17_gpio */
 #define PA17_GPIO \
@@ -348,7 +348,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -368,7 +368,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -552,7 +552,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -624,7 +624,7 @@
 
 /* pb2x_supc_wkup12 */
 #define PB2X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 2, x, extra)
+	SAM_PINMUX(b, 2, wkup12, wakeup)
 
 /* pb3_gpio */
 #define PB3_GPIO \
@@ -670,10 +670,6 @@
 #define PB5B_PWM_PWML0 \
 	SAM_PINMUX(b, 5, b, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -681,6 +677,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/sam4sXc-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sam4sXc-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -64,7 +64,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -92,7 +92,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -108,7 +108,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -150,13 +150,13 @@
 #define PA8B_ADC_ADTRG \
 	SAM_PINMUX(a, 8, b, periph)
 
-/* pa8x_supc_wkup5 */
-#define PA8X_SUPC_WKUP5 \
-	SAM_PINMUX(a, 8, x, extra)
-
 /* pa8s_supc_xout32 */
 #define PA8S_SUPC_XOUT32 \
 	SAM_PINMUX(a, 8, s, system)
+
+/* pa8x_supc_wkup5 */
+#define PA8X_SUPC_WKUP5 \
+	SAM_PINMUX(a, 8, wkup5, wakeup)
 
 /* pa9_gpio */
 #define PA9_GPIO \
@@ -176,7 +176,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -208,7 +208,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -248,7 +248,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -272,7 +272,7 @@
 
 /* pa15x_supc_wkup14 */
 #define PA15X_SUPC_WKUP14 \
-	SAM_PINMUX(a, 15, x, extra)
+	SAM_PINMUX(a, 15, wkup14, wakeup)
 
 /* pa16_gpio */
 #define PA16_GPIO \
@@ -296,7 +296,7 @@
 
 /* pa16x_supc_wkup15 */
 #define PA16X_SUPC_WKUP15 \
-	SAM_PINMUX(a, 16, x, extra)
+	SAM_PINMUX(a, 16, wkup15, wakeup)
 
 /* pa17_gpio */
 #define PA17_GPIO \
@@ -364,7 +364,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -388,7 +388,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -588,7 +588,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -660,7 +660,7 @@
 
 /* pb2x_supc_wkup12 */
 #define PB2X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 2, x, extra)
+	SAM_PINMUX(b, 2, wkup12, wakeup)
 
 /* pb3_gpio */
 #define PB3_GPIO \
@@ -706,10 +706,6 @@
 #define PB5B_PWM_PWML0 \
 	SAM_PINMUX(b, 5, b, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -717,6 +713,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/same70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70j-pinctrl.h
@@ -55,7 +55,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -79,7 +79,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -143,7 +143,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -187,7 +187,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -251,7 +251,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -351,7 +351,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pb0_gpio */
 #define PB0_GPIO \
@@ -451,7 +451,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -489,10 +489,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -500,6 +496,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/same70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70n-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -60,7 +60,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -104,7 +104,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -128,7 +128,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -236,7 +236,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -300,7 +300,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -388,7 +388,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -408,7 +408,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -592,7 +592,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -712,7 +712,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -750,10 +750,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -761,6 +757,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1308,7 +1308,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd30_gpio */
 #define PD30_GPIO \

--- a/include/dt-bindings/pinctrl/same70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70q-pinctrl.h
@@ -28,7 +28,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -52,7 +52,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -112,7 +112,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -136,7 +136,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -200,7 +200,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -244,7 +244,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -308,7 +308,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -412,7 +412,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -436,7 +436,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -636,7 +636,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -756,7 +756,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -794,10 +794,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -805,6 +801,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1860,7 +1860,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd29_gpio */
 #define PD29_GPIO \

--- a/include/dt-bindings/pinctrl/sams70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70j-pinctrl.h
@@ -55,7 +55,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -79,7 +79,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -143,7 +143,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -187,7 +187,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -251,7 +251,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -351,7 +351,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pb0_gpio */
 #define PB0_GPIO \
@@ -439,7 +439,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -477,10 +477,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -488,6 +484,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/sams70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70n-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -60,7 +60,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -104,7 +104,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -128,7 +128,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -236,7 +236,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -300,7 +300,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -388,7 +388,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -408,7 +408,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -592,7 +592,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -700,7 +700,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -738,10 +738,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -749,6 +745,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1208,7 +1208,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd30_gpio */
 #define PD30_GPIO \

--- a/include/dt-bindings/pinctrl/sams70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70q-pinctrl.h
@@ -28,7 +28,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -52,7 +52,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -112,7 +112,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -136,7 +136,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -200,7 +200,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -244,7 +244,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -308,7 +308,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -412,7 +412,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -436,7 +436,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -636,7 +636,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -744,7 +744,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -782,10 +782,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -793,6 +789,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1748,7 +1748,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd29_gpio */
 #define PD29_GPIO \

--- a/include/dt-bindings/pinctrl/samv70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70j-pinctrl.h
@@ -55,7 +55,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -79,7 +79,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -143,7 +143,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -187,7 +187,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -251,7 +251,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -351,7 +351,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pb0_gpio */
 #define PB0_GPIO \
@@ -447,7 +447,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -493,10 +493,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -504,6 +500,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/samv70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70n-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -60,7 +60,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -104,7 +104,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -128,7 +128,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -236,7 +236,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -300,7 +300,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -388,7 +388,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -408,7 +408,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -592,7 +592,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -708,7 +708,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -754,10 +754,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -765,6 +761,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1236,7 +1236,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd30_gpio */
 #define PD30_GPIO \

--- a/include/dt-bindings/pinctrl/samv70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70q-pinctrl.h
@@ -28,7 +28,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -52,7 +52,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -112,7 +112,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -136,7 +136,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -200,7 +200,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -244,7 +244,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -308,7 +308,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -412,7 +412,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -436,7 +436,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -636,7 +636,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -752,7 +752,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -798,10 +798,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -809,6 +805,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1784,7 +1784,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd29_gpio */
 #define PD29_GPIO \

--- a/include/dt-bindings/pinctrl/samv71j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71j-pinctrl.h
@@ -55,7 +55,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -79,7 +79,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -143,7 +143,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -187,7 +187,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -251,7 +251,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -351,7 +351,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pb0_gpio */
 #define PB0_GPIO \
@@ -451,7 +451,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -497,10 +497,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -508,6 +504,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \

--- a/include/dt-bindings/pinctrl/samv71n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71n-pinctrl.h
@@ -24,7 +24,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -44,7 +44,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -60,7 +60,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -104,7 +104,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -128,7 +128,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -192,7 +192,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -236,7 +236,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -300,7 +300,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -388,7 +388,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -408,7 +408,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -592,7 +592,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -712,7 +712,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -758,10 +758,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -769,6 +765,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1320,7 +1320,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd30_gpio */
 #define PD30_GPIO \

--- a/include/dt-bindings/pinctrl/samv71q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71q-pinctrl.h
@@ -28,7 +28,7 @@
 
 /* pa0x_supc_wkup0 */
 #define PA0X_SUPC_WKUP0 \
-	SAM_PINMUX(a, 0, x, extra)
+	SAM_PINMUX(a, 0, wkup0, wakeup)
 
 /* pa1_gpio */
 #define PA1_GPIO \
@@ -52,7 +52,7 @@
 
 /* pa1x_supc_wkup1 */
 #define PA1X_SUPC_WKUP1 \
-	SAM_PINMUX(a, 1, x, extra)
+	SAM_PINMUX(a, 1, wkup1, wakeup)
 
 /* pa2_gpio */
 #define PA2_GPIO \
@@ -68,7 +68,7 @@
 
 /* pa2x_supc_wkup2 */
 #define PA2X_SUPC_WKUP2 \
-	SAM_PINMUX(a, 2, x, extra)
+	SAM_PINMUX(a, 2, wkup2, wakeup)
 
 /* pa3_gpio */
 #define PA3_GPIO \
@@ -112,7 +112,7 @@
 
 /* pa4x_supc_wkup3 */
 #define PA4X_SUPC_WKUP3 \
-	SAM_PINMUX(a, 4, x, extra)
+	SAM_PINMUX(a, 4, wkup3, wakeup)
 
 /* pa5_gpio */
 #define PA5_GPIO \
@@ -136,7 +136,7 @@
 
 /* pa5x_supc_wkup4 */
 #define PA5X_SUPC_WKUP4 \
-	SAM_PINMUX(a, 5, x, extra)
+	SAM_PINMUX(a, 5, wkup4, wakeup)
 
 /* pa6_gpio */
 #define PA6_GPIO \
@@ -200,7 +200,7 @@
 
 /* pa9x_supc_wkup6 */
 #define PA9X_SUPC_WKUP6 \
-	SAM_PINMUX(a, 9, x, extra)
+	SAM_PINMUX(a, 9, wkup6, wakeup)
 
 /* pa10_gpio */
 #define PA10_GPIO \
@@ -244,7 +244,7 @@
 
 /* pa11x_supc_wkup7 */
 #define PA11X_SUPC_WKUP7 \
-	SAM_PINMUX(a, 11, x, extra)
+	SAM_PINMUX(a, 11, wkup7, wakeup)
 
 /* pa12_gpio */
 #define PA12_GPIO \
@@ -308,7 +308,7 @@
 
 /* pa14x_supc_wkup8 */
 #define PA14X_SUPC_WKUP8 \
-	SAM_PINMUX(a, 14, x, extra)
+	SAM_PINMUX(a, 14, wkup8, wakeup)
 
 /* pa15_gpio */
 #define PA15_GPIO \
@@ -412,7 +412,7 @@
 
 /* pa19x_supc_wkup9 */
 #define PA19X_SUPC_WKUP9 \
-	SAM_PINMUX(a, 19, x, extra)
+	SAM_PINMUX(a, 19, wkup9, wakeup)
 
 /* pa20_gpio */
 #define PA20_GPIO \
@@ -436,7 +436,7 @@
 
 /* pa20x_supc_wkup10 */
 #define PA20X_SUPC_WKUP10 \
-	SAM_PINMUX(a, 20, x, extra)
+	SAM_PINMUX(a, 20, wkup10, wakeup)
 
 /* pa21_gpio */
 #define PA21_GPIO \
@@ -636,7 +636,7 @@
 
 /* pa30x_supc_wkup11 */
 #define PA30X_SUPC_WKUP11 \
-	SAM_PINMUX(a, 30, x, extra)
+	SAM_PINMUX(a, 30, wkup11, wakeup)
 
 /* pa31_gpio */
 #define PA31_GPIO \
@@ -756,7 +756,7 @@
 
 /* pb3x_supc_wkup12 */
 #define PB3X_SUPC_WKUP12 \
-	SAM_PINMUX(b, 3, x, extra)
+	SAM_PINMUX(b, 3, wkup12, wakeup)
 
 /* pb4_gpio */
 #define PB4_GPIO \
@@ -802,10 +802,6 @@
 #define PB5D_SSC_TD \
 	SAM_PINMUX(b, 5, d, periph)
 
-/* pb5x_supc_wkup13 */
-#define PB5X_SUPC_WKUP13 \
-	SAM_PINMUX(b, 5, x, extra)
-
 /* pb5s_jtag_tdo */
 #define PB5S_JTAG_TDO \
 	SAM_PINMUX(b, 5, s, system)
@@ -813,6 +809,10 @@
 /* pb5s_swd_traceswo */
 #define PB5S_SWD_TRACESWO \
 	SAM_PINMUX(b, 5, s, system)
+
+/* pb5x_supc_wkup13 */
+#define PB5X_SUPC_WKUP13 \
+	SAM_PINMUX(b, 5, wkup13, wakeup)
 
 /* pb6_gpio */
 #define PB6_GPIO \
@@ -1872,7 +1872,7 @@
 
 /* pd28x_supc_wkup5 */
 #define PD28X_SUPC_WKUP5 \
-	SAM_PINMUX(d, 28, x, extra)
+	SAM_PINMUX(d, 28, wkup5, wakeup)
 
 /* pd29_gpio */
 #define PD29_GPIO \

--- a/pinconfigs/README.md
+++ b/pinconfigs/README.md
@@ -140,23 +140,25 @@ add a `WARNING` message to uses in the auto generated file asking to user look
 datasheet. Any variation with exception must map all pins to allow users access
 functionality.
 
-The `pins` section is a vaiable length list of pin definitions. Each entry is
+The `pins` section is a variable length list of pin definitions. Each entry is
 a pin itself composed by one mandatory properties which is `pincodes` and many
-optional properties: `periph`, `extra`, `system`, `lpm`. The `pincode` instructs
-the engine to generate pin definitions only for those packages were pin is, in
-fact, available. The `periph` is the set of multiplexed peripheral signals. It
-is a variable length list where each entry is a list. Each peripheral list
-entry is composed of 4 fields, where the first 3 are mandatory. The peripheral
+optional properties: `periph`, `extra`, `system`, `lpm`, `wakeup`. The `pincode`
+instructs the engine to generate pin definitions only for those packages were
+pin is, in fact, available. The `periph` is the set of multiplexed peripheral
+signals. It is a variable length list where each entry is a list. Each peripheral
+list entry is composed of 4 fields, where the first 3 are mandatory. The peripheral
 list represents:
  - `alternate function index`
  - `peripheral [instance]`
  - `signal`
  - `SoC/pincode exclusion list` (optional)
 
-Additionaly some SoCs define special pin configuration. In the datasheet user
+Additionally some SoCs define special pin configuration. In the datasheet user
 can find a column named `extra` and another as `systems`. The syntax is the
 same as `periph`. The `lpm` is reserved for future use. Some SoCs may require
-special pin configuration to allow system consume less possible power.
+special pin configuration to allow system consume less possible power. The
+special `wakeup` pin definition configure the pin to be used to wake-up the
+core power supply, see Supply Controller SUPC for more details.
 
 Example:
 
@@ -220,14 +222,13 @@ pins:
       - [a, pwm, pwmh0]
       - [b, tc0, tioa0]
       - [c, smc, a17, [c]]
-      - [d, supc, wkup0]
 ```
 
 It is recommended use one filter at exclusion list. When necessary combine both
 `series` and `pincodes` the exclusion will operate first in the series and then
 will lookup by pincode.
 
-The next example shows how to specify `extra` function and `system` functions.
+The next example shows how to specify `extra`, `wakeup` and `system` functions.
 
 ```yaml
   pb5:
@@ -236,6 +237,8 @@ The next example shows how to specify `extra` function and `system` functions.
       - [a, twi1, twck1]
       - [b, pwm, pwml0]
     extra:
+      - [x, adc, ad3]
+    wakeup:
       - [x, supc, wkup13]
     system:
       - [s, jtag, tdo]

--- a/pinconfigs/sam-3x.yml
+++ b/pinconfigs/sam-3x.yml
@@ -37,7 +37,7 @@ pins:
     periph:
       - [a, can0, rx]
       - [b, pmc, pck0]
-    extra:
+    wakeup:
       - [x, supc, wkup0]
   pa2:
     pincodes: [c, e, h]
@@ -53,6 +53,7 @@ pins:
       - [b, pwm, pwmfi1]
     extra:
       - [x, adc, ad1]
+    wakeup:
       - [x, supc, wkup1]
   pa4:
     pincodes: [c, e, h]
@@ -66,7 +67,7 @@ pins:
     periph:
       - [a, tc0, tioa2]
       - [b, pwm, pwmfi0]
-    extra:
+    wakeup:
       - [x, supc, wkup2]
   pa6:
     pincodes: [c, e, h]
@@ -80,14 +81,14 @@ pins:
     periph:
       - [a, tc0, tclk2]
       - [b, ebi, ncs1, [c]]
-    extra:
+    wakeup:
       - [x, supc, wkup3]
   pa8:
     pincodes: [c, e, h]
     periph:
       - [a, uart, rxd]
       - [b, pwm, pwmh0]
-    extra:
+    wakeup:
       - [x, supc, wkup4]
   pa9:
     pincodes: [c, e, h]
@@ -99,21 +100,21 @@ pins:
     periph:
       - [a, usart0, rxd]
       - [b, dacc, datrg]
-    extra:
+    wakeup:
       - [x, supc, wkup5]
   pa11:
     pincodes: [c, e, h]
     periph:
       - [a, usart0, txd]
       - [b, adc, adtrg]
-    extra:
+    wakeup:
       - [x, supc, wkup6]
   pa12:
     pincodes: [c, e, h]
     periph:
       - [a, usart1, rxd]
       - [b, pwm, pwml1]
-    extra:
+    wakeup:
       - [x, supc, wkup7]
   pa13:
     pincodes: [c, e, h]
@@ -130,7 +131,7 @@ pins:
     periph:
       - [a, usart1, cts]
       - [b, ssc, tf]
-    extra:
+    wakeup:
       - [x, supc, wkup8]
   pa16:
     pincodes: [c, e, h]
@@ -149,7 +150,7 @@ pins:
     periph:
       - [a, twi0, twck]
       - [b, ebi, a20, [c]]
-    extra:
+    wakeup:
       - [x, supc, wkup9]
   pa19:
     pincodes: [c, e, h]
@@ -202,14 +203,14 @@ pins:
     periph:
       - [a, spi0, spck]
       - [b, ebi, a20, [c]]
-    extra:
+    wakeup:
       - [x, supc, wkup10]
   pa28:
     pincodes: [c, e, h]
     periph:
       - [a, spi0, npcs0]
       - [b, pmc, pck2]
-    extra:
+    wakeup:
       - [x, supc, wkup11]
   pa29:
     pincodes: [c, e, h]
@@ -312,6 +313,7 @@ pins:
       - [b, pwm, pwmh3]
     extra:
       - [x, dacc, dac0]
+    wakeup:
       - [x, supc, wkup10]
   pb16:
     pincodes: [c, e, h]
@@ -355,6 +357,7 @@ pins:
       - [b, spi0, npcs2]
     extra:
       - [x, adc, ad14]
+    wakeup:
       - [x, supc, wkup13]
   pb22:
     pincodes: [c, e, h]
@@ -366,7 +369,7 @@ pins:
     periph:
       - [a, usart2, cts]
       - [b, spi0, npcs3]
-    extra:
+    wakeup:
       - [x, supc, wkup14]
   pb24:
     pincodes: [c, e, h]
@@ -383,7 +386,7 @@ pins:
     periph:
       - [a, usart0, cts]
       - [b, tc0, tclk0]
-    extra:
+    wakeup:
       - [x, supc, wkup15]
   pb27:
     pincodes: [c, e, h]

--- a/pinconfigs/sam-4e.yml
+++ b/pinconfigs/sam-4e.yml
@@ -30,7 +30,7 @@ pins:
       - [a, pwm, pwmh0]
       - [b, tc0, tioa0]
       - [c, ebi, a17, [c]]
-    extra:
+    wakeup:
       - [x, supc, wkup0]
   pa1:
     pincodes: [c, e]
@@ -38,14 +38,14 @@ pins:
       - [a, pwm, pwmh1]
       - [b, tc0, tiob0]
       - [c, ebi, a18, [c]]
-    extra:
+    wakeup:
       - [x, supc, wkup1]
   pa2:
     pincodes: [c, e]
     periph:
       - [a, pwm, pwmh2]
       - [c, dacc, datrg]
-    extra:
+    wakeup:
       - [x, supc, wkup2]
   pa3:
     pincodes: [c, e]
@@ -57,14 +57,14 @@ pins:
     periph:
       - [a, twi0, twck]
       - [b, tc0, tclk0]
-    extra:
+    wakeup:
       - [x, supc, wkup3]
   pa5:
     pincodes: [c, e]
     periph:
       - [b, spi, npcs3]
       - [c, uart1, rxd]
-    extra:
+    wakeup:
       - [x, supc, wkup4]
   pa6:
     pincodes: [c, e]
@@ -81,7 +81,7 @@ pins:
     pincodes: [c, e]
     periph:
       - [b, afec0, adtrg]
-    extra:
+    wakeup:
       - [x, supc, wkup5]
     system:
       - [s, supc, xout32]
@@ -91,7 +91,7 @@ pins:
       - [a, uart0, rxd]
       - [b, spi, npcs1]
       - [c, pwm, pwmfi0]
-    extra:
+    wakeup:
       - [x, supc, wkup6]
   pa10:
     pincodes: [c, e]
@@ -103,7 +103,7 @@ pins:
     periph:
       - [a, spi, npcs0]
       - [b, pwm, pwmh0]
-    extra:
+    wakeup:
       - [x, supc, wkup7]
   pa12:
     pincodes: [c, e]
@@ -120,7 +120,7 @@ pins:
     periph:
       - [a, spi, spck]
       - [b, pwm, pwmh3]
-    extra:
+    wakeup:
       - [x, supc, wkup8]
   pa15:
     pincodes: [c, e]
@@ -129,6 +129,7 @@ pins:
       - [c, pwm, pwml3]
     extra:
       - [x, pio, piodcen1]
+    wakeup:
       - [x, supc, wkup14]
   pa16:
     pincodes: [c, e]
@@ -137,6 +138,7 @@ pins:
       - [c, pwm, pwml2]
     extra:
       - [x, pio, piodcen2]
+    wakeup:
       - [x, supc, wkup15]
   pa17:
     pincodes: [c, e]
@@ -159,6 +161,7 @@ pins:
       - [c, ebi, a15, [c]]
     extra:
       - [x, afec0, ad2]
+    wakeup:
       - [x, supc, wkup9]
   pa20:
     pincodes: [c, e]
@@ -167,6 +170,7 @@ pins:
       - [c, ebi, a16, [c]]
     extra:
       - [x, afec0, ad3]
+    wakeup:
       - [x, supc, wkup10]
   pa21:
     pincodes: [c, e]
@@ -247,6 +251,7 @@ pins:
       - [c, hsmci, mcda0]
     extra:
       - [x, pio, piodc6]
+    wakeup:
       - [x, supc, wkup11]
   pa31:
     pincodes: [c, e]
@@ -280,6 +285,7 @@ pins:
       - [c, usart0, cts]
     extra:
       - [x, afec1, ad0]
+    wakeup:
       - [x, supc, wkup12]
   pb3:
     pincodes: [c, e]
@@ -301,7 +307,7 @@ pins:
     periph:
       - [a, twi1, twck]
       - [b, pwm, pwml0]
-    extra:
+    wakeup:
       - [x, supc, wkup13]
     system:
       - [s, jtag, tdo]

--- a/pinconfigs/sam-4s-4sa-4sd.yml
+++ b/pinconfigs/sam-4s-4sa-4sd.yml
@@ -35,7 +35,7 @@ pins:
       - [a, pwm, pwmh0]
       - [b, tc0, tioa0]
       - [c, ebi, a17, [a, b]]
-    extra:
+    wakeup:
       - [x, supc, wkup0]
   pa1:
     pincodes: [a, b, c]
@@ -43,7 +43,7 @@ pins:
       - [a, pwm, pwmh1]
       - [b, tc0, tiob0]
       - [c, ebi, a18, [a, b]]
-    extra:
+    wakeup:
       - [x, supc, wkup1]
   pa2:
     pincodes: [a, b, c]
@@ -51,7 +51,7 @@ pins:
       - [a, pwm, pwmh2]
       - [b, usart0, sck]
       - [c, dacc, datrg]
-    extra:
+    wakeup:
       - [x, supc, wkup2]
   pa3:
     pincodes: [a, b, c]
@@ -63,14 +63,14 @@ pins:
     periph:
       - [a, twi0, twck]
       - [b, tc0, tclk0]
-    extra:
+    wakeup:
       - [x, supc, wkup3]
   pa5:
     pincodes: [a, b, c]
     periph:
       - [a, usart0, rxd]
       - [b, spi, npcs3]
-    extra:
+    wakeup:
       - [x, supc, wkup4]
   pa6:
     pincodes: [a, b, c]
@@ -89,7 +89,7 @@ pins:
     periph:
       - [a, usart0, cts]
       - [b, adc, adtrg]
-    extra:
+    wakeup:
       - [x, supc, wkup5]
     system:
       - [s, supc, xout32]
@@ -99,7 +99,7 @@ pins:
       - [a, uart0, rxd]
       - [b, spi, npcs1]
       - [c, pwm, pwmfi0]
-    extra:
+    wakeup:
       - [x, supc, wkup6]
   pa10:
     pincodes: [a, b, c]
@@ -112,7 +112,7 @@ pins:
     periph:
       - [a, spi, npcs0]
       - [b, pwm, pwmh0]
-    extra:
+    wakeup:
       - [x, supc, wkup7]
   pa12:
     pincodes: [a, b, c]
@@ -129,7 +129,7 @@ pins:
     periph:
       - [a, spi, spck]
       - [b, pwm, pwmh3]
-    extra:
+    wakeup:
       - [x, supc, wkup8]
   pa15:
     pincodes: [a, b, c]
@@ -139,6 +139,7 @@ pins:
       - [c, pwm, pwml3]
     extra:
       - [x, pio, piodcen1]
+    wakeup:
       - [x, supc, wkup14]
   pa16:
     pincodes: [a, b, c]
@@ -148,6 +149,7 @@ pins:
       - [c, pwm, pwml2]
     extra:
       - [x, pio, piodcen2]
+    wakeup:
       - [x, supc, wkup15]
   pa17:
     pincodes: [a, b, c]
@@ -174,6 +176,7 @@ pins:
       - [c, ebi, a15, [a, b]]
     extra:
       - [x, adc, ad2]
+    wakeup:
       - [x, supc, wkup9]
   pa20:
     pincodes: [a, b, c]
@@ -183,6 +186,7 @@ pins:
       - [c, ebi, a16, [a, b]]
     extra:
       - [x, adc, ad3]
+    wakeup:
       - [x, supc, wkup10]
   pa21:
     pincodes: [b, c]
@@ -263,6 +267,7 @@ pins:
       - [c, hsmci, mcda0, [a]]
     extra:
       - [x, pio, piodc6]
+    wakeup:
       - [x, supc, wkup11]
   pa31:
     pincodes: [b, c]
@@ -293,6 +298,7 @@ pins:
       - [b, spi, npcs2]
     extra:
       - [x, adc, ad6]
+    wakeup:
       - [x, supc, wkup12]
   pb3:
     pincodes: [a, b, c]
@@ -313,7 +319,7 @@ pins:
     periph:
       - [a, twi1, twck]
       - [b, pwm, pwml0]
-    extra:
+    wakeup:
       - [x, supc, wkup13]
     system:
       - [s, jtag, tdo]

--- a/pinconfigs/sam-s70-e70-v7x.yml
+++ b/pinconfigs/sam-s70-e70-v7x.yml
@@ -35,7 +35,7 @@ pins:
       - [b, tc0, tioa0]
       - [c, ebi, a17_ba1, [j, n]]
       - [d, i2sc0, mck]
-    extra:
+    wakeup:
       - [x, supc, wkup0]
   pa1:
     pincodes: [n, q]
@@ -44,14 +44,14 @@ pins:
       - [b, tc0, tiob0]
       - [c, ebi, a18, [j, n]]
       - [d, i2sc0, ck]
-    extra:
+    wakeup:
       - [x, supc, wkup1]
   pa2:
     pincodes: [n, q]
     periph:
       - [a, pwmc0, pwmh1]
       - [c, dacc, datrg]
-    extra:
+    wakeup:
       - [x, supc, wkup2]
   pa3:
     pincodes: [j, n, q]
@@ -69,6 +69,7 @@ pins:
       - [c, uart1, txd]
     extra:
       - [x, pio, piodc1]
+    wakeup:
       - [x, supc, wkup3]
   pa5:
     pincodes: [j, n, q]
@@ -78,6 +79,7 @@ pins:
       - [c, uart1, rxd]
     extra:
       - [x, pio, piodc2]
+    wakeup:
       - [x, supc, wkup4]
   pa6:
     pincodes: [j, n, q]
@@ -105,6 +107,7 @@ pins:
       - [c, pwmc0, pwmfi0]
     extra:
       - [x, pio, piodc3]
+    wakeup:
       - [x, supc, wkup6]
   pa10:
     pincodes: [j, n, q]
@@ -122,6 +125,7 @@ pins:
       - [c, pwmc1, pwml0]
     extra:
       - [x, pio, piodc5]
+    wakeup:
       - [x, supc, wkup7]
   pa12:
     pincodes: [j, n, q]
@@ -147,6 +151,7 @@ pins:
       - [c, pwmc1, pwmh1]
     extra:
       - [x, pio, pioden1]
+    wakeup:
       - [x, supc, wkup8]
   pa15:
     pincodes: [n, q]
@@ -186,6 +191,7 @@ pins:
       - [d, i2sc1, mck]
     extra:
       - [x, afe0, ad8]
+    wakeup:
       - [x, supc, wkup9]
   pa20:
     pincodes: [n, q]
@@ -195,6 +201,7 @@ pins:
       - [d, i2sc1, ck]
     extra:
       - [x, afe0, ad9]
+    wakeup:
       - [x, supc, wkup10]
   pa21:
     pincodes: [j, n, q]
@@ -267,7 +274,7 @@ pins:
       - [b, pwmc1, pwmextrg0]
       - [c, hsmci, mcda0]
       - [d, i2sc0, do]
-    extra:
+    wakeup:
       - [x, supc, wkup11]
   pa31:
     pincodes: [n, q]
@@ -312,6 +319,7 @@ pins:
       - [d, isi, d2]
     extra:
       - [x, afe0, ad2]
+    wakeup:
       - [x, supc, wkup12]
   pb4:
     pincodes: [j, n, q]
@@ -329,7 +337,7 @@ pins:
       - [b, pwmc0, pwml0]
       - [c, mlb, dat, [s70, e70]]
       - [d, ssc, td]
-    extra:
+    wakeup:
       - [x, supc, wkup13]
     system:
       - [s, jtag, tdo]
@@ -744,7 +752,7 @@ pins:
       - [b, can1, rx, [s70]]
       - [c, twi2, twck]
       - [d, isi, d9]
-    extra:
+    wakeup:
       - [x, supc, wkup5]
   pd29:
     pincodes: [q]

--- a/scripts/tests/sampinctrl/data/sam-pinctrl.yml
+++ b/scripts/tests/sampinctrl/data/sam-pinctrl.yml
@@ -63,3 +63,5 @@ pins:
       - [lpm, lpm_per, sig_lpm]
   pa04:
     pincodes: [d, e, f]
+    wakeup:
+      - [x, supc, wkup1]

--- a/scripts/tests/sampinctrl/data/samad-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/samad-pinctrl.h
@@ -38,6 +38,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)

--- a/scripts/tests/sampinctrl/data/samae-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/samae-pinctrl.h
@@ -41,6 +41,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)

--- a/scripts/tests/sampinctrl/data/samaf-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/samaf-pinctrl.h
@@ -38,6 +38,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)

--- a/scripts/tests/sampinctrl/data/sambe-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/sambe-pinctrl.h
@@ -41,6 +41,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)

--- a/scripts/tests/sampinctrl/data/sambf-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/sambf-pinctrl.h
@@ -38,6 +38,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)

--- a/scripts/tests/sampinctrl/data/samcf-pinctrl.h
+++ b/scripts/tests/sampinctrl/data/samcf-pinctrl.h
@@ -38,6 +38,10 @@
 #define PA4_GPIO \
 	ATMEL_SAM_XXX(a, 4, gpio, gpio)
 
+/* pa4x_supc_wkup1 */
+#define PA4X_SUPC_WKUP1 \
+	ATMEL_SAM_XXX(a, 4, wkup1, wakeup)
+
 /* pb0_gpio */
 #define PB0_GPIO \
 	ATMEL_SAM_XXX(b, 0, gpio, gpio)


### PR DESCRIPTION
The SAM SoC requires that SUPC be configured to enable specific pins to be used as wake-up sources. This add a new section denominated as wakeup. In that section the pinmux will be used to store the correct wkupX input to be used by the pinctrl driver to configure the gpio and supc accordingly.

This update all pinconfigs, the pinctrl definitions, update the documentation  and expand the current test to cover the changes.