### PR TITLE
sam0: Name all anonymous bit-fields with qualifiers

### DIFF
--- a/asf/sam0/include/samc20/README
+++ b/asf/sam0/include/samc20/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samc20/component/ac.h
+++ b/asf/sam0/include/samc20/component/ac.h
@@ -258,12 +258,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  COMP2:1;          /*!< bit:      2  Comparator 2                       */
     __I uint8_t  COMP3:1;          /*!< bit:      3  Comparator 3                       */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:4;           /*!< bit:  0.. 3  Comparator x                       */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/adc.h
+++ b/asf/sam0/include/samc20/component/adc.h
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/dmac.h
+++ b/asf/sam0/include/samc20/component/dmac.h
@@ -748,7 +748,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samc20/component/eic.h
+++ b/asf/sam0/include/samc20/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/evsys.h
+++ b/asf/sam0/include/samc20/component/evsys.h
@@ -259,20 +259,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun                  */
     __I uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun                  */
     __I uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun                  */
-    __I uint32_t :10;              /*!< bit:  6..15  Reserved                           */
+    __I uint32_t Reserved1:10;     /*!< bit:  6..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
     __I uint32_t EVD3:1;           /*!< bit:     19  Channel 3 Event Detection          */
     __I uint32_t EVD4:1;           /*!< bit:     20  Channel 4 Event Detection          */
     __I uint32_t EVD5:1;           /*!< bit:     21  Channel 5 Event Detection          */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:6;            /*!< bit:  0.. 5  Channel x Overrun                  */
-    __I uint32_t :10;              /*!< bit:  6..15  Reserved                           */
+    __I uint32_t Reserved1:10;     /*!< bit:  6..15  Reserved                           */
     __I uint32_t EVD:6;            /*!< bit: 16..21  Channel x Event Detection          */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/freqm.h
+++ b/asf/sam0/include/samc20/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/mclk.h
+++ b/asf/sam0/include/samc20/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/nvmctrl.h
+++ b/asf/sam0/include/samc20/component/nvmctrl.h
@@ -240,7 +240,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/osc32kctrl.h
+++ b/asf/sam0/include/samc20/component/osc32kctrl.h
@@ -94,7 +94,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
     __I uint32_t CLKFAIL:1;        /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved1:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/oscctrl.h
+++ b/asf/sam0/include/samc20/component/oscctrl.h
@@ -121,14 +121,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
     __I uint32_t XOSCFAIL:1;       /*!< bit:      1  XOSC Clock Failure Detector        */
-    __I uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint32_t OSC48MRDY:1;      /*!< bit:      4  OSC48M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:      8  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:      9  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     10  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     11  DPLL Ratio Ready                   */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved3:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/pac.h
+++ b/asf/sam0/include/samc20/component/pac.h
@@ -136,7 +136,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HPB2_:1;          /*!< bit:      5  HPB2                               */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:      6  LPRAMDMAC                          */
     __I uint32_t DIVAS_:1;         /*!< bit:      7  DIVAS                              */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    __I uint32_t Reserved1:24;     /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -179,7 +179,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      9  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:     10  EIC                                */
     __I uint32_t FREQM_:1;         /*!< bit:     11  FREQM                              */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -224,7 +224,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      3  DMAC                               */
     __I uint32_t MTB_:1;           /*!< bit:      4  MTB                                */
     __I uint32_t HMATRIXHS_:1;     /*!< bit:      5  HMATRIXHS                          */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -256,7 +256,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:      2  SERCOM1                            */
     __I uint32_t SERCOM2_:1;       /*!< bit:      3  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:      4  SERCOM3                            */
-    __I uint32_t :4;               /*!< bit:  5.. 8  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  5.. 8  Reserved                           */
     __I uint32_t TCC0_:1;          /*!< bit:      9  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     10  TCC1                               */
     __I uint32_t TCC2_:1;          /*!< bit:     11  TCC2                               */
@@ -266,12 +266,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TC3_:1;           /*!< bit:     15  TC3                                */
     __I uint32_t TC4_:1;           /*!< bit:     16  TC4                                */
     __I uint32_t ADC0_:1;          /*!< bit:     17  ADC0                               */
-    __I uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    __I uint32_t Reserved2:2;      /*!< bit: 18..19  Reserved                           */
     __I uint32_t AC_:1;            /*!< bit:     20  AC                                 */
-    __I uint32_t :1;               /*!< bit:     21  Reserved                           */
+    __I uint32_t Reserved3:1;      /*!< bit:     21  Reserved                           */
     __I uint32_t PTC_:1;           /*!< bit:     22  PTC                                */
     __I uint32_t CCL_:1;           /*!< bit:     23  CCL                                */
-    __I uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+    __I uint32_t Reserved4:8;      /*!< bit: 24..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;

--- a/asf/sam0/include/samc20/component/rtc.h
+++ b/asf/sam0/include/samc20/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/sercom.h
+++ b/asf/sam0/include/samc20/component/sercom.h
@@ -813,7 +813,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -838,7 +838,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -866,7 +866,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -898,7 +898,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samc20/component/supc.h
+++ b/asf/sam0/include/samc20/component/supc.h
@@ -115,7 +115,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BODCORERDY:1;     /*!< bit:      3  BODCORE Ready                      */
     __I uint32_t BODCOREDET:1;     /*!< bit:      4  BODCORE Detection                  */
     __I uint32_t BCORESRDY:1;      /*!< bit:      5  BODCORE Synchronization Ready      */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/tc.h
+++ b/asf/sam0/include/samc20/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/tcc.h
+++ b/asf/sam0/include/samc20/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samc20/component/wdt.h
+++ b/asf/sam0/include/samc20/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/README
+++ b/asf/sam0/include/samc20n/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samc20n/component/ac.h
+++ b/asf/sam0/include/samc20n/component/ac.h
@@ -268,12 +268,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  COMP3:1;          /*!< bit:      3  Comparator 3                       */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
     __I uint8_t  WIN1:1;           /*!< bit:      5  Window 1                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:4;           /*!< bit:  0.. 3  Comparator x                       */
     __I uint8_t  WIN:2;            /*!< bit:  4.. 5  Window x                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/adc.h
+++ b/asf/sam0/include/samc20n/component/adc.h
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/dmac.h
+++ b/asf/sam0/include/samc20n/component/dmac.h
@@ -769,7 +769,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/eic.h
+++ b/asf/sam0/include/samc20n/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/evsys.h
+++ b/asf/sam0/include/samc20n/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/freqm.h
+++ b/asf/sam0/include/samc20n/component/freqm.h
@@ -141,7 +141,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/mclk.h
+++ b/asf/sam0/include/samc20n/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/nvmctrl.h
+++ b/asf/sam0/include/samc20n/component/nvmctrl.h
@@ -240,7 +240,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/osc32kctrl.h
+++ b/asf/sam0/include/samc20n/component/osc32kctrl.h
@@ -94,7 +94,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
     __I uint32_t CLKFAIL:1;        /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved1:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/oscctrl.h
+++ b/asf/sam0/include/samc20n/component/oscctrl.h
@@ -121,14 +121,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
     __I uint32_t XOSCFAIL:1;       /*!< bit:      1  XOSC Clock Failure Detector        */
-    __I uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint32_t OSC48MRDY:1;      /*!< bit:      4  OSC48M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:      8  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:      9  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     10  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     11  DPLL Ratio Ready                   */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved3:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/pac.h
+++ b/asf/sam0/include/samc20n/component/pac.h
@@ -137,7 +137,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:      6  LPRAMDMAC                          */
     __I uint32_t DIVAS_:1;         /*!< bit:      7  DIVAS                              */
     __I uint32_t HPB3_:1;          /*!< bit:      8  HPB3                               */
-    __I uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+    __I uint32_t Reserved1:23;     /*!< bit:  9..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -182,7 +182,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      9  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:     10  EIC                                */
     __I uint32_t FREQM_:1;         /*!< bit:     11  FREQM                              */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -227,7 +227,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      3  DMAC                               */
     __I uint32_t MTB_:1;           /*!< bit:      4  MTB                                */
     __I uint32_t HMATRIXHS_:1;     /*!< bit:      5  HMATRIXHS                          */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -261,7 +261,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM3_:1;       /*!< bit:      4  SERCOM3                            */
     __I uint32_t SERCOM4_:1;       /*!< bit:      5  SERCOM4                            */
     __I uint32_t SERCOM5_:1;       /*!< bit:      6  SERCOM5                            */
-    __I uint32_t :2;               /*!< bit:  7.. 8  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  7.. 8  Reserved                           */
     __I uint32_t TCC0_:1;          /*!< bit:      9  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     10  TCC1                               */
     __I uint32_t TCC2_:1;          /*!< bit:     11  TCC2                               */
@@ -271,12 +271,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TC3_:1;           /*!< bit:     15  TC3                                */
     __I uint32_t TC4_:1;           /*!< bit:     16  TC4                                */
     __I uint32_t ADC0_:1;          /*!< bit:     17  ADC0                               */
-    __I uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    __I uint32_t Reserved2:2;      /*!< bit: 18..19  Reserved                           */
     __I uint32_t AC_:1;            /*!< bit:     20  AC                                 */
