### PR TITLE
sam3x: spi: missing macro

### DIFF
--- a/asf/sam/include/sam3x/README
+++ b/asf/sam/include/sam3x/README
@@ -43,3 +43,4 @@ Patch Lst:
    * Fix RSTC registers macros
    * Fix PWM registers macros
    * Fix SSC registers macros
+   * Fix missing SPI_CSR_BITS macro

--- a/asf/sam/include/sam3x/component/spi.h
+++ b/asf/sam/include/sam3x/component/spi.h
@@ -125,6 +125,7 @@ typedef struct {
 #define SPI_CSR_CSAAT (0x1u << 3) /**< \brief (SPI_CSR[4]) Chip Select Active After Transfer */
 #define SPI_CSR_BITS_Pos 4
 #define SPI_CSR_BITS_Msk (0xfu << SPI_CSR_BITS_Pos) /**< \brief (SPI_CSR[4]) Bits Per Transfer */
+#define SPI_CSR_BITS(value)                 (SPI_CSR_BITS_Msk & ((value) << SPI_CSR_BITS_Pos))
 #define   SPI_CSR_BITS_8_BIT (0x0u << 4) /**< \brief (SPI_CSR[4]) 8 bits for transfer */
 #define   SPI_CSR_BITS_9_BIT (0x1u << 4) /**< \brief (SPI_CSR[4]) 9 bits for transfer */
 #define   SPI_CSR_BITS_10_BIT (0x2u << 4) /**< \brief (SPI_CSR[4]) 10 bits for transfer */


### PR DESCRIPTION
Add missing SPI_CSR_BITS macro for sam3x variants