### PR TITLE
same70/samv71: patch: Fix QDEC deprecated symbols

### DIFF
--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -39,6 +39,7 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix QDEC deprecated symbols.
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.
    * Fix TC_CHANNEL register name.

--- a/asf/sam/include/same70b/component/tc.h
+++ b/asf/sam/include/same70b/component/tc.h
@@ -159,6 +159,15 @@ typedef union {
 #define TC_CMR_BURST_XC0                    (TC_CMR_BURST_XC0_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC0 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC1                    (TC_CMR_BURST_XC1_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC1 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC2                    (TC_CMR_BURST_XC2_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC2 is ANDed with the selected clock. Position  */
+#define TC_CMR_LDBSTOP_Pos                  6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_LDBSTOP_Msk                  (_U_(0x1) << TC_CMR_LDBSTOP_Pos)               /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_LDBSTOP                      TC_CMR_LDBSTOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBSTOP_Msk instead */
+#define TC_CMR_LDBDIS_Pos                   7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_LDBDIS_Msk                   (_U_(0x1) << TC_CMR_LDBDIS_Pos)                /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_LDBDIS                       TC_CMR_LDBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBDIS_Msk instead */
+#define TC_CMR_ETRGEDG_Pos                  8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_ETRGEDG_Msk                  (_U_(0x3) << TC_CMR_ETRGEDG_Pos)               /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_ETRGEDG(value)               (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
 #define   TC_CMR_ETRGEDG_NONE_Val           _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
 #define   TC_CMR_ETRGEDG_RISING_Val         _U_(0x1)                                       /**< (TC_CMR) Rising edge  */
 #define   TC_CMR_ETRGEDG_FALLING_Val        _U_(0x2)                                       /**< (TC_CMR) Falling edge  */
@@ -167,11 +176,52 @@ typedef union {
 #define TC_CMR_ETRGEDG_RISING               (TC_CMR_ETRGEDG_RISING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
 #define TC_CMR_ETRGEDG_FALLING              (TC_CMR_ETRGEDG_FALLING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
 #define TC_CMR_ETRGEDG_EDGE                 (TC_CMR_ETRGEDG_EDGE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
+#define TC_CMR_ABETRG_Pos                   10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_ABETRG_Msk                   (_U_(0x1) << TC_CMR_ABETRG_Pos)                /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_ABETRG                       TC_CMR_ABETRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_ABETRG_Msk instead */
+#define TC_CMR_CPCTRG_Pos                   14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CPCTRG_Msk                   (_U_(0x1) << TC_CMR_CPCTRG_Pos)                /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CPCTRG                       TC_CMR_CPCTRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CPCTRG_Msk instead */
 #define TC_CMR_WAVE_Pos                     15                                             /**< (TC_CMR) Waveform Mode Position */
 #define TC_CMR_WAVE_Msk                     (_U_(0x1) << TC_CMR_WAVE_Pos)                  /**< (TC_CMR) Waveform Mode Mask */
 #define TC_CMR_WAVE                         TC_CMR_WAVE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVE_Msk instead */
-#define TC_CMR_MASK                         _U_(0x803F)                                    /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
-#define TC_CMR_Msk                          _U_(0x803F)                                    /**< (TC_CMR) Register Mask  */
+#define TC_CMR_LDRA_Pos                     16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_LDRA_Msk                     (_U_(0x3) << TC_CMR_LDRA_Pos)                  /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_LDRA(value)                  (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
+#define   TC_CMR_LDRA_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRA_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRA_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRA_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRA_NONE                    (TC_CMR_LDRA_NONE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRA_RISING                  (TC_CMR_LDRA_RISING_Val << TC_CMR_LDRA_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRA_FALLING                 (TC_CMR_LDRA_FALLING_Val << TC_CMR_LDRA_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRA_EDGE                    (TC_CMR_LDRA_EDGE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_LDRB_Pos                     18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_LDRB_Msk                     (_U_(0x3) << TC_CMR_LDRB_Pos)                  /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_LDRB(value)                  (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
+#define   TC_CMR_LDRB_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRB_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRB_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRB_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRB_NONE                    (TC_CMR_LDRB_NONE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRB_RISING                  (TC_CMR_LDRB_RISING_Val << TC_CMR_LDRB_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRB_FALLING                 (TC_CMR_LDRB_FALLING_Val << TC_CMR_LDRB_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRB_EDGE                    (TC_CMR_LDRB_EDGE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_SBSMPLR_Pos                  20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_SBSMPLR_Msk                  (_U_(0x7) << TC_CMR_SBSMPLR_Pos)               /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_SBSMPLR(value)               (TC_CMR_SBSMPLR_Msk & ((value) << TC_CMR_SBSMPLR_Pos))
+#define   TC_CMR_SBSMPLR_ONE_Val            _U_(0x0)                                       /**< (TC_CMR) Load a Capture Register each selected edge  */
+#define   TC_CMR_SBSMPLR_HALF_Val           _U_(0x1)                                       /**< (TC_CMR) Load a Capture Register every 2 selected edges  */
+#define   TC_CMR_SBSMPLR_FOURTH_Val         _U_(0x2)                                       /**< (TC_CMR) Load a Capture Register every 4 selected edges  */
+#define   TC_CMR_SBSMPLR_EIGHTH_Val         _U_(0x3)                                       /**< (TC_CMR) Load a Capture Register every 8 selected edges  */
+#define   TC_CMR_SBSMPLR_SIXTEENTH_Val      _U_(0x4)                                       /**< (TC_CMR) Load a Capture Register every 16 selected edges  */
+#define TC_CMR_SBSMPLR_ONE                  (TC_CMR_SBSMPLR_ONE_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
+#define TC_CMR_SBSMPLR_HALF                 (TC_CMR_SBSMPLR_HALF_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
+#define TC_CMR_SBSMPLR_FOURTH               (TC_CMR_SBSMPLR_FOURTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
+#define TC_CMR_SBSMPLR_EIGHTH               (TC_CMR_SBSMPLR_EIGHTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
+#define TC_CMR_SBSMPLR_SIXTEENTH            (TC_CMR_SBSMPLR_SIXTEENTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
+#define TC_CMR_MASK                         _U_(0x7FC7FF)                                  /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
+#define TC_CMR_Msk                          _U_(0x7FC7FF)                                  /**< (TC_CMR) Register Mask  */
 
 /* CAPTURE mode */
 #define TC_CMR_CAPTURE_LDBSTOP_Pos          6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
@@ -1155,7 +1205,4 @@ typedef struct {
 #endif /* !(defined(__ASSEMBLER__) || defined(__IAR_SYSTEMS_ASM__)) */
 /** @}  end of Timer Counter */
 
-#if !(defined(DO_NOT_USE_DEPRECATED_MACROS))
-#include "deprecated/tc.h"
-#endif /* DO_NOT_USE_DEPRECATED_MACROS */
 #endif /* _SAME70_TC_COMPONENT_H_ */

--- a/asf/sam/include/samv71b/README
+++ b/asf/sam/include/samv71b/README
@@ -39,4 +39,5 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix QDEC deprecated symbols.
    * Fix XDMAC_CHID register name.

--- a/asf/sam/include/samv71b/component/tc.h
+++ b/asf/sam/include/samv71b/component/tc.h
@@ -159,11 +159,69 @@ typedef union {
 #define TC_CMR_BURST_XC0                    (TC_CMR_BURST_XC0_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC0 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC1                    (TC_CMR_BURST_XC1_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC1 is ANDed with the selected clock. Position  */
 #define TC_CMR_BURST_XC2                    (TC_CMR_BURST_XC2_Val << TC_CMR_BURST_Pos)     /**< (TC_CMR) XC2 is ANDed with the selected clock. Position  */
+#define TC_CMR_LDBSTOP_Pos                  6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */
+#define TC_CMR_LDBSTOP_Msk                  (_U_(0x1) << TC_CMR_LDBSTOP_Pos)               /**< (TC_CMR) Counter Clock Stopped with RB Loading Mask */
+#define TC_CMR_LDBSTOP                      TC_CMR_LDBSTOP_Msk                             /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBSTOP_Msk instead */
+#define TC_CMR_LDBDIS_Pos                   7                                              /**< (TC_CMR) Counter Clock Disable with RB Loading Position */
+#define TC_CMR_LDBDIS_Msk                   (_U_(0x1) << TC_CMR_LDBDIS_Pos)                /**< (TC_CMR) Counter Clock Disable with RB Loading Mask */
+#define TC_CMR_LDBDIS                       TC_CMR_LDBDIS_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_LDBDIS_Msk instead */
+#define TC_CMR_ETRGEDG_Pos                  8                                              /**< (TC_CMR) External Trigger Edge Selection Position */
+#define TC_CMR_ETRGEDG_Msk                  (_U_(0x3) << TC_CMR_ETRGEDG_Pos)               /**< (TC_CMR) External Trigger Edge Selection Mask */
+#define TC_CMR_ETRGEDG(value)               (TC_CMR_ETRGEDG_Msk & ((value) << TC_CMR_ETRGEDG_Pos))
+#define   TC_CMR_ETRGEDG_NONE_Val           _U_(0x0)                                       /**< (TC_CMR) The clock is not gated by an external signal.  */
+#define   TC_CMR_ETRGEDG_RISING_Val         _U_(0x1)                                       /**< (TC_CMR) Rising edge  */
+#define   TC_CMR_ETRGEDG_FALLING_Val        _U_(0x2)                                       /**< (TC_CMR) Falling edge  */
+#define   TC_CMR_ETRGEDG_EDGE_Val           _U_(0x3)                                       /**< (TC_CMR) Each edge  */
+#define TC_CMR_ETRGEDG_NONE                 (TC_CMR_ETRGEDG_NONE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) The clock is not gated by an external signal. Position  */
+#define TC_CMR_ETRGEDG_RISING               (TC_CMR_ETRGEDG_RISING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Rising edge Position  */
+#define TC_CMR_ETRGEDG_FALLING              (TC_CMR_ETRGEDG_FALLING_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Falling edge Position  */
+#define TC_CMR_ETRGEDG_EDGE                 (TC_CMR_ETRGEDG_EDGE_Val << TC_CMR_ETRGEDG_Pos)  /**< (TC_CMR) Each edge Position  */
+#define TC_CMR_ABETRG_Pos                   10                                             /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Position */
+#define TC_CMR_ABETRG_Msk                   (_U_(0x1) << TC_CMR_ABETRG_Pos)                /**< (TC_CMR) TIOAx or TIOBx External Trigger Selection Mask */
+#define TC_CMR_ABETRG                       TC_CMR_ABETRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_ABETRG_Msk instead */
+#define TC_CMR_CPCTRG_Pos                   14                                             /**< (TC_CMR) RC Compare Trigger Enable Position */
+#define TC_CMR_CPCTRG_Msk                   (_U_(0x1) << TC_CMR_CPCTRG_Pos)                /**< (TC_CMR) RC Compare Trigger Enable Mask */
+#define TC_CMR_CPCTRG                       TC_CMR_CPCTRG_Msk                              /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_CPCTRG_Msk instead */
 #define TC_CMR_WAVE_Pos                     15                                             /**< (TC_CMR) Waveform Mode Position */
 #define TC_CMR_WAVE_Msk                     (_U_(0x1) << TC_CMR_WAVE_Pos)                  /**< (TC_CMR) Waveform Mode Mask */
 #define TC_CMR_WAVE                         TC_CMR_WAVE_Msk                                /**< \deprecated Old style mask definition for 1 bit bitfield. Use TC_CMR_WAVE_Msk instead */
-#define TC_CMR_MASK                         _U_(0x803F)                                    /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
-#define TC_CMR_Msk                          _U_(0x803F)                                    /**< (TC_CMR) Register Mask  */
+#define TC_CMR_LDRA_Pos                     16                                             /**< (TC_CMR) RA Loading Edge Selection Position */
+#define TC_CMR_LDRA_Msk                     (_U_(0x3) << TC_CMR_LDRA_Pos)                  /**< (TC_CMR) RA Loading Edge Selection Mask */
+#define TC_CMR_LDRA(value)                  (TC_CMR_LDRA_Msk & ((value) << TC_CMR_LDRA_Pos))
+#define   TC_CMR_LDRA_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRA_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRA_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRA_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRA_NONE                    (TC_CMR_LDRA_NONE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRA_RISING                  (TC_CMR_LDRA_RISING_Val << TC_CMR_LDRA_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRA_FALLING                 (TC_CMR_LDRA_FALLING_Val << TC_CMR_LDRA_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRA_EDGE                    (TC_CMR_LDRA_EDGE_Val << TC_CMR_LDRA_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_LDRB_Pos                     18                                             /**< (TC_CMR) RB Loading Edge Selection Position */
+#define TC_CMR_LDRB_Msk                     (_U_(0x3) << TC_CMR_LDRB_Pos)                  /**< (TC_CMR) RB Loading Edge Selection Mask */
+#define TC_CMR_LDRB(value)                  (TC_CMR_LDRB_Msk & ((value) << TC_CMR_LDRB_Pos))
+#define   TC_CMR_LDRB_NONE_Val              _U_(0x0)                                       /**< (TC_CMR) None  */
+#define   TC_CMR_LDRB_RISING_Val            _U_(0x1)                                       /**< (TC_CMR) Rising edge of TIOAx  */
+#define   TC_CMR_LDRB_FALLING_Val           _U_(0x2)                                       /**< (TC_CMR) Falling edge of TIOAx  */
+#define   TC_CMR_LDRB_EDGE_Val              _U_(0x3)                                       /**< (TC_CMR) Each edge of TIOAx  */
+#define TC_CMR_LDRB_NONE                    (TC_CMR_LDRB_NONE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) None Position  */
+#define TC_CMR_LDRB_RISING                  (TC_CMR_LDRB_RISING_Val << TC_CMR_LDRB_Pos)    /**< (TC_CMR) Rising edge of TIOAx Position  */
+#define TC_CMR_LDRB_FALLING                 (TC_CMR_LDRB_FALLING_Val << TC_CMR_LDRB_Pos)   /**< (TC_CMR) Falling edge of TIOAx Position  */
+#define TC_CMR_LDRB_EDGE                    (TC_CMR_LDRB_EDGE_Val << TC_CMR_LDRB_Pos)      /**< (TC_CMR) Each edge of TIOAx Position  */
+#define TC_CMR_SBSMPLR_Pos                  20                                             /**< (TC_CMR) Loading Edge Subsampling Ratio Position */
+#define TC_CMR_SBSMPLR_Msk                  (_U_(0x7) << TC_CMR_SBSMPLR_Pos)               /**< (TC_CMR) Loading Edge Subsampling Ratio Mask */
+#define TC_CMR_SBSMPLR(value)               (TC_CMR_SBSMPLR_Msk & ((value) << TC_CMR_SBSMPLR_Pos))
+#define   TC_CMR_SBSMPLR_ONE_Val            _U_(0x0)                                       /**< (TC_CMR) Load a Capture Register each selected edge  */
+#define   TC_CMR_SBSMPLR_HALF_Val           _U_(0x1)                                       /**< (TC_CMR) Load a Capture Register every 2 selected edges  */
+#define   TC_CMR_SBSMPLR_FOURTH_Val         _U_(0x2)                                       /**< (TC_CMR) Load a Capture Register every 4 selected edges  */
+#define   TC_CMR_SBSMPLR_EIGHTH_Val         _U_(0x3)                                       /**< (TC_CMR) Load a Capture Register every 8 selected edges  */
+#define   TC_CMR_SBSMPLR_SIXTEENTH_Val      _U_(0x4)                                       /**< (TC_CMR) Load a Capture Register every 16 selected edges  */
+#define TC_CMR_SBSMPLR_ONE                  (TC_CMR_SBSMPLR_ONE_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register each selected edge Position  */
+#define TC_CMR_SBSMPLR_HALF                 (TC_CMR_SBSMPLR_HALF_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 2 selected edges Position  */
+#define TC_CMR_SBSMPLR_FOURTH               (TC_CMR_SBSMPLR_FOURTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 4 selected edges Position  */
+#define TC_CMR_SBSMPLR_EIGHTH               (TC_CMR_SBSMPLR_EIGHTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 8 selected edges Position  */
+#define TC_CMR_SBSMPLR_SIXTEENTH            (TC_CMR_SBSMPLR_SIXTEENTH_Val << TC_CMR_SBSMPLR_Pos)  /**< (TC_CMR) Load a Capture Register every 16 selected edges Position  */
+#define TC_CMR_MASK                         _U_(0x7FC7FF)                                  /**< \deprecated (TC_CMR) Register MASK  (Use TC_CMR_Msk instead)  */
+#define TC_CMR_Msk                          _U_(0x7FC7FF)                                  /**< (TC_CMR) Register Mask  */
 
 /* CAPTURE mode */
 #define TC_CMR_CAPTURE_LDBSTOP_Pos          6                                              /**< (TC_CMR) Counter Clock Stopped with RB Loading Position */


### PR DESCRIPTION
Keep old symbols for compatibility and easy reading.