### PR TITLE
sam0: dac: Rename EMPTY bit-fields to avoid name collision.

### DIFF
--- a/asf/sam0/include/samc21/README
+++ b/asf/sam0/include/samc21/README
@@ -38,3 +38,4 @@ License Link:
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samc21/component/dac.h
+++ b/asf/sam0/include/samc21/component/dac.h
@@ -133,7 +133,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -154,7 +154,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -175,7 +175,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
-    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samc21n/README
+++ b/asf/sam0/include/samc21n/README
@@ -38,3 +38,4 @@ License Link:
 Patch List:
    * Fix ADC_INPUTCTRL ground mask value.
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samc21n/component/dac.h
+++ b/asf/sam0/include/samc21n/component/dac.h
@@ -133,7 +133,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -154,7 +154,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -175,7 +175,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
-    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  Reserved1:6;      /*!< bit:  2.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samd20/README
+++ b/asf/sam0/include/samd20/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samd20/component/dac.h
+++ b/asf/sam0/include/samd20/component/dac.h
@@ -126,7 +126,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -150,7 +150,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -174,7 +174,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
-    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
     __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */

--- a/asf/sam0/include/samd21/README
+++ b/asf/sam0/include/samd21/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samd21/component/dac.h
+++ b/asf/sam0/include/samd21/component/dac.h
@@ -128,7 +128,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -152,7 +152,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -176,7 +176,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
-    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
     __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */

--- a/asf/sam0/include/samd51/README
+++ b/asf/sam0/include/samd51/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samd51/component/dac.h
+++ b/asf/sam0/include/samd51/component/dac.h
@@ -161,7 +161,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -217,7 +217,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Result x Underrun                  */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready                     */
     __I uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Result x Overrun                   */
   } vec;                       /*!< Structure used for vec  access                  */

--- a/asf/sam0/include/same51/README
+++ b/asf/sam0/include/same51/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/same51/component/dac.h
+++ b/asf/sam0/include/same51/component/dac.h
@@ -161,7 +161,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -217,7 +217,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Result x Underrun                  */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready                     */
     __I uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Result x Overrun                   */
   } vec;                       /*!< Structure used for vec  access                  */

--- a/asf/sam0/include/same53/README
+++ b/asf/sam0/include/same53/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/same53/component/dac.h
+++ b/asf/sam0/include/same53/component/dac.h
@@ -161,7 +161,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -217,7 +217,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Result x Underrun                  */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready                     */
     __I uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Result x Overrun                   */
   } vec;                       /*!< Structure used for vec  access                  */

--- a/asf/sam0/include/same54/README
+++ b/asf/sam0/include/same54/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/same54/component/dac.h
+++ b/asf/sam0/include/same54/component/dac.h
@@ -161,7 +161,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -217,7 +217,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun x Interrupt Enable        */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready Interrupt Enable    */
     uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Overrun x Interrupt Enable         */
   } vec;                       /*!< Structure used for vec  access                  */
@@ -273,7 +273,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Result x Underrun                  */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  RESRDY:2;         /*!< bit:  4.. 5  Result x Ready                     */
     __I uint8_t  OVERRUN:2;        /*!< bit:  6.. 7  Result x Overrun                   */
   } vec;                       /*!< Structure used for vec  access                  */

--- a/asf/sam0/include/saml21/README
+++ b/asf/sam0/include/saml21/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/saml21/component/dac.h
+++ b/asf/sam0/include/saml21/component/dac.h
@@ -150,7 +150,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -188,7 +188,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samr21/README
+++ b/asf/sam0/include/samr21/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samr21/component/dac.h
+++ b/asf/sam0/include/samr21/component/dac.h
@@ -128,7 +128,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -152,7 +152,7 @@ typedef union {
 typedef union {
   struct {
     uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
-    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty Interrupt Enable */
     uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
     uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */
@@ -176,7 +176,7 @@ typedef union {
 typedef union { // __I to avoid read-modify-write on write-to-clear register
   struct {
     __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
-    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  DBEMPTY:1;        /*!< bit:      1  Data Buffer Empty                  */
     __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
     __I uint8_t  Reserved1:5;      /*!< bit:  3.. 7  Reserved                           */
   } bit;                       /*!< Structure used for bit  access                  */

--- a/asf/sam0/include/samr34/README
+++ b/asf/sam0/include/samr34/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samr34/component/dac.h
+++ b/asf/sam0/include/samr34/component/dac.h
@@ -150,7 +150,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -188,7 +188,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */

--- a/asf/sam0/include/samr35/README
+++ b/asf/sam0/include/samr35/README
@@ -37,3 +37,4 @@ License Link:
 
 Patch List:
    * Fix anonymous bit-fields with qualifiers.
+   * Rename DAC EMPTY bit-fields to DBEMPTY to avoid collision with Zephyr macros.

--- a/asf/sam0/include/samr35/component/dac.h
+++ b/asf/sam0/include/samr35/component/dac.h
@@ -150,7 +150,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -188,7 +188,7 @@ typedef union {
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  Underrun Interrupt Enable for DAC x */
-    uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
+    uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty Interrupt Enable */
     uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */
@@ -226,7 +226,7 @@ typedef union { // __I to avoid read-modify-write on write-to-clear register
   } bit;                       /*!< Structure used for bit  access                  */
   struct {
     __I uint8_t  UNDERRUN:2;       /*!< bit:  0.. 1  DAC x Underrun                     */
-    __I uint8_t  EMPTY:2;          /*!< bit:  2.. 3  Data Buffer x Empty                */
+    __I uint8_t  DBEMPTY:2;        /*!< bit:  2.. 3  Data Buffer x Empty                */
     __I uint8_t  Reserved1:4;      /*!< bit:  4.. 7  Reserved                           */
   } vec;                       /*!< Structure used for vec  access                  */
   uint8_t reg;                 /*!< Type      used for register access              */


### PR DESCRIPTION
Rename EMPTY bit-fields, since they collide with Zephyr's utility macro [EMPTY](https://docs.zephyrproject.org/apidoc/latest/group__sys-util.html#ga2b7cf2a3641be7b89138615764d60ba3).