### PR TITLE
same70b: patch: Fix SMC struct naming

### DIFF
--- a/asf/sam/include/same70/README
+++ b/asf/sam/include/same70/README
@@ -39,6 +39,7 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix SmcCs struct naming.
    * Fix the GMAC priority queue registers to match the datasheet.
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.

--- a/asf/sam/include/same70/component/smc.h
+++ b/asf/sam/include/same70/component/smc.h
@@ -372,12 +372,12 @@ typedef struct {
   __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register (CS_number = 0) */
   __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register (CS_number = 0) */
   __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC MODE Register (CS_number = 0) */
-} SmcCsNumber;
+} SmcCs_number;
 
-#define SMCCSNUMBER_NUMBER 4
+#define SMCCS_NUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCs_number SMC_CS_NUMBER[SMCCS_NUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC OCMS MODE Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC OCMS KEY1 Register */
@@ -394,11 +394,11 @@ typedef struct {
   __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register (CS_number = 0) */
   __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register (CS_number = 0) */
   __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC MODE Register (CS_number = 0) */
-} SmcCsNumber;
+} SmcCs_number;
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCs_number                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC OCMS MODE Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC OCMS KEY1 Register */

--- a/asf/sam/include/same70b/README
+++ b/asf/sam/include/same70b/README
@@ -39,6 +39,7 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix SmcCs struct naming.
    * Fix QDEC deprecated symbols.
    * Fix GMAC_SA register name.
    * Fix XDMAC_CHID register name.

--- a/asf/sam/include/same70b/component/smc.h
+++ b/asf/sam/include/same70b/component/smc.h
@@ -372,12 +372,12 @@ typedef struct {
   __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register */
   __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register */
   __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register */
-} SmcCsNumber;
+} SmcCs_number;
 
-#define SMCCSNUMBER_NUMBER 4
+#define SMCCS_NUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SMC_CS_NUMBER[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCs_number SMC_CS_NUMBER[SMCCS_NUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
@@ -394,11 +394,11 @@ typedef struct {
   __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register */
   __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register */
   __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register */
-} SmcCsNumber;
+} SmcCs_number;
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCs_number                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */

--- a/asf/sam/include/samv71/README
+++ b/asf/sam/include/samv71/README
@@ -39,5 +39,6 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix SmcCs struct naming.
    * Fix the GMAC priority queue registers to match the datasheet.
    * Fix XDMAC_CHID register name.

--- a/asf/sam/include/samv71/component/smc.h
+++ b/asf/sam/include/samv71/component/smc.h
@@ -399,12 +399,12 @@ typedef struct {
   __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register (CS_number = 0) */
   __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register (CS_number = 0) */
   __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register (CS_number = 0) */
-} SmcCsNumber;
+} SmcCs_number;
 
-#define SMCCSNUMBER_NUMBER 4
+#define SMCCS_NUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCs_number SMC_CS_NUMBER[SMCCS_NUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
@@ -423,11 +423,11 @@ typedef struct {
   __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register (CS_number = 0) */
   __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register (CS_number = 0) */
   __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register (CS_number = 0) */
-} SmcCsNumber;
+} SmcCs_number;
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
+       SmcCs_number                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register (CS_number = 0) */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */

--- a/asf/sam/include/samv71b/README
+++ b/asf/sam/include/samv71b/README
@@ -39,5 +39,6 @@ License Link:
    https://www.apache.org/licenses/LICENSE-2.0
 
 Patch List:
+   * Fix SmcCs struct naming.
    * Fix QDEC deprecated symbols.
    * Fix XDMAC_CHID register name.

--- a/asf/sam/include/samv71b/component/smc.h
+++ b/asf/sam/include/samv71b/component/smc.h
@@ -372,12 +372,12 @@ typedef struct {
   __IO uint32_t SMC_PULSE;      /**< (SMC_CS_NUMBER Offset: 0x04) SMC Pulse Register */
   __IO uint32_t SMC_CYCLE;      /**< (SMC_CS_NUMBER Offset: 0x08) SMC Cycle Register */
   __IO uint32_t SMC_MODE;       /**< (SMC_CS_NUMBER Offset: 0x0C) SMC Mode Register */
-} SmcCsNumber;
+} SmcCs_number;
 
-#define SMCCSNUMBER_NUMBER 4
+#define SMCCS_NUMBER_NUMBER 4
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber SmcCsNumber[SMCCSNUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCs_number SMC_CS_NUMBER[SMCCS_NUMBER_NUMBER]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO uint32_t SMC_OCMS;       /**< (SMC Offset: 0x80) SMC Off-Chip Memory Scrambling Register */
   __O  uint32_t SMC_KEY1;       /**< (SMC Offset: 0x84) SMC Off-Chip Memory Scrambling KEY1 Register */
@@ -394,11 +394,11 @@ typedef struct {
   __IO SMC_PULSE_Type                 SMC_PULSE;      /**< Offset: 0x04 (R/W  32) SMC Pulse Register */
   __IO SMC_CYCLE_Type                 SMC_CYCLE;      /**< Offset: 0x08 (R/W  32) SMC Cycle Register */
   __IO SMC_MODE_Type                  SMC_MODE;       /**< Offset: 0x0C (R/W  32) SMC Mode Register */
-} SmcCsNumber;
+} SmcCs_number;
 
 /** \brief SMC hardware registers */
 typedef struct {  
-       SmcCsNumber                    SmcCsNumber[4]; /**< Offset: 0x00 SMC Setup Register */
+       SmcCs_number                    SMC_CS_NUMBER[4]; /**< Offset: 0x00 SMC Setup Register */
   __I  uint8_t                        Reserved1[64];
   __IO SMC_OCMS_Type                  SMC_OCMS;       /**< Offset: 0x80 (R/W  32) SMC Off-Chip Memory Scrambling Register */
   __O  SMC_KEY1_Type                  SMC_KEY1;       /**< Offset: 0x84 ( /W  32) SMC Off-Chip Memory Scrambling KEY1 Register */


### PR DESCRIPTION
Renames SmcCs struct names and defines to match the names for SAM4S, since the existing memc-sam-driver is built on SAM4S.

Fixes a build failure when adding support for the SMC peripheral to the same70-dts.

See also related PR in main Zephyr-repo.

Note that I've only done this change in the same70b-files, as that is the hardware I've had to test it with. It should probably be the same for same70 and maybe samv71 / samv71b - as far as I could tell from a quick glance it has the same issues (and the SMC peripheral is the same for this entire series).