### PR TITLE
sam3x: spi: missing macro

### DIFF
--- a/asf/sam/include/sam3x/README
+++ b/asf/sam/include/sam3x/README
@@ -44,3 +44,4 @@ Patch Lst:
    * Fix PWM registers macros
    * Fix SSC registers macros
    * Fix missing SPI_CSR_BITS macro
+   * Fix missing ADC_MR_STARTUP and ADC_MR_SETTLING macros

--- a/asf/sam/include/sam3x/component/adc.h
+++ b/asf/sam/include/sam3x/component/adc.h
@@ -104,6 +104,7 @@ typedef struct {
 #define ADC_MR_PRESCAL(value) ((ADC_MR_PRESCAL_Msk & ((value) << ADC_MR_PRESCAL_Pos)))
 #define ADC_MR_STARTUP_Pos 16
 #define ADC_MR_STARTUP_Msk (0xfu << ADC_MR_STARTUP_Pos) /**< \brief (ADC_MR) Start Up Time */
+#define ADC_MR_STARTUP(value) ((ADC_MR_STARTUP_Msk & ((value) << ADC_MR_STARTUP_Pos)))
 #define   ADC_MR_STARTUP_SUT0 (0x0u << 16) /**< \brief (ADC_MR) 0 periods of ADCClock */
 #define   ADC_MR_STARTUP_SUT8 (0x1u << 16) /**< \brief (ADC_MR) 8 periods of ADCClock */
 #define   ADC_MR_STARTUP_SUT16 (0x2u << 16) /**< \brief (ADC_MR) 16 periods of ADCClock */
@@ -122,6 +123,7 @@ typedef struct {
 #define   ADC_MR_STARTUP_SUT960 (0xFu << 16) /**< \brief (ADC_MR) 960 periods of ADCClock */
 #define ADC_MR_SETTLING_Pos 20
 #define ADC_MR_SETTLING_Msk (0x3u << ADC_MR_SETTLING_Pos) /**< \brief (ADC_MR) Analog Settling Time */
+#define ADC_MR_SETTLING(value) ((ADC_MR_SETTLING_Msk & ((value) << ADC_MR_SETTLING_Pos)))
 #define   ADC_MR_SETTLING_AST3 (0x0u << 20) /**< \brief (ADC_MR) 3 periods of ADCClock */
 #define   ADC_MR_SETTLING_AST5 (0x1u << 20) /**< \brief (ADC_MR) 5 periods of ADCClock */
 #define   ADC_MR_SETTLING_AST9 (0x2u << 20) /**< \brief (ADC_MR) 9 periods of ADCClock */


### PR DESCRIPTION
Add missing SPI_CSR_BITS macro for sam3x variants