-    __I uint32_t :1;               /*!< bit:     21  Reserved                           */
+    __I uint32_t Reserved3:1;      /*!< bit:     21  Reserved                           */
     __I uint32_t PTC_:1;           /*!< bit:     22  PTC                                */
     __I uint32_t CCL_:1;           /*!< bit:     23  CCL                                */
-    __I uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+    __I uint32_t Reserved4:8;      /*!< bit: 24..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -334,7 +334,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TC5_:1;           /*!< bit:      2  TC5                                */
     __I uint32_t TC6_:1;           /*!< bit:      3  TC6                                */
     __I uint32_t TC7_:1;           /*!< bit:      4  TC7                                */
-    __I uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+    __I uint32_t Reserved1:27;     /*!< bit:  5..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/samc20n/component/rtc.h
+++ b/asf/sam0/include/samc20n/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/sercom.h
+++ b/asf/sam0/include/samc20n/component/sercom.h
@@ -813,7 +813,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -838,7 +838,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -866,7 +866,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -898,7 +898,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samc20n/component/supc.h
+++ b/asf/sam0/include/samc20n/component/supc.h
@@ -122,7 +122,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BODCOREDET:1;     /*!< bit:      4  BODCORE Detection                  */
     __I uint32_t BCORESRDY:1;      /*!< bit:      5  BODCORE Synchronization Ready      */
     __I uint32_t VREG33RDY:1;      /*!< bit:      6  VREG33 Ready                       */
-    __I uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+    __I uint32_t Reserved1:25;     /*!< bit:  7..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/tc.h
+++ b/asf/sam0/include/samc20n/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/tcc.h
+++ b/asf/sam0/include/samc20n/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samc20n/component/wdt.h
+++ b/asf/sam0/include/samc20n/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samc21/README
+++ b/asf/sam0/include/samc21/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samc21/component/ac.h
+++ b/asf/sam0/include/samc21/component/ac.h
@@ -268,12 +268,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  COMP3:1;          /*!< bit:      3  Comparator 3                       */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
     __I uint8_t  WIN1:1;           /*!< bit:      5  Window 1                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:4;           /*!< bit:  0.. 3  Comparator x                       */
     __I uint8_t  WIN:2;            /*!< bit:  4.. 5  Window x                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/adc.h
+++ b/asf/sam0/include/samc21/component/adc.h
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/dac.h
+++ b/asf/sam0/include/samc21/component/dac.h
@@ -176,7 +176,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/dmac.h
+++ b/asf/sam0/include/samc21/component/dmac.h
@@ -820,7 +820,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samc21/component/eic.h
+++ b/asf/sam0/include/samc21/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/evsys.h
+++ b/asf/sam0/include/samc21/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/freqm.h
+++ b/asf/sam0/include/samc21/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/mclk.h
+++ b/asf/sam0/include/samc21/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/nvmctrl.h
+++ b/asf/sam0/include/samc21/component/nvmctrl.h
@@ -240,7 +240,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/osc32kctrl.h
+++ b/asf/sam0/include/samc21/component/osc32kctrl.h
@@ -94,7 +94,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
     __I uint32_t CLKFAIL:1;        /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved1:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/oscctrl.h
+++ b/asf/sam0/include/samc21/component/oscctrl.h
@@ -121,14 +121,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
     __I uint32_t XOSCFAIL:1;       /*!< bit:      1  XOSC Clock Failure Detector        */
-    __I uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint32_t OSC48MRDY:1;      /*!< bit:      4  OSC48M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:      8  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:      9  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     10  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     11  DPLL Ratio Ready                   */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved3:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/pac.h
+++ b/asf/sam0/include/samc21/component/pac.h
@@ -136,7 +136,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HPB2_:1;          /*!< bit:      5  HPB2                               */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:      6  LPRAMDMAC                          */
     __I uint32_t DIVAS_:1;         /*!< bit:      7  DIVAS                              */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    __I uint32_t Reserved1:24;     /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -180,7 +180,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EIC_:1;           /*!< bit:     10  EIC                                */
     __I uint32_t FREQM_:1;         /*!< bit:     11  FREQM                              */
     __I uint32_t TSENS_:1;         /*!< bit:     12  TSENS                              */
-    __I uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+    __I uint32_t Reserved1:19;     /*!< bit: 13..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -227,7 +227,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      3  DMAC                               */
     __I uint32_t MTB_:1;           /*!< bit:      4  MTB                                */
     __I uint32_t HMATRIXHS_:1;     /*!< bit:      5  HMATRIXHS                          */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -278,7 +278,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     21  DAC                                */
     __I uint32_t PTC_:1;           /*!< bit:     22  PTC                                */
     __I uint32_t CCL_:1;           /*!< bit:     23  CCL                                */
-    __I uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+    __I uint32_t Reserved1:8;      /*!< bit: 24..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;

--- a/asf/sam0/include/samc21/component/rtc.h
+++ b/asf/sam0/include/samc21/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/sdadc.h
+++ b/asf/sam0/include/samc21/component/sdadc.h
@@ -216,7 +216,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SDADC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/sercom.h
+++ b/asf/sam0/include/samc21/component/sercom.h
@@ -813,7 +813,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -838,7 +838,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -866,7 +866,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -898,7 +898,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samc21/component/supc.h
+++ b/asf/sam0/include/samc21/component/supc.h
@@ -115,7 +115,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BODCORERDY:1;     /*!< bit:      3  BODCORE Ready                      */
     __I uint32_t BODCOREDET:1;     /*!< bit:      4  BODCORE Detection                  */
     __I uint32_t BCORESRDY:1;      /*!< bit:      5  BODCORE Synchronization Ready      */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/tc.h
+++ b/asf/sam0/include/samc21/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/tcc.h
+++ b/asf/sam0/include/samc21/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/tsens.h
+++ b/asf/sam0/include/samc21/component/tsens.h
@@ -205,7 +205,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  OVF:1;            /*!< bit:      3  Overflow                           */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TSENS_INTFLAG_Type;

--- a/asf/sam0/include/samc21/component/wdt.h
+++ b/asf/sam0/include/samc21/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/README
+++ b/asf/sam0/include/samc21n/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samc21n/component/ac.h
+++ b/asf/sam0/include/samc21n/component/ac.h
@@ -268,12 +268,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  COMP3:1;          /*!< bit:      3  Comparator 3                       */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
     __I uint8_t  WIN1:1;           /*!< bit:      5  Window 1                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:4;           /*!< bit:  0.. 3  Comparator x                       */
     __I uint8_t  WIN:2;            /*!< bit:  4.. 5  Window x                           */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/adc.h
+++ b/asf/sam0/include/samc21n/component/adc.h
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/dac.h
+++ b/asf/sam0/include/samc21n/component/dac.h
@@ -176,7 +176,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/dmac.h
+++ b/asf/sam0/include/samc21n/component/dmac.h
@@ -769,7 +769,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/eic.h
+++ b/asf/sam0/include/samc21n/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/evsys.h
+++ b/asf/sam0/include/samc21n/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/freqm.h
+++ b/asf/sam0/include/samc21n/component/freqm.h
@@ -141,7 +141,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/mclk.h
+++ b/asf/sam0/include/samc21n/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/nvmctrl.h
+++ b/asf/sam0/include/samc21n/component/nvmctrl.h
@@ -240,7 +240,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/osc32kctrl.h
+++ b/asf/sam0/include/samc21n/component/osc32kctrl.h
@@ -94,7 +94,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
     __I uint32_t CLKFAIL:1;        /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved1:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/oscctrl.h
+++ b/asf/sam0/include/samc21n/component/oscctrl.h
@@ -121,14 +121,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
     __I uint32_t XOSCFAIL:1;       /*!< bit:      1  XOSC Clock Failure Detector        */
-    __I uint32_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint32_t OSC48MRDY:1;      /*!< bit:      4  OSC48M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:      8  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:      9  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     10  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     11  DPLL Ratio Ready                   */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved3:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/pac.h
+++ b/asf/sam0/include/samc21n/component/pac.h
@@ -137,7 +137,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:      6  LPRAMDMAC                          */
     __I uint32_t DIVAS_:1;         /*!< bit:      7  DIVAS                              */
     __I uint32_t HPB3_:1;          /*!< bit:      8  HPB3                               */
-    __I uint32_t :23;              /*!< bit:  9..31  Reserved                           */
+    __I uint32_t Reserved1:23;     /*!< bit:  9..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -183,7 +183,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EIC_:1;           /*!< bit:     10  EIC                                */
     __I uint32_t FREQM_:1;         /*!< bit:     11  FREQM                              */
     __I uint32_t TSENS_:1;         /*!< bit:     12  TSENS                              */
-    __I uint32_t :19;              /*!< bit: 13..31  Reserved                           */
+    __I uint32_t Reserved1:19;     /*!< bit: 13..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -230,7 +230,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      3  DMAC                               */
     __I uint32_t MTB_:1;           /*!< bit:      4  MTB                                */
     __I uint32_t HMATRIXHS_:1;     /*!< bit:      5  HMATRIXHS                          */
-    __I uint32_t :26;              /*!< bit:  6..31  Reserved                           */
+    __I uint32_t Reserved1:26;     /*!< bit:  6..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -281,7 +281,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     21  DAC                                */
     __I uint32_t PTC_:1;           /*!< bit:     22  PTC                                */
     __I uint32_t CCL_:1;           /*!< bit:     23  CCL                                */
