### PR TITLE
Rename some (wrong named) macro in samv71q-pinctrl.h for AFEC0 pins

### DIFF
--- a/include/dt-bindings/pinctrl/same70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70q-pinctrl.h
@@ -1986,8 +1986,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */
@@ -2002,6 +2002,6 @@
 #define PE5B_TC3_TCLK10 \
 	SAM_PINMUX(e, 5, b, periph)
 
-/* pe5x_afe1_ad3 */
-#define PE5X_AFE1_AD3 \
+/* pe5x_afe0_ad3 */
+#define PE5X_AFE0_AD3 \
 	SAM_PINMUX(e, 5, x, extra)

--- a/include/dt-bindings/pinctrl/sams70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70q-pinctrl.h
@@ -1874,8 +1874,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */
@@ -1890,6 +1890,6 @@
 #define PE5B_TC3_TCLK10 \
 	SAM_PINMUX(e, 5, b, periph)
 
-/* pe5x_afe1_ad3 */
-#define PE5X_AFE1_AD3 \
+/* pe5x_afe0_ad3 */
+#define PE5X_AFE0_AD3 \
 	SAM_PINMUX(e, 5, x, extra)

--- a/include/dt-bindings/pinctrl/samv70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70q-pinctrl.h
@@ -1910,8 +1910,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */
@@ -1926,6 +1926,6 @@
 #define PE5B_TC3_TCLK10 \
 	SAM_PINMUX(e, 5, b, periph)
 
-/* pe5x_afe1_ad3 */
-#define PE5X_AFE1_AD3 \
+/* pe5x_afe0_ad3 */
+#define PE5X_AFE0_AD3 \
 	SAM_PINMUX(e, 5, x, extra)

--- a/include/dt-bindings/pinctrl/samv71q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71q-pinctrl.h
@@ -1998,8 +1998,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */
@@ -2014,6 +2014,6 @@
 #define PE5B_TC3_TCLK10 \
 	SAM_PINMUX(e, 5, b, periph)
 
-/* pe5x_afe1_ad3 */
-#define PE5X_AFE1_AD3 \
+/* pe5x_afe0_ad3 */
+#define PE5X_AFE0_AD3 \
 	SAM_PINMUX(e, 5, x, extra)

--- a/pinconfigs/sam-s70-e70-v7x.yml
+++ b/pinconfigs/sam-s70-e70-v7x.yml
@@ -805,11 +805,11 @@ pins:
       - [a, ebi, d12, [j, n]]
       - [b, tc3, tiob10]
     extra:
-      - [x, afe1, ad4]
+      - [x, afe0, ad4]
   pe5:
     pincodes: [q]
     periph:
       - [a, ebi, d13, [j, n]]
       - [b, tc3, tclk10]
     extra:
-      - [x, afe1, ad3]
+      - [x, afe0, ad3]


### PR DESCRIPTION
The pin macro for SAM V71 Q relative to PE5 use as AFEC0 AD3 is now named PE5X_AFE0_AD3. Previously it was named as if it is relative to AFEC1 AD3 (PE5X_AFE1_AD3). A check can be made by reading the pinout table of ATSAMV71 for 144 pinout (datasheet: https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-E70-S70-V70-V71-Family-Data-Sheet-DS60001527.pdf) (start fo the table: page 28; relevant table section: page 33, LQFP pin 28).