### PR TITLE
asf: CMakeLists.txt: Use new family prefix

### DIFF
--- a/asf/CMakeLists.txt
+++ b/asf/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_subdirectory(common)
-add_subdirectory_ifdef(CONFIG_SOC_FAMILY_SAM sam)
-add_subdirectory_ifdef(CONFIG_SOC_FAMILY_SAM0 sam0)
+add_subdirectory_ifdef(CONFIG_SOC_FAMILY_ATMEL_SAM sam)
+add_subdirectory_ifdef(CONFIG_SOC_FAMILY_ATMEL_SAM0 sam0)


### PR DESCRIPTION
The newer HWMv2 impose a different semantic in the family names. This update from SOC_FAMILY_SAMx to SOC_FAMILY_ATMEL_SAMx to comply with.