-    __I uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+    __I uint32_t Reserved1:8;      /*!< bit: 24..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -349,7 +349,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TC5_:1;           /*!< bit:      2  TC5                                */
     __I uint32_t TC6_:1;           /*!< bit:      3  TC6                                */
     __I uint32_t TC7_:1;           /*!< bit:      4  TC7                                */
-    __I uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+    __I uint32_t Reserved1:27;     /*!< bit:  5..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/samc21n/component/rtc.h
+++ b/asf/sam0/include/samc21n/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/sdadc.h
+++ b/asf/sam0/include/samc21n/component/sdadc.h
@@ -216,7 +216,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SDADC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/sercom.h
+++ b/asf/sam0/include/samc21n/component/sercom.h
@@ -813,7 +813,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -838,7 +838,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -866,7 +866,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -898,7 +898,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samc21n/component/supc.h
+++ b/asf/sam0/include/samc21n/component/supc.h
@@ -122,7 +122,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BODCOREDET:1;     /*!< bit:      4  BODCORE Detection                  */
     __I uint32_t BCORESRDY:1;      /*!< bit:      5  BODCORE Synchronization Ready      */
     __I uint32_t VREG33RDY:1;      /*!< bit:      6  VREG33 Ready                       */
-    __I uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+    __I uint32_t Reserved1:25;     /*!< bit:  7..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/tc.h
+++ b/asf/sam0/include/samc21n/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/tcc.h
+++ b/asf/sam0/include/samc21n/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/tsens.h
+++ b/asf/sam0/include/samc21n/component/tsens.h
@@ -205,7 +205,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  OVF:1;            /*!< bit:      3  Overflow                           */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TSENS_INTFLAG_Type;

--- a/asf/sam0/include/samc21n/component/wdt.h
+++ b/asf/sam0/include/samc21n/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samd20/README
+++ b/asf/sam0/include/samd20/README
@@ -1,0 +1,39 @@
+Atmel SAM D20
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMD20 Series Device Support (1.2.91)
+   http://packs.download.atmel.com/Atmel.SAMD20_DFP.1.2.91.atpack
+
+Status:
+   version 1.2.91
+
+Purpose:
+   Official package for SAM D20.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMD20_DFP.1.2.91.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samd20/component/ac.h
+++ b/asf/sam0/include/samd20/component/ac.h
@@ -224,15 +224,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/adc.h
+++ b/asf/sam0/include/samd20/component/adc.h
@@ -478,7 +478,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/dac.h
+++ b/asf/sam0/include/samd20/component/dac.h
@@ -176,7 +176,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/eic.h
+++ b/asf/sam0/include/samd20/component/eic.h
@@ -360,11 +360,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/evsys.h
+++ b/asf/sam0/include/samd20/component/evsys.h
@@ -378,12 +378,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
     __I uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection          */
     __I uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/nvmctrl.h
+++ b/asf/sam0/include/samd20/component/nvmctrl.h
@@ -231,7 +231,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/pm.h
+++ b/asf/sam0/include/samd20/component/pm.h
@@ -425,7 +425,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/rtc.h
+++ b/asf/sam0/include/samd20/component/rtc.h
@@ -615,13 +615,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -647,13 +647,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -680,13 +680,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/sercom.h
+++ b/asf/sam0/include/samd20/component/sercom.h
@@ -761,7 +761,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master on Bus                      */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave on Bus                       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CM_INTFLAG_Type;
@@ -783,7 +783,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received                      */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match                      */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Ready                         */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_I2CS_INTFLAG_Type;
@@ -807,7 +807,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_SPI_INTFLAG_Type;
@@ -832,7 +832,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } SERCOM_USART_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/sysctrl.h
+++ b/asf/sam0/include/samd20/component/sysctrl.h
@@ -157,7 +157,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/tc.h
+++ b/asf/sam0/include/samd20/component/tc.h
@@ -405,16 +405,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samd20/component/wdt.h
+++ b/asf/sam0/include/samd20/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samd21/README
+++ b/asf/sam0/include/samd21/README
@@ -1,0 +1,39 @@
+Atmel SAM D21
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMD21 Series Device Support (1.2.276)
+   http://packs.download.atmel.com/Atmel.SAMD21_DFP.1.2.276.atpack
+
+Status:
+   version 1.2.276
+
+Purpose:
+   Official package for SAM D21.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMD21_DFP.1.2.276.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samd21/component/ac.h
+++ b/asf/sam0/include/samd21/component/ac.h
@@ -223,15 +223,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/adc.h
+++ b/asf/sam0/include/samd21/component/adc.h
@@ -477,7 +477,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/dac.h
+++ b/asf/sam0/include/samd21/component/dac.h
@@ -178,7 +178,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/dmac.h
+++ b/asf/sam0/include/samd21/component/dmac.h
@@ -823,7 +823,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samd21/component/eic.h
+++ b/asf/sam0/include/samd21/component/eic.h
@@ -359,11 +359,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/evsys.h
+++ b/asf/sam0/include/samd21/component/evsys.h
@@ -485,20 +485,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/i2s.h
+++ b/asf/sam0/include/samd21/component/i2s.h
@@ -313,26 +313,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/nvmctrl.h
+++ b/asf/sam0/include/samd21/component/nvmctrl.h
@@ -230,7 +230,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/pm.h
+++ b/asf/sam0/include/samd21/component/pm.h
@@ -442,7 +442,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/rtc.h
+++ b/asf/sam0/include/samd21/component/rtc.h
@@ -614,13 +614,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -646,13 +646,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -679,13 +679,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/sercom.h
+++ b/asf/sam0/include/samd21/component/sercom.h
@@ -827,7 +827,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -852,7 +852,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -880,7 +880,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -912,7 +912,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samd21/component/sysctrl.h
+++ b/asf/sam0/include/samd21/component/sysctrl.h
@@ -176,11 +176,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    __I uint32_t Reserved2:14;     /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/tc.h
+++ b/asf/sam0/include/samd21/component/tc.h
@@ -404,16 +404,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/tcc.h
+++ b/asf/sam0/include/samd21/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    __I uint32_t Reserved1:7;      /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -970,12 +970,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samd21/component/usb.h
+++ b/asf/sam0/include/samd21/component/usb.h
@@ -626,7 +626,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -661,7 +661,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -670,7 +670,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1145,14 +1145,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1196,11 +1196,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/samd21/component/wdt.h
+++ b/asf/sam0/include/samd21/component/wdt.h
@@ -217,7 +217,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samd51/README
+++ b/asf/sam0/include/samd51/README
@@ -1,0 +1,39 @@
+Atmel SAM D51
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMD51 Series Device Support (1.2.139)
+   http://packs.download.atmel.com/Atmel.SAMD51_DFP.1.2.139.atpack
+
+Status:
+   version 1.2.139
+
+Purpose:
+   Official package for SAM D51.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMD51_DFP.1.2.139.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samd51/component/ac.h
+++ b/asf/sam0/include/samd51/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/adc.h
+++ b/asf/sam0/include/samd51/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/aes.h
+++ b/asf/sam0/include/samd51/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/dmac.h
+++ b/asf/sam0/include/samd51/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samd51/component/eic.h
+++ b/asf/sam0/include/samd51/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/evsys.h
+++ b/asf/sam0/include/samd51/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/asf/sam0/include/samd51/component/freqm.h
+++ b/asf/sam0/include/samd51/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/i2s.h
+++ b/asf/sam0/include/samd51/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/mclk.h
+++ b/asf/sam0/include/samd51/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/nvmctrl.h
+++ b/asf/sam0/include/samd51/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/osc32kctrl.h
+++ b/asf/sam0/include/samd51/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved2:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/oscctrl.h
+++ b/asf/sam0/include/samd51/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved3:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved4:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/pac.h
+++ b/asf/sam0/include/samd51/component/pac.h
@@ -144,7 +144,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SDHC1_:1;         /*!< bit:     13  SDHC1                              */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -207,7 +207,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -262,16 +262,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    __I uint32_t Reserved3:15;     /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint32_t :3;               /*!< bit:  0.. 2  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit:  0.. 2  Reserved                           */
     __I uint32_t TCC2_:1;          /*!< bit:      3  TCC2                               */
     __I uint32_t TCC3_:1;          /*!< bit:      4  TCC3                               */
     __I uint32_t TC4_:1;           /*!< bit:      5  TC4                                */
