### PR TITLE
pinctrl: SAMx7x: Fix incorrect pinctrl config for pa21

### DIFF
--- a/include/dt-bindings/pinctrl/same70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70j-pinctrl.h
@@ -269,8 +269,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/same70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70n-pinctrl.h
@@ -426,8 +426,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/same70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70q-pinctrl.h
@@ -454,8 +454,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/sams70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70j-pinctrl.h
@@ -269,8 +269,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/sams70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70n-pinctrl.h
@@ -426,8 +426,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/sams70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70q-pinctrl.h
@@ -454,8 +454,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv70j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70j-pinctrl.h
@@ -269,8 +269,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv70n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70n-pinctrl.h
@@ -426,8 +426,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70q-pinctrl.h
@@ -454,8 +454,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv71j-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71j-pinctrl.h
@@ -269,8 +269,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv71n-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71n-pinctrl.h
@@ -426,8 +426,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/include/dt-bindings/pinctrl/samv71q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71q-pinctrl.h
@@ -454,8 +454,8 @@
 #define PA21C_PWMC1_PWMFI0 \
 	SAM_PINMUX(a, 21, c, periph)
 
-/* pa21x_afe1_ad1 */
-#define PA21X_AFE1_AD1 \
+/* pa21x_afe0_ad1 */
+#define PA21X_AFE0_AD1 \
 	SAM_PINMUX(a, 21, x, extra)
 
 /* pa21x_pio_piodcen2 */

--- a/pinconfigs/sam-s70-e70-v7x.yml
+++ b/pinconfigs/sam-s70-e70-v7x.yml
@@ -210,7 +210,7 @@ pins:
       - [b, pmc, pck1]
       - [c, pwmc1, pwmfi0]
     extra:
-      - [x, afe1, ad1]
+      - [x, afe0, ad1]
       - [x, pio, piodcen2]
   pa22:
     pincodes: [j, n, q]


### PR DESCRIPTION
The pinctrl configuration for SAMx7x SOC pa21 is incorrect. Instead of afe1_ad1 it should be afe0_ad1.

This updates the pinconfigs yml file and all the updated header files.

See the associated datasheet section:

![image](https://github.com/zephyrproject-rtos/hal_atmel/assets/1459569/540f504d-6002-4f90-a655-0b87d33b4d69)