@@ -329,7 +329,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved2:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -380,7 +380,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/samd51/component/pdec.h
+++ b/asf/sam0/include/samd51/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/pm.h
+++ b/asf/sam0/include/samd51/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/qspi.h
+++ b/asf/sam0/include/samd51/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/ramecc.h
+++ b/asf/sam0/include/samd51/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/rtc.h
+++ b/asf/sam0/include/samd51/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/sercom.h
+++ b/asf/sam0/include/samd51/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samd51/component/supc.h
+++ b/asf/sam0/include/samd51/component/supc.h
@@ -110,11 +110,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
-    __I uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint32_t Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/tc.h
+++ b/asf/sam0/include/samd51/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/tcc.h
+++ b/asf/sam0/include/samd51/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/trng.h
+++ b/asf/sam0/include/samd51/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/samd51/component/usb.h
+++ b/asf/sam0/include/samd51/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/samd51/component/wdt.h
+++ b/asf/sam0/include/samd51/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/same51/README
+++ b/asf/sam0/include/same51/README
@@ -1,0 +1,39 @@
+Atmel SAM E51
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAME51 Series Device Support (1.2.129)
+   http://packs.download.atmel.com/Atmel.SAME51_DFP.1.1.129.atpack
+
+Status:
+   version 1.2.129
+
+Purpose:
+   Official package for SAM E51.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAME51_DFP.1.1.129.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/same51/component/ac.h
+++ b/asf/sam0/include/same51/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/adc.h
+++ b/asf/sam0/include/same51/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/aes.h
+++ b/asf/sam0/include/same51/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/dmac.h
+++ b/asf/sam0/include/same51/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/same51/component/eic.h
+++ b/asf/sam0/include/same51/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/evsys.h
+++ b/asf/sam0/include/same51/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/asf/sam0/include/same51/component/freqm.h
+++ b/asf/sam0/include/same51/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/i2s.h
+++ b/asf/sam0/include/same51/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/mclk.h
+++ b/asf/sam0/include/same51/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/nvmctrl.h
+++ b/asf/sam0/include/same51/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/osc32kctrl.h
+++ b/asf/sam0/include/same51/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved2:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/oscctrl.h
+++ b/asf/sam0/include/same51/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved3:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved4:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/pac.h
+++ b/asf/sam0/include/same51/component/pac.h
@@ -141,10 +141,10 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HPB3_:1;          /*!< bit:     10  HPB3                               */
     __I uint32_t PUKCC_:1;         /*!< bit:     11  PUKCC                              */
     __I uint32_t SDHC0_:1;         /*!< bit:     12  SDHC0                              */
-    __I uint32_t :1;               /*!< bit:     13  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:     13  Reserved                           */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved2:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -205,7 +205,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -260,16 +260,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    __I uint32_t Reserved3:15;     /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t CAN0_:1;          /*!< bit:      0  CAN0                               */
     __I uint32_t CAN1_:1;          /*!< bit:      1  CAN1                               */
-    __I uint32_t :1;               /*!< bit:      2  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      2  Reserved                           */
     __I uint32_t TCC2_:1;          /*!< bit:      3  TCC2                               */
     __I uint32_t TCC3_:1;          /*!< bit:      4  TCC3                               */
     __I uint32_t TC4_:1;           /*!< bit:      5  TC4                                */
@@ -329,7 +329,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved2:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -384,7 +384,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/same51/component/pdec.h
+++ b/asf/sam0/include/same51/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/pm.h
+++ b/asf/sam0/include/same51/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/qspi.h
+++ b/asf/sam0/include/same51/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/ramecc.h
+++ b/asf/sam0/include/same51/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/rtc.h
+++ b/asf/sam0/include/same51/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/sercom.h
+++ b/asf/sam0/include/same51/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/same51/component/supc.h
+++ b/asf/sam0/include/same51/component/supc.h
@@ -110,11 +110,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
-    __I uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint32_t Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/tc.h
+++ b/asf/sam0/include/same51/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/tcc.h
+++ b/asf/sam0/include/same51/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/trng.h
+++ b/asf/sam0/include/same51/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/same51/component/usb.h
+++ b/asf/sam0/include/same51/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/same51/component/wdt.h
+++ b/asf/sam0/include/same51/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/same53/README
+++ b/asf/sam0/include/same53/README
@@ -1,0 +1,39 @@
+Atmel SAM E53
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAME53 Series Device Support (1.1.118)
+   http://packs.download.atmel.com/Atmel.SAME53_DFP.1.1.118.atpack
+
+Status:
+   version 1.1.118
+
+Purpose:
+   Official package for SAM E53.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAME53_DFP.1.1.118.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/same53/component/ac.h
+++ b/asf/sam0/include/same53/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/adc.h
+++ b/asf/sam0/include/same53/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/aes.h
+++ b/asf/sam0/include/same53/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/dmac.h
+++ b/asf/sam0/include/same53/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/same53/component/eic.h
+++ b/asf/sam0/include/same53/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/evsys.h
+++ b/asf/sam0/include/same53/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/asf/sam0/include/same53/component/freqm.h
+++ b/asf/sam0/include/same53/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/i2s.h
+++ b/asf/sam0/include/same53/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/mclk.h
+++ b/asf/sam0/include/same53/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/nvmctrl.h
+++ b/asf/sam0/include/same53/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/osc32kctrl.h
+++ b/asf/sam0/include/same53/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved2:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/oscctrl.h
+++ b/asf/sam0/include/same53/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved3:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved4:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/pac.h
+++ b/asf/sam0/include/same53/component/pac.h
@@ -144,7 +144,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SDHC1_:1;         /*!< bit:     13  SDHC1                              */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -207,7 +207,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -262,16 +262,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    __I uint32_t Reserved3:15;     /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -316,7 +316,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint32_t GMAC_:1;          /*!< bit:      2  GMAC                               */
     __I uint32_t TCC2_:1;          /*!< bit:      3  TCC2                               */
     __I uint32_t TCC3_:1;          /*!< bit:      4  TCC3                               */
@@ -330,7 +330,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved2:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -383,7 +383,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/same53/component/pdec.h
+++ b/asf/sam0/include/same53/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/pm.h
+++ b/asf/sam0/include/same53/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/qspi.h
+++ b/asf/sam0/include/same53/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/ramecc.h
+++ b/asf/sam0/include/same53/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/rtc.h
+++ b/asf/sam0/include/same53/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/sercom.h
+++ b/asf/sam0/include/same53/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/same53/component/supc.h
+++ b/asf/sam0/include/same53/component/supc.h
@@ -110,11 +110,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
-    __I uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint32_t Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/tc.h
+++ b/asf/sam0/include/same53/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/tcc.h
+++ b/asf/sam0/include/same53/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/trng.h
+++ b/asf/sam0/include/same53/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/same53/component/usb.h
+++ b/asf/sam0/include/same53/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/same53/component/wdt.h
+++ b/asf/sam0/include/same53/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/same54/README
+++ b/asf/sam0/include/same54/README
@@ -1,0 +1,39 @@
+Atmel SAM E54
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAME54 Series Device Support (1.1.118)
+   http://packs.download.atmel.com/Atmel.SAME54_DFP.1.1.134.atpack
+
+Status:
+   version 1.1.134
+
+Purpose:
+   Official package for SAM E54.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAME54_DFP.1.1.134.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/same54/component/ac.h
+++ b/asf/sam0/include/same54/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/adc.h
+++ b/asf/sam0/include/same54/component/adc.h
@@ -569,7 +569,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/aes.h
+++ b/asf/sam0/include/same54/component/aes.h
@@ -217,7 +217,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/dmac.h
+++ b/asf/sam0/include/same54/component/dmac.h
@@ -1143,7 +1143,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/same54/component/eic.h
+++ b/asf/sam0/include/same54/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt                 */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/evsys.h
+++ b/asf/sam0/include/same54/component/evsys.h
@@ -498,7 +498,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVR:1;            /*!< bit:      0  Channel Overrun                    */
     __I uint8_t  EVD:1;            /*!< bit:      1  Channel Event Detected             */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } EVSYS_CHINTFLAG_Type;

--- a/asf/sam0/include/same54/component/freqm.h
+++ b/asf/sam0/include/same54/component/freqm.h
@@ -138,7 +138,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DONE:1;           /*!< bit:      0  Measurement Done                   */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } FREQM_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/i2s.h
+++ b/asf/sam0/include/same54/component/i2s.h
@@ -309,26 +309,26 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint16_t RXRDY0:1;         /*!< bit:      0  Receive Ready 0                    */
     __I uint16_t RXRDY1:1;         /*!< bit:      1  Receive Ready 1                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR0:1;          /*!< bit:      4  Receive Overrun 0                  */
     __I uint16_t RXOR1:1;          /*!< bit:      5  Receive Overrun 1                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY0:1;         /*!< bit:      8  Transmit Ready 0                   */
     __I uint16_t TXRDY1:1;         /*!< bit:      9  Transmit Ready 1                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR0:1;          /*!< bit:     12  Transmit Underrun 0                */
     __I uint16_t TXUR1:1;          /*!< bit:     13  Transmit Underrun 1                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t RXRDY:2;          /*!< bit:  0.. 1  Receive Ready x                    */
-    __I uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint16_t RXOR:2;           /*!< bit:  4.. 5  Receive Overrun x                  */
-    __I uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint16_t Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint16_t TXRDY:2;          /*!< bit:  8.. 9  Transmit Ready x                   */
-    __I uint16_t :2;               /*!< bit: 10..11  Reserved                           */
+    __I uint16_t Reserved3:2;      /*!< bit: 10..11  Reserved                           */
     __I uint16_t TXUR:2;           /*!< bit: 12..13  Transmit Underrun x                */
-    __I uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+    __I uint16_t Reserved4:2;      /*!< bit: 14..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } I2S_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/mclk.h
+++ b/asf/sam0/include/same54/component/mclk.h
@@ -80,7 +80,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/nvmctrl.h
+++ b/asf/sam0/include/same54/component/nvmctrl.h
@@ -324,7 +324,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t SEESFULL:1;       /*!< bit:      8  Active SEES Full                   */
     __I uint16_t SEESOVF:1;        /*!< bit:      9  Active SEES Overflow               */
     __I uint16_t SEEWRC:1;         /*!< bit:     10  SEE Write Completed                */
-    __I uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 11..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/osc32kctrl.h
+++ b/asf/sam0/include/same54/component/osc32kctrl.h
@@ -88,9 +88,9 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
-    __I uint32_t :1;               /*!< bit:      1  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      1  Reserved                           */
     __I uint32_t XOSC32KFAIL:1;    /*!< bit:      2  XOSC32K Clock Failure Detector     */
-    __I uint32_t :29;              /*!< bit:  3..31  Reserved                           */
+    __I uint32_t Reserved2:29;     /*!< bit:  3..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/oscctrl.h
+++ b/asf/sam0/include/same54/component/oscctrl.h
@@ -235,28 +235,28 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t XOSCRDY1:1;       /*!< bit:      1  XOSC 1 Ready                       */
     __I uint32_t XOSCFAIL0:1;      /*!< bit:      2  XOSC 0 Clock Failure Detector      */
     __I uint32_t XOSCFAIL1:1;      /*!< bit:      3  XOSC 1 Clock Failure Detector      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLL0LCKR:1;      /*!< bit:     16  DPLL0 Lock Rise                    */
     __I uint32_t DPLL0LCKF:1;      /*!< bit:     17  DPLL0 Lock Fall                    */
     __I uint32_t DPLL0LTO:1;       /*!< bit:     18  DPLL0 Lock Timeout                 */
     __I uint32_t DPLL0LDRTO:1;     /*!< bit:     19  DPLL0 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved3:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t DPLL1LCKR:1;      /*!< bit:     24  DPLL1 Lock Rise                    */
     __I uint32_t DPLL1LCKF:1;      /*!< bit:     25  DPLL1 Lock Fall                    */
     __I uint32_t DPLL1LTO:1;       /*!< bit:     26  DPLL1 Lock Timeout                 */
     __I uint32_t DPLL1LDRTO:1;     /*!< bit:     27  DPLL1 Loop Divider Ratio Update Complete */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved4:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t XOSCRDY:2;        /*!< bit:  0.. 1  XOSC x Ready                       */
     __I uint32_t XOSCFAIL:2;       /*!< bit:  2.. 3  XOSC x Clock Failure Detector      */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/pac.h
+++ b/asf/sam0/include/same54/component/pac.h
@@ -144,7 +144,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SDHC1_:1;         /*!< bit:     13  SDHC1                              */
     __I uint32_t QSPI_:1;          /*!< bit:     14  QSPI                               */
     __I uint32_t BKUPRAM_:1;       /*!< bit:     15  BKUPRAM                            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -207,7 +207,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t SERCOM1_:1;       /*!< bit:     13  SERCOM1                            */
     __I uint32_t TC0_:1;           /*!< bit:     14  TC0                                */
     __I uint32_t TC1_:1;           /*!< bit:     15  TC1                                */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -262,16 +262,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DMAC_:1;          /*!< bit:      5  DMAC                               */
     __I uint32_t HMATRIX_:1;       /*!< bit:      6  HMATRIX                            */
     __I uint32_t EVSYS_:1;         /*!< bit:      7  EVSYS                              */
-    __I uint32_t :1;               /*!< bit:      8  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      8  Reserved                           */
     __I uint32_t SERCOM2_:1;       /*!< bit:      9  SERCOM2                            */
     __I uint32_t SERCOM3_:1;       /*!< bit:     10  SERCOM3                            */
     __I uint32_t TCC0_:1;          /*!< bit:     11  TCC0                               */
     __I uint32_t TCC1_:1;          /*!< bit:     12  TCC1                               */
     __I uint32_t TC2_:1;           /*!< bit:     13  TC2                                */
     __I uint32_t TC3_:1;           /*!< bit:     14  TC3                                */
-    __I uint32_t :1;               /*!< bit:     15  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     15  Reserved                           */
     __I uint32_t RAMECC_:1;        /*!< bit:     16  RAMECC                             */
-    __I uint32_t :15;              /*!< bit: 17..31  Reserved                           */
+    __I uint32_t Reserved3:15;     /*!< bit: 17..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -331,7 +331,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PUKCC_:1;         /*!< bit:     12  PUKCC                              */
     __I uint32_t QSPI_:1;          /*!< bit:     13  QSPI                               */
     __I uint32_t CCL_:1;           /*!< bit:     14  CCL                                */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved1:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -388,7 +388,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:      9  DAC                                */
     __I uint32_t I2S_:1;           /*!< bit:     10  I2S                                */
     __I uint32_t PCC_:1;           /*!< bit:     11  PCC                                */
-    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+    __I uint32_t Reserved1:20;     /*!< bit: 12..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;

--- a/asf/sam0/include/same54/component/pdec.h
+++ b/asf/sam0/include/same54/component/pdec.h
@@ -361,12 +361,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  VLC:1;            /*!< bit:      3  Velocity                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  Channel 0 Compare Match            */
     __I uint8_t  MC1:1;            /*!< bit:      5  Channel 1 Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Channel x Compare Match            */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PDEC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/pm.h
+++ b/asf/sam0/include/same54/component/pm.h
@@ -132,7 +132,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SLEEPRDY:1;       /*!< bit:      0  Sleep Mode Entry Ready             */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/qspi.h
+++ b/asf/sam0/include/same54/component/qspi.h
@@ -282,11 +282,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DRE:1;            /*!< bit:      1  Transmit Data Register Empty       */
     __I uint32_t TXC:1;            /*!< bit:      2  Transmission Complete              */
     __I uint32_t ERROR:1;          /*!< bit:      3  Overrun Error                      */
-    __I uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
     __I uint32_t CSRISE:1;         /*!< bit:      8  Chip Select Rise                   */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t INSTREND:1;       /*!< bit:     10  Instruction End                    */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } QSPI_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/ramecc.h
+++ b/asf/sam0/include/same54/component/ramecc.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  SINGLEE:1;        /*!< bit:      0  Single Bit ECC Error Interrupt     */
     __I uint8_t  DUALE:1;          /*!< bit:      1  Dual Bit ECC Error Interrupt       */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RAMECC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/rtc.h
+++ b/asf/sam0/include/same54/component/rtc.h
@@ -1082,14 +1082,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -1146,14 +1146,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
     __I uint16_t CMP2:1;           /*!< bit:     10  Compare 2                          */
     __I uint16_t CMP3:1;           /*!< bit:     11  Compare 3                          */
-    __I uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit: 12..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:4;            /*!< bit:  8..11  Compare x                          */
-    __I uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -1212,14 +1212,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
     __I uint16_t ALARM1:1;         /*!< bit:      9  Alarm 1                            */
-    __I uint16_t :4;               /*!< bit: 10..13  Reserved                           */
+    __I uint16_t Reserved1:4;      /*!< bit: 10..13  Reserved                           */
     __I uint16_t TAMPER:1;         /*!< bit:     14  Tamper                             */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:2;          /*!< bit:  8.. 9  Alarm x                            */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/sercom.h
+++ b/asf/sam0/include/same54/component/sercom.h
@@ -901,7 +901,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -926,7 +926,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -954,7 +954,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -986,7 +986,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/same54/component/supc.h
+++ b/asf/sam0/include/same54/component/supc.h
@@ -110,11 +110,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      0  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:      1  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:      2  BOD33 Synchronization Ready        */
-    __I uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint32_t Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
-    __I uint32_t :1;               /*!< bit:      9  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:      9  Reserved                           */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved3:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/tc.h
+++ b/asf/sam0/include/same54/component/tc.h
@@ -377,15 +377,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/tcc.h
+++ b/asf/sam0/include/same54/component/tcc.h
@@ -996,7 +996,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -1009,12 +1009,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
     __I uint32_t MC4:1;            /*!< bit:     20  Match or Capture 4                 */
     __I uint32_t MC5:1;            /*!< bit:     21  Match or Capture 5                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:6;             /*!< bit: 16..21  Match or Capture x                 */
-    __I uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+    __I uint32_t Reserved2:10;     /*!< bit: 22..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/trng.h
+++ b/asf/sam0/include/same54/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/same54/component/usb.h
+++ b/asf/sam0/include/same54/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/same54/component/wdt.h
+++ b/asf/sam0/include/same54/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/saml21/README
+++ b/asf/sam0/include/saml21/README
@@ -1,0 +1,39 @@
+Atmel SAM L21
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAML21 Series Device Support (1.1.125)
+   http://packs.download.atmel.com/Atmel.SAML21_DFP.1.2.125.atpack
+
+Status:
+   version 1.2.125
+
+Purpose:
+   Official package for SAM L21.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAML21_DFP.1.2.125.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/saml21/component/ac.h
+++ b/asf/sam0/include/saml21/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/adc.h
+++ b/asf/sam0/include/saml21/component/adc.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/aes.h
+++ b/asf/sam0/include/saml21/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/dac.h
+++ b/asf/sam0/include/saml21/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/dmac.h
+++ b/asf/sam0/include/saml21/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/saml21/component/eic.h
+++ b/asf/sam0/include/saml21/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/evsys.h
+++ b/asf/sam0/include/saml21/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/mclk.h
+++ b/asf/sam0/include/saml21/component/mclk.h
@@ -91,7 +91,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/nvmctrl.h
+++ b/asf/sam0/include/saml21/component/nvmctrl.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/osc32kctrl.h
+++ b/asf/sam0/include/saml21/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/oscctrl.h
+++ b/asf/sam0/include/saml21/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved3:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved4:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/pac.h
+++ b/asf/sam0/include/saml21/component/pac.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    __I uint32_t Reserved1:11;     /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    __I uint32_t Reserved3:6;      /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved1:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -277,7 +277,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved1:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -330,7 +330,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
     __I uint32_t OPAMP_:1;         /*!< bit:      6  OPAMP                              */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    __I uint32_t Reserved1:24;     /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -363,7 +363,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/asf/sam0/include/saml21/component/pm.h
+++ b/asf/sam0/include/saml21/component/pm.h
@@ -154,7 +154,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/rtc.h
+++ b/asf/sam0/include/saml21/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/sercom.h
+++ b/asf/sam0/include/saml21/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/saml21/component/supc.h
+++ b/asf/sam0/include/saml21/component/supc.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved2:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/tc.h
+++ b/asf/sam0/include/saml21/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/tcc.h
+++ b/asf/sam0/include/saml21/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/trng.h
+++ b/asf/sam0/include/saml21/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/saml21/component/usb.h
+++ b/asf/sam0/include/saml21/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/saml21/component/wdt.h
+++ b/asf/sam0/include/saml21/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samr21/README
+++ b/asf/sam0/include/samr21/README
@@ -1,0 +1,39 @@
+Atmel SAM R21
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMR21 Series Device Support (1.1.72)
+   http://packs.download.atmel.com/Atmel.SAMR21_DFP.1.1.72.atpack
+
+Status:
+   version 1.1.72
+
+Purpose:
+   Official package for SAM R21.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMR21_DFP.1.1.72.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samr21/component/ac.h
+++ b/asf/sam0/include/samr21/component/ac.h
@@ -223,15 +223,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/adc.h
+++ b/asf/sam0/include/samr21/component/adc.h
@@ -477,7 +477,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/dac.h
+++ b/asf/sam0/include/samr21/component/dac.h
@@ -178,7 +178,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
     __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/dmac.h
+++ b/asf/sam0/include/samr21/component/dmac.h
@@ -823,7 +823,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samr21/component/eic.h
+++ b/asf/sam0/include/samr21/component/eic.h
@@ -359,11 +359,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
     __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
     __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/evsys.h
+++ b/asf/sam0/include/samr21/component/evsys.h
@@ -485,20 +485,20 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:     17  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     18  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     19  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVD8:1;           /*!< bit:     24  Channel 8 Event Detection          */
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
     __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
     __I uint32_t OVRp8:4;          /*!< bit: 16..19  Channel x+8 Overrun                */
-    __I uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 20..23  Reserved                           */
     __I uint32_t EVDp8:4;          /*!< bit: 24..27  Channel x+8 Event Detection        */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/nvmctrl.h
+++ b/asf/sam0/include/samr21/component/nvmctrl.h
@@ -230,7 +230,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/pm.h
+++ b/asf/sam0/include/samr21/component/pm.h
@@ -443,7 +443,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/rtc.h
+++ b/asf/sam0/include/samr21/component/rtc.h
@@ -614,13 +614,13 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -646,13 +646,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
     __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
-    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  2.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -679,13 +679,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
-    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  1.. 5  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
     __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/sercom.h
+++ b/asf/sam0/include/samr21/component/sercom.h
@@ -827,7 +827,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -852,7 +852,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -880,7 +880,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -912,7 +912,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samr21/component/sysctrl.h
+++ b/asf/sam0/include/samr21/component/sysctrl.h
@@ -176,11 +176,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
     __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
     __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
-    __I uint32_t :3;               /*!< bit: 12..14  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit: 12..14  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     15  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     16  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     17  DPLL Lock Timeout                  */
-    __I uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+    __I uint32_t Reserved2:14;     /*!< bit: 18..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SYSCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/tc.h
+++ b/asf/sam0/include/samr21/component/tc.h
@@ -404,16 +404,16 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
     __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
-    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      2  Reserved                           */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
     __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
     __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/tcc.h
+++ b/asf/sam0/include/samr21/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :7;               /*!< bit:  4..10  Reserved                           */
+    __I uint32_t Reserved1:7;      /*!< bit:  4..10  Reserved                           */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
     __I uint32_t FAULTB:1;         /*!< bit:     13  Recoverable Fault B                */
@@ -970,12 +970,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samr21/component/usb.h
+++ b/asf/sam0/include/samr21/component/usb.h
@@ -626,7 +626,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -661,7 +661,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -670,7 +670,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1145,14 +1145,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1196,11 +1196,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/samr21/component/wdt.h
+++ b/asf/sam0/include/samr21/component/wdt.h
@@ -217,7 +217,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samr34/README
+++ b/asf/sam0/include/samr34/README
@@ -1,0 +1,39 @@
+Atmel SAM R34
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMR34 Series Device Support (1.0.11)
+   http://packs.download.atmel.com/Atmel.SAMR34_DFP.1.0.11.atpack
+
+Status:
+   version 1.0.11
+
+Purpose:
+   Official package for SAM R34.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMR34_DFP.1.0.11.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samr34/component/ac.h
+++ b/asf/sam0/include/samr34/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/adc.h
+++ b/asf/sam0/include/samr34/component/adc.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/aes.h
+++ b/asf/sam0/include/samr34/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/dac.h
+++ b/asf/sam0/include/samr34/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/dmac.h
+++ b/asf/sam0/include/samr34/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samr34/component/eic.h
+++ b/asf/sam0/include/samr34/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/evsys.h
+++ b/asf/sam0/include/samr34/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/mclk.h
+++ b/asf/sam0/include/samr34/component/mclk.h
@@ -91,7 +91,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/nvmctrl.h
+++ b/asf/sam0/include/samr34/component/nvmctrl.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/osc32kctrl.h
+++ b/asf/sam0/include/samr34/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/oscctrl.h
+++ b/asf/sam0/include/samr34/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved3:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved4:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/pac.h
+++ b/asf/sam0/include/samr34/component/pac.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    __I uint32_t Reserved1:11;     /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    __I uint32_t Reserved3:6;      /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved1:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -239,7 +239,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved1:28;     /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -277,7 +277,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved1:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -328,9 +328,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t ADC_:1;           /*!< bit:      3  ADC                                */
     __I uint32_t AC_:1;            /*!< bit:      4  AC                                 */
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
-    __I uint32_t :1;               /*!< bit:      6  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    __I uint32_t Reserved2:24;     /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -361,7 +361,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/asf/sam0/include/samr34/component/pm.h
+++ b/asf/sam0/include/samr34/component/pm.h
@@ -154,7 +154,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/rtc.h
+++ b/asf/sam0/include/samr34/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/sercom.h
+++ b/asf/sam0/include/samr34/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samr34/component/supc.h
+++ b/asf/sam0/include/samr34/component/supc.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved2:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/tc.h
+++ b/asf/sam0/include/samr34/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/tcc.h
+++ b/asf/sam0/include/samr34/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/trng.h
+++ b/asf/sam0/include/samr34/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/samr34/component/usb.h
+++ b/asf/sam0/include/samr34/component/usb.h
@@ -613,7 +613,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t LPMNYET:1;        /*!< bit:      8  Link Power Management Not Yet      */
     __I uint16_t LPMSUSP:1;        /*!< bit:      9  Link Power Management Suspend      */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_DEVICE_INTFLAG_Type;
@@ -648,7 +648,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    __I uint16_t Reserved1:2;      /*!< bit:  0.. 1  Reserved                           */
     __I uint16_t HSOF:1;           /*!< bit:      2  Host Start Of Frame                */
     __I uint16_t RST:1;            /*!< bit:      3  Bus Reset                          */
     __I uint16_t WAKEUP:1;         /*!< bit:      4  Wake Up                            */
@@ -657,7 +657,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t RAMACER:1;        /*!< bit:      7  Ram Access                         */
     __I uint16_t DCONN:1;          /*!< bit:      8  Device Connection                  */
     __I uint16_t DDISC:1;          /*!< bit:      9  Device Disconnection               */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved2:6;      /*!< bit: 10..15  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } USB_HOST_INTFLAG_Type;
@@ -1132,14 +1132,14 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXSTP:1;          /*!< bit:      4  Received Setup                     */
     __I uint8_t  STALL0:1;         /*!< bit:      5  Stall 0 In/out                     */
     __I uint8_t  STALL1:1;         /*!< bit:      6  Stall 1 In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x                */
     __I uint8_t  TRFAIL:2;         /*!< bit:  2.. 3  Error Flow x                       */
-    __I uint8_t  :1;               /*!< bit:      4  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      4  Reserved                           */
     __I uint8_t  STALL:2;          /*!< bit:  5.. 6  Stall x In/out                     */
-    __I uint8_t  :1;               /*!< bit:      7  Reserved                           */
+    __I uint8_t  Reserved2:1;      /*!< bit:      7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_DEVICE_EPINTFLAG_Type;
@@ -1183,11 +1183,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PERR:1;           /*!< bit:      3  Pipe Error Interrupt Flag          */
     __I uint8_t  TXSTP:1;          /*!< bit:      4  Transmit  Setup Interrupt Flag     */
     __I uint8_t  STALL:1;          /*!< bit:      5  Stall Interrupt Flag               */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  TRCPT:2;          /*!< bit:  0.. 1  Transfer Complete x Interrupt Flag */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } USB_HOST_PINTFLAG_Type;

--- a/asf/sam0/include/samr34/component/wdt.h
+++ b/asf/sam0/include/samr34/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;

--- a/asf/sam0/include/samr35/README
+++ b/asf/sam0/include/samr35/README
@@ -1,0 +1,39 @@
+Atmel SAM R35
+##############
+
+Origin:
+   Microchip Packs Repository
+   http://packs.download.atmel.com/
+
+   Atmel SAMR35 Series Device Support (1.0.10)
+   http://packs.download.atmel.com/Atmel.SAMR35_DFP.1.0.10.atpack
+
+Status:
+   version 1.0.10
+
+Purpose:
+   Official package for SAM R35.
+
+Description:
+   Atmel Software Framework (ASF) provides a set of low-level
+   header files that give access to different hardware
+   peripherals of Atmel's ICs.
+
+URL:
+   http://packs.download.atmel.com/
+   http://packs.download.atmel.com/Atmel.SAMR35_DFP.1.0.10.atpack
+
+commit:
+  n/a
+
+Maintained-by:
+   External
+
+License:
+   Apache-2.0
+
+License Link:
+   https://www.apache.org/licenses/LICENSE-2.0
+
+Patch List:
+   * Fix anonymous bit-fields with qualifiers.

--- a/asf/sam0/include/samr35/component/ac.h
+++ b/asf/sam0/include/samr35/component/ac.h
@@ -229,15 +229,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
     __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
-    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint8_t  Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/adc.h
+++ b/asf/sam0/include/samr35/component/adc.h
@@ -223,7 +223,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Flag        */
     __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Flag             */
     __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Flag      */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } ADC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/aes.h
+++ b/asf/sam0/include/samr35/component/aes.h
@@ -167,7 +167,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  ENCCMP:1;         /*!< bit:      0  Encryption Complete                */
     __I uint8_t  GFMCMP:1;         /*!< bit:      1  GF Multiplication Complete         */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } AES_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/dac.h
+++ b/asf/sam0/include/samr35/component/dac.h
@@ -222,12 +222,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  UNDERRUN1:1;      /*!< bit:      1  DAC 1 Underrun                     */
     __I uint8_t  EMPTY0:1;         /*!< bit:      2  Data Buffer 0 Empty                */
     __I uint8_t  EMPTY1:1;         /*!< bit:      3  Data Buffer 1 Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
     __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
-    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DAC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/dmac.h
+++ b/asf/sam0/include/samr35/component/dmac.h
@@ -868,7 +868,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TERR:1;           /*!< bit:      0  Channel Transfer Error             */
     __I uint8_t  TCMPL:1;          /*!< bit:      1  Channel Transfer Complete          */
     __I uint8_t  SUSP:1;           /*!< bit:      2  Channel Suspend                    */
-    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } DMAC_CHINTFLAG_Type;

--- a/asf/sam0/include/samr35/component/eic.h
+++ b/asf/sam0/include/samr35/component/eic.h
@@ -202,7 +202,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt Flag            */
-    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit: 16..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EIC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/evsys.h
+++ b/asf/sam0/include/samr35/component/evsys.h
@@ -373,7 +373,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t OVR9:1;           /*!< bit:      9  Channel 9 Overrun                  */
     __I uint32_t OVR10:1;          /*!< bit:     10  Channel 10 Overrun                 */
     __I uint32_t OVR11:1;          /*!< bit:     11  Channel 11 Overrun                 */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD0:1;           /*!< bit:     16  Channel 0 Event Detection          */
     __I uint32_t EVD1:1;           /*!< bit:     17  Channel 1 Event Detection          */
     __I uint32_t EVD2:1;           /*!< bit:     18  Channel 2 Event Detection          */
@@ -386,13 +386,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t EVD9:1;           /*!< bit:     25  Channel 9 Event Detection          */
     __I uint32_t EVD10:1;          /*!< bit:     26  Channel 10 Event Detection         */
     __I uint32_t EVD11:1;          /*!< bit:     27  Channel 11 Event Detection         */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint32_t OVR:12;           /*!< bit:  0..11  Channel x Overrun                  */
-    __I uint32_t :4;               /*!< bit: 12..15  Reserved                           */
+    __I uint32_t Reserved1:4;      /*!< bit: 12..15  Reserved                           */
     __I uint32_t EVD:12;           /*!< bit: 16..27  Channel x Event Detection          */
-    __I uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+    __I uint32_t Reserved2:4;      /*!< bit: 28..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } EVSYS_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/mclk.h
+++ b/asf/sam0/include/samr35/component/mclk.h
@@ -91,7 +91,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } MCLK_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/nvmctrl.h
+++ b/asf/sam0/include/samr35/component/nvmctrl.h
@@ -243,7 +243,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
     __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
-    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+    __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } NVMCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/osc32kctrl.h
+++ b/asf/sam0/include/samr35/component/osc32kctrl.h
@@ -87,7 +87,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSC32KRDY:1;     /*!< bit:      0  XOSC32K Ready                      */
     __I uint32_t OSC32KRDY:1;      /*!< bit:      1  OSC32K Ready                       */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSC32KCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/oscctrl.h
+++ b/asf/sam0/include/samr35/component/oscctrl.h
@@ -146,20 +146,20 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
-    __I uint32_t :3;               /*!< bit:  1.. 3  Reserved                           */
+    __I uint32_t Reserved1:3;      /*!< bit:  1.. 3  Reserved                           */
     __I uint32_t OSC16MRDY:1;      /*!< bit:      4  OSC16M Ready                       */
-    __I uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    __I uint32_t Reserved2:3;      /*!< bit:  5.. 7  Reserved                           */
     __I uint32_t DFLLRDY:1;        /*!< bit:      8  DFLL Ready                         */
     __I uint32_t DFLLOOB:1;        /*!< bit:      9  DFLL Out Of Bounds                 */
     __I uint32_t DFLLLCKF:1;       /*!< bit:     10  DFLL Lock Fine                     */
     __I uint32_t DFLLLCKC:1;       /*!< bit:     11  DFLL Lock Coarse                   */
     __I uint32_t DFLLRCS:1;        /*!< bit:     12  DFLL Reference Clock Stopped       */
-    __I uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    __I uint32_t Reserved3:3;      /*!< bit: 13..15  Reserved                           */
     __I uint32_t DPLLLCKR:1;       /*!< bit:     16  DPLL Lock Rise                     */
     __I uint32_t DPLLLCKF:1;       /*!< bit:     17  DPLL Lock Fall                     */
     __I uint32_t DPLLLTO:1;        /*!< bit:     18  DPLL Timeout                       */
     __I uint32_t DPLLLDRTO:1;      /*!< bit:     19  DPLL Ratio Ready                   */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved4:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } OSCCTRL_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/pac.h
+++ b/asf/sam0/include/samr35/component/pac.h
@@ -133,18 +133,18 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t HSRAMDSU_:1;      /*!< bit:      2  HSRAMDSU                           */
     __I uint32_t HPB1_:1;          /*!< bit:      3  HPB1                               */
     __I uint32_t H2LBRIDGES_:1;    /*!< bit:      4  H2LBRIDGES                         */
-    __I uint32_t :11;              /*!< bit:  5..15  Reserved                           */
+    __I uint32_t Reserved1:11;     /*!< bit:  5..15  Reserved                           */
     __I uint32_t HPB0_:1;          /*!< bit:     16  HPB0                               */
     __I uint32_t HPB2_:1;          /*!< bit:     17  HPB2                               */
     __I uint32_t HPB3_:1;          /*!< bit:     18  HPB3                               */
     __I uint32_t HPB4_:1;          /*!< bit:     19  HPB4                               */
-    __I uint32_t :1;               /*!< bit:     20  Reserved                           */
+    __I uint32_t Reserved2:1;      /*!< bit:     20  Reserved                           */
     __I uint32_t LPRAMHS_:1;       /*!< bit:     21  LPRAMHS                            */
     __I uint32_t LPRAMPICOP_:1;    /*!< bit:     22  LPRAMPICOP                         */
     __I uint32_t LPRAMDMAC_:1;     /*!< bit:     23  LPRAMDMAC                          */
     __I uint32_t L2HBRIDGES_:1;    /*!< bit:     24  L2HBRIDGES                         */
     __I uint32_t HSRAMLP_:1;       /*!< bit:     25  HSRAMLP                            */
-    __I uint32_t :6;               /*!< bit: 26..31  Reserved                           */
+    __I uint32_t Reserved3:6;      /*!< bit: 26..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGAHB_Type;
@@ -198,7 +198,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t RTC_:1;           /*!< bit:      8  RTC                                */
     __I uint32_t EIC_:1;           /*!< bit:      9  EIC                                */
     __I uint32_t PORT_:1;          /*!< bit:     10  PORT                               */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved1:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGA_Type;
@@ -235,11 +235,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
 #if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
-    __I uint32_t :1;               /*!< bit:      0  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      0  Reserved                           */
     __I uint32_t DSU_:1;           /*!< bit:      1  DSU                                */
     __I uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL                            */
     __I uint32_t MTB_:1;           /*!< bit:      3  MTB                                */
-    __I uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+    __I uint32_t Reserved2:28;     /*!< bit:  4..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGB_Type;
@@ -275,7 +275,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t DAC_:1;           /*!< bit:     12  DAC                                */
     __I uint32_t AES_:1;           /*!< bit:     13  AES                                */
     __I uint32_t TRNG_:1;          /*!< bit:     14  TRNG                               */
-    __I uint32_t :17;              /*!< bit: 15..31  Reserved                           */
+    __I uint32_t Reserved1:17;     /*!< bit: 15..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGC_Type;
@@ -326,9 +326,9 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t ADC_:1;           /*!< bit:      3  ADC                                */
     __I uint32_t AC_:1;            /*!< bit:      4  AC                                 */
     __I uint32_t PTC_:1;           /*!< bit:      5  PTC                                */
-    __I uint32_t :1;               /*!< bit:      6  Reserved                           */
+    __I uint32_t Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint32_t CCL_:1;           /*!< bit:      7  CCL                                */
-    __I uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+    __I uint32_t Reserved2:24;     /*!< bit:  8..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGD_Type;
@@ -359,7 +359,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint32_t PAC_:1;           /*!< bit:      0  PAC                                */
     __I uint32_t DMAC_:1;          /*!< bit:      1  DMAC                               */
-    __I uint32_t :30;              /*!< bit:  2..31  Reserved                           */
+    __I uint32_t Reserved1:30;     /*!< bit:  2..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } PAC_INTFLAGE_Type;

--- a/asf/sam0/include/samr35/component/pm.h
+++ b/asf/sam0/include/samr35/component/pm.h
@@ -154,7 +154,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  PLRDY:1;          /*!< bit:      0  Performance Level Ready            */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } PM_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/rtc.h
+++ b/asf/sam0/include/samr35/component/rtc.h
@@ -766,13 +766,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:1;            /*!< bit:      8  Compare x                          */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE0_INTFLAG_Type;
@@ -823,13 +823,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t CMP0:1;           /*!< bit:      8  Compare 0                          */
     __I uint16_t CMP1:1;           /*!< bit:      9  Compare 1                          */
-    __I uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    __I uint16_t Reserved1:5;      /*!< bit: 10..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t CMP:2;            /*!< bit:  8.. 9  Compare x                          */
-    __I uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit: 10..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE1_INTFLAG_Type;
@@ -881,13 +881,13 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint16_t PER6:1;           /*!< bit:      6  Periodic Interval 6                */
     __I uint16_t PER7:1;           /*!< bit:      7  Periodic Interval 7                */
     __I uint16_t ALARM0:1;         /*!< bit:      8  Alarm 0                            */
-    __I uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    __I uint16_t Reserved1:6;      /*!< bit:  9..14  Reserved                           */
     __I uint16_t OVF:1;            /*!< bit:     15  Overflow                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint16_t PER:8;            /*!< bit:  0.. 7  Periodic Interval x                */
     __I uint16_t ALARM:1;          /*!< bit:      8  Alarm x                            */
-    __I uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+    __I uint16_t Reserved1:7;      /*!< bit:  9..15  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint16_t reg;                /*!< Type      used for register access              */
 } RTC_MODE2_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/sercom.h
+++ b/asf/sam0/include/samr35/component/sercom.h
@@ -780,7 +780,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  MB:1;             /*!< bit:      0  Master On Bus Interrupt            */
     __I uint8_t  SB:1;             /*!< bit:      1  Slave On Bus Interrupt             */
-    __I uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    __I uint8_t  Reserved1:5;      /*!< bit:  2.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -805,7 +805,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt            */
     __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt            */
     __I uint8_t  DRDY:1;           /*!< bit:      2  Data Interrupt                     */
-    __I uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  3.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -833,7 +833,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt        */
     __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt         */
     __I uint8_t  SSL:1;            /*!< bit:      3  Slave Select Low Interrupt Flag    */
-    __I uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    __I uint8_t  Reserved1:3;      /*!< bit:  4.. 6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -865,7 +865,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
     __I uint8_t  CTSIC:1;          /*!< bit:      4  Clear To Send Input Change Interrupt */
     __I uint8_t  RXBRK:1;          /*!< bit:      5  Break Received Interrupt           */
-    __I uint8_t  :1;               /*!< bit:      6  Reserved                           */
+    __I uint8_t  Reserved1:1;      /*!< bit:      6  Reserved                           */
     __I uint8_t  ERROR:1;          /*!< bit:      7  Combined Error Interrupt           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samr35/component/supc.h
+++ b/asf/sam0/include/samr35/component/supc.h
@@ -135,11 +135,11 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t BOD12RDY:1;       /*!< bit:      3  BOD12 Ready                        */
     __I uint32_t BOD12DET:1;       /*!< bit:      4  BOD12 Detection                    */
     __I uint32_t B12SRDY:1;        /*!< bit:      5  BOD12 Synchronization Ready        */
-    __I uint32_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint32_t Reserved1:2;      /*!< bit:  6.. 7  Reserved                           */
     __I uint32_t VREGRDY:1;        /*!< bit:      8  Voltage Regulator Ready            */
     __I uint32_t APWSRDY:1;        /*!< bit:      9  Automatic Power Switch Ready       */
     __I uint32_t VCORERDY:1;       /*!< bit:     10  VDDCORE Ready                      */
-    __I uint32_t :21;              /*!< bit: 11..31  Reserved                           */
+    __I uint32_t Reserved2:21;     /*!< bit: 11..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } SUPC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/tc.h
+++ b/asf/sam0/include/samr35/component/tc.h
@@ -355,15 +355,15 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  OVF:1;            /*!< bit:      0  OVF Interrupt Flag                 */
     __I uint8_t  ERR:1;            /*!< bit:      1  ERR Interrupt Flag                 */
-    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  Reserved1:2;      /*!< bit:  2.. 3  Reserved                           */
     __I uint8_t  MC0:1;            /*!< bit:      4  MC Interrupt Flag 0                */
     __I uint8_t  MC1:1;            /*!< bit:      5  MC Interrupt Flag 1                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  Reserved1:4;      /*!< bit:  0.. 3  Reserved                           */
     __I uint8_t  MC:2;             /*!< bit:  4.. 5  MC Interrupt Flag x                */
-    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+    __I uint8_t  Reserved2:2;      /*!< bit:  6.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/tcc.h
+++ b/asf/sam0/include/samr35/component/tcc.h
@@ -960,7 +960,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t TRG:1;            /*!< bit:      1  Retrigger                          */
     __I uint32_t CNT:1;            /*!< bit:      2  Counter                            */
     __I uint32_t ERR:1;            /*!< bit:      3  Error                              */
-    __I uint32_t :6;               /*!< bit:  4.. 9  Reserved                           */
+    __I uint32_t Reserved1:6;      /*!< bit:  4.. 9  Reserved                           */
     __I uint32_t UFS:1;            /*!< bit:     10  Non-Recoverable Update Fault       */
     __I uint32_t DFS:1;            /*!< bit:     11  Non-Recoverable Debug Fault        */
     __I uint32_t FAULTA:1;         /*!< bit:     12  Recoverable Fault A                */
@@ -971,12 +971,12 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
     __I uint32_t MC1:1;            /*!< bit:     17  Match or Capture 1                 */
     __I uint32_t MC2:1;            /*!< bit:     18  Match or Capture 2                 */
     __I uint32_t MC3:1;            /*!< bit:     19  Match or Capture 3                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
-    __I uint32_t :16;              /*!< bit:  0..15  Reserved                           */
+    __I uint32_t Reserved1:16;     /*!< bit:  0..15  Reserved                           */
     __I uint32_t MC:4;             /*!< bit: 16..19  Match or Capture x                 */
-    __I uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+    __I uint32_t Reserved2:12;     /*!< bit: 20..31  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint32_t reg;                /*!< Type      used for register access              */
 } TCC_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/trng.h
+++ b/asf/sam0/include/samr35/component/trng.h
@@ -121,7 +121,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  DATARDY:1;        /*!< bit:      0  Data Ready Interrupt Flag          */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } TRNG_INTFLAG_Type;

--- a/asf/sam0/include/samr35/component/wdt.h
+++ b/asf/sam0/include/samr35/component/wdt.h
@@ -218,7 +218,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
-    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+    __I uint8_t  Reserved1:7;      /*!< bit:  1.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
 } WDT_INTFLAG_Type;


### PR DESCRIPTION
Names all anonymous bit-fields with qualifiers to `Reserved1`, `Reserved2`, ...

This conforms to [CWG2229](https://cplusplus.github.io/CWG/issues/2229.html) and enables compilation with [clang++](https://clang.llvm.org/cxx_dr_status.html).  

(See Zephyr Issue zephyrproject-rtos/zephyr#84242)