### PR TITLE
wifi: winc1500: Update HAL version to 19.7.6

### DIFF
--- a/asf/common/components/wifi/winc1500/bsp/include/nm_bsp.h
+++ b/asf/common/components/wifi/winc1500/bsp/include/nm_bsp.h
@@ -4,289 +4,285 @@
  *
  * \brief WINC BSP API Declarations.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
  */
- 
-/** \defgroup nm_bsp BSP
+
+/** @defgroup nm_bsp BSP
+    @brief
+        Description of the BSP (<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage) module.
+    @{
+        @defgroup   DataT       Data Types
+        @defgroup   BSPDefine   Defines
+        @defgroup   BSPAPI      Functions
+        @brief
+            Lists the available BSP (<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage) APIs.
+    @}
  */
-/**@defgroup  BSPDefine Defines
- * @ingroup nm_bsp
- * @{
+
+/**@addtogroup BSPDefine
+   @{
  */
 #ifndef _NM_BSP_H_
 #define _NM_BSP_H_
 
 #define NMI_API
-/*!< 
-*        Attribute used to define memory section to map Functions in host memory.
-*/
+/*!<
+ *  Attribute used to define the memory section to map Functions in host memory.
+ */
 #define CONST const
 
-/*!< 
-*     Used for code portability.
-*/
+/*!<
+ *  Used for code portability.
+ */
 
 #ifndef NULL
 #define NULL ((void*)0)
 #endif
-/*!< 
-*    Void Pointer to '0' in case of NULL is not defined. 
+/*!<
+*   Void Pointer to '0' in case NULL is not defined.
 */
-
 
 #define BSP_MIN(x,y) ((x)>(y)?(y):(x))
-/*!< 
-*     Computes the minimum of \b x and \b y.
+/*!<
+*     Computes the minimum value between \b x and \b y.
 */
+/**@}*/     //BSPDefine
 
- //@}
-
-/**@defgroup  DataT  DataTypes
- * @ingroup nm_bsp
+/**@addtogroup DataT
  * @{
  */
- 
 /*!
- * @typedef      void (*tpfNmBspIsr) (void);
- * @brief           Pointer to function.\n
- *                     Used as a data type of ISR function registered by \ref nm_bsp_register_isr
- * @return         None
+ * @typedef     void (*tpfNmBspIsr) (void);
+ * @brief       Pointer to function.\n Used as a data type of ISR function registered by
+ *              @ref nm_bsp_register_isr.
+ * @return      None
  */
 typedef void (*tpfNmBspIsr)(void);
-  /*!
- * @ingroup DataTypes
- * @typedef      unsigned char	uint8;
- * @brief        Range of values between 0 to 255
- */
-typedef unsigned char	uint8;
 
- /*!
- * @ingroup DataTypes
- * @typedef      unsigned short	uint16;
- * @brief        Range of values between 0 to 65535
- */
-typedef unsigned short	uint16;
+/*!
+* @ingroup DataTypes
+* @typedef      unsigned char  uint8;
+* @brief        Range of values between 0 to 255
+*/
+typedef unsigned char   uint8;
 
- /*!
- * @ingroup Data Types
- * @typedef      unsigned long	uint32;
- * @brief        Range of values between 0 to 4294967295
- */ 
-typedef unsigned long	uint32;
-  /*!
- * @ingroup Data Types
- * @typedef      signed char		sint8;
- * @brief        Range of values between -128 to 127
- */
-typedef signed char		sint8;
+/*!
+* @ingroup DataTypes
+* @typedef      unsigned short uint16;
+* @brief        Range of values between 0 to 65535
+*/
+typedef unsigned short  uint16;
 
- /*!
- * @ingroup DataTypes
- * @typedef      signed short	sint16;
- * @brief        Range of values between -32768 to 32767
- */
-typedef signed short	sint16;
+/*!
+* @ingroup Data Types
+* @typedef      unsigned long  uint32;
+* @brief        Range of values between 0 to 4294967295
+*/
+typedef unsigned long   uint32;
 
-  /*!
- * @ingroup DataTypes
- * @typedef      signed long		sint32;
- * @brief        Range of values between -2147483648 to 2147483647
- */
+/*!
+* @ingroup Data Types
+* @typedef      signed char        sint8;
+* @brief        Range of values between -128 to 127
+*/
+typedef signed char     sint8;
 
-typedef signed long		sint32;
- //@}
+/*!
+* @ingroup DataTypes
+* @typedef      signed short   sint16;
+* @brief        Range of values between -32768 to 32767
+*/
+typedef signed short    sint16;
+
+/*!
+* @ingroup DataTypes
+* @typedef      signed long        sint32;
+* @brief        Range of values between -2147483648 to 2147483647
+*/
+typedef signed long     sint32;
+/**@}*/     //DataTypes
 
 #ifndef CORTUS_APP
 
-
 #ifdef __cplusplus
-extern "C"{
+extern "C" {
 #endif
-
-/** \defgroup BSPAPI Function
- *   @ingroup nm_bsp
- */
-
 
 /** @defgroup NmBspInitFn nm_bsp_init
  *  @ingroup BSPAPI
- *
- *  Initialization for BSP (<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage) such as Reset and Chip Enable Pins for WINC, delays,
- *  register ISR, enable/disable IRQ for WINC, ...etc. You must use this function in the head of your application to 
- *  enable WINC and Host Driver to communicate with each other. 
+ *      Initialization for BSP (<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage)
+ *      such as Reset and Chip Enable Pins for WINC, delays, register ISR, enable/disable IRQ for WINC, etc.
+ *      You must use this function at the head of your application to enable WINC and Host Driver to
+ *      communicate with each other.
+ *  @{
  */
- /**@{*/
 /*!
- * @fn           sint8 nm_bsp_init(void);
- * @brief		 This function is used to initialize the <strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage <strong>(BSP)</strong> in order to prepare the WINC
- *				 before it start working.
+ * @fn          sint8 nm_bsp_init(void);
+ * @brief       This function is used to initialize the <strong>B</strong>oard <strong>S</strong>upport
+ *              <strong>P</strong>ackage <strong>(BSP)</strong> in order to prepare the WINC before any
+ *              WINC API calls.
+ * @details     The nm_bsp_init function is the first function that should be called at the beginning of
+ *              every application to initialize the BSP and the WINC board. Otherwise, the rest of the BSP
+ *              function calls will return with failure. This function should also be called after the WINC
+ *              has been switched off with a successful call to @ref nm_bsp_deinit in order to reinitialize
+ *              the BSP before the Application can use any of the WINC APIs again. After the function
+ *              initializes the WINC, a hard reset must be applied to start the WINC board by calling
+ *              @ref nm_bsp_reset.
  *
- *				 The nm_bsp_init function is the first function that should be called at the beginning of
- *				 every application to initialize the BSP and the WINC board. Otherwise, the rest of the BSP function
- *				 calls will return with failure. This function should also be called after the WINC has been switched off with 
- *				 a successful call to "nm_bsp_deinit" in order to reinitialize the BSP before the user can use any of the WINC API
- *				 functions again. After the function initialize the WINC. Hard reset must be applied to start the WINC board.
- * @note         Implementation of this function is host dependent.
- * @warning      inappropriate use of this function will lead to unavailability of host-chip communication.\n
- *  
- * @see			 nm_bsp_deinit, nm_bsp_reset
+ * @note        Implementation of this function is host dependent.
+ * @warning     Omitting this function will lead to unavailability of host-chip communication.
+ *
+ * @see          nm_bsp_deinit, nm_bsp_reset
  * @return       The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-
  */
 sint8 nm_bsp_init(void);
- /**@}*/
+/**@}*/     //NmBspInitFn
 
- 
- /** @defgroup NmBspDeinitFn nm_bsp_deinit
- *    @ingroup BSPAPI
- *   	 De-initialization for BSP ((<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage)). This function should be called only after
- *		 a successful call to nm_bsp_init. 
+
+/** @defgroup NmBspDeinitFn nm_bsp_deinit
+ *  @ingroup BSPAPI
+ *      De-initialization of the BSP (<strong>B</strong>oard <strong>S</strong>upport <strong>P</strong>ackage).\n
+ *      This function should be called only after a successful call to @ref nm_bsp_init.
+ *  @{
  */
- /**@{*/
 /*!
- * @fn           sint8 nm_bsp_deinit(void);
- * @pre          The BSP should be initialized through \ref nm_bsp_init first.
- * @brief		 This function is used to de-initialize the BSP and turn off the WINC board.
- *				 
- *				 The nm_bsp_deinit is the last function that should be called after the application has finished and before the WINC is switched 
- *				 off. The function call turns off the WINC board by setting CHIP_EN and RESET_N signals low.Every function call of "nm_bsp_init" should
- *				 be matched with a call to nm_bsp_deinit. Failure to do so may result in the WINC consuming higher power than expected. 
- * @note         Implementation of this function is host dependent.
- * @warning      misuse may lead to unknown behavior in case of soft reset.\n
- * @see          nm_bsp_init               
+ * @fn          sint8 nm_bsp_deinit(void);
+ * @brief       This function is used to de-initialize the BSP and turn off the WINC board.
+ * @details     The nm_bsp_deinit is the last function that should be called after the application has
+ *              finished and before the WINC is switched off. A call to this function will turn off the WINC
+ *              board by setting CHIP_EN and RESET_N signals low. Every function call of @ref nm_bsp_init
+ *              should be matched with a call to nm_bsp_deinit. Failure to do so may result in the WINC
+ *              consuming higher power than expected, since it won't be properly de-initialized.
+ * @pre         The BSP should be initialized through @ref nm_bsp_init first.
+ * @note        Implementation of this function is host dependent.
+ * @warning     Omitting this function may lead to unknown behavior in case of soft reset.
+ * @see         nm_bsp_init
  * @return      The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 
  */
 sint8 nm_bsp_deinit(void);
- /**@}*/
+/**@}*/     //NmBspDeinitFn
 
- 
 /** @defgroup NmBspResetFn  nm_bsp_reset
-*     @ingroup BSPAPI
-*      Resetting WINC1500 SoC by setting CHIP_EN and RESET_N signals low, then after specific delay the function will put CHIP_EN high then RESET_N high,
-*      for the timing between signals please review the WINC data-sheet
-*/
-/**@{*/
- /*!
- * @fn           void nm_bsp_reset(void);    
- * @param [in]   None
- * @brief		 Applies a hardware reset to the WINC board.
- *				 The "nm_bsp_reset" is used to apply a hard reset to the WINC board by setting CHIP_EN and RESET_N signals low, then after specific delay
- *				 the function will put CHIP_EN high then RESET_N high, for the detailed timing between signals please review the WINC data-sheet. After a
- *				 successful call, the WINC board firmware will kick off to load and kick off the WINC firmware. This function should be called to reset the 
- *				 WINC firmware after the BSP is initialized and before the start of any communication with WINC board. Calling this function at any other time
- *				 will result in losing the state and connections saved in the WINC board and starting again from the initial state. The host driver will need 
- * 				 to be de-initialized before calling nm_bsp_reset and initialized again after it using the " m2m_wifi_(de)init". 
- * @pre          Initialize \ref nm_bsp_init first
- * @note         Implementation of this function is host dependent and called by HIF layer.
- * @warning		 Calling this function will drop any connection and internal state saved on the WINC firmware.
- * @see          nm_bsp_init, m2m_wifi_init,  m2m_wifi_deinit
- * @return       None
-
+ *  @ingroup BSPAPI
+ *      Resets the WINC SoC by setting CHIP_EN and RESET_N signals low, then after an appropriate delay,
+ *      this function will put CHIP_EN high then RESET_N high, for more details on the timing between signals
+ *      please check the WINC data-sheet.
+ *  @{
  */
-void nm_bsp_reset(void);
- /**@}*/
-
- 
-/** @defgroup NmBspSleepFn nm_bsp_sleep
-*     @ingroup BSPAPI
-*     Sleep in units of milliseconds.\n
-*    This function used by HIF Layer according to different situations. 
-*/
-/**@{*/
 /*!
- * @fn           void nm_bsp_sleep(uint32);
- * @brief   	 Used to put the host to sleep for the specified duration.
- *				 Forcing the host to sleep for extended period may lead to host not being able to respond to WINC board events.It's important to
- *				 be considerate while choosing the sleep period. 
- * @param [in]   u32TimeMsec
- *               Time unit in milliseconds
- * @pre          Initialize \ref nm_bsp_init first
- * @warning      Maximum value must nor exceed 4294967295 milliseconds which is equal to 4294967.295 seconds.\n
- * @note         Implementation of this function is host dependent.
- * @see           nm_bsp_init               
- * @return       None
+ * @fn          void nm_bsp_reset(void);
+ * @brief       Performs a hardware reset to the WINC board.
+ * @details     The nm_bsp_reset is used to perform a hard reset on the WINC board by setting CHIP_EN and
+ *              RESET_N signals low, then after an appropriate delay this function puts CHIP_EN high then
+ *              RESET_N high, for more details on the timing between signals please check the WINC data-sheet.
+ *              After a successful call, the WINC board firmware will kick off to load and start the WINC
+ *              firmware. This function should be called to reset the WINC firmware after the BSP is
+ *              initialized and before the start of any communication with WINC board. Calling this
+ *              function at any other time will result in losing the state and connections saved in the
+ *              WINC board and starting again from the initial state. The host driver will need to be
+ *              de-initialized before calling nm_bsp_reset and initialized again, which can be achieved by
+ *              use of @ref m2m_wifi_init and @ref m2m_wifi_deinit.
+ * @pre         Initialize the BSP first by calling @ref nm_bsp_init.
+ * @note        Implementation of this function is host dependent and called by HIF layer.
+ * @warning     Calling this function will drop any connection and lose the internal state saved on the WINC firmware.
+ * @see         nm_bsp_init, m2m_wifi_init,  m2m_wifi_deinit
+ * @return      None
+*/
+void nm_bsp_reset(void);
+/**@}*/     //NmBspResetFn
+
+/** @defgroup NmBspSleepFn nm_bsp_sleep
+ *  @ingroup BSPAPI
+ *      Sleep in units of milliseconds.\n
+ *      This function used by the HIF Layer on several different scenarios.
+ *  @{
+ */
+/*!
+ * @fn          void nm_bsp_sleep(uint32 u32TimeMsec);
+ * @brief       Used to put the host to sleep for the specified duration (in milliseconds).
+ *              Forcing the host to sleep for extended period may lead to host not being able to respond
+ *              to WINC board events. It is important to be considerate while choosing the sleep period.
+ * @param [in]  u32TimeMsec
+ *                  Time unit in milliseconds.
+ * @pre         Initialize @ref nm_bsp_init first.
+ * @note        Implementation of this function is host dependent.
+ * @warning     Maximum value must nor exceed 4294967295 milliseconds which is equal to 4294967.295 seconds.
+ * @see         nm_bsp_init
+ * @return      None
  */
 void nm_bsp_sleep(uint32 u32TimeMsec);
-/**@}*/
+/**@}*/     //NmBspSleepFn
 
-  
 /** @defgroup NmBspRegisterFn nm_bsp_register_isr
-*     @ingroup BSPAPI
-*   Register ISR (Interrupt Service Routine) in the initialization of HIF (Host Interface) Layer. 
-*   When the interrupt trigger the BSP layer should call the pfisr function once inside the interrupt.
-*/
-/**@{*/
+ *  @ingroup BSPAPI
+ *      Register ISR (Interrupt Service Routine) in the initialization of the HIF (Host Interface) Layer.
+ *      When the interrupt is triggered, the BSP layer should call the pfisr function from the interrupt handler.
+ *  @{
+ */
 /*!
- * @fn           void nm_bsp_register_isr(tpfNmBspIsr);
- * @param [in]   tpfNmBspIsr  pfIsr
- *               Pointer to ISR handler in HIF
- * @brief		 Register the host interface interrupt service routine.
- *				 WINC board utilize SPI interface to communicate with the host. This function register the SPI interrupt the notify
- *				 the host whenever there is an outstanding message from the WINC board. The function should be called during the initialization
- *				 of the host interface. It an internal driver function and shouldn't be called by the application. 
- * @warning      Make sure that ISR for IRQ pin for WINC is disabled by default in your implementation.
- * @note         Implementation of this function is host dependent and called by HIF layer.
- * @see          tpfNmBspIsr
- * @return       None
-
+ * @fn          void nm_bsp_register_isr(tpfNmBspIsr pfIsr);
+ * @brief       Register the host interface interrupt service routine.
+ * @details     The WINC board uses the SPI interface to communicate with the host. This function registers
+ *              the SPI interrupt to notify the host whenever there is an outstanding message from the WINC
+ *              board. This function should be called during the initialization of the host interface. It is
+ *              an internal driver function and shouldn't be called by the Application.
+ * @param [in]  pfIsr
+ *                  Pointer to ISR handler in the HIF layer.
+ * @note        Implementation of this function is host dependent and called by HIF layer.
+ * @warning     Make sure that ISR for IRQ pin for WINC is disabled by default in your implementation.
+ * @see         tpfNmBspIsr
+ * @return      None
  */
 void nm_bsp_register_isr(tpfNmBspIsr pfIsr);
-/**@}*/
+/**@}*/     //NmBspRegisterFn
 
-  
 /** @defgroup NmBspInterruptCtrl nm_bsp_interrupt_ctrl
-*     @ingroup BSPAPI
-*    Synchronous enable/disable interrupts function
-*/
-/**@{*/
+ *  @ingroup BSPAPI
+ *      Synchronous enable/disable of WINC to host interrupts.
+ *  @{
+ */
 /*!
- * @fn           void nm_bsp_interrupt_ctrl(uint8);
- * @pre			 The interrupt must be registered using nm_bsp_register_isr first.
- * @brief        Enable/Disable interrupts
- *				 This function can be used to enable/disable the WINC to host interrupt as the depending on how the driver is implemented.
- *               It an internal driver function and shouldn't be called by the application.
- * @param [in]   u8Enable
- *               '0' disable interrupts. '1' enable interrupts 
- * @see          tpfNmBspIsr, nm_bsp_register_isr     
- * @note         Implementation of this function is host dependent and called by HIF layer.
- * @return       None
-
+ * @fn          void nm_bsp_interrupt_ctrl(uint8 u8Enable);
+ * @brief       Enable/Disable interrupts from the WINC.
+ * @details     This function can be used to enable/disable the WINC to host interrupts, depending on how
+ *              the driver is implemented. It is an internal driver function and shouldn't be called by
+ *              the application.
+ * @param [in]  u8Enable
+ *                  - '0' disable interrupts.
+ *                  - '1' enable interrupts.
+ * @pre         The interrupt must be registered using @ref nm_bsp_register_isr first.
+ * @note        Implementation of this function is host dependent and called by HIF layer.
+ * @see         tpfNmBspIsr, nm_bsp_register_isr
+ * @return      None
  */
 void nm_bsp_interrupt_ctrl(uint8 u8Enable);
-  /**@}*/
+/**@}*/     //NmBspInterruptCtrl
 
 #ifdef __cplusplus
 }
@@ -294,19 +290,28 @@ void nm_bsp_interrupt_ctrl(uint8 u8Enable);
 
 #endif
 
+/**
+ * @addtogroup BSPDefine
+ * @{
+ */
 #ifdef _NM_BSP_BIG_END
+/*! Switch endianness of 32bit word (In the case that Host is BE) */
 #define NM_BSP_B_L_32(x) \
 ((((x) & 0x000000FF) << 24) + \
 (((x) & 0x0000FF00) << 8)  + \
 (((x) & 0x00FF0000) >> 8)   + \
 (((x) & 0xFF000000) >> 24))
+
+/*! Switch endianness of 16bit word (In the case that Host is BE) */
 #define NM_BSP_B_L_16(x) \
 ((((x) & 0x00FF) << 8) + \
 (((x)  & 0xFF00) >> 8))
 #else
+/*! Retain endianness of 32bit word (In the case that Host is LE) */
 #define NM_BSP_B_L_32(x)  (x)
+/*! Retain endianness of 16bit word (In the case that Host is LE) */
 #define NM_BSP_B_L_16(x)  (x)
 #endif
+/**@}*/     //BSPDefine
 
-
-#endif	/*_NM_BSP_H_*/
+#endif  /*_NM_BSP_H_*/

--- a/asf/common/components/wifi/winc1500/bsp/include/nm_bsp_internal.h
+++ b/asf/common/components/wifi/winc1500/bsp/include/nm_bsp_internal.h
@@ -1,14 +1,120 @@
-/*
- * Copyright (c) 2016 Intel Corporation.
+/**
  *
- * SPDX-License-Identifier: Apache-2.0
+ * \file
+ *
+ * \brief This module contains NMC1500 BSP APIs declarations.
+ *
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
+ *
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
+ *
+ * \asf_license_stop
+ *
  */
-
+/**@defgroup  BSPDefine Defines
+ * @ingroup nm_bsp
+ * @{
+ */
 #ifndef _NM_BSP_INTERNAL_H_
 #define _NM_BSP_INTERNAL_H_
 
-#if defined(CONFIG_WIFI_WINC1500)
-#include <wifi_winc1500_nm_bsp_internal.h>
-#endif /* CONFIG_WIFI_WINC1500 */
+
+
+#ifdef WIN32
+#include "nm_bsp_win32.h"
+#endif
+
+#ifdef __K20D50M__
+#include "nm_bsp_k20d50m.h"
+#endif
+
+#ifdef __MSP430FR5739__
+#include "bsp_msp430fr5739.h"
+#endif
+
+#ifdef _FREESCALE_MCF51CN128_
+#include "bsp/include/nm_bsp_mcf51cn128.h"
+#endif
+
+#ifdef __MCF964548__
+#include "bsp/include/nm_bsp_mc96f4548.h"
+#endif
+
+#ifdef __APP_APS3_CORTUS__
+#include "nm_bsp_aps3_cortus.h"
+#endif
+
+#if (defined __SAMR21G18A__) || (defined __SAMR21E18A__)
+#include "bsp/include/nm_bsp_samr21.h"
+#endif
+
+#if (defined __SAML21J18A__) || (defined __SAML21J18B__)
+#include "bsp/include/nm_bsp_saml21.h"
+#endif
+
+#if (defined __SAML22N18A__)
+#include "bsp/include/nm_bsp_saml22.h"
+#endif
+
+#if (defined __SAMD21J18A__) || (defined __SAMD21G18A__)
+#include "bsp/include/nm_bsp_samd21.h"
+#endif
+
+#if (defined __SAM4S16C__) || (defined __SAM4SD32C__)
+#include "bsp/include/nm_bsp_sam4s.h"
+#endif
+
+#ifdef __SAMG53N19__
+#include "bsp/include/nm_bsp_samg53.h"
+#endif
+
+#ifdef __SAMG55J19__
+#include "bsp/include/nm_bsp_samg55.h"
+#endif
+
+#if (defined __SAME70Q21__) || (defined __SAME70Q21B__) || (defined __SAMV71Q21__)
+#include "bsp/include/nm_bsp_same70.h"
+#endif
+
+#if (defined __SAMR30G18A__) || (defined __SAMR30E18A__)
+#include "bsp/include/nm_bsp_samr30.h"
+#endif
+
+#ifdef CORTUS_APP
+#include "crt_iface.h"
+#endif
+
+#ifdef NRF51
+#include "nm_bsp_nrf51822.h"
+#endif
+
+#ifdef _ARDUINO_UNO_
+#include "bsp/include/nm_bsp_arduino_uno.h"
+#endif
+
+#ifdef CONFIG_ATMEL_WINC1500
+#include "wifi_winc1500_nm_bsp_internal.h"
+#endif
+
 
 #endif //_NM_BSP_INTERNAL_H_

--- a/asf/common/components/wifi/winc1500/bus_wrapper/include/nm_bus_wrapper.h
+++ b/asf/common/components/wifi/winc1500/bus_wrapper/include/nm_bus_wrapper.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 bus wrapper APIs declarations.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -59,12 +52,12 @@
 												(same start/stop conditions) ==> I2C only. Parameter:tstrNmI2cSpecial */
 #define NM_BUS_IOCTL_RW			((uint8)3)	/*!< Read/Write at the same time ==> SPI only. Parameter:tstrNmSpiRw */
 
-#define NM_BUS_IOCTL_WR_RESTART	((uint8)4)				/*!< Write buffer then made restart condition then read ==> I2C only. parameter:tstrNmI2cSpecial */
+#define NM_BUS_IOCTL_WR_RESTART	((uint8)4)				/*!< Write buffer then made restart condition then read ==> I2C only. parameter:tstrNmI2cSpecial */ 
 /**
 *	@struct	tstrNmBusCapabilities
 *	@brief	Structure holding bus capabilities information
 *	@sa	NM_BUS_TYPE_I2C, NM_BUS_TYPE_SPI
-*/
+*/ 
 typedef struct
 {
 	uint16	u16MaxTrxSz;	/*!< Maximum transfer size. Must be >= 16 bytes*/
@@ -74,7 +67,7 @@ typedef struct
 *	@struct	tstrNmI2cDefault
 *	@brief	Structure holding I2C default operation parameters
 *	@sa		NM_BUS_IOCTL_R, NM_BUS_IOCTL_W
-*/
+*/ 
 typedef struct
 {
 	uint8 u8SlaveAdr;
@@ -86,12 +79,12 @@ typedef struct
 *	@struct	tstrNmI2cSpecial
 *	@brief	Structure holding I2C special operation parameters
 *	@sa		NM_BUS_IOCTL_W_SPECIAL
-*/
+*/ 
 typedef struct
 {
 	uint8 u8SlaveAdr;
 	uint8	*pu8Buf1;	/*!< pointer to the 1st buffer */
-	uint8	*pu8Buf2;	/*!< pointer to the 2nd buffer */
+	uint8	*pu8Buf2;	/*!< pointer to the 2nd buffer */	
 	uint16	u16Sz1;		/*!< 1st buffer size */
 	uint16	u16Sz2;		/*!< 2nd buffer size */
 } tstrNmI2cSpecial;
@@ -100,14 +93,14 @@ typedef struct
 *	@struct	tstrNmSpiRw
 *	@brief	Structure holding SPI R/W parameters
 *	@sa		NM_BUS_IOCTL_RW
-*/
+*/ 
 typedef struct
 {
-	uint8	*pu8InBuf;		/*!< pointer to input buffer.
+	uint8	*pu8InBuf;		/*!< pointer to input buffer. 
 							Can be set to null and in this case zeros should be sent at MOSI */
-	uint8	*pu8OutBuf;		/*!< pointer to output buffer.
+	uint8	*pu8OutBuf;		/*!< pointer to output buffer. 
 							Can be set to null and in this case data from MISO can be ignored  */
-	uint16	u16Sz;			/*!< Transfere size */
+	uint16	u16Sz;			/*!< Transfere size */	
 } tstrNmSpiRw;
 
 
@@ -115,7 +108,7 @@ typedef struct
 *	@struct	tstrNmUartDefault
 *	@brief	Structure holding UART default operation parameters
 *	@sa		NM_BUS_IOCTL_R, NM_BUS_IOCTL_W
-*/
+*/ 
 typedef struct
 {
 	uint8	*pu8Buf;	/*!< Operation buffer */
@@ -132,7 +125,7 @@ extern tstrNmBusCapabilities egstrNmBusCapabilities;
 *	@fn		nm_bus_init
 *	@brief	Initialize the bus wrapper
 *	@return	ZERO in case of success and M2M_ERR_BUS_FAIL in case of failure
-*/
+*/ 
 sint8 nm_bus_init(void *);
 
 /**
@@ -144,14 +137,14 @@ sint8 nm_bus_init(void *);
 *					Arbitrary parameter depending on IOCTL
 *	@return	ZERO in case of success and M2M_ERR_BUS_FAIL in case of failure
 *	@note	For SPI only, it's important to be able to send/receive at the same time
-*/
+*/ 
 sint8 nm_bus_ioctl(uint8 u8Cmd, void* pvParameter);
 
 /**
 *	@fn		nm_bus_deinit
 *	@brief	De-initialize the bus wrapper
 *	@return	ZERO in case of success and M2M_ERR_BUS_FAIL in case of failure
-*/
+*/ 
 sint8 nm_bus_deinit(void);
 
 /*
@@ -166,11 +159,24 @@ sint8 nm_bus_reinit(void *);
 *	@fn			nm_bus_get_chip_type
 *	@brief		get chip type
 *	@return		ZERO in case of success and M2M_ERR_BUS_FAIL in case of failure
-*/
+*/ 
 #ifdef CONF_WINC_USE_UART
 uint8 nm_bus_get_chip_type(void);
 sint8 nm_bus_break(void);
 #endif
+
+/**
+ *  @fn         spi_rw
+ *  @brief      Process SPI Read/Write operation
+ *  @param      pu8Mosi TX Data buffer
+ *  @param      pu8Miso RX Data buffer
+ *  @param      u16Sz Transfer length
+ *  @return     ZERO in case of success and M2M_ERR_BUS_FAIL in case of failure
+ */
+#ifdef CONF_WINC_USE_SPI
+sint8 nm_spi_rw(uint8* pu8Mosi, uint8* pu8Miso, uint16 u16Sz);
+#endif
+
 #ifdef __cplusplus
 	 }
  #endif

--- a/asf/common/components/wifi/winc1500/common/include/nm_common.h
+++ b/asf/common/components/wifi/winc1500/common/include/nm_common.h
@@ -4,39 +4,39 @@
  *
  * \brief WINC Driver Common API Declarations.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
+ */
+
+/** @defgroup COMMON Common
+@{
+    @defgroup COMMONDEF Defines
+    @defgroup COMMONAPI Functions
+@}
  */
 
 #ifndef _NM_COMMON_H_
@@ -45,11 +45,10 @@
 #include "bsp/include/nm_bsp.h"
 #include "common/include/nm_debug.h"
 
-/**@defgroup  CommonDefines CommonDefines
- * @ingroup WlanDefines
+/**@addtogroup COMMONDEF
+ * @{
  */
-/**@{*/
-#define M2M_TIME_OUT_DELAY 10000
+#define M2M_TIME_OUT_DELAY          10000
 
 /*states*/
 #define M2M_SUCCESS         ((sint8)0)
@@ -67,87 +66,199 @@
 #define M2M_ERR_FAIL		((sint8)-12)
 #define M2M_ERR_FW_VER_MISMATCH         ((sint8)-13)
 #define M2M_ERR_SCAN_IN_PROGRESS         ((sint8)-14)
-#define M2M_ERR_INVALID_ARG				 ((sint8)-15)
-#define M2M_ERR_INVALID					((sint8)-16)
+/* Invalid argument */
+#define M2M_ERR_INVALID_ARG         ((sint8)-15)
+#define M2M_ERR_INVALID             ((sint8)-16)
 
-/*i2c MAASTER ERR*/
-#define I2C_ERR_LARGE_ADDRESS 	  0xE1UL	/*the address exceed the max addressing mode in i2c flash*/
-#define I2C_ERR_TX_ABRT 		  0xE2UL	/*NO ACK from slave*/
-#define I2C_ERR_OVER_SIZE 		  0xE3UL	/**/
-#define ERR_PREFIX_NMIS		      0xE4UL	/*wrong first four byte in flash NMIS*/
-#define ERR_FIRMEWARE_EXCEED_SIZE 0xE5UL	/*Total size of firmware exceed the max size 256k*/
-/**/
-#define PROGRAM_START		0x26961735UL
-#define BOOT_SUCCESS		0x10add09eUL
-#define BOOT_START		    0x12345678UL
+/* I2C MASTER ERR */
+#define I2C_ERR_LARGE_ADDRESS       0xE1UL  /*!< The address exceeds the max addressing mode in I2C flash. */
+#define I2C_ERR_TX_ABRT             0xE2UL  /*!< NO ACK from slave. */
+#define I2C_ERR_OVER_SIZE           0xE3UL
+#define ERR_PREFIX_NMIS             0xE4UL  /*!< Wrong first four bytes in flash NMIS. */
+#define ERR_FIRMWARE_EXCEED_SIZE    0xE5UL  /*!< Total size of firmware exceeds the max size 256k. */
 
+#define PROGRAM_START               0x26961735UL
+#define BOOT_SUCCESS                0x10add09eUL
+#define BOOT_START                  0x12345678UL
 
-#define NBIT31				(0x80000000)
-#define NBIT30				(0x40000000)
-#define NBIT29				(0x20000000)
-#define NBIT28				(0x10000000)
-#define NBIT27				(0x08000000)
-#define NBIT26				(0x04000000)
-#define NBIT25				(0x02000000)
-#define NBIT24				(0x01000000)
-#define NBIT23				(0x00800000)
-#define NBIT22				(0x00400000)
-#define NBIT21				(0x00200000)
-#define NBIT20				(0x00100000)
-#define NBIT19				(0x00080000)
-#define NBIT18				(0x00040000)
-#define NBIT17				(0x00020000)
-#define NBIT16				(0x00010000)
-#define NBIT15				(0x00008000)
-#define NBIT14				(0x00004000)
-#define NBIT13				(0x00002000)
-#define NBIT12				(0x00001000)
-#define NBIT11				(0x00000800)
-#define NBIT10				(0x00000400)
-#define NBIT9				(0x00000200)
-#define NBIT8				(0x00000100)
-#define NBIT7				(0x00000080)
-#define NBIT6				(0x00000040)
-#define NBIT5				(0x00000020)
-#define NBIT4				(0x00000010)
-#define NBIT3				(0x00000008)
-#define NBIT2				(0x00000004)
-#define NBIT1				(0x00000002)
-#define NBIT0				(0x00000001)
+#define NBIT31                      (0x80000000)
+#define NBIT30                      (0x40000000)
+#define NBIT29                      (0x20000000)
+#define NBIT28                      (0x10000000)
+#define NBIT27                      (0x08000000)
+#define NBIT26                      (0x04000000)
+#define NBIT25                      (0x02000000)
+#define NBIT24                      (0x01000000)
+#define NBIT23                      (0x00800000)
+#define NBIT22                      (0x00400000)
+#define NBIT21                      (0x00200000)
+#define NBIT20                      (0x00100000)
+#define NBIT19                      (0x00080000)
+#define NBIT18                      (0x00040000)
+#define NBIT17                      (0x00020000)
+#define NBIT16                      (0x00010000)
+#define NBIT15                      (0x00008000)
+#define NBIT14                      (0x00004000)
+#define NBIT13                      (0x00002000)
+#define NBIT12                      (0x00001000)
+#define NBIT11                      (0x00000800)
+#define NBIT10                      (0x00000400)
+#define NBIT9                       (0x00000200)
+#define NBIT8                       (0x00000100)
+#define NBIT7                       (0x00000080)
+#define NBIT6                       (0x00000040)
+#define NBIT5                       (0x00000020)
+#define NBIT4                       (0x00000010)
+#define NBIT3                       (0x00000008)
+#define NBIT2                       (0x00000004)
+#define NBIT1                       (0x00000002)
+#define NBIT0                       (0x00000001)
 
-#define M2M_MAX(A,B)					((A) > (B) ? (A) : (B))
-#define M2M_SEL(x,m1,m2,m3)				((x>1)?((x>2)?(m3):(m2)):(m1))
-#define WORD_ALIGN(val) 				(((val) & 0x03) ? ((val) + 4 - ((val) & 0x03)) : (val))
-
-
+/*! Maximum of two values */
+#define M2M_MAX(A,B)                ((A) > (B) ? (A) : (B))
+/*! Choose one of three values */
+#define M2M_SEL(x,m1,m2,m3)         ((x>1)?((x>2)?(m3):(m2)):(m1))
+/*! Align to next multiple of 4 */
+#define WORD_ALIGN(val)             (((val) & 0x03) ? ((val) + 4 - ((val) & 0x03)) : (val))
 
 #define DATA_PKT_OFFSET	4
 
-#ifndef BIG_ENDIAN
-#define BYTE_0(word)   					((uint8)(((word) >> 0 	) & 0x000000FFUL))
-#define BYTE_1(word)  	 				((uint8)(((word) >> 8 	) & 0x000000FFUL))
-#define BYTE_2(word)   					((uint8)(((word) >> 16) & 0x000000FFUL))
-#define BYTE_3(word)   					((uint8)(((word) >> 24) & 0x000000FFUL))
+#if _BYTE_ORDER == _LITTLE_ENDIAN
+/*! Most significant byte of 32bit word (LE) */
+#define BYTE_0(word)                ((uint8)(((word) >> 0)  & 0x000000FFUL))
+/*! Second most significant byte of 32bit word (LE) */
+#define BYTE_1(word)                ((uint8)(((word) >> 8)  & 0x000000FFUL))
+/*! Third most significant byte of 32bit word (LE) */
+#define BYTE_2(word)                ((uint8)(((word) >> 16) & 0x000000FFUL))
+/*! Least significant byte of 32bit word (LE) */
+#define BYTE_3(word)                ((uint8)(((word) >> 24) & 0x000000FFUL))
 #else
-#define BYTE_0(word)   					((uint8)(((word) >> 24) & 0x000000FFUL))
-#define BYTE_1(word)  	 				((uint8)(((word) >> 16) & 0x000000FFUL))
-#define BYTE_2(word)   					((uint8)(((word) >> 8 	) & 0x000000FFUL))
-#define BYTE_3(word)   					((uint8)(((word) >> 0 	) & 0x000000FFUL))
+/*! Most significant byte of 32bit word (BE) */
+#define BYTE_0(word)                ((uint8)(((word) >> 24) & 0x000000FFUL))
+/*! Second most significant byte of 32bit word (BE) */
+#define BYTE_1(word)                ((uint8)(((word) >> 16) & 0x000000FFUL))
+/*! Third most significant byte of 32bit word (BE) */
+#define BYTE_2(word)                ((uint8)(((word) >> 8)  & 0x000000FFUL))
+/*! Least significant byte of 32bit word (BE) */
+#define BYTE_3(word)                ((uint8)(((word) >> 0)  & 0x000000FFUL))
+#endif
+/**@}*/
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-/**@}*/
-#ifdef __cplusplus
-     extern "C" {
- #endif
-NMI_API void m2m_memcpy(uint8* pDst,uint8* pSrc,uint32 sz);
-NMI_API void m2m_memset(uint8* pBuf,uint8 val,uint32 sz);
-NMI_API uint16 m2m_strlen(uint8 * pcStr);
-NMI_API sint8 m2m_memcmp(uint8 *pu8Buff1,uint8 *pu8Buff2 ,uint32 u32Size);
-NMI_API uint8 m2m_strncmp(uint8 *pcS1, uint8 *pcS2, uint16 u16Len);
-NMI_API uint8 * m2m_strstr(uint8 *pcIn, uint8 *pcStr);
-NMI_API uint8 m2m_checksum(uint8* buf, int sz);
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          void m2m_memcpy(uint8* pDst, uint8* pSrc, uint32 sz);
+ * @brief       Copy specified number of bytes from source buffer to destination buffer.
+ * @param [in]  sz
+ *                  Number of data bytes to copy.
+ * @param [in]  pSrc
+ *                  Source buffer.
+ * @param [out] pDst
+ *                  Destination buffer.
+ * @return      None
+ */
+NMI_API void m2m_memcpy(uint8 *pDst, uint8 *pSrc, uint32 sz);
 
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          void m2m_memset(uint8* pBuf, uint8 val, uint32 sz);
+ * @brief       Set specified number of data bytes in specified data buffer to specified value.
+ * @param [in]  sz
+ *                  Number of data bytes (in specified data buffer whose values are to be set to the specified value).
+ * @param [in]  val
+ *                  The specified value (to which data bytes in data buffer will be set).
+ * @param [out] pBuf
+ *                  The specified data buffer (whose data bytes will be set to the specified value).
+ * @return      None
+ */
+NMI_API void m2m_memset(uint8 *pBuf, uint8 val, uint32 sz);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          uint16 m2m_strlen(uint8 * pcStr);
+ * @brief       Returns the length of a null terminated string buffer.
+ * @param [in]  pcStr
+ *                  Null terminated string buffer.
+ * @return      Length of the string in the specified string buffer.
+ */
+NMI_API uint16 m2m_strlen(uint8 *pcStr);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          sint8 m2m_memcmp(uint8 *pu8Buff1, uint8 *pu8Buff2, uint32 u32Size);
+ * @brief       Compare specified number of data bytes in pu8Buff1 and pu8Buff2 and decide if they all match.
+ * @param [in]  u32Size
+ *                  Number of data bytes to compare.
+ * @param [in]  pu8Buff1
+ *                  One of two data buffers for the comparison.
+ * @param [in]  pu8Buff2
+ *                  One of two data buffers for the comparison.
+ * @return      Zero if matched, one if not matched.
+ */
+NMI_API sint8 m2m_memcmp(uint8 *pu8Buff1, uint8 *pu8Buff2, uint32 u32Size);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          uint8 m2m_strncmp(uint8 *pcS1, uint8 *pcS2, uint16 u16Len);
+ * @brief       Compare specified number of data bytes in string buffers pcS1 and pcS2.
+ * @param [in]  u16Len
+ *                  Number of data bytes to compare.
+ * @param [in]  pcS1
+ *                  First of two string buffers for the comparison.
+ * @param [in]  pcS2
+ *                  Second of two string buffers for the comparison.
+ * @return      0 if matched, -1 if the first non-matching byte in pcS1 is smaller than that in pcS2, +1 if it is bigger.
+ */
+NMI_API uint8 m2m_strncmp(uint8 *pcS1, uint8 *pcS2, uint16 u16Len);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          uint8 * m2m_strstr(uint8 *pcIn, uint8 *pcStr);
+ * @brief       Find the occurrence of pcStr string in pcIn string.
+ * @param [in]  pcStr
+ *                  One of two string buffers.
+ * @param [in]  pcIn
+ *                  One of two string buffers.
+ * @return      If pcStr string is part of pcIn string return a valid pointer to the start of pcStr within pcIn. If not, a NULL Pointer is returned.
+ */
+NMI_API uint8 *m2m_strstr(uint8 *pcIn, uint8 *pcStr);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          uint8 m2m_checksum(uint8* buf, int sz);
+ * @brief       Calculates checksum for the specified number of data bytes in specified data buffer.
+ * @param [in]  sz
+ *                  Number of data bytes used in the checksum calculation.
+ * @param [in]  buf
+ *                  The specified data buffer (whose data bytes will be used to calculate the checksum).
+ * @return      The calculated checksum.
+ */
+NMI_API uint8 m2m_checksum(uint8 *buf, int sz);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          sint8 hexstr_2_bytes(uint8 *pu8Out, uint8 *pu8In, uint8 u8SizeOut);
+ * @brief       Converts a string of hex characters to bytes.
+ * @param[out]  pu8Out
+ *                  Output buffer (eg {0x11, 0x12, 0x13,...})
+ * @param[in]   pu8In
+ *                  Input buffer (eg {0x31, 0x31, 0x31, 0x32, 0x31, 0x33, ...})
+ * @param[in]   u8SizeOut
+ *                  Length of output buffer (should be half of the length of the input buffer).
+ * @return      @ref M2M_SUCCESS if successful, M2M_ERR_INVALID_ARG otherwise (eg unrecognised hexchar in input).
+ */
+sint8 hexstr_2_bytes(uint8 *pu8Out, uint8 *pu8In, uint8 u8SizeOut);
+
+/*!
+ * @ingroup     COMMONAPI
+ * @fn          void (*at_sb_printf)(const char *_format, ...);
+ * @brief       Chooses which function to use in order to output debug.
+ */
+//NMI_API void (*at_sb_printf)(const char *_format, ...);
 #ifdef __cplusplus
 }
- #endif
-#endif	/*_NM_COMMON_H_*/
+#endif
+#endif  /*_NM_COMMON_H_*/

--- a/asf/common/components/wifi/winc1500/common/include/nm_debug.h
+++ b/asf/common/components/wifi/winc1500/common/include/nm_debug.h
@@ -1,39 +1,32 @@
-/**
+﻿/**
  *
  * \file
  *
  * \brief This module contains debug APIs declarations.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -72,7 +65,7 @@
 
 #if (CONF_WINC_DEBUG == 1)
 #undef M2M_PRINT
-#define M2M_PRINT(...)							do{CONF_WINC_PRINTF(__VA_ARGS__);CONF_WINC_PRINTF("\r");}while(0)
+#define M2M_PRINT(...)							do{CONF_WINC_PRINTF(__VA_ARGS__);}while(0)
 #if (M2M_LOG_LEVEL >= M2M_LOG_ERROR)
 #undef M2M_ERR
 #define M2M_ERR(...)							do{CONF_WINC_PRINTF("(APP)(ERR)[%s][%d]",__FUNCTION__,__LINE__); CONF_WINC_PRINTF(__VA_ARGS__);CONF_WINC_PRINTF("\r");}while(0)

--- a/asf/common/components/wifi/winc1500/common/source/nm_common.c
+++ b/asf/common/components/wifi/winc1500/common/source/nm_common.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains common APIs declarations.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -93,7 +86,7 @@ uint8 m2m_strncmp(uint8 *pcS1, uint8 *pcS2, uint16 u16Len)
     return 0;
 }
 
-/* Finds the occurance of pcStr in pcIn.
+/* Finds the occurrence of pcStr in pcIn.
 If pcStr is part of pcIn it returns a valid pointer to the start of pcStr within pcIn.
 Otherwise a NULL Pointer is returned.
 */
@@ -133,4 +126,38 @@ sint8 m2m_memcmp(uint8 *pu8Buff1,uint8 *pu8Buff2 ,uint32 u32Size)
 		}
 	}
 	return s8Result;
+}
+
+/* Convert hexchar to value 0-15 */
+static uint8 hexchar_2_val(uint8 ch)
+{
+    /* ch -= '0' */
+    ch -= 0x30;
+    if(ch <= 9)
+        return ch;
+    /* OR with 0x20 to convert upper case to lower case. */
+    ch |= 0x20;
+    /* ch -= ('a'-'0') */
+    ch -= 0x31;
+    if(ch <= 5)
+        return ch + 10;
+    return 0xFF;
+}
+
+/* Convert hexstring to bytes */
+sint8 hexstr_2_bytes(uint8 *pu8Out, uint8 *pu8In, uint8 u8SizeOut)
+{
+    while(u8SizeOut--)
+    {
+        uint8   u8Out = hexchar_2_val(*pu8In++);
+        if(u8Out > 0xF)
+            return M2M_ERR_INVALID_ARG;
+        *pu8Out = u8Out * 0x10;
+        u8Out = hexchar_2_val(*pu8In++);
+        if(u8Out > 0xF)
+            return M2M_ERR_INVALID_ARG;
+        *pu8Out += u8Out;
+        pu8Out++;
+    }
+    return M2M_SUCCESS;
 }

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_ate_mode.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_ate_mode.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC ATE Test Driver Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -49,6 +42,7 @@ INCLUDES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 #include "common/include/nm_common.h"
 #include "driver/include/m2m_types.h"
+
 
 /** \defgroup m2m_ate ATE
 */
@@ -70,7 +64,7 @@ Maximum number of all rates (b,g and n)
 /*!< Minimum number of length for each frame
  */ 
 #define M2M_ATE_SUCCESS					(M2M_SUCCESS)
-/*!< No Error and operation has been completed successfully.
+/*!< No Error and operation completed successfully.
 */
 #define M2M_ATE_ERR_VALIDATE			(M2M_ERR_FAIL)	
 /*!< Error in parameters passed to functions.
@@ -186,7 +180,7 @@ typedef enum {
  */
 typedef enum {
 	M2M_ATE_TX_DPD_DYNAMIC	= 0x00,
-	/*!< Dynamic mode indicates that DPD values will be set dynamically from a lookup table pre-set with the DPD coefficents.
+	/*!< Dynamic mode indicates that DPD values will be set dynamically from a lookup table pre-set with the DPD coefficients.
 	*/
 	M2M_ATE_TX_DPD_BYPASS	= 0x01,
 	/*!< Bypass mode indicates that the DPD control will be bypassed.
@@ -247,10 +241,10 @@ typedef enum {
  */
 typedef enum {
 	M2M_ATE_TX_MODE_NORM	= 0x00,
-	/*!< When the TX source is set to PHY,normal mode indicates that continous transmission is disabled. 
+	/*!< When the TX source is set to PHY,normal mode indicates that continuous transmission is disabled.
 	*/
 	M2M_ATE_TX_MODE_CW		= 0x01,
-	/*!< When the TX source is set to PHY, continous mode indicates that transmission sequences occur back to back in a continous wave from the PHY layer.
+	/*!< When the TX source is set to PHY, continuous mode indicates that transmission sequences occur back to back in a continuous wave from the PHY layer.
 	*/
 }tenuM2mAteTxMode;
 
@@ -334,7 +328,7 @@ typedef struct {
 
 /*!
  *@struct	tstrM2mAteRxStatus
- *@brief	Used to save recieve test case configuration  
+ *@brief	Used to save receive test case configuration
  *@see    tenuM2mAteRxPwrMode
  */
 typedef struct {
@@ -407,7 +401,7 @@ typedef struct {
 	/*!< Set to 0 to use the XO offset provided in xo_offset_x1000. Set to 1 to use XO offset programmed on WINC efuse. 
 	*/
 	uint8    self_mac_addr[6];
-	/*!< Set to the self mac address required to be overriden. 
+	/*!< Set to the self mac address required to be overridden.
 	*/
 	uint8    peer_mac_addr[6];
 	/*!< Set to the source mac address expected to filter frames from. 

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_crypto.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_crypto.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC Crypto Application Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -94,7 +87,7 @@ typedef enum{
 @typedef \
 	tpfAppCryproCb
 
-@brief			Crypto Calback function receiving the crypto related messages
+@brief			Crypto Callback function receiving the crypto related messages
 @param [in]	u8MsgType
 				Crypto command about which the notification is received.
 @param [in]	pvResp
@@ -123,7 +116,7 @@ FUNCTION PROTOTYPES
 @brief	crypto initialization.
 
 @param[in]	pfAppCryproCb
-				Pointer to the Crypto Calback function receiving the crypto related messages.
+				Pointer to the Crypto Callback function receiving the crypto related messages.
 @see
 	tpfAppCryproCb
 	
@@ -158,7 +151,7 @@ sint8 m2m_crypto_sha256_hash_init(tstrM2mSha256Ctxt *psha256Ctxt);
 				Buffer holding the data submitted to the hash.
 				
 @param [in]	u16DataLength
-				Size of the data bufefr in bytes.
+				Size of the data buffer in bytes.
 @pre SHA256 module should be initialized first through m2m_crypto_sha256_hash_init function.
 
 @see m2m_crypto_sha256_hash_init
@@ -257,7 +250,7 @@ sint8 m2m_crypto_rsa_sign_verify(uint8 *pu8N, uint16 u16NSize, uint8 *pu8E, uint
 				The length of the hash digest.
 				
 @param[out] pu8RsaSignature
-				Pointer to a user buffer allocated by teh caller shall hold the generated signature.
+				Pointer to a user buffer allocated by the caller shall hold the generated signature.
 				
 @return		
 	The function returns @ref M2M_SUCCESS for successful operation and a negative value otherwise.

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_ota.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_ota.h
@@ -4,40 +4,68 @@
  *
  * \brief WINC OTA Upgrade API Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
  */
+
+/**@defgroup OTAAPI OTA
+   @brief
+        The WINC supports OTA (Over-The-Air) updates. Using the APIs described in this module,
+        it is possible to request an ATWINC15x0 to update its firmware image, or safely rollback to
+        the previous firmware image.\n Note that it is NOT possible to update other areas of the WINC
+		flash (e.g. the HTTP file area) using the OTA mechanism.\n\n There are also APIs to download 
+		files and store them in the WINC's Flash (supported by ATWINC1510 only), which can be used 
+		for Host MCU OTA updates or accessing information stored remotely.
+    @{
+        @defgroup   OTACALLBACKS    Callbacks
+        @brief
+            Lists the different callbacks that can be used during OTA updates.\n
+            Callbacks of type @ref tpfOtaNotifCb and @ref tpfOtaUpdateCb should be passed
+            onto @ref m2m_ota_init at system initialization. Other callbacks are provided
+            to handle the various steps of Host File Download.
+
+        @defgroup   OTADEFINE       Defines
+        @brief
+            Specifies the macros and defines used by the OTA APIs.
+
+        @defgroup   OTATYPEDEF      Enumerations and Typedefs
+        @brief
+            Specifies the enums and Data Structures used by the OTA APIs.
+
+        @defgroup   OTAFUNCTIONS    Functions
+        @brief
+            Lists the full set of available APIs to manage OTA updates and Host File Downloads.
+        @{
+            @defgroup OTACOMMON     Common
+            @defgroup WINCOTA       WINC
+            @defgroup HFD           HFD
+        @}
+    @}
+*/
 
 #ifndef __M2M_OTA_H__
 #define __M2M_OTA_H__
@@ -49,378 +77,716 @@ INCLUDES
 #include "common/include/nm_common.h"
 #include "driver/include/m2m_types.h"
 #include "driver/source/nmdrv.h"
-/**@addtogroup WlanEnums DataTypes
- * @ingroup m2m_wifi
+
+/*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
+MACROS
+*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
+
+/**@addtogroup OTACALLBACKS
+ * @{
  */
- /* @{ */
-
-
 /*!
-@typedef void (*tpfOtaNotifCb) (tstrOtaUpdateInfo *);
+@typedef void (*tpfOtaNotifCb) (tstrOtaUpdateInfo *pstrOtaUpdateInfo);
 
-@brief 	
-		A callback to get notification about a potential OTA update.
- 
-@param[in] pstrOtaUpdateInfo 
-		A structure to provide notification payload.
-@sa 
-	tstrOtaUpdateInfo
-@warning 
-		The notification is not supported (Not implemented yet)
+@brief
+    A callback to get notification about a potential OTA update.
 
+@param[in] pstrOtaUpdateInfo
+    A structure to provide notification payload.
+
+@sa
+    tstrOtaUpdateInfo
+
+@warning
+    The notification is not supported (Not implemented yet)
 */
-typedef void (*tpfOtaNotifCb) (tstrOtaUpdateInfo * pstrOtaUpdateInfo);
+typedef void (*tpfOtaNotifCb)(tstrOtaUpdateInfo *pstrOtaUpdateInfo);
 
 
 /*!
 @typedef void (*tpfOtaUpdateCb) (uint8 u8OtaUpdateStatusType ,uint8 u8OtaUpdateStatus);
 
 @brief 
-   A callback to get OTA status update, the callback provide the status type and its status.
-   The OTA callback provides the download status, the switch to the downloaded firmware status and roll-back status. 
+   A callback to get OTA status update, the callback provides the status type and its status.\n
+   The OTA callback provides the download status, the switch to the downloaded firmware status,
+   roll-back status and Host File Download status.
  
-@param[in] u8OtaUpdateStatusType Possible values are listed in tenuOtaUpdateStatusType.
+@param[in] u8OtaUpdateStatusType
+    Possible values are listed in @ref tenuOtaUpdateStatusType.
 
-@param[in] u8OtaUpdateStatus Possible values are listed as enumerated by @ref tenuOtaUpdateStatus. 
+@param[in] u8OtaUpdateStatus
+    Possible values are listed as enumerated by @ref tenuOtaUpdateStatus.
+
+@note
+    Executes other callbacks passed to the OTA module.
 
 @see
-	tenuOtaUpdateStatusType
-	tenuOtaUpdateStatus
+    tenuOtaUpdateStatusType
+    tenuOtaUpdateStatus
  */
-typedef void (*tpfOtaUpdateCb) (uint8 u8OtaUpdateStatusType ,uint8 u8OtaUpdateStatus);
- /**@}*/
+typedef void (*tpfOtaUpdateCb)(uint8 u8OtaUpdateStatusType, uint8 u8OtaUpdateStatus);
+
+/*!
+@typedef void (*tpfFileGetCb) (uint8 u8Status, uint8 u8Handler, uint32 u32Size);
+
+@brief 
+   A callback to notify the application of the result of the download (success/fail),
+   the generated handler ID and the size of the file which has just finished
+   downloading (size expressed in bytes).
+
+@param[in] u8Status
+    Status of the operation (see @ref tenuOtaUpdateStatus).
+
+@param[in] u8Handler
+    Generated handler ID for the new file.
+
+@param[in] u32Size
+    Total size of the downloaded file (in bytes).
+ 
+@warning
+    The file handler passed onto this callback will be the valid file handler generated
+    by the WINC when the download finished successfully. This handler will be required
+    for all operations on the file like read and erase.
+ */
+typedef void (*tpfFileGetCb)(uint8 u8Status, uint8 u8Handler, uint32 u32Size);
+
+/*!
+@typedef void (*tpfFileReadCb) (uint8 u8Status, void *pBuff, uint32 u32Size);
+
+@brief
+   A callback to handle a buffer of data after requesting a Host File read.
+   The callback will provide the status of the read operation and if successful,
+   a pointer to a valid placeholder containing the data read and the amount of
+   data available. Such callback is required when using Host File read via the HIF.
+
+@param[in] u8Status
+    Status of the operation (see @ref tenuOtaUpdateStatus).
+
+@param[in] pBuff
+    Pointer to a placeholder where the data can be retrieved from.
+
+@param[in] u32Size
+    Amount of data available after reading (in bytes).
+
+@warning
+    After the callback is executed, pBuff will be freed.
+ */
+typedef void (*tpfFileReadCb)(uint8 u8Status, void *pBuff, uint32 u32Size);
+
+/*!
+@typedef void (*tpfFileEraseCb) (uint8 u8Status);
+
+@brief
+   A callback executed when the file erase has been completed.
+
+@param[in] u8Status
+    Status of the operation (see @ref tenuOtaUpdateStatus).
+ */
+typedef void (*tpfFileEraseCb)(uint8 u8Status);
+/**@}*/     //OTACALLBACKS
+
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 FUNCTION PROTOTYPES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 
 #ifdef __cplusplus
-     extern "C" {
+extern "C" {
 #endif
 
-/** @defgroup OtaInitFn m2m_ota_init
- *  @ingroup WLANAPI
-* Synchronous initialization function for the OTA layer by registering the update callback.
-* The notification callback is not supported at the current version. Calling this API is a
-* MUST for all the OTA API's.
-
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb  pfOtaUpdateCb,tpfOtaNotifCb  pfOtaNotifCb)
-
-@param [in]	pfOtaUpdateCb
-				OTA Update callback function
-				
-@param [in]	pfOtaNotifCb
-				OTA notify callback function 
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb  pfOtaUpdateCb,tpfOtaNotifCb  pfOtaNotifCb);
- /**@}*/
- 
- /** @defgroup OtaNotifStFn m2m_ota_notif_set_url
- *  @ingroup WLANAPI
- * Set the OTA notification server URL, the functions need to be called before any check for update
- */
- /**@{*/
-/*!
-@fn	\
-	NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url);
-
-@param [in]	u8Url
-			 Set the OTA notification server URL, the functions need to be called before any check for update.
-@warning 
-			Calling m2m_ota_init is required
-			Notification Server is not supported in the current version (function is not implemented)
-@see    
-			m2m_ota_init			
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url);
- /**@}*/
- /** @defgroup OtaNotifCheckFn m2m_ota_notif_check_for_update
- *  @ingroup WLANAPI
- * Synchronous function to check for the OTA update using the Notification Server
- * URL. Function is not implemented (not supported at the current version)
- *
- */
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8  m2m_ota_notif_check_for_update(void);
-
-@warning 
-		Function is not implemented (not supported at the current version)
-		
-@sa   
-			m2m_ota_init
-			m2m_ota_notif_set_url
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8  m2m_ota_notif_check_for_update(void);
- /**@}*/
- /** @defgroup OtaSched m2m_ota_notif_sched
-*  @ingroup WLANAPI
-* Schedule OTA notification Server check for update request after specific number of days
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period);
-
-
-@param [in]	u32Period
-			Period in days
-
-@sa 
-		m2m_ota_init
-		m2m_ota_notif_check_for_update
-		m2m_ota_notif_set_url
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period);
-  /**@}*/
-/** @defgroup OtaStartUpdatefn m2m_ota_start_update
-*  @ingroup WLANAPI
-*	Request OTA start update using the downloaded URL, the OTA module will download the OTA image and ensure integrity of the image, 
-*   and update the validity of the image in control structure. Switching to that image requires calling @ref m2m_ota_switch_firmware API. 
-*   As a prerequisite @ref m2m_ota_init should be called before using @ref m2m_ota_start().
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_start_update(uint8 * u8DownloadUrl);
-
-@param [in]	u8DownloadUrl
-		The download firmware URL, you get it from device info according to the application server
-
-@warning
-	Calling this API does not guarantee OTA WINC image update, It depends on the connection with the download server and the validity of the image.
-	If the API response is failure this may invalidate the roll-back image if it was previously valid, since the WINC does not have any internal memory 
-	except the flash roll-back image location to validate the downloaded image from
-				
-@see		
-		m2m_ota_init
-		tpfOtaUpdateCb
-		
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-\section Example
-   The example shows an example of how the OTA image update is carried out.
-@code
-static void OtaUpdateCb(uint8 u8OtaUpdateStatusType ,uint8 u8OtaUpdateStatus)
-{
-	if(u8OtaUpdateStatusType == DL_STATUS) {
-		if(u8OtaUpdateStatus == OTA_STATUS_SUCSESS) {
-			//switch to the upgraded firmware
-			m2m_ota_switch_firmware();
-		}
-	}
-	else if(u8OtaUpdateStatusType == SW_STATUS) {
-		if(u8OtaUpdateStatus == OTA_STATUS_SUCSESS) {
-			M2M_INFO("Now OTA successfully done");
-			//start the host SW upgrade then system reset is required (Reinitialize the driver)
-		}
-	}
-}
-void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
-{
-	case M2M_WIFI_REQ_DHCP_CONF:
-	{
-		//after successfully connection, start the over air upgrade
-		m2m_ota_start_update(OTA_URL);
-	}
-	break;
-	default:
-	break;
-}
-int main (void)
-{
-	tstrWifiInitParam param;
-	tstr1xAuthCredentials gstrCred1x    = AUTH_CREDENTIALS;
-	nm_bsp_init();
-	
-	m2m_memset((uint8*)&param, 0, sizeof(param));
-	param.pfAppWifiCb = wifi_event_cb;
-	
-	//Initialize the WINC Driver
-	ret = m2m_wifi_init(&param);
-	if (M2M_SUCCESS != ret)
-	{
-		M2M_ERR("Driver Init Failed <%d>\n",ret);
-		while(1);
-	}
-	//Initialize the OTA module
-	m2m_ota_init(OtaUpdateCb,NULL);
-	//connect to AP that provide connection to the OTA server
-	m2m_wifi_default_connect();
-
-	while(1)
-	{
-		
-		//Handle the app state machine plus the WINC event handler                                                                     
-		while(m2m_wifi_handle_events(NULL) != M2M_SUCCESS) {
-			
-		}
-		
-	}
-}
-@endcode		
-
-*/
-NMI_API sint8 m2m_ota_start_update(uint8 * u8DownloadUrl);
-    /**@}*/
-/** @defgroup OtaStartUpdatefn m2m_ota_start_update_crt
-*  @ingroup WLANAPI
-*	Request OTA start for cortus application image using the downloaded URL, the OTA module will download the OTA image and ensure integrity of the image, 
-*   and update the validity of the image in control structure. Switching to that image requires calling @ref m2m_ota_switch_crt API. 
-*   As a prerequisite @ref m2m_ota_init should be called before using @ref m2m_ota_start_update_crt().
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_start_update_crt(uint8 * u8DownloadUrl);
-
-@param [in]	u8DownloadUrl
-		The cortus application image url.
-@warning
-	Calling this API does not guarantee cortus application image update, It depends on the connection with the download server and the validity of the image.
-	If the API response is failure this may invalidate the roll-back image if it was previously valid, since the WINC does not have any internal memory 
-	except the flash roll-back image location to validate the downloaded image from
-				
-@see		
-		m2m_ota_init
-		tpfOtaUpdateCb
-		
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_start_update_crt(uint8 * u8DownloadUrl);
-  /**@}*/
-/** @defgroup OtaRollbackfn m2m_ota_rollback
-*  @ingroup WLANAPI
-	Request OTA Roll-back to the old (other) WINC image, the WINC firmware will check the validation of the Roll-back image
-	and switch to it if it is valid.
-	If the API response is success, system restart is required (re-initialize the driver with hardware rest) update the host driver version may
-	be required if it is did not match the minimum version supported by the  WINC firmware.
-
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_rollback(void);
-
-@sa 
-	m2m_ota_init
-	m2m_ota_start_update	
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_rollback(void);
-    /**@}*/
-/** @defgroup OtaRollbackfn m2m_ota_rollback_crt
-*  @ingroup WLANAPI
-	Request Cortus application OTA Roll-back to the old (other) cortus application image, the WINC firmware will check the validation of the Roll-back image
-	and switch to it if it is valid.
-	If the API response is success, system restart is required (re-initialize the driver with hardware rest) update the host driver version may
-	be required.
-
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_rollback_crt(void);
-
-@sa 
-	m2m_ota_init
-	m2m_ota_start_update_crt	
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_rollback_crt(void);
-  /**@}*/
-/** @defgroup OtaAbortfn m2m_ota_abort
-*  @ingroup WLANAPI
-	Request abort of current OTA download.
-	The WINC firmware will terminate the OTA download if one is in progress.
-	If no download is in progress, the API will respond with failure.
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_abort(void);
-
-@return
-	The function returns @ref M2M_SUCCESS for successful operation and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_abort(void);
-  /**@}*/
-  /**@}*/
-/** @defgroup OtaSwitchFirmware m2m_ota_switch_firmware
-*  @ingroup WLANAPI
-* Switch to the upgraded Firmware, that API will update the control structure working image to the upgraded image
-  take effect will be on the next system restart
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_switch_firmware(void);
-
-@warning
-   It is important to note that if the API succeeds, system restart is required (re-initializing the driver with hardware reset) updating the host driver version may be required 
-   if it does not match the minimum driver version supported by the WINC's firmware.
-@sa 
-	m2m_ota_init
-	m2m_ota_start_update
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_switch_firmware(void);
-  /**@}*/
-  /**@}*/
-/** @defgroup OtaSwitchFirmware m2m_ota_switch_crt
-*  @ingroup WLANAPI
-* Switch to the upgraded cortus application, that API will update the control structure working image to the upgraded image
-  take effect will be on the next system restart
-*/
-  /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_switch_firmware(void);
-
-@warning
-   It is important to note that if the API succeeds, system restart is required (re-initializing the driver with hardware reset) updating the host driver version may be required 
-   if it does not match the minimum driver version supported by the WINC's firmware.
-@sa 
-	m2m_ota_init
-	m2m_ota_start_update_crt
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_switch_crt(void);
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_get_firmware_version(void);
+@ingroup OTACOMMON
+@fn \
+    sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNotifCb);
 
 @brief
-	Get the OTA Firmware version.
+    Synchronous initialization function for the OTA layer by registering the update callback.\n
+    The notification callback is not supported at the current version. Calling this API is a
+    MUST for all the OTA API's.
+
+@param[in]  pfOtaUpdateCb
+    OTA Update callback function.
+
+@param[in]  pfOtaNotifCb
+    OTA Notify callback function.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNotifCb);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8  m2m_ota_notif_set_url(uint8 * u8Url);
+
+@brief
+    Set the OTA notification server URL, the function needs to be called before any check for update.\n
+    This functionality is not supported by WINC firmware.
+
+@param[in]  u8Url
+    Set the OTA notification server URL, the function needs to be called before any check for update.
+
+@pre
+    Prior calling of @ref m2m_ota_init is required.
+
+@warning
+    Notification Server is not supported in the current version (function is not implemented).
+
+@see
+    m2m_ota_init
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8  m2m_ota_notif_set_url(uint8 *u8Url);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8  m2m_ota_notif_check_for_update(void);
+
+@brief
+    Synchronous function to check for the OTA update using the Notification Server URL.\n
+    Function is not implemented (not supported at the current version).
+
+@warning
+    Function is not implemented (not supported at the current version).
+
+@sa
+    m2m_ota_init
+    m2m_ota_notif_set_url
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8  m2m_ota_notif_check_for_update(void);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8 m2m_ota_notif_sched(uint32 u32Period);
+
+@brief
+    Schedule OTA notification Server check for update request after specific number of days.\n
+    Function is not implemented (not supported at the current version).
+
+@param[in]  u32Period
+    Period in days
+
+@warning
+    Function is not implemented (not supported at the current version).
+
+@sa
+    m2m_ota_init
+    m2m_ota_notif_check_for_update
+    m2m_ota_notif_set_url
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8 m2m_ota_start_update(unsigned char * pcDownloadUrl);
+
+@brief
+    Request OTA start update using the download URL. The OTA module will download the OTA image, ensure integrity of the image
+    and update the validity of the image in the control structure. On completion, a callback of type @ref tpfOtaUpdateCb is called
+    (callback previously provided via @ref m2m_ota_init). Switching to the updated image additionally requires completion of
+    @ref m2m_ota_switch_firmware and @ref system_reset.
+
+@param[in]  pcDownloadUrl
+    The download firmware URL, according to the application server.
+
+@warning
+    Calling this API does not guarantee OTA WINC image update, it depends on the connection with the
+    download server and the validity of the image.\n
+    Calling this API invalidates any previous valid rollback image, irrespective of the result, but when
+    the OTA succeeds, the current image will become the rollback image after @ref m2m_ota_switch_firmware.
+
+@pre
+    @ref m2m_ota_init is a prerequisite and must have been called before using @ref m2m_ota_start_update.\n
+    Switching to the newly downloaded image requires calling @ref m2m_ota_switch_firmware API.
+
+@sa
+    @ref m2m_ota_init
+    @ref m2m_ota_switch_firmware
+    @ref tpfOtaUpdateCb
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    Note that successful operation in this context means the OTA update request has reached the firmware OTA module.
+    It does not indicate whether or not the image update succeeded.
+
+@section OTAExample Example
+        This example shows how an OTA image update and switch is carried out.
+        It demonstrates use of the following OTA APIs:
+            - @ref m2m_ota_init
+            - @ref tpfOtaUpdateCb
+            - @ref m2m_ota_start_update
+            - @ref m2m_ota_switch_firmware
+            - @ref m2m_ota_rollback
+
+@code
+static void OtaUpdateCb(uint8 u8OtaUpdateStatusType, uint8 u8OtaUpdateStatus)
+{
+    M2M_INFO("%d %d\n", u8OtaUpdateStatusType, u8OtaUpdateStatus);
+    switch(u8OtaUpdateStatusType)
+    {
+    case DL_STATUS:
+        if(u8OtaUpdateStatus == OTA_STATUS_SUCCESS)
+        {
+            M2M_INFO("OTA download succeeded\n");
+
+            // In this case the application MAY WANT TO update the host driver before calling
+            // @ref m2m_ota_switch_firmware(). Switching firmware image and resetting without
+            // updating host driver may lead to suboptimal functionality.
+
+            // Switch to the upgraded firmware
+            M2M_INFO("Now switching active partition...\n");
+            m2m_ota_switch_firmware();
+        }
+        break;
+    case SW_STATUS:
+    case RB_STATUS:
+        if(u8OtaUpdateStatus == OTA_STATUS_SUCCESS)
+        {
+            M2M_INFO("Switch/Rollback succeeded\n");
+
+            // Start the host SW upgrade if required, then system reset is required (Reinitialize the driver)
+
+            M2M_INFO("Now resetting the system...\n");
+            system_reset();
+        }
+        break;
+    }
+}
+
+static void wifi_event_cb(uint8 u8WiFiEvent, void *pvMsg)
+{
+    // ...
+    case M2M_WIFI_REQ_DHCP_CONF:
+    {
+        // After successful connection, start the OTA upgrade
+        m2m_ota_start_update(OTA_URL);
+    }
+    break;
+    default:
+    break;
+    // ...
+}
+
+int main (void)
+{
+    tstrWifiInitParam     param;
+    sint8                 s8Ret             = M2M_SUCCESS;
+    bool                  rollback_required = FALSE;
+    tstr1xAuthCredentials gstrCred1x        = AUTH_CREDENTIALS;
+
+    // System init, etc should be here...
+
+    m2m_memset((uint8*)&param, 0, sizeof(param));
+    param.pfAppWifiCb = wifi_event_cb;
+
+    // Initialize the WINC Driver
+    s8Ret = m2m_wifi_init(&param);
+    if(s8Ret == M2M_ERR_FW_VER_MISMATCH)
+    {
+        M2M_ERR("Firmware version mismatch\n");
+    }
+    if (M2M_SUCCESS != s8Ret)
+    {
+        M2M_ERR("Driver Init Failed <%d>\n",s8Ret);
+        while(1);
+    }
+    // Initialize the OTA module
+    m2m_ota_init(OtaUpdateCb,NULL);
+
+    // Connect to AP that provides connection to the OTA server
+    m2m_wifi_default_connect();
+
+    while(1)
+    {
+        // Handle the app state machine plus the WINC event handler
+        while(m2m_wifi_handle_events(NULL) != M2M_SUCCESS) {
+        }
+    }
+}
+@endcode
+*/
+NMI_API sint8 m2m_ota_start_update(unsigned char *pcDownloadUrl);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8 m2m_ota_rollback(void);
+
+@brief
+    Request OTA Roll-back to the old (inactive) WINC image, the WINC firmware will check the validity of the inactive image
+    and activate it if valid. On completion, a callback of type @ref tpfOtaUpdateCb is called (application must previously have
+    provided the callback via @ref m2m_ota_init). If the callback indicates successful activation, the newly-activated image
+    will start running after next system reset.
+
+@warning
+    If rollback requires a host driver update in order to maintain HIF compatibility (HIF
+    major value change), then it is recommended to update the host driver prior to calling this API.\n
+    In the event of system reset with incompatible driver/firmware, compatibility can be
+    recovered by calling @ref m2m_ota_rollback or @ref m2m_ota_switch_firmware. See @ref OTAExample.
+
+@sa
+    m2m_ota_init
+    m2m_ota_start_update
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8 m2m_ota_rollback(void);
+
+/*!
+@ingroup OTACOMMON
+@fn \
+    sint8 m2m_ota_abort(void);
+
+@brief
+    Request the WINC to abort an OTA or Host File download in progress.\n
+    If no download is in progress, the API will respond with failure.
+
+@sa
+    m2m_ota_init
+    m2m_ota_start_update
+
+@return
+    The function returns @ref M2M_SUCCESS for a successful operation and a negative value otherwise.
+*/
+NMI_API sint8 m2m_ota_abort(void);
+
+/*!
+@ingroup WINCOTA
+@fn \
+    sint8 m2m_ota_switch_firmware(void);
+
+@brief
+    Request switch to the updated WINC image. The WINC firmware will check the validity of the
+    inactive image and activate it if valid. On completion, a callback of type @ref tpfOtaUpdateCb
+    is called (application must previously have provided the callback via @ref m2m_ota_init).
+    If the callback indicates successful activation, the newly-activated image will start running
+    after next system reset.
+
+@warning
+    If switch requires a host driver update in order to maintain HIF compatibility (HIF
+    major value change), then it is recommended to update the host driver prior to calling this API.\n
+    In the event of system reset with incompatible driver/firmware, compatibility can be
+    recovered by calling @ref m2m_ota_rollback or @ref m2m_ota_switch_firmware. See @ref OTAExample.
+
+@sa
+    m2m_ota_init
+    m2m_ota_start_update
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*/
+NMI_API sint8 m2m_ota_switch_firmware(void);
+
+/*!
+@ingroup HFD
+@fn \
+    sint8 m2m_ota_host_file_get(unsigned char *pcDownloadUrl, tpfFileGetCb pfHFDGetCb);
+
+@brief
+    Download a file from a remote location and store it in WINC's Flash.
+
+@param[in]  pcDownloadUrl
+    Url pointing to the remote file. HTTP/HTTPS only.
+
+@param[in]  pfHFDGetCb
+    Pointer to a callback (see @ref tpfFileGetCb) to be executed when the download finishes.
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@pre
+    Requires @ref m2m_ota_init to be called before a download can start.
+
+@warning
+    This functionality is only supported from WINC release 19.6.1 onwards.
+    The maximum file size that can be stored in WINC1510 is 508KB, the
+    WINC1500 variant is not supported for Host File Download.\n
+    Concurrent use of Host File Get and WINC OTA is not possible.\n
+    Providing a callback is mandatory.
+
+@sa
+    m2m_ota_init
+    tpfFileGetCb
+*/
+NMI_API sint8 m2m_ota_host_file_get(unsigned char *pcDownloadUrl, tpfFileGetCb pfHFDGetCb);
+
+/*!
+@ingroup HFD
+@fn \
+    sint8 m2m_ota_host_file_read_hif(uint8 u8Handler, uint32 u32Offset, uint32 u32Size, tpfFileReadCb pfHFDReadCb);
+
+@brief
+    Read a certain amount of bytes from a file previously stored in WINC's Flash using HIF transfer.
+
+@param[in]  u8Handler
+    Handler of the file we are trying to read from. Must be valid.
+
+@param[in]  u32Offset
+    Offset from start of the file to read from (in bytes).
+
+@param[in]  u32Size
+    The amount of data to read (in bytes).
+
+@param[in]  pfHFDReadCb
+    Callback (see @ref tpfFileReadCb) to be executed when the read operation completes.
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@pre
+    Requires @ref m2m_ota_init to be called before a read via HIF can be requested.
+
+@warning
+    There is a limitation on how much data can be transferred at a time using HIF read, which is 128 bytes.
+    The limitation described above can potentially reduce the speed of the read due to extra overhead, but
+    using the HIF is non-blocking and therefore the Application can continue execution as normal, being
+    interrupted only when data is available. Another advantage is that it does not require the WINC to be
+    reset or put in download mode, as it is the case for reading the file via SPI (see @ref m2m_ota_host_file_read_spi).\n
+    A valid file handler must be provided, this means that it needs to match the handler internally stored
+    by the WINC and must not be @ref HFD_INVALID_HANDLER.\n
+    Providing a callback is mandatory.
+
+@note
+    When calling this API while specifying a size > 128 bytes, the read will be limited to the first 128 bytes
+    starting at the read offset. It it recommended that a read for sizes above 128 bytes is performed in
+    multiple steps, using the callback to advance the offset and request another read of 128 bytes (or less) each time.
+
+@sa
+    m2m_ota_init
+    m2m_ota_host_file_get
+    tpfFileReadCb
+*/
+NMI_API sint8 m2m_ota_host_file_read_hif(uint8 u8Handler, uint32 u32Offset, uint32 u32Size, tpfFileReadCb pfHFDReadCb);
+
+/*!
+@ingroup HFD
+@fn \
+    sint8 m2m_ota_host_file_read_spi(uint8 u8Handler, uint8 *pu8Buff, uint32 u32Offset, uint32 u32Size);
+
+@brief
+    Read a certain amount of bytes from a file in WINC's Flash using SPI transfer.
+
+@param[in]  u8Handler
+    Handler of the file we are trying to read from. Must be valid.
+
+@param[in]  pu8Buff
+    Pointer to a buffer to store the data being read. Must not be NULL.
+
+@param[in]  u32Offset
+    Offset from start of the file to read from (in bytes).
+
+@param[in]  u32Size
+    The amount of data to read (in Bytes).
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@warning
+    Reading of a file via SPI can be much faster than by reading it via the HIF. However, the read will
+    be blocking and it will require the WINC to be put into download mode prior to the read, the download
+    mode means that the WINC will act as Flash device and not as a Wifi device. So, before using
+    m2m_ota_host_file_read_spi, the Application should call @ref m2m_wifi_download_mode before trying to
+    read. After the read finishes, the WINC needs to be reset (see @ref m2m_wifi_reinit).\n
+    A valid file handler must be provided, this means that it needs to match the handler internally stored
+    by the WINC and must not be @ref HFD_INVALID_HANDLER.
+
+@sa
+    m2m_ota_init
+    m2m_ota_host_file_get
+
+\section Host File Download SPI Read Example
+The following is an example of how to perform a read file from the WINC via SPI.
+@code
+typedef struct {
+    uint8 u8Handler;
+    uint32 u32Offset;
+    uint32 u32Size;
+    uint8 au8Buff[200];
+}FileDescriptor;
+
+tstrWifiInitParam gstrWifiParam;
+static FileDescriptor gstrAppFile;
+
+char *acURL = "http://www.microchip.com/_images/ics/medium-ATWINC1500-MODULE-28.png";
+
+static void ReadFileSPI(void);
+static void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg);
+static void FileGetCallback(uint8 u8Status, uint8 u8Handler, uint32 u32Size);
+static void OtaUpdateCb(uint8 u8OtaUpdateStatusType ,uint8 u8OtaUpdateStatus);
+
+static void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
+{
+    case M2M_WIFI_REQ_DHCP_CONF:
+    {
+        // After successfully connection, start the File Download
+        gstrAppFile.u32Offset = 0;
+        s8Ret = m2m_ota_host_file_get(acURL, FileGetCallback);
+        if(s8Ret != M2M_SUCCESS)
+        {
+            M2M_ERR("File Download Failed!\n");
+        }
+    }
+    break;
+    default:
+    break;
+}
+
+static void OtaUpdateCb(uint8 u8OtaUpdateStatusType ,uint8 u8OtaUpdateStatus)
+{
+    M2M_INFO("%d %d\n",u8OtaUpdateStatusType,u8OtaUpdateStatus);
+
+    if(u8OtaUpdateStatus == OTA_STATUS_SUCCESS)
+    {
+        if(u8OtaUpdateStatusType == HFD_STATUS)
+        {
+            // Read the file and process it
+            ReadFileSPI();
+        }
+    }
+}
+
+static void FileGetCallback(uint8 u8Status, uint8 u8Handler, uint32 u32Size)
+{
+    if(OTA_STATUS_SUCCESS == u8Status)
+    {
+        gstrAppFile.u8Handler = u8Handler;
+        gstrAppFile.u32Size   = u32Size;
+        // File Get Successful
+    }
+    else
+    {
+        M2M_ERR("File Get Failed!\n");
+        // File Get Failed
+    }
+}
+
+static void ReadFileSPI(void)
+{
+    sint8 s8Ret = M2M_ERR_FAIL;
+
+    if(WIFI_STATE_DEINIT != m2m_wifi_get_state())
+        m2m_wifi_deinit(NULL);
+
+    s8Ret = m2m_wifi_download_mode();
+    if(M2M_SUCCESS != s8Ret) goto EXIT;
+
+    // gstrAppFile.u32Offset can be changed to define a starting point for the read,
+    // in which case the size of the requested read should be adjusted to accommodate for this.
+    // This call assumes that m2m_ota_host_file_get was called earlier, in this example it is fine
+    // since ReadFileSPI is only called from the within OtaUpdateCb
+    // This example simply reads the first 200 bytes of the file.
+    uint32 u32AmountToRead = 200;
+    s8Ret = m2m_ota_host_file_read_spi(gstrAppFile.u8Handler, gstrAppFile.au8Buff, gstrAppFile.u32Offset, u32AmountToRead);
+
+    if(M2M_SUCCESS == s8Ret)
+        M2M_INFO("\nFile Read completed, Offset: %lu, Size of Read: %lu.\n", gstrAppFile.u32Offset, u32AmountToRead);
+
+    // *** Do something with the contents of gstrAppFile.au8Buff ***
+
+    s8Ret = m2m_wifi_reinit(&gstrWifiParam);
+    if(M2M_SUCCESS != s8Ret) goto EXIT;
+
+    // Initialize the OTA again and reconnect to the previously connected SSID
+    m2m_ota_init(OtaUpdateCb, NULL);
+    m2m_wifi_default_connect();
+
+EXIT:
+    return;
+}
+
+void main(void)
+{
+    nm_bsp_init();
+
+    m2m_memset((uint8*)&gstrWifiParam, 0, sizeof(gstrWifiParam));
+    gstrWifiParam.pfAppWifiCb = wifi_event_cb;
+
+    // Initialize the WINC Driver
+    sint8 s8Ret = m2m_wifi_init(&gstrWifiParam);
+    if (M2M_SUCCESS != s8Ret)
+    {
+        M2M_ERR("Driver Init Failed <%d>\n",s8Ret);
+        while(1);
+    }
+
+    // Initialize the OTA module
+    m2m_ota_init(OtaUpdateCb, NULL);
+
+    // *** Connect to a wifi network by calling m2m_wifi_connect() ***
+
+    while(1) m2m_wifi_handle_events(NULL);
+}
+@endcode
+*/
+NMI_API sint8 m2m_ota_host_file_read_spi(uint8 u8Handler, uint8 *pu8Buff, uint32 u32Offset, uint32 u32Size);
+
+/*!
+@ingroup HFD
+@fn \
+    sint8 m2m_ota_host_file_erase(uint8 u8Handler, tpfFileEraseCb pfHFDEraseCb);
+
+@brief
+    Erase any traces of file stored in WINC's Flash.
+
+@param[in]  u8Handler
+    Handler of the file we are trying to erase. Must be valid.
+
+@param[in]  pfHFDEraseCb
+    Pointer to callback (see @ref tpfFileEraseCb) to execute when the file erase is completed by the WINC.
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@pre
+    In order to execute the callback, @ref m2m_ota_init must be called before requesting the erase.
+
+@note
+    Providing a callback is optional.
+    If the current handler is invalid at this point, it means one of the three:
+        1. The file never existed;
+        2. The file has already been already deleted;
+        3. The request to get the file hasn't fully completed.
+    \par
+    For 1. and 2. there is no need to signal the WINC to erase the file in Flash.\n
+    For 3. the Flash can't be erased while a file download is ongoing.
+
+@warning
+    A valid file handler must be provided, this means that it needs to match the handler internally stored
+    by the WINC and must not be @ref HFD_INVALID_HANDLER.\n
+    The handlers will be destroyed regardless of the call returning success or not.
+
+@sa
+    m2m_ota_init
+    m2m_ota_host_file_get
+*/
+NMI_API sint8 m2m_ota_host_file_erase(uint8 u8Handler, tpfFileEraseCb pfHFDEraseCb);
+
+#if 0
+NMI_API sint8 m2m_ota_test(void);
+#endif
+
+/*!
+@ingroup        VERSIONAPI
+@fn             sint8 m2m_ota_get_firmware_version(tstrM2mRev* pstrRev);
+@brief          Get the OTA Firmware version.
+@details        Get OTA Firmware version info from the inactive partition, as defined in the structure tstrM2mRev.
+@param[out]     pstrRev
+                    Pointer to the structure tstrM2mRev that contains the firmware version parameters.
+@return         The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_get_firmware_version(tstrM2mRev *pstrRev);
-  /**@}*/
-NMI_API sint8 m2m_ota_test(void);
 
 #ifdef __cplusplus
 }

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_periph.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_periph.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC Peripherals Application Interface.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -60,144 +53,63 @@ DATA TYPES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 
 /*!
-@struct	\
-	tstrPerphInitParam
+@enum \
+    tenuGpioNum
 
 @brief
-	Peripheral module initialization parameters.
-*/
-typedef struct {
-	void * arg;
-} tstrPerphInitParam;
-
-
-/*!
-@enum	\
-	tenuGpioNum
-
-@brief
-	A list of GPIO numbers configurable through the m2m_periph module.
+    A list of GPIO numbers configurable through the m2m_periph module.
 */
 typedef enum {
-	M2M_PERIPH_GPIO3, /*!< GPIO15 pad	*/
-	M2M_PERIPH_GPIO4, /*!< GPIO16 pad	*/
-	M2M_PERIPH_GPIO5, /*!< GPIO18 pad	*/
-	M2M_PERIPH_GPIO6, /*!< GPIO18 pad	*/
-	M2M_PERIPH_GPIO15, /*!< GPIO15 pad	*/
-	M2M_PERIPH_GPIO16, /*!< GPIO16 pad	*/
-	M2M_PERIPH_GPIO18, /*!< GPIO18 pad	*/
-	M2M_PERIPH_GPIO_MAX
+    M2M_PERIPH_GPIO0 = 0,   /*!< GPIO0 pad */
+    M2M_PERIPH_GPIO1 = 1,   /*!< GPIO1 pad */
+    M2M_PERIPH_GPIO2 = 2,   /*!< GPIO2 pad */
+    M2M_PERIPH_GPIO3 = 3,   /*!< GPIO3 pad */
+    M2M_PERIPH_GPIO4 = 4,   /*!< GPIO4 pad */
+    M2M_PERIPH_GPIO5 = 5,   /*!< GPIO5 pad */
+    M2M_PERIPH_GPIO6 = 6,   /*!< GPIO6 pad */
+    M2M_PERIPH_GPIO_MAX
 } tenuGpioNum;
 
-
 /*!
-@enum	\
-	tenuI2cMasterSclMuxOpt
+@enum   \
+    tenuPullupMask
 
 @brief
-	Allowed pin multiplexing options for I2C master SCL signal.
+    Bitwise-ORed flags for use in @ref m2m_periph_pullup_ctrl.
+
+@sa
+    m2m_periph_pullup_ctrl
 */
 typedef enum {
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_HOST_WAKEUP, /*!< I2C master SCL is avaiable on HOST_WAKEUP. */
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_SD_DAT3,     /*!< I2C master SCL is avaiable on SD_DAT3 (GPIO 7). */
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_GPIO13,      /*!< I2C master SCL is avaiable on GPIO 13. */
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_GPIO4,       /*!< I2C master SCL is avaiable on GPIO 4.*/
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_I2C_SCL,     /*!< I2C master SCL is avaiable on I2C slave SCL. */
-	M2M_PERIPH_I2C_MASTER_SCL_MUX_OPT_NUM
-} tenuI2cMasterSclMuxOpt;
-
-/*!
-@enum	\
-	tenuI2cMasterSdaMuxOpt
-
-@brief
-	Allowed pin multiplexing options for I2C master SDA signal.
-*/
-typedef enum {
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_RTC_CLK , /*!< I2C master SDA is avaiable on RTC_CLK. */
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_SD_CLK,   /*!< I2C master SDA is avaiable on SD_CLK (GPIO 8). */
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_GPIO14,   /*!< I2C master SDA is avaiable on GPIO 14. */
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_GPIO6,    /*!< I2C master SDA is avaiable on GPIO 6.*/
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_I2C_SDA,  /*!< I2C master SDA is avaiable on I2C slave SDA. */
-	M2M_PERIPH_I2C_MASTER_SDA_MUX_OPT_NUM
-} tenuI2cMasterSdaMuxOpt;
-
-
-/*!
-@struct	\
-	tstrI2cMasterInitParam
-
-@brief
-	I2C master configuration parameters.
-@sa
-	tenuI2cMasterSclMuxOpt
-	tenuI2cMasterSdaMuxOpt
-*/
-typedef struct {
-	uint8 enuSclMuxOpt; /*!< SCL multiplexing option. Allowed value are defined in tenuI2cMasterSclMuxOpt  */
-	uint8 enuSdaMuxOpt; /*!< SDA multiplexing option. Allowed value are defined in tenuI2cMasterSdaMuxOpt  */
-	uint8 u8ClkSpeedKHz; /*!< I2C master clock speed in KHz. */
-} tstrI2cMasterInitParam;
-
-/*!
-@enum	\
-	tenuI2cMasterFlags
-
-@brief
-	Bitwise-ORed flags for use in m2m_periph_i2c_master_write and m2m_periph_i2c_master_read
-@sa
-	m2m_periph_i2c_master_write
-	m2m_periph_i2c_master_read
-*/
-typedef enum  {
-    I2C_MASTER_NO_FLAGS          = 0x00,
-	/*!< No flags.  */
-    I2C_MASTER_NO_STOP           = 0x01,
-	/*!< No stop bit after this transaction. Useful for scattered buffer read/write operations. */
-	I2C_MASTER_NO_START          = 0x02,
-	/*!< No start bit at the beginning of this transaction. Useful for scattered buffer read/write operations.*/
-} tenuI2cMasterFlags;
-
-/*!
-@enum	\
-	tenuPullupMask
-
-@brief
-	Bitwise-ORed flags for use in m2m_perph_pullup_ctrl.
-@sa
-	m2m_periph_pullup_ctrl
-
-*/
-typedef enum {
-	M2M_PERIPH_PULLUP_DIS_HOST_WAKEUP     = (1ul << 0),
-	M2M_PERIPH_PULLUP_DIS_RTC_CLK         = (1ul << 1),
-	M2M_PERIPH_PULLUP_DIS_IRQN            = (1ul << 2),
-	M2M_PERIPH_PULLUP_DIS_GPIO_3          = (1ul << 3),
-	M2M_PERIPH_PULLUP_DIS_GPIO_4          = (1ul << 4),
-	M2M_PERIPH_PULLUP_DIS_GPIO_5          = (1ul << 5),
-	M2M_PERIPH_PULLUP_DIS_SD_DAT3         = (1ul << 6),
-	M2M_PERIPH_PULLUP_DIS_SD_DAT2_SPI_RXD = (1ul << 7),
-	M2M_PERIPH_PULLUP_DIS_SD_DAT1_SPI_SSN = (1ul << 9),
-	M2M_PERIPH_PULLUP_DIS_SD_CMD_SPI_SCK  = (1ul << 10),
-	M2M_PERIPH_PULLUP_DIS_SD_DAT0_SPI_TXD = (1ul << 11),
-	M2M_PERIPH_PULLUP_DIS_GPIO_6          = (1ul << 12),
-	M2M_PERIPH_PULLUP_DIS_SD_CLK          = (1ul << 13),
-	M2M_PERIPH_PULLUP_DIS_I2C_SCL         = (1ul << 14),
-	M2M_PERIPH_PULLUP_DIS_I2C_SDA         = (1ul << 15),
-	M2M_PERIPH_PULLUP_DIS_GPIO_11         = (1ul << 16),
-	M2M_PERIPH_PULLUP_DIS_GPIO_12         = (1ul << 17),
-	M2M_PERIPH_PULLUP_DIS_GPIO_13         = (1ul << 18),
-	M2M_PERIPH_PULLUP_DIS_GPIO_14         = (1ul << 19),
-	M2M_PERIPH_PULLUP_DIS_GPIO_15         = (1ul << 20),
-	M2M_PERIPH_PULLUP_DIS_GPIO_16         = (1ul << 21),
-	M2M_PERIPH_PULLUP_DIS_GPIO_17         = (1ul << 22),
-	M2M_PERIPH_PULLUP_DIS_GPIO_18         = (1ul << 23),
-	M2M_PERIPH_PULLUP_DIS_GPIO_19         = (1ul << 24),
-	M2M_PERIPH_PULLUP_DIS_GPIO_20         = (1ul << 25),
-	M2M_PERIPH_PULLUP_DIS_GPIO_21         = (1ul << 26),
-	M2M_PERIPH_PULLUP_DIS_GPIO_22         = (1ul << 27),
-	M2M_PERIPH_PULLUP_DIS_GPIO_23         = (1ul << 28),
-	M2M_PERIPH_PULLUP_DIS_GPIO_24         = (1ul << 29),
+    M2M_PERIPH_PULLUP_DIS_HOST_WAKEUP     = (1ul << 0),
+    M2M_PERIPH_PULLUP_DIS_RTC_CLK         = (1ul << 1),
+    M2M_PERIPH_PULLUP_DIS_IRQN            = (1ul << 2),
+    M2M_PERIPH_PULLUP_DIS_GPIO_3          = (1ul << 3),
+    M2M_PERIPH_PULLUP_DIS_GPIO_4          = (1ul << 4),
+    M2M_PERIPH_PULLUP_DIS_GPIO_5          = (1ul << 5),
+    M2M_PERIPH_PULLUP_DIS_SD_DAT3         = (1ul << 6),
+    M2M_PERIPH_PULLUP_DIS_SD_DAT2_SPI_RXD = (1ul << 7),
+    M2M_PERIPH_PULLUP_DIS_SD_DAT1_SPI_SSN = (1ul << 9),
+    M2M_PERIPH_PULLUP_DIS_SD_CMD_SPI_SCK  = (1ul << 10),
+    M2M_PERIPH_PULLUP_DIS_SD_DAT0_SPI_TXD = (1ul << 11),
+    M2M_PERIPH_PULLUP_DIS_GPIO_6          = (1ul << 12),
+    M2M_PERIPH_PULLUP_DIS_SD_CLK          = (1ul << 13),
+    M2M_PERIPH_PULLUP_DIS_I2C_SCL         = (1ul << 14),
+    M2M_PERIPH_PULLUP_DIS_I2C_SDA         = (1ul << 15),
+    M2M_PERIPH_PULLUP_DIS_GPIO_11         = (1ul << 16),
+    M2M_PERIPH_PULLUP_DIS_GPIO_12         = (1ul << 17),
+    M2M_PERIPH_PULLUP_DIS_GPIO_13         = (1ul << 18),
+    M2M_PERIPH_PULLUP_DIS_GPIO_14         = (1ul << 19),
+    M2M_PERIPH_PULLUP_DIS_GPIO_15         = (1ul << 20),
+    M2M_PERIPH_PULLUP_DIS_GPIO_16         = (1ul << 21),
+    M2M_PERIPH_PULLUP_DIS_GPIO_17         = (1ul << 22),
+    M2M_PERIPH_PULLUP_DIS_GPIO_18         = (1ul << 23),
+    M2M_PERIPH_PULLUP_DIS_GPIO_19         = (1ul << 24),
+    M2M_PERIPH_PULLUP_DIS_GPIO_20         = (1ul << 25),
+    M2M_PERIPH_PULLUP_DIS_GPIO_21         = (1ul << 26),
+    M2M_PERIPH_PULLUP_DIS_GPIO_22         = (1ul << 27),
+    M2M_PERIPH_PULLUP_DIS_GPIO_23         = (1ul << 28),
+    M2M_PERIPH_PULLUP_DIS_GPIO_24         = (1ul << 29),
 } tenuPullupMask;
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
@@ -206,197 +118,87 @@ FUNCTION PROTOTYPES
 
 
 #ifdef __cplusplus
-     extern "C" {
+extern "C" {
 #endif
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_periph_init(tstrPerphInitParam * param);
+@fn \
+    NMI_API sint8 m2m_periph_gpio_set_dir(uint8 u8GpioNum, uint8 u8GpioDir);
 
 @brief
-	Initialize the NMC1500 peripheral driver module.
+    Configure a specific WINC15x0 pad as a GPIO and sets its direction (input or output).
 
-@param [in]	param
-				Peripheral module initialization structure. See members of tstrPerphInitParam.
+@param[in]  u8GpioNum
+    GPIO number. Allowed values are defined in @ref tenuGpioNum.
 
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-@sa
-	tstrPerphInitParam
-*/
-NMI_API sint8 m2m_periph_init(tstrPerphInitParam * param);
-
-/*!
-@fn	\
-	NMI_API sint8 m2m_periph_gpio_set_dir(uint8 u8GpioNum, uint8 u8GpioDir);
-
-@brief
-	Configure a specific NMC1500 pad as a GPIO and sets its direction (input or output).
-
-@param [in]	u8GpioNum
-				GPIO number. Allowed values are defined in tenuGpioNum.
-
-@param [in]	u8GpioDir
-				GPIO direction: Zero = input. Non-zero = output.
+@param[in]  u8GpioDir
+    GPIO direction: Zero = input. Non-zero = output.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 
 @sa
-	tenuGpioNum
+    tenuGpioNum
 */
 NMI_API sint8 m2m_periph_gpio_set_dir(uint8 u8GpioNum, uint8 u8GpioDir);
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_periph_gpio_set_val(uint8 u8GpioNum, uint8 u8GpioVal);
+@fn \
+    NMI_API sint8 m2m_periph_gpio_set_val(uint8 u8GpioNum, uint8 u8GpioVal);
 
 @brief
-	Set an NMC1500 GPIO output level high or low.
+    Set an WINC15x0 GPIO output level high or low.
 
-@param [in]	u8GpioNum
-				GPIO number. Allowed values are defined in tenuGpioNum.
+@param[in]  u8GpioNum
+    GPIO number. Allowed values are defined in @ref tenuGpioNum.
 
-@param [in]	u8GpioVal
-				GPIO output value. Zero = low, non-zero = high.
+@param[in]  u8GpioVal
+    GPIO output value. Zero = low, non-zero = high.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function SHALL return 0 for success and a negative value otherwise.
 
 @sa
-	tenuGpioNum
+    tenuGpioNum
 */
 NMI_API sint8 m2m_periph_gpio_set_val(uint8 u8GpioNum, uint8 u8GpioVal);
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_periph_gpio_get_val(uint8 u8GpioNum, uint8 * pu8GpioVal);
+@fn \
+    NMI_API sint8 m2m_periph_gpio_get_val(uint8 u8GpioNum, uint8 * pu8GpioVal);
 
 @brief
-	Read an NMC1500 GPIO input level.
+    Read an WINC15x0 GPIO input level.
 
-@param [in]	u8GpioNum
-				GPIO number. Allowed values are defined in tenuGpioNum.
+@param[in]  u8GpioNum
+    GPIO number. Allowed values are defined in @ref tenuGpioNum.
 
 @param [out] pu8GpioVal
-				GPIO input value. Zero = low, non-zero = high.
+    GPIO input value. Zero = low, non-zero = high.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 
 @sa
-	tenuGpioNum
+    tenuGpioNum
 */
-NMI_API sint8 m2m_periph_gpio_get_val(uint8 u8GpioNum, uint8 * pu8GpioVal);
+NMI_API sint8 m2m_periph_gpio_get_val(uint8 u8GpioNum, uint8 *pu8GpioVal);
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_periph_gpio_pullup_ctrl(uint8 u8GpioNum, uint8 u8PullupEn);
+@fn \
+    NMI_API sint8 m2m_periph_pullup_ctrl(uint32 pinmask, uint8 enable);
 
 @brief
-	Set an NMC1500 GPIO pullup resisitor enable or disable.
+    Control the programmable pull-up resistor on the chip pads .
 
-@param [in]	u8GpioNum
-				GPIO number. Allowed values are defined in tenuGpioNum.
+@param[in]  pinmask
+    Write operation bitwise-ORed mask for which pads to control. Allowed values are defined in @ref tenuPullupMask.
 
-@param [in] u8PullupEn
-				Zero: pullup disabled. Non-zero: pullup enabled.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-@sa
-	tenuGpioNum
-*/
-NMI_API sint8 m2m_periph_gpio_pullup_ctrl(uint8 u8GpioNum, uint8 u8PullupEn);
-
-/*!
-@fn	\
-	NMI_API sint8 m2m_periph_i2c_master_init(tstrI2cMasterInitParam * param);
-
-@brief
-	Initialize and configure the NMC1500 I2C master peripheral.
-
-@param [in]	param
-				I2C master initialization structure. See members of tstrI2cMasterInitParam.
+@param[in]  enable
+    Set to 0 to disable pull-up resistor. Non-zero will enable the pull-up.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-@sa
-	tstrI2cMasterInitParam
-*/
-NMI_API sint8 m2m_periph_i2c_master_init(tstrI2cMasterInitParam * param);
-
-/*!
-@fn	\
-	NMI_API sint8 m2m_periph_i2c_master_write(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint8 flags);
-
-@brief
-	Write a stream of bytes to the I2C slave device.
-
-@param [in]	u8SlaveAddr
-				7-bit I2C slave address.
-@param [in]	pu8Buf
-				A pointer to an input buffer which contains a stream of bytes.
-@param [in]	u16BufLen
-				Input buffer length in bytes.
-@param [in]	flags
-				Write operation bitwise-ORed flags. See tenuI2cMasterFlags.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-@sa
-	tenuI2cMasterFlags
-*/
-NMI_API sint8 m2m_periph_i2c_master_write(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint8 flags);
-
-
-/*!
-@fn	\
-	NMI_API sint8 m2m_periph_i2c_master_read(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint16 * pu16ReadLen, uint8 flags);
-
-@brief
-	Write a stream of bytes to the I2C slave device.
-
-@param [in]	u8SlaveAddr
-				7-bit I2C slave address.
-@param [out] pu8Buf
-				A pointer to an output buffer in which a stream of bytes are received.
-@param [in]	u16BufLen
-				Max output buffer length in bytes.
-@param [out] pu16ReadLen
-				Actual number of bytes received.
-@param [in]	flags
-				Write operation bitwise-ORed flags. See tenuI2cMasterFlags.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-@sa
-	tenuI2cMasterFlags
-*/
-NMI_API sint8 m2m_periph_i2c_master_read(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint16 * pu16ReadLen, uint8 flags);
-
-
-/*!
-@fn	\
-	NMI_API sint8 m2m_periph_pullup_ctrl(uint32 pinmask, uint8 enable);
-
-@brief
-	Control the programmable pull-up resistor on the chip pads .
-
-
-@param [in]	pinmask
-				Write operation bitwise-ORed mask for which pads to control. Allowed values are defined in tenuPullupMask.
-
-@param [in]	enable
-				Set to 0 to disable pull-up resistor. Non-zero will enable the pull-up.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 
 @sa
 	tenuPullupMask

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_types.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_types.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC Application Interface Internal Types.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -46,21 +39,25 @@
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 INCLUDES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-
 #ifndef	_BOOT_
 #ifndef _FIRMWARE_
 #include "common/include/nm_common.h"
 #else
+#ifndef LINT
 #include "m2m_common.h"
+#else
+#include "../../../firmware/wifi_v111/src/m2m/include/m2m_common.h"
 #endif
+#endif
+
+#ifndef _lint
 #endif
 
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 MACROS
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-/**@defgroup  WlanDefines Defines
- * @ingroup m2m_wifi
+/**@addtogroup  VERSIONDEF
  */
 /**@{*/
 #define M2M_MAJOR_SHIFT (8)
@@ -95,40 +92,55 @@ MACROS
 	( ((uint32)M2M_MAKE_VERSION((fw_major),  (fw_minor),  (fw_patch)))  << M2M_FW_VERSION_SHIFT) | \
 	( ((uint32)M2M_MAKE_VERSION((drv_major), (drv_minor), (drv_patch))) << M2M_DRV_VERSION_SHIFT))
 
-#define REL_19_5_2_VER			M2M_MAKE_VERSION_INFO(19,5,2,19,3,0)
-#define REL_19_5_1_VER			M2M_MAKE_VERSION_INFO(19,5,1,19,3,0)
-#define REL_19_5_0_VER			M2M_MAKE_VERSION_INFO(19,5,0,19,3,0)
-#define REL_19_4_6_VER			M2M_MAKE_VERSION_INFO(19,4,6,19,3,0)
-#define REL_19_4_5_VER			M2M_MAKE_VERSION_INFO(19,4,5,19,3,0)
-#define REL_19_4_4_VER			M2M_MAKE_VERSION_INFO(19,4,4,19,3,0)
-#define REL_19_4_3_VER			M2M_MAKE_VERSION_INFO(19,4,3,19,3,0)
-#define REL_19_4_2_VER			M2M_MAKE_VERSION_INFO(19,4,2,19,3,0)
-#define REL_19_4_1_VER			M2M_MAKE_VERSION_INFO(19,4,1,19,3,0)
-#define REL_19_4_0_VER			M2M_MAKE_VERSION_INFO(19,4,0,19,3,0)
-#define REL_19_3_1_VER			M2M_MAKE_VERSION_INFO(19,3,1,19,3,0)
-#define REL_19_3_0_VER			M2M_MAKE_VERSION_INFO(19,3,0,19,3,0)
-#define REL_19_2_2_VER			M2M_MAKE_VERSION_INFO(19,2,2,19,2,0)
-#define REL_19_2_1_VER			M2M_MAKE_VERSION_INFO(19,2,1,19,2,0)
-#define REL_19_2_0_VER			M2M_MAKE_VERSION_INFO(19,2,0,19,2,0)
-#define REL_19_1_0_VER			M2M_MAKE_VERSION_INFO(19,1,0,18,2,0)
-#define REL_19_0_0_VER			M2M_MAKE_VERSION_INFO(19,0,0,18,1,1)
+#define REL_19_7_6_VER          M2M_MAKE_VERSION_INFO(19,7,6,19,3,0)
+#define REL_19_7_5_VER          M2M_MAKE_VERSION_INFO(19,7,5,19,3,0)
+#define REL_19_7_0_VER          M2M_MAKE_VERSION_INFO(19,7,0,19,3,0)
+#define REL_19_6_4_VER          M2M_MAKE_VERSION_INFO(19,6,4,19,3,0)
+#define REL_19_6_0_VER          M2M_MAKE_VERSION_INFO(19,6,0,19,3,0)
+#define REL_19_5_3_VER          M2M_MAKE_VERSION_INFO(19,5,3,19,3,0)
+#define REL_19_5_2_VER          M2M_MAKE_VERSION_INFO(19,5,2,19,3,0)
+#define REL_19_5_1_VER          M2M_MAKE_VERSION_INFO(19,5,1,19,3,0)
+#define REL_19_5_0_VER          M2M_MAKE_VERSION_INFO(19,5,0,19,3,0)
+#define REL_19_4_6_VER          M2M_MAKE_VERSION_INFO(19,4,6,19,3,0)
+#define REL_19_4_5_VER          M2M_MAKE_VERSION_INFO(19,4,5,19,3,0)
+#define REL_19_4_4_VER          M2M_MAKE_VERSION_INFO(19,4,4,19,3,0)
+#define REL_19_4_3_VER          M2M_MAKE_VERSION_INFO(19,4,3,19,3,0)
+#define REL_19_4_2_VER          M2M_MAKE_VERSION_INFO(19,4,2,19,3,0)
+#define REL_19_4_1_VER          M2M_MAKE_VERSION_INFO(19,4,1,19,3,0)
+#define REL_19_4_0_VER          M2M_MAKE_VERSION_INFO(19,4,0,19,3,0)
+#define REL_19_3_1_VER          M2M_MAKE_VERSION_INFO(19,3,1,19,3,0)
+#define REL_19_3_0_VER          M2M_MAKE_VERSION_INFO(19,3,0,19,3,0)
+#define REL_19_2_2_VER          M2M_MAKE_VERSION_INFO(19,2,2,19,2,0)
+#define REL_19_2_1_VER          M2M_MAKE_VERSION_INFO(19,2,1,19,2,0)
+#define REL_19_2_0_VER          M2M_MAKE_VERSION_INFO(19,2,0,19,2,0)
+#define REL_19_1_0_VER          M2M_MAKE_VERSION_INFO(19,1,0,18,2,0)
+#define REL_19_0_0_VER          M2M_MAKE_VERSION_INFO(19,0,0,18,1,1)
 
 /*======*======*======*======*
-		FIRMWARE VERSION NO INFO
+        FIRMWARE VERSION NO INFO
  *======*======*======*======*/
 
-#define M2M_RELEASE_VERSION_MAJOR_NO 						(19)
+#define M2M_RELEASE_VERSION_MAJOR_NO                        (19)
 /*!< Firmware Major release version number.
 */
 
 
-#define M2M_RELEASE_VERSION_MINOR_NO						(5)
+#ifndef BLDTESTVERSION1
+// the real version number must appear first as the release script greps it out to create folder.
+#define M2M_RELEASE_VERSION_MINOR_NO                        (7)
+#else
+#define M2M_RELEASE_VERSION_MINOR_NO                        (8)
+#endif
 /*!< Firmware Minor release version number.
 */
 
-#define M2M_RELEASE_VERSION_PATCH_NO						(2)
+#define M2M_RELEASE_VERSION_PATCH_NO                        (6)
 /*!< Firmware patch release version number.
 */
+
+#define M2M_RELEASE_VERSION_SVN_VERSION						(SVN_REVISION)
+/*!< Firmware SVN release version number.
+ */
 
 /*======*======*======*======*
   SUPPORTED DRIVER VERSION NO INFO
@@ -151,11 +163,15 @@ MACROS
 /*!< Driver svn version.
 */
 
-
-
 #if !defined(M2M_RELEASE_VERSION_MAJOR_NO) || !defined(M2M_RELEASE_VERSION_MINOR_NO)
 #error Undefined version number
 #endif
+
+/**@}*/     //VERSIONDEF
+
+/**@addtogroup  WlanDefines
+ * @{
+ */
 
 #define M2M_BUFFER_MAX_SIZE								(1600UL - 4)
 /*!< Maximum size for the shared packet buffer.
@@ -163,7 +179,7 @@ MACROS
 
 
 #define M2M_MAC_ADDRES_LEN                               6
-/*!< The size fo 802 MAC address.
+/*!< The size of the 802 MAC address.
  */
 
 #define M2M_ETHERNET_HDR_OFFSET							34
@@ -172,27 +188,34 @@ MACROS
 
 
 #define M2M_ETHERNET_HDR_LEN							14
-/*!< Length of the Etherenet header in bytes.
+/*!< Length of the Ethernet header in bytes.
 */
 
 
 #define M2M_MAX_SSID_LEN 								33
-/*!< Maximum size for the Wi-Fi SSID including the NULL termination.
+/*!< 1 more than the max SSID length.
+	This matches the size of SSID buffers (max SSID length + 1-byte length field).
  */
 
 
 #define M2M_MAX_PSK_LEN           						65
-/*!< Maximum size for the WPA PSK including the NULL termination.
+/*!< 1 more than the WPA PSK length (in ASCII format).
+	This matches the size of the WPA PSK/Passphrase buffer (max ASCII contents + 1-byte length field).
+	Alternatively it matches the WPA PSK length (in ASCII format) + 1 byte NULL termination.
  */
 
 #define M2M_MIN_PSK_LEN           						9
-/*!< Maximum size for the WPA PSK including the NULL termination.
+/*!< 1 more than the minimum WPA PSK Passphrase length.
+	It matches the minimum WPA PSK Passphrase length + 1 byte NULL termination.
  */
 
 #define M2M_DEVICE_NAME_MAX								48
 /*!< Maximum Size for the device name including the NULL termination.
  */
 
+#define M2M_NTP_MAX_SERVER_NAME_LENGTH					32
+/*!< Maximum NTP server name length
+*/
 
 #define M2M_LISTEN_INTERVAL 							1
 /*!< The STA uses the Listen Interval parameter to indicate to the AP how
@@ -202,25 +225,73 @@ MACROS
 
 #define MAX_HIDDEN_SITES 								4
 /*!<
-	max number of hidden SSID suuported by scan request
-*/
-
-
-#define M2M_1X_USR_NAME_MAX								21
-/*!< The maximum size of the user name including the NULL termination.
-	It is used for RADIUS authentication in case of connecting the device to
-	an AP secured with WPA-Enterprise.
-*/
-
-
-#define M2M_1X_PWD_MAX									41
-/*!< The maximum size of the password including the NULL termination.
-	It is used for RADIUS authentication in case of connecting the device to
-	an AP secured with WPA-Enterprise.
+	max number of hidden SSID supported by scan request
 */
 
 #define M2M_CUST_IE_LEN_MAX								252
 /*!< The maximum size of IE (Information Element).
+*/
+
+#define M2M_CRED_STORE_FLAG								0x01
+/*!< Flag used in @ref tstrM2mConnCredHdr to indicate that Wi-Fi connection
+	credentials should be stored in WINC flash.
+*/
+#define M2M_CRED_ENCRYPT_FLAG							0x02
+/*!< Flag used in @ref tstrM2mConnCredHdr to indicate that Wi-Fi connection
+	credentials should be encrypted when stored in WINC flash.
+*/
+#define M2M_CRED_IS_STORED_FLAG							0x10
+/*!< Flag used in @ref tstrM2mConnCredHdr to indicate that Wi-Fi connection
+	credentials are stored in WINC flash. May only be set by WINC firmware.
+*/
+#define M2M_CRED_IS_ENCRYPTED_FLAG						0x20
+/*!< Flag used in @ref tstrM2mConnCredHdr to indicate that Wi-Fi connection
+	credentials are encrypted in WINC flash. May only be set by WINC firmware.
+*/
+
+#define M2M_WIFI_CONN_BSSID_FLAG						0x01
+/*!< Flag used in @ref tstrM2mConnCredCmn to indicate that Wi-Fi connection
+	must be restricted to an AP with a certain BSSID.
+*/
+
+#define M2M_AUTH_1X_USER_LEN_MAX                        100
+/*!< The maximum length (in ASCII characters) of domain name + username (including '@' or '\')
+	for authentication with Enterprise methods.
+*/
+#define M2M_AUTH_1X_PASSWORD_LEN_MAX					256
+/*!< The maximum length (in ASCII characters) of password for authentication with Enterprise MSCHAPv2 methods.
+*/
+#define M2M_AUTH_1X_PRIVATEKEY_LEN_MAX					256
+/*!< The maximum length (in bytes) of private key modulus for authentication with Enterprise TLS methods.
+	Private key exponent must be the same length as modulus, pre-padded with 0s if necessary.
+*/
+#define M2M_AUTH_1X_CERT_LEN_MAX						1584
+/*!< The maximum length (in bytes) of certificate for authentication with Enterprise TLS methods.
+*/
+#define M2M_802_1X_UNENCRYPTED_USERNAME_FLAG			0x80
+/*!< Flag to indicate that the 802.1x user-name should be sent (unencrypted) in the initial EAP
+	identity response. Intended for use with EAP-TLS only.
+*/
+#define M2M_802_1X_PREPEND_DOMAIN_FLAG					0x40
+/*!< Flag to indicate that the 802.1x domain name should be prepended to the user-name:
+	"Domain\Username". If the flag is not set then domain name is appended to the user-name:
+	"Username@Domain". (Note that the '@' or '\' must be included in the domain name.)
+*/
+#define M2M_802_1X_MSCHAP2_FLAG							0x01
+/*!< Flag to indicate 802.1x MsChapV2 credentials: domain/user-name/password.
+*/
+#define M2M_802_1X_TLS_FLAG								0x02
+/*!< Flag to indicate 802.1x TLS credentials: domain/user-name/private-key/certificate.
+*/
+#define M2M_802_1X_TLS_CLIENT_CERTIFICATE				1
+/*!< Info type used in @ref tstrM2mWifiAuthInfoHdr to indicate Enterprise TLS client certificate.
+*/
+
+#define PSK_CALC_LEN									40
+/*!< PSK is 32 bytes generated either:
+    - from 64 ASCII characters
+    - by SHA1 operations on up to 63 ASCII characters
+    40 byte array is required during SHA1 operations, so we define PSK_CALC_LEN as 40.
 */
 
 #define PWR_DEFAULT                                        PWR_HIGH
@@ -238,11 +309,20 @@ MACROS
 #define M2M_AP_CMD_BASE										70
 /*!< The base value of all the Access Point mode host commands opcodes.
 */
-#define M2M_P2P_CMD_BASE									90
+
+/**@cond P2P_DOC
+ */
+#define M2M_P2P_CMD_BASE                                    90
 /*!< The base value of all the P2P mode host commands opcodes.
 */
-#define M2M_SERVER_CMD_BASE									100
+/**@endcond*/ //P2P_DOC
+
+#define M2M_SERVER_CMD_BASE                                 100
 /*!< The base value of all the power save mode host commands codes.
+*/
+#define M2M_GEN_CMD_BASE									105
+/*!< The base value of additional host wifi command opcodes.
+ * Usage restrictions (eg STA mode only) should always be made clear at the API layer in any case.
 */
 /**********************
  * OTA GROUP requests
@@ -264,94 +344,160 @@ MACROS
 /*!< max number of request in one group equal to 127 as the last bit reserved for config or data pkt
 */
 
-#define WEP_40_KEY_STRING_SIZE 								((uint8)10)
-/*!< Indicate the wep key size in bytes for 40 bit string passphrase.
+#define WEP_40_KEY_SIZE										((uint8)5)
+/*!< The size in bytes of a 40-bit wep key.
+*/
+#define WEP_104_KEY_SIZE									((uint8)13)
+/*!< The size in bytes of a 104-bit wep key.
 */
 
-#define WEP_104_KEY_STRING_SIZE 							((uint8)26)
-/*!< Indicate the wep key size in bytes for 104 bit string passphrase.
+#define WEP_40_KEY_STRING_SIZE 								((uint8)10)
+/*!< The string length of a 40-bit wep key.
 */
+#define WEP_104_KEY_STRING_SIZE 							((uint8)26)
+/*!< The string length of a 104-bit wep key.
+*/
+
 #define WEP_KEY_MAX_INDEX									((uint8)4)
-/*!< Indicate the max key index value for WEP authentication
+/*!< WEP key index is in the range 1 to 4 inclusive. (This is decremented to
+ * result in an index in the range 0 to 3 on air.)
 */
 #define M2M_SHA256_CONTEXT_BUFF_LEN							(128)
 /*!< sha256 context size
 */
 #define M2M_SCAN_DEFAULT_NUM_SLOTS							(2)
-/*!< The default. number of scan slots performed by the WINC board.
+/*!< The default number of scan slots used by the WINC board.
 */
 #define M2M_SCAN_DEFAULT_SLOT_TIME							(30)
-/*!< The default. duration in miliseconds of a scan slots performed by the WINC board.
+/*!< The default duration in miliseconds of an active scan slot used by the WINC board.
+*/
+#define M2M_SCAN_DEFAULT_PASSIVE_SLOT_TIME					(300)
+/*!< The passive scan slot default duration in ms.
 */
 #define M2M_SCAN_DEFAULT_NUM_PROBE							(2)
-/*!< The default. number of scan slots performed by the WINC board.
+/*!< The default number of probes per scan slot.
+*/
+#define M2M_FASTCONNECT_DEFAULT_RSSI_THRESH					(-45)
+/*!< The default threshold RSSI for fast reconnection to an AP.
 */
 
-
 /*======*======*======*======*
-	CONNECTION ERROR DEFINITIONS
+    TLS DEFINITIONS
  *======*======*======*======*/
-typedef enum { 		
-	M2M_DEFAULT_CONN_INPROGRESS = ((sint8)-23),  		
-	/*!<
-	A failure that indicates that a default connection or forced connection is in progress
-	*/
-	M2M_DEFAULT_CONN_FAIL,				
-	/*!<
-	A failure response that indicates that the winc failed to connect to the cached network
-	*/
-	 M2M_DEFAULT_CONN_SCAN_MISMATCH,	 													
-	/*!<
-	A failure response that indicates that no one of the cached networks 
-	was found in the scan results, as a result to the function call m2m_default_connect.
-	*/
-	M2M_DEFAULT_CONN_EMPTY_LIST
-	/*!<
-	A failure response that indicates an empty network list as 
-	a result to the function call m2m_default_connect.
-	*/
-
-}tenuM2mDefaultConnErrcode;
-
-
-
-/*======*======*======*======*
-	TLS DEFINITIONS
- *======*======*======*======*/
-#define TLS_FILE_NAME_MAX								48
+#define TLS_FILE_NAME_MAX                               48
 /*!<  Maximum length for each TLS certificate file name including null terminator.
 */
-#define TLS_SRV_SEC_MAX_FILES							8
+#define TLS_SRV_SEC_MAX_FILES                           8
 /*!<  Maximum number of certificates allowed in TLS_SRV section.
 */
-#define TLS_SRV_SEC_START_PATTERN_LEN					8
+#define TLS_SRV_SEC_START_PATTERN_LEN                   8
 /*!<  Length of certificate struct start pattern.
 */
+
+/*======*======*======*======*
+    SSL DEFINITIONS
+ *======*======*======*======*/
+
+#define TLS_CRL_DATA_MAX_LEN    64
+/*<!
+    Maximum data length in a CRL entry (= Hash length for SHA512)
+	*/
+#define TLS_CRL_MAX_ENTRIES     10
+/*<!
+    Maximum number of entries in a CRL
+	*/
+
+#define TLS_CRL_TYPE_NONE       0
+/*<!
+    No CRL check
+	*/
+#define TLS_CRL_TYPE_CERT_HASH  1
+/*<!
+    CRL contains certificate hashes
+	*/
+
+#define TLS_CERTS_CHUNKED_SIG_VALUE 0x6ec8
+
+/* Commonly used initializers for rate lists for B, G, N or mixed modes for iteration on rates. */
+#define WLAN_11B_RATES_INITIALIZER { \
+    TX_RATE_1, TX_RATE_2, TX_RATE_5_5, \
+    TX_RATE_11 \
+}
+
+#define WLAN_11G_RATES_INITIALIZER  { \
+    TX_RATE_6, TX_RATE_9, TX_RATE_12, \
+    TX_RATE_18, TX_RATE_24, TX_RATE_36, \
+    TX_RATE_48, TX_RATE_54 \
+}
+
+#define WLAN_11N_RATES_INITIALIZER { \
+    TX_RATE_MCS_0, TX_RATE_MCS_1, TX_RATE_MCS_2, \
+    TX_RATE_MCS_3, TX_RATE_MCS_4, TX_RATE_MCS_5, \
+    TX_RATE_MCS_6, TX_RATE_MCS_7 \
+}
+
+#define WLAN_11BGN_RATES_ASC_INITIALIZER { \
+    TX_RATE_1, TX_RATE_2, TX_RATE_5_5, \
+    TX_RATE_6, TX_RATE_MCS_0, TX_RATE_9, \
+    TX_RATE_11, TX_RATE_12, TX_RATE_MCS_1, \
+    TX_RATE_18, TX_RATE_MCS_2, TX_RATE_24, \
+    TX_RATE_MCS_3, TX_RATE_36, TX_RATE_MCS_4, \
+    TX_RATE_48, TX_RATE_MCS_5, TX_RATE_54, \
+    TX_RATE_MCS_6, TX_RATE_MCS_7, \
+}
+
+#define WLAN_11BG_RATES_ASC_INITIALIZER { \
+     TX_RATE_1, TX_RATE_2, TX_RATE_5_5, \
+     TX_RATE_6, TX_RATE_9, TX_RATE_11, \
+     TX_RATE_12, TX_RATE_18, TX_RATE_24, \
+     TX_RATE_36, TX_RATE_48, TX_RATE_54 \
+}
+
+#define DEFAULT_CONF_AR_INITIALIZER { 5, 1, TX_RATE_AUTO, TX_RATE_AUTO, 10, 5, 3 }
+
+/**@}*/     //WlanDefines
+
+/**@addtogroup OTADEFINE
+ * @{
+*/
+
 /*======*======*======*======*
 	OTA DEFINITIONS
  *======*======*======*======*/
  
 #define OTA_STATUS_VALID					(0x12526285)
 /*!< 
-	Magic value updated in the Control structure in case of ROLLACK image Valid
+	Magic value updated in the Control structure in case of ROLLBACK image Valid
 */
 #define OTA_STATUS_INVALID					(0x23987718)
 /*!< 
-	Magic value updated in the Control structure in case of ROLLACK image InValid
+	Magic value updated in the Control structure in case of ROLLBACK image InValid
 */
 #define OTA_MAGIC_VALUE						(0x1ABCDEF9)
 /*!< 
 	Magic value set at the beginning of the OTA image header
 */
+#ifdef CORTUS_APP
 #define M2M_MAGIC_APP 						(0xef522f61UL)
 /*!< 
 	Magic value set at the beginning of the Cortus OTA image header
 */
+#endif
 
-#define OTA_FORMAT_VER_0					(0)	/*Till 19.2.2 format*/
-#define OTA_FORMAT_VER_1					(1) /*starting from 19.3.0 CRC is used and sequence number is used*/
+#define OTA_FORMAT_VER_0                    (0)
 /*!<
-	Control structure format version
+    Control structure format version 0.\n
+    Format used until version 19.2.2.
+*/
+#define OTA_FORMAT_VER_1                    (1)
+/*!<
+    Control structure format version 1.\n
+    Starting from 19.3.0 CRC is used and sequence number is used.
+*/
+#define OTA_FORMAT_VER_2                    (2)
+/*!<
+    Control structure format version 2.\n
+    Starting from 19.6.1 a flexible flash map is used.
 */
 #define OTA_SHA256_DIGEST_SIZE 				(32)
 /*!< 
@@ -359,77 +505,62 @@ typedef enum {
  the sha256 digest is set at the beginning of image before the OTA header
  */
 
-/*======*======*======*======*
-	SSL DEFINITIONS
- *======*======*======*======*/
-
-#define TLS_CRL_DATA_MAX_LEN	64
-/*<!
-	Maximum data length in a CRL entry (= Hash length for SHA512)
-*/
-#define TLS_CRL_MAX_ENTRIES		10
-/*<!
-	Maximum number of entries in a CRL
-*/
-
-#define TLS_CRL_TYPE_NONE		0
-/*<!
-	No CRL check
-*/
-#define TLS_CRL_TYPE_CERT_HASH	1
-/*<!
-	CRL contains certificate hashes
-*/
-
-/**@}*/
-
-/**
-* @addtogroup WlanEnums Enumerations and Typedefs
-* @ingroup m2m_wifi
-*/
- /**@{*/
-
-typedef enum {
-	OTA_SUCCESS = (0),
-	/*!<
-	 OTA Success status
-	 */
-	OTA_ERR_WORKING_IMAGE_LOAD_FAIL = ((sint8) -1),
-	/*!<
-	 Failure to load the firmware image
-	 */
-	OTA_ERR_INVAILD_CONTROL_SEC = ((sint8) -2),
-	/*!<
-	 Control structure is being corrupted
-	 */
-	M2M_ERR_OTA_SWITCH_FAIL = ((sint8) -3),
-	/*!<
-	 switching to the updated image failed as may be the image is invalid
-	 */
-	M2M_ERR_OTA_START_UPDATE_FAIL = ((sint8) -4),
-	/*!<
-	 OTA update fail due to multiple reasons
-	 - Connection failure
-	 - Image integrity fail
-
-	 */
-	M2M_ERR_OTA_ROLLBACK_FAIL = ((sint8) -5),
-	/*!<
-	 Roll-back failed due to Roll-back image is not valid
-	 */
-	M2M_ERR_OTA_INVAILD_FLASH_SIZE = ((sint8) -6),
-	/*!<
-	 The OTA Support at least 4MB flash size, if the above error will appear if the current flash is less than 4M
-	 */
-	M2M_ERR_OTA_INVAILD_ARG = ((sint8) -7),
-	/*!<
-	 * Ota still in progress
-	 */
-	M2M_ERR_OTA_INPROGRESS = ((sint8) -8)
+#define MAX_FILE_READ_STEP               128
 /*!<
- Invalid argument in any OTA Function
+ Max amount of bytes to read a file via HIF messages.
+*/
+
+#define HFD_INVALID_HANDLER                 (0xff)
+/*!<
+ Defines an ID which symbolizes an invalid handler.
+*/
+/**@}*/     //OTADEFINE
+
+#define tstrM2MSNTPConfig_PAD (4 - ((M2M_NTP_MAX_SERVER_NAME_LENGTH + 1 + 1) % 4))
+
+/**@addtogroup WlanEnums
+ * @{
  */
-} tenuOtaError;
+
+/*======*======*======*======*
+ *   FLASH ID DEFINITIONS    *
+ *======*======*======*======*/
+typedef enum {
+    ENTRY_ID_FW         = 0x0011,
+    ENTRY_ID_PLLGAIN    = 0x0021,
+    ENTRY_ID_TLSROOT    = 0x0031,
+    ENTRY_ID_TLSCLIENT  = 0x0032,
+    ENTRY_ID_TLSSERVER  = 0x0033,
+    ENTRY_ID_CONNPARAMS = 0x0034,
+    ENTRY_ID_HTTPFILES  = 0x0035,
+    ENTRY_ID_TLSCOMMON  = 0x0036,
+    ENTRY_ID_HOSTFILE   = 0x0041
+} tenuFlashLUTEntryID;
+
+/*======*======*======*======*
+    CONNECTION ERROR DEFINITIONS
+ *======*======*======*======*/
+typedef enum {
+    M2M_DEFAULT_CONN_INPROGRESS = ((sint8)-23),
+    /*!<
+    A failure that indicates that a default connection or forced connection is in progress
+    */
+    M2M_DEFAULT_CONN_FAIL,
+    /*!<
+    A failure response that indicates that the winc failed to connect to the cached network
+    */
+    M2M_DEFAULT_CONN_SCAN_MISMATCH,
+    /*!<
+    A failure response that indicates that no one of the cached networks
+    was found in the scan results, as a result to the function call m2m_default_connect.
+    */
+    M2M_DEFAULT_CONN_EMPTY_LIST
+    /*!<
+    A failure response that indicates an empty network list as
+    a result to the function call m2m_default_connect.
+    */
+
+} tenuM2mDefaultConnErrcode;
 
 /*!
 @enum	\
@@ -482,16 +613,16 @@ typedef enum {
 	PWR_AUTO = ((uint8) 1),
 	/*!< FW will decide the best power mode to use internally. */
 	PWR_LOW1,
-	/*low power mode #1*/
+    /*!< Low power mode #1 */
 	PWR_LOW2,
-	/*low power mode #2*/
+    /*!< Low power mode #2 */
 	PWR_HIGH
-	/* high power mode*/
+    /*!< High power mode */
 }tenuM2mPwrMode;
 
 /*!
 @struct	\	
-	tstrM2mPwrState
+    tstrM2mPwrMode
 
 @brief
 	Power Mode
@@ -504,6 +635,14 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mPwrMode;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mPwrMode)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mPwrMode)%4)==0, "Structure alignment error");
+#endif
+#endif
+
 /*!
 @enum	\
 	tenuM2mTxPwrLevel
@@ -535,6 +674,36 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mTxPwrLevel;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mTxPwrLevel)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mTxPwrLevel)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\	
+	tstrM2mWiFiGainIdx
+
+@brief
+	Gain Table index selection corresponding to specific WiFi region.
+*/
+typedef struct {
+	uint8	u8GainTableIdx; 
+	/*!< Gain table index
+	*/
+	uint8	__PAD24__[3];
+	/*!< Padding bytes for forcing 4-byte alignment
+	*/
+}tstrM2mWiFiGainIdx;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWiFiGainIdx)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWiFiGainIdx)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\	
@@ -551,6 +720,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mEnableLogs;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mEnableLogs)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mEnableLogs)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\	
@@ -568,10 +744,68 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mBatteryVoltage;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mBatteryVoltage)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mBatteryVoltage)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
-@enum	\
-	tenuM2mReqGroup
+@struct	\	
+	tstrM2mWiFiRoaming
+
+@brief
+	Roaming related information .
+*/
+typedef struct {
+	uint8	u8EnableRoaming; 
+	/*!< Enable/Disable Roaming
+	*/
+	uint8 	u8EnableDhcp;
+	/*!< Enable/Disable DHCP client when u8EnableRoaming is true
+	*/
+	uint8	__PAD16__[2];
+	/*!< Padding bytes for forcing 4-byte alignment
+	*/
+}tstrM2mWiFiRoaming;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWiFiRoaming)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWiFiRoaming)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrM2mWiFiXOSleepEnable
+
+@brief
+    Choose to keep the XO on or off over deep sleep.
+*/
+typedef struct {
+    uint8   u8EnableXODuringSleep;
+    /*!< Enable/Disable XO during deep sleep
+    */
+    uint8   __PAD16__[3];
+    /*!< Padding bytes for forcing 4-byte alignment
+    */
+} tstrM2mWiFiXOSleepEnable;
+
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWiFiXOSleepEnable)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWiFiXOSleepEnable)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+
+/*!
+@enum   \
+    tenuM2mReqGroup
 
 @brief
 */
@@ -583,7 +817,8 @@ typedef enum{
 	M2M_REQ_GROUP_OTA,
 	M2M_REQ_GROUP_SSL,
 	M2M_REQ_GROUP_CRYPTO,
-	M2M_REQ_GROUP_SIGMA
+	M2M_REQ_GROUP_SIGMA,
+	M2M_REQ_GROUP_INTERNAL
 }tenuM2mReqGroup;
 
 /*!
@@ -601,7 +836,7 @@ typedef enum{
 	tenuM2mConfigCmd
 
 @brief
-	This enum contains all the host commands used to configure the WINC board.
+	This enum contains host commands used to configure the WINC board.
 
 */
 typedef enum {
@@ -626,120 +861,134 @@ typedef enum {
 	*/
 	M2M_WIFI_RESP_CONN_INFO,
 
-	/*!< Connect with default AP response.
-	*/
-	M2M_WIFI_REQ_SET_DEVICE_NAME,
-	/*!<
-		Set the WINC device name property.
-	*/
-	M2M_WIFI_REQ_START_PROVISION_MODE,
-	/*!<
-		Start the provisioning mode for the M2M Device.
-	*/
-	M2M_WIFI_RESP_PROVISION_INFO,
-	/*!<
-		Send the provisioning information to the host.
-	*/
-	M2M_WIFI_REQ_STOP_PROVISION_MODE,
-	/*!<
-		Stop the current running provision mode.
-	*/
-	M2M_WIFI_REQ_SET_SYS_TIME,
-	/*!<
-		Set time of day from host.
-	*/
-	M2M_WIFI_REQ_ENABLE_SNTP_CLIENT,
-	/*!<
-		Enable the simple network time protocol to get the
-		time from the Internet. this is required for security purposes.
-	*/
-	M2M_WIFI_REQ_DISABLE_SNTP_CLIENT,
-	/*!<
-		Disable the simple network time protocol for applications that
-		do not need it.
-	*/
-	M2M_WIFI_RESP_MEMORY_RECOVER,
-	/*!<
-	 * Reserved for debuging
-	 * */
-	M2M_WIFI_REQ_CUST_INFO_ELEMENT,
-	/*!< Add Custom ELement to Beacon Managament Frame.
-	*/
-	M2M_WIFI_REQ_SCAN,
-	/*!< Request scan command.
-	*/
-	M2M_WIFI_RESP_SCAN_DONE,
-	/*!< Scan complete notification response.
-	*/
-	M2M_WIFI_REQ_SCAN_RESULT,
-	/*!< Request Scan results command.
-	*/
-	M2M_WIFI_RESP_SCAN_RESULT,
-	/*!< Request Scan results resopnse.
-	*/
-	M2M_WIFI_REQ_SET_SCAN_OPTION,
-	/*!< Set Scan options "slot time, slot number .. etc" .
-	*/
-	M2M_WIFI_REQ_SET_SCAN_REGION,
-	/*!< Set scan region.
-	*/
-	M2M_WIFI_REQ_SET_POWER_PROFILE,
-	/*!< The API shall set power mode to one of 3 modes
-	*/
-	M2M_WIFI_REQ_SET_TX_POWER,
-	/*!<  API to set TX power. 
-	*/
-	M2M_WIFI_REQ_SET_BATTERY_VOLTAGE,
-	/*!<  API to set Battery Voltage. 
-	*/
-	M2M_WIFI_REQ_SET_ENABLE_LOGS,
-	/*!<  API to set Battery Voltage. 
-	*/
-	M2M_WIFI_REQ_GET_SYS_TIME,
-	/*!<
-		REQ GET time of day from WINC.
-	*/
-	M2M_WIFI_RESP_GET_SYS_TIME,
-	/*!<
-		RESP time of day from host.
-	*/
-	M2M_WIFI_REQ_SEND_ETHERNET_PACKET,
-	/*!< Send Ethernet packet in bypass mode.
-	*/
-	M2M_WIFI_RESP_ETHERNET_RX_PACKET,
-	/*!< Receive Ethernet packet in bypass mode.
-	*/	
-	M2M_WIFI_REQ_SET_MAC_MCAST,
-	/*!< Set the WINC multicast filters.
-	*/
-	M2M_WIFI_REQ_GET_PRNG,
-	/*!< Request PRNG.
-	*/
-	M2M_WIFI_RESP_GET_PRNG,
-	/*!< Response for PRNG.
-	*/
-	M2M_WIFI_REQ_SCAN_SSID_LIST,
-	/*!< Request scan with list of hidden SSID plus the broadcast scan.
-	*/
-	M2M_WIFI_REQ_SET_GAINS,
-	/*!< Request set the PPA gain
-	*/
-	M2M_WIFI_REQ_PASSIVE_SCAN,
-	/*!< Request a passivr scan command.
-	*/
-	M2M_WIFI_MAX_CONFIG_ALL
-}tenuM2mConfigCmd;
+    /*!< Connect with default AP response.
+    */
+    M2M_WIFI_REQ_SET_DEVICE_NAME,
+    /*!<
+        Set the WINC device name property.
+    */
+    M2M_WIFI_REQ_START_PROVISION_MODE,
+    /*!<
+        Start the provisioning mode for the M2M Device.
+    */
+    M2M_WIFI_RESP_PROVISION_INFO,
+    /*!<
+        Send the provisioning information to the host.
+    */
+    M2M_WIFI_REQ_STOP_PROVISION_MODE,
+    /*!<
+        Stop the current running provision mode.
+    */
+    M2M_WIFI_REQ_SET_SYS_TIME,
+    /*!<
+        Set time of day from host.
+    */
+    M2M_WIFI_REQ_ENABLE_SNTP_CLIENT,
+    /*!<
+        Enable the simple network time protocol to get the
+        time from the Internet. this is required for security purposes.
+    */
+    M2M_WIFI_REQ_DISABLE_SNTP_CLIENT,
+    /*!<
+        Disable the simple network time protocol for applications that
+        do not need it.
+    */
+    M2M_WIFI_RESP_MEMORY_RECOVER,
+    /*!<
+     * Reserved for debugging
+     * */
+    M2M_WIFI_REQ_CUST_INFO_ELEMENT,
+    /*!< Add Custom Element to Beacon Management Frame.
+    */
+    M2M_WIFI_REQ_SCAN,
+    /*!< Request scan command.
+    */
+    M2M_WIFI_RESP_SCAN_DONE,
+    /*!< Scan complete notification response.
+    */
+    M2M_WIFI_REQ_SCAN_RESULT,
+    /*!< Request Scan results command.
+    */
+    M2M_WIFI_RESP_SCAN_RESULT,
+    /*!< Request Scan results response.
+    */
+    M2M_WIFI_REQ_SET_SCAN_OPTION,
+    /*!< Set Scan options "slot time, slot number .. etc" .
+    */
+    M2M_WIFI_REQ_SET_SCAN_REGION,
+    /*!< Set scan region.
+    */
+    M2M_WIFI_REQ_SET_POWER_PROFILE,
+    /*!< The API shall set power mode to one of 3 modes
+    */
+    M2M_WIFI_REQ_SET_TX_POWER,
+    /*!<  API to set TX power.
+    */
+    M2M_WIFI_REQ_SET_BATTERY_VOLTAGE,
+    /*!<  API to set Battery Voltage.
+    */
+    M2M_WIFI_REQ_SET_ENABLE_LOGS,
+    /*!<  API to set Battery Voltage.
+    */
+    M2M_WIFI_REQ_GET_SYS_TIME,
+    /*!<
+        REQ GET time of day from WINC.
+    */
+    M2M_WIFI_RESP_GET_SYS_TIME,
+    /*!<
+        RESP time of day from host.
+    */
+    M2M_WIFI_REQ_SEND_ETHERNET_PACKET,
+    /*!< Send Ethernet packet in bypass mode.
+    */
+    M2M_WIFI_RESP_ETHERNET_RX_PACKET,
+    /*!< Receive Ethernet packet in bypass mode.
+    */
+    M2M_WIFI_REQ_SET_MAC_MCAST,
+    /*!< Set the WINC multicast filters.
+    */
+    M2M_WIFI_REQ_GET_PRNG,
+    /*!< Request PRNG.
+    */
+    M2M_WIFI_RESP_GET_PRNG,
+    /*!< Response for PRNG.
+    */
+    M2M_WIFI_REQ_SCAN_SSID_LIST,
+    /*!< Request scan with list of hidden SSID plus the broadcast scan.
+    */
+    M2M_WIFI_REQ_SET_GAINS,
+    /*!< Request to set the PPA gain
+    */
+    M2M_WIFI_REQ_PASSIVE_SCAN,
+    /*!< Request a passive scan.
+    */
+    M2M_WIFI_REQ_CONG_AUTO_RATE,
+    /*!< Configure auto TX rate selection algorithm.
+    */
+    M2M_WIFI_REQ_CONFIG_SNTP,
+    /*!< Configure NTP servers.
+    */
+    M2M_WIFI_REQ_SET_GAIN_TABLE_IDX,
+    /*!<  API to set Gain table index.
+    */
+    M2M_WIFI_REQRSP_DELETE_APID,
+    /*!< Request/response to delete AP security credentials from WINC flash.
+    */
+    /* This enum is now 'full' in the sense that (M2M_WIFI_REQRSP_DELETE_APID+1) == M2M_STA_CMD_BASE.
+     * Any new config values should be placed in tenuM2mGenCmd. */
+    M2M_WIFI_MAX_CONFIG_ALL
+} tenuM2mConfigCmd;
 
 /*!
 @enum	\
 	tenuM2mStaCmd
 	
 @brief
-	This enum contains all the WINC commands while in Station mode.
+	This enum contains WINC commands while in Station mode.
 */
 typedef enum {
 	M2M_WIFI_REQ_CONNECT = M2M_STA_CMD_BASE,
-	/*!< Connect with AP command.
+	/*!< Connect with AP command. This command is deprecated in favour of @ref M2M_WIFI_REQ_CONN.
 	*/
 	M2M_WIFI_REQ_DEFAULT_CONNECT,
 	/*!< Connect with default AP command.
@@ -798,6 +1047,17 @@ typedef enum {
 	M2M_WIFI_REQ_DOZE,
 	/*!< Used to force the WINC to sleep in manual PS mode.
 	*/
+	M2M_WIFI_REQ_CONN,
+	/*!< New command to connect with AP.
+		This replaces M2M_WIFI_REQ_CONNECT. (Firmware continues to handle
+		M2M_WIFI_REQ_CONNECT for backwards compatibility purposes.)
+	*/
+	M2M_WIFI_IND_CONN_PARAM,
+	/*!< Provide extra information (such as Enterprise client certificate) required for connection.
+	*/
+	M2M_WIFI_REQ_DHCP_FAILURE,
+	/*!< Response indicating that IP address could not be obtained or renewed. If the IP could not be renewed then the previous IP will continue to be used.
+	*/
 	M2M_WIFI_MAX_STA_ALL
 } tenuM2mStaCmd;
 
@@ -806,7 +1066,7 @@ typedef enum {
 	tenuM2mApCmd
 
 @brief
-	This enum contains all the WINC commands while in AP mode.
+	This enum contains WINC commands while in AP mode.
 */
 typedef enum {
 	M2M_WIFI_REQ_ENABLE_AP = M2M_AP_CMD_BASE,
@@ -822,38 +1082,11 @@ typedef enum {
 }tenuM2mApCmd;
 
 /*!
-@enum	\
-	tenuM2mP2pCmd
+@enum   \
+    tenuM2mServerCmd
 
 @brief
-	This enum contains all the WINC commands while in P2P mode.
-*/
-typedef enum {
-	M2M_WIFI_REQ_P2P_INT_CONNECT = M2M_P2P_CMD_BASE,
-	/*!< This command is for internal use by the WINC and 
-		should not be used by the host driver.
-	*/
-	M2M_WIFI_REQ_ENABLE_P2P,
-	/*!< Enable P2P mode command.
-	*/
-	M2M_WIFI_REQ_DISABLE_P2P,
-	/*!< Disable P2P mode command.
-	*/
-	M2M_WIFI_REQ_P2P_REPOST,
-	/*!< This command is for internal use by the WINC and 
-		should not be used by the host driver.
-	*/
-	M2M_WIFI_MAX_P2P_ALL
-}tenuM2mP2pCmd;
-
-
-
-/*!
-@enum	\
-	tenuM2mServerCmd
-
-@brief
-	This enum contains all the WINC commands while in PS mode.
+	This enum contains WINC commands while in PS mode.
 	These command are currently not supported.
 */
 typedef enum {
@@ -863,31 +1096,28 @@ typedef enum {
 	M2M_WIFI_MAX_SERVER_ALL
 }tenuM2mServerCmd;
 
-
-
 /*!
 @enum	\
-	tenuM2mOtaCmd
-	
-@brief
+	tenuM2mGenCmd
 
+@brief
+	This enum contains additional WINC commands (overflow of previous enums).
 */
 typedef enum {
-	M2M_OTA_REQ_NOTIF_SET_URL = M2M_OTA_CMD_BASE,
-	M2M_OTA_REQ_NOTIF_CHECK_FOR_UPDATE,
-	M2M_OTA_REQ_NOTIF_SCHED,
-	M2M_OTA_REQ_START_FW_UPDATE,
-	M2M_OTA_REQ_SWITCH_FIRMWARE,
-	M2M_OTA_REQ_ROLLBACK_FW,
-	M2M_OTA_RESP_NOTIF_UPDATE_INFO,
-	M2M_OTA_RESP_UPDATE_STATUS,
-	M2M_OTA_REQ_TEST,
-	M2M_OTA_REQ_START_CRT_UPDATE,
-	M2M_OTA_REQ_SWITCH_CRT_IMG,
-	M2M_OTA_REQ_ROLLBACK_CRT,
-	M2M_OTA_REQ_ABORT,
-	M2M_OTA_MAX_ALL,
-}tenuM2mOtaCmd;
+    M2M_WIFI_REQ_ROAMING = M2M_GEN_CMD_BASE,
+    /*!< Request to enable/disable wifi roaming.
+        (Processing matches @ref tenuM2mConfigCmd.)
+    */
+    M2M_WIFI_REQ_XO_SLEEP_ENABLE,
+    /*!< Request to enable/disable the crystal oscillator during deep sleep.
+        (Processing matches @ref tenuM2mConfigCmd.)
+    */
+    M2M_WIFI_REQ_SET_STOP_SCAN_OPTION,
+    /*!< Set Scan option to stop on first result.
+        (Processing matches @ref tenuM2mConfigCmd.)
+    */
+    M2M_WIFI_MAX_GEN_ALL
+} tenuM2mGenCmd;
 
 /*!
 @enum	\
@@ -901,8 +1131,8 @@ typedef enum {
 	M2M_CRYPTO_RESP_SHA256_INIT,
 	M2M_CRYPTO_REQ_SHA256_UPDATE,
 	M2M_CRYPTO_RESP_SHA256_UPDATE,
-	M2M_CRYPTO_REQ_SHA256_FINSIH,
-	M2M_CRYPTO_RESP_SHA256_FINSIH,
+	M2M_CRYPTO_REQ_SHA256_FINISH,
+	M2M_CRYPTO_RESP_SHA256_FINISH,
 	M2M_CRYPTO_REQ_RSA_SIGN_GEN,
 	M2M_CRYPTO_RESP_RSA_SIGN_GEN,
 	M2M_CRYPTO_REQ_RSA_SIGN_VERIFY,
@@ -946,17 +1176,6 @@ typedef enum {
 	M2M_SIGMA_SET_SYSTIME
 } tenuM2mSigmaCmd;
 
-
-typedef enum{
-	M2M_SSL_REQ_CERT_VERIF,
-	M2M_SSL_REQ_ECC,
-	M2M_SSL_RESP_ECC,
-	M2M_SSL_IND_CRL,
-	M2M_SSL_IND_CERTS_ECC,
-	M2M_SSL_REQ_SET_CS_LIST,
-	M2M_SSL_RESP_SET_CS_LIST
-}tenuM2mSslCmd;
-
 /*!
 @enum	\
 	tenuM2mConnState
@@ -970,6 +1189,9 @@ typedef enum {
 	*/
 	M2M_WIFI_CONNECTED,
 	/*!< Wi-Fi state is connected.
+	*/
+	M2M_WIFI_ROAMED,
+	/*!< Wi-Fi state is roamed to new AP.
 	*/
 	M2M_WIFI_UNDEF = 0xff
 	/*!< Undefined Wi-Fi State.
@@ -994,10 +1216,13 @@ typedef enum {
 	/*!< Wi-Fi network is secured with WPA/WPA2 personal(PSK).
 	*/
 	M2M_WIFI_SEC_WEP,
-	/*!< Security type WEP (40 or 104) OPEN OR SHARED.
+	/*!< WEP is deprecated as of 19.7.5.
 	*/
-	M2M_WIFI_SEC_802_1X
-	/*!< Wi-Fi network is secured with WPA/WPA2 Enterprise.IEEE802.1x user-name/password authentication.
+	M2M_WIFI_SEC_802_1X,
+	/*!< Wi-Fi network is secured with WPA/WPA2 Enterprise.IEEE802.1x.
+	 */
+	M2M_WIFI_NUM_AUTH_TYPES
+	/*!< Upper limit for enum value.
 	 */
 }tenuM2mSecType;
 
@@ -1131,7 +1356,7 @@ typedef enum {
 	/*!< Config Mode in LOW POWER means to run production test firmware version which is known as ATE (Burst) firmware.
 	 */
 	M2M_WIFI_MODE_ETHERNET,
-	/*!< etherent Mode
+	/*!< ethernet Mode
 	 */
 	M2M_WIFI_MODE_MAX
 }tenuM2mWifiMode;
@@ -1153,6 +1378,22 @@ typedef enum{
 }tenuWPSTrigger;
 
 /*!
+@enum	\
+	tenuSNTPUseDHCP
+
+@brief
+	Use NTP server provided by the DHCP server.
+*/
+typedef enum{
+	SNTP_DISABLE_DHCP = 0,
+	/*!< Don't use the NTP server provided by the DHCP server when falling back.
+	*/
+	SNTP_ENABLE_DHCP = 1
+	/*!< Use the NTP server provided by the DHCP server when falling back.
+	*/
+}tenuSNTPUseDHCP;
+
+/*! 
 @struct	\
 	tstrM2mWifiGainsParams
 
@@ -1161,7 +1402,7 @@ typedef enum{
 */
 typedef struct{
 	uint16	u8PPAGFor11B;
-	/*!< PPA gain for 11B (as the RF document represenation)
+	/*!< PPA gain for 11B (as the RF document representation)
 	PPA_AGC<0:2> Every bit have 3dB gain control each.
 	for example:
 	1 ->3db
@@ -1180,109 +1421,276 @@ typedef struct{
 
 /*!
 @struct	\
-	tstrM2mWifiWepParams
+	tstrM2mConnCredHdr
 
 @brief
-	WEP security key parameters.
+	Wi-Fi Connect Credentials Header
 */
 typedef struct{
-	uint8	u8KeyIndx;
-	/*!< Wep key Index.
+	uint16	u16CredSize;
+	/*!< Total size of connect credentials, not including tstrM2mConnCredHdr:
+			tstrM2mConnCredCmn
+			Auth details (variable size)
 	*/
-	uint8	u8KeySz;
-	/*!< Wep key Size.
+	uint8	u8CredStoreFlags;
+	/*!< Credential storage options represented with flags:
+			@ref M2M_CRED_STORE_FLAG
+			@ref M2M_CRED_ENCRYPT_FLAG
+			@ref M2M_CRED_IS_STORED_FLAG
+			@ref M2M_CRED_IS_ENCRYPTED_FLAG
 	*/
-	uint8	au8WepKey[WEP_104_KEY_STRING_SIZE + 1];
-	/*!< WEP Key represented as a NULL terminated ASCII string.
+	uint8	u8Channel;
+	/*!< Wi-Fi channel(s) on which to attempt connection. */
+}tstrM2mConnCredHdr;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mConnCredHdr)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mConnCredHdr)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mConnCredCmn
+
+@brief
+	Wi-Fi Connect Credentials Common section
+*/
+typedef struct{
+	uint8	u8SsidLen;
+	/*!< SSID length. */
+	uint8	au8Ssid[M2M_MAX_SSID_LEN-1];
+	/*!< SSID. */
+	uint8	u8Options;
+	/*!< Common flags:
+			@ref M2M_WIFI_CONN_BSSID_FLAG
+	*/
+	uint8	au8Bssid[M2M_MAC_ADDRES_LEN];
+	/*!< BSSID to restrict on, or all 0 if M2M_WIFI_CONN_BSSID_FLAG is not set in u8Options. */
+	uint8	u8AuthType;
+	/*!< Connection auth type. See @ref tenuM2mSecType. */
+	uint8	au8Rsv[3];
+	/*!< Reserved for future use. Set to 0. */
+}tstrM2mConnCredCmn;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mConnCredCmn)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mConnCredCmn)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mWifiWep
+
+@brief
+	WEP security key header.
+	*/
+typedef struct{
+	uint8	u8KeyIndex;
+	/*!< WEP Key Index. */
+	uint8	u8KeyLen;
+	/*!< WEP Key Size. */
+	uint8	au8WepKey[WEP_104_KEY_SIZE];
+	/*!< WEP Key represented in bytes (padded with 0's if WEP-40). */
+	uint8	u8Rsv;
+	/*!< Reserved for future use. Set to 0. */
+}tstrM2mWifiWep;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiWep)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiWep)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+    tstrM2mWifiPsk
+
+@brief
+	Passphrase and PSK for WPA(2) PSK.
+*/
+typedef struct{
+	uint8	u8PassphraseLen;
+	/*!< Length of passphrase (8 to 63) or 64 if au8Passphrase contains ASCII representation of PSK. */
+	uint8	au8Passphrase[M2M_MAX_PSK_LEN-1];
+	/*!< Passphrase, or ASCII representation of PSK if u8PassphraseLen is 64. */
+	uint8	au8Psk[PSK_CALC_LEN];
+	/*!< PSK calculated by firmware. Driver sets this to 0. */
+	uint8	u8PskCalculated;
+	/*!< Flag used by firmware to avoid unnecessary recalculation of PSK. Driver sets this to 0. */
+	uint8	au8Rsv[2];
+	/*!< Reserved for future use. Set to 0. */
+}tstrM2mWifiPsk;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiPsk)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiPsk)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mWifi1xHdr
+
+@brief
+	Wi-Fi Authentication 802.1x header for parameters.
+	The parameters (Domain, UserName, PrivateKey/Password) are appended to this structure.
+*/
+typedef struct {
+    uint8   u8Flags;
+    /*!< 802.1x-specific flags:
+            @ref M2M_802_1X_MSCHAP2_FLAG
+            @ref M2M_802_1X_TLS_FLAG
+            @ref M2M_802_1X_UNENCRYPTED_USERNAME_FLAG
+            @ref M2M_802_1X_PREPEND_DOMAIN_FLAG
+    */
+    uint8   u8DomainLength;
+    /*!< Length of Domain. (Offset of Domain, within au81xAuthDetails, understood to be 0.) */
+    uint8   u8UserNameLength;
+    /*!< Length of UserName. (Offset of UserName, within au81xAuthDetails, understood to be u8DomainLength.) */
+    uint8   u8HdrLength;
+    /*!< Length of header (offset of au81xAuthDetails within tstrM2mWifi1xHdr).
+        Legacy implementations may have 0 here, in which case header is 12 bytes.
+        The unusual placing of this field is in order to hit a zero in legacy implementations. */
+    uint16  u16PrivateKeyOffset;
+    /*!< Offset within au81xAuthDetails of PrivateKey/Password. */
+    uint16  u16PrivateKeyLength;
+    /*!< Length of PrivateKey/Password. In the case of PrivateKey, this is the length of the modulus. */
+    uint16  u16CertificateOffset;
+    /*!< Offset within au81xAuthDetails of Certificate. */
+    uint16  u16CertificateLength;
+    /*!< Length of Certificate. */
+    uint8   au8TlsSpecificRootNameSha1[20];
+    /*!< SHA1 digest of subject name to identify specific root certificate for phase 1 server verification. */
+    uint32  u32Rsv1;
+    /*!< Reserved, set to 0. */
+    uint32  u32TlsHsFlags;
+    /*!< TLS handshake flags for phase 1. */
+    uint32  u32Rsv2;
+    /*!< Reserved, set to 0. */
+    uint8   au81xAuthDetails[];
+    /*!< Placeholder for concatenation of Domain, UserName, PrivateKey/Password, Certificate.
+            Certificate (for 1x Tls only) is sent over HIF separately from the other parameters. */
+} tstrM2mWifi1xHdr;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifi1xHdr)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifi1xHdr)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mWifiAuthInfoHdr
+
+@brief
+	Generic Wi-Fi authentication information to be sent in a separate HIF message of type
+	@ref M2M_WIFI_IND_CONN_PARAM (preceding @ref M2M_WIFI_REQ_CONN).
+	*/
+typedef struct{
+	uint8	u8Type;
+	/*!< Type of info:
+			@ref M2M_802_1X_TLS_CLIENT_CERTIFICATE
+	*/
+	uint8	au8Rsv[3];
+	/*!< Reserved for future use. Set to 0. */
+	uint16  u16InfoPos;
+	/*!< Information about positioning of the Info. The interpretation depends on u8Type. */
+	uint16	u16InfoLen;
+	/*!< Info length (not including this header). */
+	uint8	au8Info[];
+	/*!< Placeholder for info. */
+}tstrM2mWifiAuthInfoHdr;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiAuthInfoHdr)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiAuthInfoHdr)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mWifiConnHdr
+
+@brief
+	Wi-Fi Connect Request (new format) for use with @ref M2M_WIFI_REQ_CONN.
+	This structure is sent across the HIF along with the relevant auth details. One of:
+		@ref tstrM2mWifiPsk
+		@ref tstrM2mWifiWep
+		@ref tstrM2mWifi1xHdr
+	If further authentication details need to be sent (such as client certificate for 1x TLS), they
+	are sent with header @ref tstrM2mWifiAuthInfoHdr in a preceding HIF message of type
+	@ref M2M_WIFI_IND_CONN_PARAM
+*/
+typedef struct{
+	tstrM2mConnCredHdr	strConnCredHdr;
+	/*!< Credentials header. */
+	tstrM2mConnCredCmn	strConnCredCmn;
+	/*!< Credentials common section, including auth type and SSID. */
+}tstrM2mWifiConnHdr;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiConnHdr)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiConnHdr)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2mWifiApId
+
+@brief
+	Specify an access point (by SSID)
+*/
+typedef struct{
+	uint8				au8SSID[M2M_MAX_SSID_LEN];
+	/*!<
+		SSID of the desired AP, prefixed by length byte.
+		First byte 0xFF used to mean all access points.
+	*/
+	uint8	__PAD__[3];
+	/*!< Padding bytes for forcing 4-byte alignment
+	*/
+}tstrM2mWifiApId;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiApId)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiApId)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2MGenericResp
+
+@brief
+	Generic success/error response
+*/
+typedef struct{
+	sint8		s8ErrorCode;
+	/*!<
+		Generic success/error code. Possible values are:
+		- @ref M2M_SUCCESS
+		- @ref M2M_ERR_FAIL
 	*/
 	uint8	__PAD24__[3];
-	/*!< Padding bytes to keep the structure word alligned.
-	*/
-}tstrM2mWifiWepParams;
-
-
-/*!
-@struct	\
-	tstr1xAuthCredentials
-
-@brief
-	Credentials for the user to authenticate with the AAA server (WPA-Enterprise Mode IEEE802.1x).
-*/
-typedef struct{
-	uint8	au8UserName[M2M_1X_USR_NAME_MAX];
-	/*!< User Name. It must be Null terminated string.
-	*/
-	uint8	au8Passwd[M2M_1X_PWD_MAX];
-	/*!< Password corresponding to the user name. It must be Null terminated string.
-	*/
-}tstr1xAuthCredentials;
-
-
-/*!
-@union	\
-	tuniM2MWifiAuth
-
-@brief
-	Wi-Fi Security Parameters for all supported security modes.
-*/
-typedef union{
-	uint8				au8PSK[M2M_MAX_PSK_LEN];
-	/*!< Pre-Shared Key in case of WPA-Personal security.
-	*/
-	tstr1xAuthCredentials	strCred1x;
-	/*!< Credentials for RADIUS server authentication in case of WPA-Enterprise security.
-	*/
-	tstrM2mWifiWepParams	strWepInfo;
-	/*!< WEP key parameters in case of WEP security.
-	*/
-}tuniM2MWifiAuth;
-
-
-/*!
-@struct	\
-	tstrM2MWifiSecInfo
-
-@brief
-	Authentication credentials to connect to a Wi-Fi network.
-*/
-typedef struct{
-	tuniM2MWifiAuth		uniAuth;
-	/*!< Union holding all possible authentication parameters corresponding the current security types.
-	*/
-	uint8				u8SecType;
-	/*!< Wi-Fi network security type. See tenuM2mSecType for supported security types.
-	*/
-#define __PADDING__		(4 - ((sizeof(tuniM2MWifiAuth) + 1) % 4))
-	uint8				__PAD__[__PADDING__];
-	/*!< Padding bytes for forcing 4-byte alignment
-	*/
-}tstrM2MWifiSecInfo;
-
-
-/*!
-@struct	\
-	tstrM2mWifiConnect
-
-@brief
-	Wi-Fi Connect Request
-*/
-typedef struct{
-	tstrM2MWifiSecInfo		strSec;
-	/*!< Security parameters for authenticating with the AP.
-	*/
-	uint16				u16Ch;
-	/*!< RF Channel for the target SSID.
-	*/
-	uint8				au8SSID[M2M_MAX_SSID_LEN];
-	/*!< SSID of the desired AP. It must be NULL terminated string.
-	*/
-	uint8 				u8NoSaveCred;
-#define __CONN_PAD_SIZE__		(4 - ((sizeof(tstrM2MWifiSecInfo) + M2M_MAX_SSID_LEN + 3) % 4))
-	uint8				__PAD__[__CONN_PAD_SIZE__];
-	/*!< Padding bytes for forcing 4-byte alignment
-	*/
-}tstrM2mWifiConnect;
-
+}tstrM2MGenericResp;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MGenericResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MGenericResp)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1305,7 +1713,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2MWPSConnect;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MWPSConnect)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MWPSConnect)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1356,13 +1770,20 @@ typedef struct{
 	*/
 	uint8	__PAD24__[3];
 }tstrM2MDefaultConnResp;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MDefaultConnResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MDefaultConnResp)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
 	tstrM2MScanOption
 
 @brief
-	Scan options and configurations.
+    This struct contains the configuration options for Wi-Fi scan.
 
 @sa
 	tenuM2mScanCh
@@ -1370,26 +1791,76 @@ typedef struct{
 */
 typedef struct {
 	uint8   u8NumOfSlot;
-	/*|< The min number of slots is 2 for every channel,
-	every slot the soc will send Probe Request on air, and wait/listen for PROBE RESP/BEACONS for the u16slotTime
+    /*!< The number of scan slots per channel. Refers to both active and passive scan.
+         Valid settings are in the range 0<Slots<=255.
+         Default setting is @ref M2M_SCAN_DEFAULT_NUM_SLOTS.
 	*/
 	uint8   u8SlotTime;
-	/*|< the time that the Soc will wait on every channel listening to the frames on air
-		when that time increaseed number of AP will increased in the scan results
-		min time is 10 ms and the max is 250 ms
-	*/
-	uint8  u8ProbesPerSlot;
-	/*!< Number of probe requests to be sent per channel scan slot.
+    /*!< The length of each scan slot in milliseconds. Refers to active scan only.
+         The device listens for probe responses and beacons during this time.
+         Valid settings are in the range 10<=SlotTime<=250.
+         Default setting is @ref M2M_SCAN_DEFAULT_SLOT_TIME.
+    */
+    uint8   u8ProbesPerSlot;
+    /*!< Number of probe requests to be sent for each scan slot (when not specifying network to scan).
+         Number of probe requests to be sent for each ssid to scan in each scan slot (when specifying network to scan).
+         Refers to active scan only.
+         Valid settings are in the range 0<Probes<=2.
+         Default setting is @ref M2M_SCAN_DEFAULT_NUM_PROBE.
 	*/
 	sint8   s8RssiThresh;
-	/*! < The RSSI threshold of the AP which will be connected to directly.
+    /*!< The Received Signal Strength Indicator threshold required for (fast) reconnection to an AP without scanning all channels first.
+         Refers to active scan as part of reconnection to a previously connected AP.
+         The device connects to the target AP immediately if it receives a sufficiently strong probe response on the expected channel.
+         Low thresholds facilitate fast reconnection. High thresholds facilitate connection to the strongest signal.
+         Valid settings are in the range -128<=Thresh<0.
+         Default setting is @ref M2M_FASTCONNECT_DEFAULT_RSSI_THRESH.
 	*/
 
 }tstrM2MScanOption;
 
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MScanOption)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MScanOption)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+
 /*!
-@struct	\
-	tstrM2MScanRegion
+@struct \
+    tstrM2MStopScanOption
+
+@brief  This struct holds additional configuration options for Wi-Fi scan.
+
+        These scan options should be set by the application prior to issuing the scan request, and once configured,
+        WINC will keep the settings until the scan options are set again, via the same API, or until the device is
+        either reset or power cycled.
+*/
+typedef struct {
+    uint8                       u8StopOnFirstResult;
+    /*!<
+        Stop scan as soon as an SSID is detected.
+        1 = Enabled, 0 = Disabled (default)
+    */
+
+    uint8                       au8Rsv[3];
+    /*!< Reserved for future use. Set to 0. */
+
+} tstrM2MStopScanOption;
+
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MStopScanOption)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MStopScanOption)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrM2MScanRegion
 
 @brief
 	Wi-Fi channel regulation region information.
@@ -1402,8 +1873,15 @@ typedef struct {
 	/*|< Specifies the number of channels allowed in the region (e.g. North America = 11 ... etc.).
 	*/
 	uint8 __PAD16__[2];
-
+	/*!< Padding bytes for forcing 4-byte alignment */
 }tstrM2MScanRegion;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MScanRegion)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MScanRegion)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1424,7 +1902,10 @@ typedef struct {
 	/*!< Reserved for future use.
 	*/
 	uint16 	u16PassiveScanTime;
-	/*!< Passive Scan Timeout in ms. The field is ignored for active scan.
+    /*!< The length of each scan slot in milliseconds. Refers to passive scan only.
+         The device listens for beacons during this time.
+         Valid settings are in the range 10<=PassiveScanTime<=1200.
+         Default setting is @ref M2M_SCAN_DEFAULT_PASSIVE_SLOT_TIME.
 	*/
 }tstrM2MScan;
 
@@ -1442,7 +1923,13 @@ typedef struct {
 	/*
 	*/
 }tstrCyptoResp;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrCyptoResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrCyptoResp)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1462,7 +1949,13 @@ typedef struct{
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mScanDone;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mScanDone)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mScanDone)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1480,7 +1973,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mReqScanResult;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mReqScanResult)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mReqScanResult)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1513,7 +2012,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mWifiscanResult;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiscanResult)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiscanResult)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1536,7 +2041,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mWifiStateChanged;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mWifiStateChanged)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mWifiStateChanged)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1559,6 +2070,13 @@ typedef struct{
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mPsType;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mPsType)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mPsType)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1592,7 +2110,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mLsnInt;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mLsnInt)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mLsnInt)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1624,13 +2148,19 @@ typedef struct{
 	*/
 	uint8 u8EnRecvHdr;
 	/*
-	 Enable recv the full hder before the payload	
+	 Enable receive the full header before the payload
 	*/
 	uint8	__PAD16__[2];
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2MWifiMonitorModeCtrl;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MWifiMonitorModeCtrl)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MWifiMonitorModeCtrl)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1685,7 +2215,13 @@ typedef struct{
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2MWifiRxPacketInfo;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MWifiRxPacketInfo)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MWifiRxPacketInfo)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1705,69 +2241,116 @@ typedef struct{
 	*/
 }tstrM2MWifiTxPacketInfo;
 
-
 /*!
- @struct	\
- 	tstrM2MP2PConnect
-
- @brief
- 	Set the device to operate in the Wi-Fi Direct (P2P) mode.
-*/
-typedef struct {
-	uint8 	u8ListenChannel;
-	/*!< P2P Listen Channel (1, 6 or 11)
-	*/
-	uint8	__PAD24__[3];
-	/*!< Padding bytes for forcing 4-byte alignment
-	*/
-}tstrM2MP2PConnect;
-
-/*!
-@struct	\
-	tstrM2MAPConfig
+@struct \
+    tstrM2MAPConfig
 
 @brief	AP Configuration
 
-	This structure holds the configuration parameters for the M2M AP mode. It should be set by the application when
-	it requests to enable the M2M AP operation mode. The M2M AP mode currently supports only WEP security (with
-	the NO Security option available of course).
+    This structure holds the configuration parameters for the M2M AP mode. It should be set by the application when
+    it requests to enable the M2M AP operation mode. This mode supports either open, WEP or WPA/WPA2 mixed mode security types.
 */
 typedef struct {
+    /*!<
+        Configuration parameters for the WiFi AP.
+    */
+    uint8   au8SSID[M2M_MAX_SSID_LEN];
+    /*!< AP SSID
+    */
+    uint8   u8ListenChannel;
+    /*!< Wi-Fi RF Channel which the AP will operate on
+    */
+    uint8   u8KeyIndx;
+    /*!< Wep key Index
+    */
+    uint8   u8KeySz;
+    /*!< Wep/WPA key Size
+    */
+    uint8   au8WepKey[WEP_104_KEY_STRING_SIZE + 1];
+    /*!< Wep key
+    */
+    uint8   u8SecType;
+    /*!< Security type: Open, WEP or WPA/WPA2 mixed mode
+    */
+    uint8   u8SsidHide;
+    /*!< SSID Status "Hidden(1)/Visible(0)"
+    */
+    uint8   au8DHCPServerIP[4];
+    /*!< Ap IP server address
+    */
+    uint8   au8Key[M2M_MAX_PSK_LEN];
+    /*!< WPA key
+    */
+    uint8   __PAD16__[2];
+    /*!< Padding bytes for forcing alignment
+    */
+} tstrM2MAPConfig;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MAPConfig)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MAPConfig)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2MAPConfigExt
+
+@brief	AP Configuration Extension
+
+	This structure holds additional configuration parameters for the M2M AP mode. If modification of the extended parameters
+	in AP mode is desired then @ref tstrM2MAPModeConfig should be set by the application, which contains the main AP configuration
+	structure as well as this extended parameters structure.
+	When configuring provisioning mode then @ref tstrM2MProvisionModeConfig should be used, which also contains the main AP configuration
+	structure, this extended parameters structure and additional provisioning parameters.
+*/
+typedef struct {
+	uint8	au8DefRouterIP[4];
+	/*!< Ap Default Router address
+	*/
+	uint8	au8DNSServerIP[4];
+	/*!< Ap DNS server address
+	*/
+    uint8   au8SubnetMask[4];
+	/*!< Network Subnet Mask
+	*/
+}tstrM2MAPConfigExt;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MAPConfigExt)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MAPConfigExt)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrM2MAPModeConfig
+
+@brief	AP Configuration
+
+    This structure holds the AP configuration parameters plus the extended AP configuration parameters for M2M AP mode.
+    It should be set by the application when it requests to enable M2M AP operation mode. This mode supports 
+    either open, WEP or WPA/WPA2 mixed mode security types.
+*/
+typedef struct {
+	tstrM2MAPConfig		strApConfig;
 	/*!<
 		Configuration parameters for the WiFi AP.
 	*/
-	uint8 	au8SSID[M2M_MAX_SSID_LEN];
-	/*!< AP SSID
+	tstrM2MAPConfigExt		strApConfigExt;
+	/*!<
+		Additional configuration parameters for the WiFi AP.
 	*/
-	uint8 	u8ListenChannel;
-	/*!< Wi-Fi RF Channel which the AP will operate on
-	*/
-	uint8	u8KeyIndx;
-	/*!< Wep key Index
-	*/
-	uint8	u8KeySz;
-	/*!< Wep/WPA key Size
-	*/
-	uint8	au8WepKey[WEP_104_KEY_STRING_SIZE + 1];
-	/*!< Wep key
-	*/
-	uint8 	u8SecType;
-	/*!< Security type: Open or WEP or WPA in the current implementation
-	*/
-	uint8 	u8SsidHide;
-	/*!< SSID Status "Hidden(1)/Visible(0)"
-	*/
-	uint8	au8DHCPServerIP[4];
-	/*!< Ap IP server address
-	*/
-	uint8	au8Key[M2M_MAX_PSK_LEN];
-	/*!< WPA key
-	*/
-	uint8	__PAD24__[2];
-	/*!< Padding bytes for forcing alignment
-	*/
-}tstrM2MAPConfig;
-
+}tstrM2MAPModeConfig;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MAPModeConfig)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MAPModeConfig)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1784,7 +2367,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mServerInit;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mServerInit)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mServerInit)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1801,7 +2390,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mClientState;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mClientState)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mClientState)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1818,7 +2413,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2Mservercmd;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2Mservercmd)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2Mservercmd)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1839,7 +2440,13 @@ typedef struct {
 	/*!< Padding bytes for forcing 4-byte alignment
 	*/
 }tstrM2mSetMacAddress;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2mSetMacAddress)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2mSetMacAddress)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1862,26 +2469,29 @@ typedef struct {
  	tstrM2MIPConfig
 
 @brief
- 	Static IP configuration.
+ 	IP configuration (static/DHCP). The same structure is used for DCHP callback as well as static IP configuration.
 
 @note
  	All member IP addresses are expressed in Network Byte Order (eg. "192.168.10.1" will be expressed as 0x010AA8C0).
  */
 typedef struct {
 	uint32 	u32StaticIP;
-	/*!< The static IP assigned to the device.
+	/*!< If DHCP callback, this is the IP address obtained from the DHCP. In static IP config, this is the assigned to the device from the application.
 	*/
 	uint32 	u32Gateway;
-	/*!< IP of the Default internet gateway.
+	/*!< IP of the default internet gateway.
 	*/
 	uint32 	u32DNS;
 	/*!< IP for the DNS server.
+	*/
+	uint32 	u32AlternateDNS;
+	/*!< IP for the secondary DNS server (if any). Must set to zero if not provided in static IP configuration from the application.
 	*/
 	uint32 	u32SubnetMask;
 	/*!< Subnet mask for the local area network.
 	*/
 	uint32 u32DhcpLeaseTime;
-	/*!< Dhcp Lease Time in sec
+	/*!< DHCP Lease Time in sec. This field is is ignored in static IP configuration.
 	*/
 } tstrM2MIPConfig;
 
@@ -1923,9 +2533,19 @@ typedef struct {
 		- 0 : Disable HTTP Redirect.
 		- 1 : Enable HTTP Redirect.
 	*/
+	tstrM2MAPConfigExt		strApConfigExt;
+	/*!<
+		Additional configuration parameters for the WiFi AP.
+	*/
 	uint8			__PAD24__[3];
 }tstrM2MProvisionModeConfig;
-
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MProvisionModeConfig)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MProvisionModeConfig)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
 @struct	\
@@ -1974,285 +2594,332 @@ typedef struct{
 	/*!< MAC address of the peer Wi-Fi station */ 
 	sint8	s8RSSI;
 	/*!< Connection RSSI signal */
-	uint8	__PAD24__[3];
+	uint8	u8CurrChannel; 
+	/*!< Wi-Fi RF channel number  1,2,... 14.  */
+	uint8	__PAD16__[2];
 	/*!< Padding bytes for forcing 4-byte alignment */
 }tstrM2MConnInfo;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MConnInfo)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MConnInfo)%4)==0, "Structure alignment error");
+#endif
+#endif
 
-/*!
-@struct	\
- 	tstrOtaInitHdr
-
-@brief
- 	OTA Image Header 
+/**@cond P2P_DOC
  */
-
-typedef struct{
-	uint32 u32OtaMagicValue;
-	/*!< Magic value kept in the OTA image after the 
-	sha256 Digest buffer to define the Start of OTA Header */
-	uint32 u32OtaPayloadSzie;
-	/*!<
-	The Total OTA image payload size, include the sha256 key size
-	*/
-
-}tstrOtaInitHdr;
-	
-
 /*!
-@struct	\
- 	tstrOtaControlSec
+@enum   \
+    tenuM2mP2pCmd
 
 @brief
- 	Control section structure is used to define the working image and 
-	the validity of the roll-back image and its offset, also both firmware versions is kept in that structure.
- */
-
-typedef struct {
-	uint32 u32OtaMagicValue;
-/*!<
-	Magic value used to ensure the structure is valid or not 
-*/
-	uint32 u32OtaFormatVersion;
-/*!<
-		NA   NA   NA   Flash version   cs struct version
-		00   00   00   00              00 
-	Control structure format version, the value will be incremented in case of structure changed or updated
-*/
-	uint32 u32OtaSequenceNumber;
-/*!<
-	Sequence number is used while update the control structure to keep track of how many times that section updated 
-*/
-	uint32 u32OtaLastCheckTime;
-/*!<
-	Last time OTA check for update
-*/
-	uint32 u32OtaCurrentworkingImagOffset;
-/*!<
-	Current working offset in flash 
-*/
-	uint32 u32OtaCurrentworkingImagFirmwareVer;
-/*!<
-	current working image version ex 18.0.1
-*/
-	uint32 u32OtaRollbackImageOffset;
-/*!<
-	Roll-back image offset in flash 
-*/
-	uint32 u32OtaRollbackImageValidStatus;
-/*!<
-	roll-back image valid status 
-*/
-	uint32 u32OtaRollbackImagFirmwareVer;
-/*!<
-	Roll-back image version (ex 18.0.3)
-*/
-	uint32 u32OtaCortusAppWorkingOffset;
-/*!<
-	cortus app working offset in flash 
-*/
-	uint32 u32OtaCortusAppWorkingValidSts;
-/*!<
-	Working Cortus app valid status 
-*/
-	uint32 u32OtaCortusAppWorkingVer;
-/*!<
-	Working cortus app version (ex 18.0.3)
-*/
-	uint32 u32OtaCortusAppRollbackOffset;
-/*!<
-	cortus app rollback offset in flash 
-*/
-	uint32 u32OtaCortusAppRollbackValidSts;
-/*!<
-	roll-back cortus app valid status 
-*/
-	uint32 u32OtaCortusAppRollbackVer;
-/*!<
-	Roll-back cortus app version (ex 18.0.3)
-*/
-	uint32 u32OtaControlSecCrc;
-/*!<
-	CRC for the control structure to ensure validity 
-*/
-} tstrOtaControlSec;
-
-/*!
-@enum	\
-	tenuOtaUpdateStatus
-
-@brief
-	OTA return status
+    This enum contains WINC commands while in P2P mode.
 */
 typedef enum {
-	OTA_STATUS_SUCSESS        = 0,
-	/*!< OTA Success with not errors. */
-	OTA_STATUS_FAIL           = 1,
-	/*!< OTA generic fail. */
-	OTA_STATUS_INVAILD_ARG    = 2,
-	/*!< Invalid or malformed download URL. */
-	OTA_STATUS_INVAILD_RB_IMAGE    = 3,
-	/*!< Invalid rollback image. */
-	OTA_STATUS_INVAILD_FLASH_SIZE    = 4,
-	/*!< Flash size on device is not enough for OTA. */
-	OTA_STATUS_AlREADY_ENABLED    = 5,
-	/*!< An OTA operation is already enabled. */
-	OTA_STATUS_UPDATE_INPROGRESS    = 6,
-	/*!< An OTA operation update is in progress */
-	OTA_STATUS_IMAGE_VERIF_FAILED = 7,
-	/*!<  OTA Verfication failed */
-	OTA_STATUS_CONNECTION_ERROR = 8,
-	/*!< OTA connection error */
-	OTA_STATUS_SERVER_ERROR = 9,
-	/*!< OTA server Error (file not found or else ...) */
-	OTA_STATUS_ABORTED        = 10
-	/*!< OTA download has been aborted by the application. */
-} tenuOtaUpdateStatus;
+    M2M_WIFI_REQ_P2P_INT_CONNECT = M2M_P2P_CMD_BASE,
+    /*!< This command is for internal use by the WINC and
+        should not be used by the host driver.
+    */
+    M2M_WIFI_REQ_ENABLE_P2P,
+    /*!< Enable P2P mode command.
+    */
+    M2M_WIFI_REQ_DISABLE_P2P,
+    /*!< Disable P2P mode command.
+    */
+    M2M_WIFI_REQ_P2P_REPOST,
+    /*!< This command is for internal use by the WINC and
+        should not be used by the host driver.
+    */
+    M2M_WIFI_MAX_P2P_ALL
+} tenuM2mP2pCmd;
+
 /*!
-@enum	\
-	tenuOtaUpdateStatusType
+ @struct    \
+    tstrM2MP2PConnect
+
+ @brief
+    Set the device to operate in the Wi-Fi Direct (P2P) mode.
+*/
+typedef struct {
+    uint8   u8ListenChannel;
+    /*!< P2P Listen Channel (1, 6 or 11)
+    */
+    uint8   __PAD24__[3];
+    /*!< Padding bytes for forcing 4-byte alignment
+    */
+} tstrM2MP2PConnect;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MP2PConnect)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MP2PConnect)%4)==0, "Structure alignment error");
+#endif
+#endif
+/**@endcond*/ //P2P_DOC
+
+/*!
+@struct \
+    tstrM2MSNTPConfig
+
+@brief  SNTP Client Configuration
+
+    Configuration structure for the SNTP client.
+*/
+typedef struct {
+    /*!<
+        Configuration parameters for the NTP Client.
+    */
+    char                    acNTPServer[M2M_NTP_MAX_SERVER_NAME_LENGTH + 1];
+    /*!< Custom NTP server name.
+    */
+    tenuSNTPUseDHCP         enuUseDHCP;
+    /*!< Use NTP server provided by the DHCP server when falling back
+    */
+#if tstrM2MSNTPConfig_PAD != 4
+    uint8                   __PAD8__[tstrM2MSNTPConfig_PAD];
+    /*!< Padding bytes for forcing 4-byte alignment
+    */
+#endif
+} tstrM2MSNTPConfig;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MSNTPConfig)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MSNTPConfig)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrSystemTime
 
 @brief
-	OTA update Status type
+    Used for time storage.
+*/
+typedef struct {
+    uint16  u16Year;
+    uint8   u8Month;
+    uint8   u8Day;
+    uint8   u8Hour;
+    uint8   u8Minute;
+    uint8   u8Second;
+    uint8   __PAD8__;
+} tstrSystemTime;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrSystemTime)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrSystemTime)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrM2MMulticastMac
+
+@brief
+    M2M add/remove multi-cast mac address
+ */
+typedef struct {
+    uint8 au8macaddress[M2M_MAC_ADDRES_LEN];
+    /*!<
+        Mac address needed to be added or removed from filter.
+    */
+    uint8 u8AddRemove;
+    /*!<
+        set by 1 to add or 0 to remove from filter.
+    */
+    uint8   __PAD8__;
+    /*!< Padding bytes for forcing 4-byte alignment
+    */
+} tstrM2MMulticastMac;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrM2MMulticastMac)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrM2MMulticastMac)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrPrng
+
+@brief
+    M2M Request PRNG
+ */
+typedef struct {
+    /*!<
+    return buffer address
+    */
+    uint8 *pu8RngBuff;
+    /*!<
+    PRNG size requested
+    */
+    uint16  u16PrngSize;
+    /*!<
+        PRNG pads
+    */
+    uint8 __PAD16__[2];
+} tstrPrng;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrPrng)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrPrng)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@enum\
+    tenuWlanTxRate
+
+@brief  All possible supported 802.11 WLAN TX rates.
 */
 typedef enum {
-
-	DL_STATUS        = 1,
-	/*!< Download OTA file status
-	*/
-	SW_STATUS        = 2,
-	/*!< Switching to the upgrade firmware status
-	*/
-	RB_STATUS        = 3,
-	/*!< Roll-back status
-	*/
-	AB_STATUS        = 4
-	/*!< Abort status
-	*/
-}tenuOtaUpdateStatusType;
-
+    TX_RATE_AUTO  = 0xFF, /*!<  Automatic rate selection */
+    TX_RATE_LOWEST  = 0xFE, /*!< Force the lowest possible data rate for longest range. */
+    TX_RATE_1     = 0x00, /* 1 Mbps  */
+    TX_RATE_2     = 0x01, /* 2 Mbps  */
+    TX_RATE_5_5   = 0x02, /* 5 Mbps  */
+    TX_RATE_11    = 0x03, /* 11 Mbps */
+    TX_RATE_6     = 0x0B, /* 6 Mbps  */
+    TX_RATE_9     = 0x0F, /* 9 Mbps  */
+    TX_RATE_12    = 0x0A, /* 12 Mbps */
+    TX_RATE_18    = 0x0E, /* 18 Mbps */
+    TX_RATE_24    = 0x09, /* 24 Mbps */
+    TX_RATE_36    = 0x0D, /* 36 Mbps */
+    TX_RATE_48    = 0x08, /* 48 Mbps */
+    TX_RATE_54    = 0x0C, /* 54 Mbps */
+    TX_RATE_MCS_0 = 0x80, /* MCS-0: 6.5 Mbps */
+    TX_RATE_MCS_1 = 0x81, /* MCS-1: 13 Mbps */
+    TX_RATE_MCS_2 = 0x82, /* MCS-2: 19.5 Mbps */
+    TX_RATE_MCS_3 = 0x83, /* MCS-3: 26 Mbps */
+    TX_RATE_MCS_4 = 0x84, /* MCS-4: 39 Mbps */
+    TX_RATE_MCS_5 = 0x85, /* MCS-5: 52 Mbps */
+    TX_RATE_MCS_6 = 0x86, /* MCS-6: 58.5 Mbps */
+    TX_RATE_MCS_7 = 0x87, /* MCS-7: 65 Mbps */
+} tenuWlanTxRate;
 
 /*!
-@struct	\
-	tstrOtaUpdateStatusResp
+@struct \
+    tstrConfAutoRate
 
 @brief
-	OTA Update Information
-
-@sa
-	tenuWPSTrigger
+    Auto TX rate selection parameters passed to m2m_wifi_conf_auto_rate.
 */
 typedef struct {
-	uint8	u8OtaUpdateStatusType;
-	/*!<
-		Status type tenuOtaUpdateStatusType
-	*/
-	uint8	u8OtaUpdateStatus;
-	/*!<
-	OTA_SUCCESS 						
-	OTA_ERR_WORKING_IMAGE_LOAD_FAIL		
-	OTA_ERR_INVAILD_CONTROL_SEC			
-	M2M_ERR_OTA_SWITCH_FAIL     		
-	M2M_ERR_OTA_START_UPDATE_FAIL     	
-	M2M_ERR_OTA_ROLLBACK_FAIL     		
-	M2M_ERR_OTA_INVAILD_FLASH_SIZE     	
-	M2M_ERR_OTA_INVAILD_ARG		     
-	*/
-	uint8 _PAD16_[2];
-}tstrOtaUpdateStatusResp;
+    uint16 u16ArMaxRecoveryFailThreshold;
+    /*!<
+        To stabilize the TX rate and avoid oscillation, the algorithm will not attempt to
+        push the rate up again after a failed attempt to push the rate up.
+        An attempt to push the rate up is considered failed if the next rate suffers from
+        very high retransmission. In this case, WINC will not attempt again until a
+        duration of time is elapsed to keep the TX rate stable.
+        The min duration is (u16ArMinRecoveryFailThreshold) seconds and doubles
+        on every failed attempt. The doubling continues until the duration is
+        (u16ArMaxRecoveryFailThreshold) max.
 
-/*!
-@struct	\
-	tstrOtaUpdateInfo
+        Increasing u16ArMaxRecoveryFailThreshold will cause the TX rate to be
+        stable over a long period of time with fewer attempts to increase the data rate.
+        However, increasing it to a very large value will deter the algorithm from
+        attempting to increase the rate if, for instance, the wireless conditions before were better.
 
-@brief
-	OTA Update Information
+        Default is 5 seconds.
+    */
+    uint16 u16ArMinRecoveryFailThreshold;
+    /*!<
+        To stabilize the TX rate and avoid oscillation, the algorithm will not attempt to
+        push the rate up again after a failed attempt to push the rate up.
+        An attempt to push the rate up is considered failed if the next rate suffers from
+        very high retransmission. In this case, WINC will not attempt again until a
+        duration of time is elapsed to keep the TX rate stable.
+        The min duration is (u16ArMinRecoveryFailThreshold) seconds and doubles
+        on every failed attempt. The doubling continues until the duration is
+        (u16ArMaxRecoveryFailThreshold) max.
 
-@sa
-	tenuWPSTrigger
-*/
-typedef struct {
-	uint32	u8NcfUpgradeVersion;
-	/*!< NCF OTA Upgrade Version
-	*/
-	uint32	u8NcfCurrentVersion;
-	/*!< NCF OTA Current firmware version
-	*/
-	uint32	u8NcdUpgradeVersion;
-	/*!< NCD (host) upgraded version (if the u8NcdRequiredUpgrade == true)
-	*/
-	uint8	u8NcdRequiredUpgrade;
-	/*!< NCD Required upgrade to the above version
-	*/
-	uint8 	u8DownloadUrlOffset;
-	/*!< Download URL offset in the received packet
-	*/
-	uint8 	u8DownloadUrlSize;
-	/*!< Download URL size in the received packet
-	*/
-	uint8	__PAD8__;
-	/*!< Padding bytes for forcing 4-byte alignment
-	*/
-} tstrOtaUpdateInfo;
+        Default is 1 second.
+    */
 
-/*!
-@struct	\
-	tstrSystemTime
+    tenuWlanTxRate enuWlanTxRate;
+    /*!<
+        The TX data rate selected as enumerated in tenuWlanTxRate
+        Default is TX_RATE_AUTO.
 
-@brief
-	Used for time storage.
-*/
-typedef struct{
-	uint16	u16Year;
-	uint8	u8Month;
-	uint8	u8Day;
-	uint8	u8Hour;
-	uint8	u8Minute;
-	uint8	u8Second;
-	uint8	__PAD8__;
-}tstrSystemTime;
+        WINC shall override the rate provided through this API if it not supported by the peer WLAN device (STA/AP).
+        For instance, if the TX_RATE_MCS_0 is requested while the connection is to a BG only AP, WINC shall
+        elect the nearest BG data rate to the requested rate. In this example, it will be TX_RATE_9.
+    */
+    tenuWlanTxRate enuArInitialRateSel;
+    /*!<
+        Configures the initial WLAN TX rate used right after association.
+        This is the starting point for auto rate algorithm.
+        The algorithm tunes the rate up or down based on the wireless
+        medium condition if enuWlanTxRate is set to TX_RATE_AUTO.
+        If enuWlanTxRate is set to any value other than TX_RATE_AUTO, then
+        u8ArInitialRateSel is ignored.
 
-/*!
-@struct	\
- 	tstrM2MMulticastMac
+        By default WINC selects the best initial rate based on the receive
+        signal level from the WLAN peer. For applications that favor range
+        right after association, TX_RATE_LOWEST can bs used.
+    */
+    uint8 u8ArEnoughTxThreshold;
+    /*!<
+        Configures the minimum number of transmitted packets per second for auto
+        rate selection algorithm to start to make rate up or down decisions.
+        Default is 10.
+    */
+    uint8 u8ArSuccessTXThreshold;
+    /*!<
+        Configures the threshold for rate up. Rate goes up if number of
+        WLAN TX retries is less than (1/u8ArSuccessTXThreshold) of the
+        number of packet transmitted within one second.
+        This can be tuned to speed up or slow down the rate at which the algorithm
+        moves the WLAN TX rate up. Default value is 5.
+    */
+    uint8 u8ArFailTxThreshold;
+    /*!<
+        Configures the threshold for rate down. Rate goes down if number of
+        WLAN TX retries is greater than (1/u8ArFailTxThreshold) of the
+        number of packet transmitted within one second.
+        This can be tuned to speed up or slow down the rate at which the algorithm
+        moves the WLAN TX rate down. Default value is 3.
+    */
+    uint8 __PAD24__[3];
+    /*!< Pad bytes for forcing 4-byte alignment
+    */
+} tstrConfAutoRate;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrConfAutoRate)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrConfAutoRate)%4)==0, "Structure alignment error");
+#endif
+#endif
+/**@}*/     //WlanEnums
 
-@brief
- 	M2M add/remove multi-cast mac address
+/**@addtogroup  SSLEnums
+ * @{
  */
- typedef struct {
-	uint8 au8macaddress[M2M_MAC_ADDRES_LEN];
-	/*!<
-		Mac address needed to be added or removed from filter.
-	*/
-	uint8 u8AddRemove;
-	/*!<
-		set by 1 to add or 0 to remove from filter.
-	*/
-	uint8	__PAD8__;
-	/*!< Padding bytes for forcing 4-byte alignment
-	*/
-}tstrM2MMulticastMac;
-
-/*!
-@struct	\
- 	tstrPrng
-
-@brief
- 	M2M Request PRNG
- */
- typedef struct {
-	 /*!<
-		return buffer address
-	*/
-	uint8 *pu8RngBuff;
-	 /*!<
-		PRNG size requested
-	*/
-	uint16 	u16PrngSize;
-	/*!<
-		PRNG pads
-	*/
-	uint8 __PAD16__[2];
-}tstrPrng;
+typedef enum {
+    M2M_SSL_REQ_CERT_VERIF,
+    /*!< For internal use only during RSA signature verification. */
+    M2M_SSL_REQ_ECC,
+    /*!< Request from WINC for an elliptic curve operation. */
+    M2M_SSL_RESP_ECC,
+    /*!< Response to WINC with the result of an elliptic curve operation. */
+    M2M_SSL_IND_CRL,
+    /*!< Indication to WINC of a custom-format certificate revocation list. */
+    M2M_SSL_REQ_WRITE_OWN_CERTS,
+    /*!< Request to WINC with local certificates to write into WINC flash. */
+    M2M_SSL_REQ_SET_CS_LIST,
+    /*!< Request to WINC to set the list of ciphersuites to be globally enabled. */
+    M2M_SSL_RESP_SET_CS_LIST,
+    /*!< Response from WINC with the list of ciphersuites that are globally enabled. */
+    M2M_SSL_RESP_WRITE_OWN_CERTS
+    /*!< Response from WINC to indicate that local certificates have been written into WINC flash. */
+} tenuM2mSslCmd;
 
 /*
  * TLS certificate revocation list
@@ -2260,124 +2927,499 @@ typedef struct{
  */
 
 /*!
-@struct	\
- 	tstrTlsCrlEntry
+@struct \
+    tstrTlsCrlEntry
 
 @brief
- 	Certificate data for inclusion in a revocation list (CRL)
+    Certificate data for inclusion in a revocation list (CRL)
 */
 typedef struct {
-	uint8	u8DataLen;
-	/*!<
-		Length of certificate data (maximum possible is @ref TLS_CRL_DATA_MAX_LEN)
-	*/
-	uint8	au8Data[TLS_CRL_DATA_MAX_LEN];
-	/*!<
-		Certificate data
-	*/
-	uint8	__PAD24__[3];
-	/*!<
-		Padding bytes for forcing 4-byte alignment
-	*/
-}tstrTlsCrlEntry;
+    uint8   u8DataLen;
+    /*!< Length of certificate data (maximum possible is @ref TLS_CRL_DATA_MAX_LEN) */
+    uint8   au8Data[TLS_CRL_DATA_MAX_LEN];
+    /*!< Certificate data */
+    uint8   __PAD24__[3];
+    /*!< Padding bytes for forcing 4-byte alignment */
+} tstrTlsCrlEntry;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrTlsCrlEntry)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrTlsCrlEntry)%4)==0, "Structure alignment error");
+#endif
+#endif
 
 /*!
-@struct	\
- 	tstrTlsCrlInfo
+@struct \
+    tstrTlsCrlInfo
 
 @brief
- 	Certificate revocation list details
+    Certificate revocation list details
 */
 typedef struct {
-	uint8			u8CrlType;
-	/*!<
-		Type of certificate data contained in list
-	*/
-	uint8			u8Rsv1;
-	/*!<
-		Reserved for future use
-	*/
-	uint8			u8Rsv2;
-	/*!<
-		Reserved for future use
-	*/
-	uint8			u8Rsv3;
-	/*!<
-		Reserved for future use
-	*/
-	tstrTlsCrlEntry	astrTlsCrl[TLS_CRL_MAX_ENTRIES];
-	/*!<
-		List entries
-	*/
-}tstrTlsCrlInfo;
+    uint8           u8CrlType;
+    /*!< Type of certificate data contained in list */
+    uint8           u8Rsv1;
+    /*!< Reserved for future use */
+    uint8           u8Rsv2;
+    /*!< Reserved for future use */
+    uint8           u8Rsv3;
+    /*!< Reserved for future use */
+    tstrTlsCrlEntry astrTlsCrl[TLS_CRL_MAX_ENTRIES];
+    /*!< List entries */
+} tstrTlsCrlInfo;
 
- /*!
+/*!
 @enum\
-	tenuSslCertExpSettings
+tenuSslCertExpSettings
 
-@brief	SSL Certificate Expiry Validation Options	
+@brief  SSL Certificate Expiry Validation Options
 */
-typedef enum{
-	SSL_CERT_EXP_CHECK_DISABLE,
-	/*!<
-		ALWAYS OFF.
-		Ignore certificate expiration date validation. If a certificate is
-		expired or there is no configured system time, the SSL connection SUCCEEDs.
-	*/
-	SSL_CERT_EXP_CHECK_ENABLE,
-	/*!<
-		ALWAYS ON.
-		Validate certificate expiration date. If a certificate is expired or 
-		there is no configured system time, the SSL connection FAILs.
-	*/
-	SSL_CERT_EXP_CHECK_EN_IF_SYS_TIME
-	/*!<
-		CONDITIONAL VALIDATION (Default setting at startup).
-		Validate the certificate expiration date only if there is a configured system time.
-		If there is no configured system time, the certificate expiration is bypassed and the
-		SSL connection SUCCEEDs.
-	*/
-}tenuSslCertExpSettings;
+typedef enum {
+    SSL_CERT_EXP_CHECK_DISABLE,
+    /*!<
+        ALWAYS OFF.
+        Ignore certificate expiration date validation. If a certificate is
+        expired or there is no configured system time, the SSL connection SUCCEEDs.
+    */
+    SSL_CERT_EXP_CHECK_ENABLE,
+    /*!<
+        ALWAYS ON.
+        Validate certificate expiration date. If a certificate is expired or
+        there is no configured system time, the SSL connection FAILs.
+    */
+    SSL_CERT_EXP_CHECK_EN_IF_SYS_TIME
+    /*!<
+        CONDITIONAL VALIDATION (Default setting at startup).
+        Validate the certificate expiration date only if there is a configured system time.
+        If there is no configured system time, the certificate expiration is bypassed and the
+        SSL connection SUCCEEDs.
+    */
+} tenuSslCertExpSettings;
 
 
 /*!
-@struct	\
- 	tstrTlsSrvSecFileEntry
+@struct \
+    tstrTlsSrvSecFileEntry
 
 @brief
- 	This struct contains a TLS certificate.
+    This struct contains a TLS certificate.
  */
-typedef struct{
-	char	acFileName[TLS_FILE_NAME_MAX];
-	/*!< Name of the certificate.	*/
-	uint32	u32FileSize;
-	/*!< Size of the certificate.	*/
-	uint32	u32FileAddr;
-	/*!< Error Code.	*/
-}tstrTlsSrvSecFileEntry;
+typedef struct {
+    char    acFileName[TLS_FILE_NAME_MAX];
+    /*!< Name of the certificate.   */
+    uint32  u32FileSize;
+    /*!< Size of the certificate.   */
+    uint32  u32FileAddr;
+    /*!< Error Code.    */
+} tstrTlsSrvSecFileEntry;
+
+/*!
+@struct \
+    tstrTlsSrvSecHdr
+
+@brief
+    This struct contains a set of TLS certificates.
+ */
+typedef struct {
+    uint8                   au8SecStartPattern[TLS_SRV_SEC_START_PATTERN_LEN];
+    /*!< Start pattern. */
+    uint32                  u32nEntries;
+    /*!< Number of certificates stored in the struct.   */
+    uint32                  u32NextWriteAddr;
+    /*  */
+    tstrTlsSrvSecFileEntry  astrEntries[TLS_SRV_SEC_MAX_FILES];
+    /*!< TLS Certificate headers.   */
+    uint32                  u32CRC;
+    /*!< CRC32 of entire cert block, only the cert writer computes this, the FW just does a compare with replacement blocks.    */
+} tstrTlsSrvSecHdr;
+
+typedef enum {
+    TLS_FLASH_OK,
+    /*!< Operation succeeded. Flash modified. */
+    TLS_FLASH_OK_NO_CHANGE,
+    /*!< Operation was unnecessary. Flash not modified. */
+    TLS_FLASH_ERR_CORRUPT,
+    /*!< Operation failed. Flash modified. */
+    TLS_FLASH_ERR_NO_CHANGE,
+    /*!< Operation failed. Flash not modified. */
+    TLS_FLASH_ERR_UNKNOWN
+    /*!< Operation failed. Flash status unknown. */
+} tenuTlsFlashStatus;
+
+typedef struct {
+    uint16  u16Sig;
+    uint16  u16TotalSize32;
+    uint16  u16Offset32;
+    uint16  u16Size32;
+} tstrTlsSrvChunkHdr;
+
+typedef struct {
+    uint32  u32CsBMP;
+} tstrSslSetActiveCsList;
+/**@}*/     //SSLEnums
+
+/**@addtogroup OTATYPEDEF
+ * @{
+ */
+/*!
+@enum   \
+    tenuOtaError
+
+@brief
+    OTA Error codes.
+*/
+typedef enum {
+    OTA_SUCCESS = (0),
+    /*!< OTA Success status */
+    OTA_ERR_WORKING_IMAGE_LOAD_FAIL = ((sint8) -1),
+    /*!< Failure to load the firmware image */
+    OTA_ERR_INVALID_CONTROL_SEC = ((sint8) -2),
+    /*!< Control structure is corrupted */
+    M2M_ERR_OTA_SWITCH_FAIL = ((sint8) -3),
+    /*!< Switching to the updated image failed as may be the image is invalid */
+    M2M_ERR_OTA_START_UPDATE_FAIL = ((sint8) -4),
+    /*!<
+     OTA update fail due to multiple reasons:
+     - Connection failure
+     - Image integrity fail
+     */
+    M2M_ERR_OTA_ROLLBACK_FAIL = ((sint8) -5),
+    /*!< Roll-back failed due to Roll-back image is not valid */
+    M2M_ERR_OTA_INVALID_FLASH_SIZE = ((sint8) -6),
+    /*!< The OTA Support at least 4MB flash size, this error code will appear if the current flash is less than 4M */
+    M2M_ERR_OTA_INVALID_ARG = ((sint8) -7),
+    /*!< Ota still in progress */
+    M2M_ERR_OTA_INPROGRESS = ((sint8) -8)
+                             /*!< Invalid argument in any OTA Function */
+} tenuOtaError;
+
+/*!
+@enum   \
+    tenuM2mOtaCmd
+
+@brief
+    This enum contains all the WINC commands used for OTA operation.
+*/
+typedef enum {
+    M2M_OTA_REQ_NOTIF_SET_URL = M2M_OTA_CMD_BASE,
+    M2M_OTA_REQ_NOTIF_CHECK_FOR_UPDATE,
+    M2M_OTA_REQ_NOTIF_SCHED,
+    M2M_OTA_REQ_START_FW_UPDATE,
+    /*!< Request to start an OTA update.*/
+    M2M_OTA_REQ_SWITCH_FIRMWARE,
+    /*!< Request to switch firmware.*/
+    M2M_OTA_REQ_ROLLBACK_FW,
+    /*!< Request to perform an OTA rollback.*/
+    M2M_OTA_RESP_NOTIF_UPDATE_INFO,
+    M2M_OTA_RESP_UPDATE_STATUS,
+    /*!< Response to indicate the OTA update status. */
+    M2M_OTA_REQ_TEST,
+    M2M_OTA_REQ_START_CRT_UPDATE,
+    M2M_OTA_REQ_SWITCH_CRT_IMG,
+    M2M_OTA_REQ_ROLLBACK_CRT,
+    M2M_OTA_REQ_ABORT,
+    /*!< Request to abort OTA.*/
+    M2M_OTA_REQ_HOST_FILE_STATUS,
+    M2M_OTA_RESP_HOST_FILE_STATUS,
+    M2M_OTA_REQ_HOST_FILE_DOWNLOAD,
+    M2M_OTA_RESP_HOST_FILE_DOWNLOAD,
+    M2M_OTA_REQ_HOST_FILE_READ,
+    M2M_OTA_RESP_HOST_FILE_READ,
+    M2M_OTA_REQ_HOST_FILE_ERASE,
+    M2M_OTA_RESP_HOST_FILE_ERASE,
+    M2M_OTA_MAX_ALL,
+} tenuM2mOtaCmd;
+
+/*!
+@enum   \
+    tenuOtaUpdateStatus
+
+@brief
+    This struct contains the OTA return status.
+*/
+typedef enum {
+    OTA_STATUS_SUCCESS        = 0,
+    /*!< OTA Success with no errors. */
+    OTA_STATUS_FAIL               = 1,
+    /*!< OTA generic fail. */
+    OTA_STATUS_INVALID_ARG        = 2,
+    /*!< Invalid or malformed download URL. */
+    OTA_STATUS_INVALID_RB_IMAGE   = 3,
+    /*!< Invalid rollback image. */
+    OTA_STATUS_INVALID_FLASH_SIZE = 4,
+    /*!< Flash size on device is not enough for OTA. */
+    OTA_STATUS_ALREADY_ENABLED    = 5,
+    /*!< An OTA operation is already enabled. */
+    OTA_STATUS_UPDATE_INPROGRESS  = 6,
+    /*!< An OTA operation update is in progress. */
+    OTA_STATUS_IMAGE_VERIF_FAILED = 7,
+    /*!< OTA Verification failed. */
+    OTA_STATUS_CONNECTION_ERROR   = 8,
+    /*!< OTA connection error. */
+    OTA_STATUS_SERVER_ERROR       = 9,
+    /*!< OTA server Error (file not found or else...) */
+    OTA_STATUS_ABORTED            = 10,
+                                /*!< OTA download has been aborted by the application. */
+} tenuOtaUpdateStatus;
+
+/*!
+@enum   \
+    tenuOtaUpdateStatusType
+
+@brief
+    This struct contains the OTA update status type.
+*/
+typedef enum {
+    DL_STATUS        = 1,
+    /*!< Download WINC OTA file status */
+    SW_STATUS        = 2,
+    /*!< Switching to the upgrade firmware status */
+    RB_STATUS        = 3,
+    /*!< Roll-back status */
+    AB_STATUS        = 4,
+    /*!< Abort status */
+    HFD_STATUS       = 5,
+    /*!< Host File Download status */
+} tenuOtaUpdateStatusType;
+
+/*!
+@struct \
+    tstrOtaInitHdr
+
+@brief
+    This struct contains the OTA image header.
+ */
+typedef struct {
+    uint32 u32OtaMagicValue;
+    /*!< Magic value kept in the OTA image after the
+    sha256 Digest buffer to define the Start of OTA Header. */
+    uint32 u32OtaPayloadSize;
+    /*!< The Total OTA image payload size, include the sha256 key size. */
+} tstrOtaInitHdr;
 
 /*!
 @struct	\
- 	tstrTlsSrvSecHdr
+ 	tstrOtaControlSec
 
 @brief
- 	This struct contains a set of TLS certificates.
+    Control Section Structure. The Control Section is used to define the working image and the validity
+    of the roll-back image and its offset, also both firmware versions are kept in this structure.
  */
-typedef struct{
-	uint8					au8SecStartPattern[TLS_SRV_SEC_START_PATTERN_LEN];
-	/*!< Start pattern.	*/	
-	uint32					u32nEntries;
-	/*!< Number of certificates stored in the struct.	*/
-	uint32					u32NextWriteAddr;
-	/*!< TLS Certificates.	*/
-	tstrTlsSrvSecFileEntry	astrEntries[TLS_SRV_SEC_MAX_FILES];
-}tstrTlsSrvSecHdr;
 
-typedef struct{
-	uint32	u32CsBMP;
-}tstrSslSetActiveCsList;
+typedef struct {
+    uint32 u32OtaMagicValue;
+    /*!< Magic value used to ensure the structure is valid or not. */
+    uint32 u32OtaFormatVersion;
+    /*!<
+            NA   NA   NA   Flash version   cs struct version
+            00   00   00   00              00
+        Control structure format version, the value will be incremented in case of structure changed or updated
+    */
+    uint32 u32OtaSequenceNumber;
+    /*!< Sequence number is used while update the control structure to keep track of how many times that section updated. */
+    uint32 u32OtaLastCheckTime;
+    /*!< Last time OTA check for update. */
+    uint32 u32OtaCurrentworkingImagOffset;
+    /*!< Current working offset in flash. */
+    uint32 u32OtaCurrentworkingImagFirmwareVer;
+    /*!< Current working image version ex 18.0.1. */
+    uint32 u32OtaRollbackImageOffset;
+    /*!<
+        Roll-back image offset in flash
+    */
+    uint32 u32OtaRollbackImageValidStatus;
+    /*!< Roll-back image valid status. */
+    uint32 u32OtaRollbackImagFirmwareVer;
+    /*!< Roll-back image version (ex 18.0.3). */
+    uint32 u32OtaCortusAppWorkingOffset;
+    /*!<
+        Cortus app working offset in flash.
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaCortusAppWorkingValidSts;
+    /*!<
+        Working Cortus app valid status.
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaCortusAppWorkingVer;
+    /*!<
+        Working cortus app version (ex 18.0.3).
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaCortusAppRollbackOffset;
+    /*!<
+        Cortus app rollback offset in flash.
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaCortusAppRollbackValidSts;
+    /*!<
+        Roll-back cortus app valid status.
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaCortusAppRollbackVer;
+    /*!<
+        Roll-back cortus app version (ex 18.0.3).
+        Removed in v19.6.1.
+    */
+    uint32 u32OtaControlSecCrc;
+    /*!< CRC for the control structure to ensure validity. */
+} tstrOtaControlSec;
 
+/*!
+@struct	\
+	tstrOtaUpdateStatusResp
 
- /**@}*/
+@brief
+    This struct contains the OTA update status.
 
+@sa
+    tenuWPSTrigger
+*/
+typedef struct {
+    uint8   u8OtaUpdateStatusType;
+    /*!< Status type, see @ref tenuOtaUpdateStatusType. */
+    uint8   u8OtaUpdateStatus;
+    /*!< The status of the update, see @ref tenuOtaError. */
+    uint8 _PAD16_[2];
+} tstrOtaUpdateStatusResp;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrOtaUpdateStatusResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrOtaUpdateStatusResp)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct	\
+	tstrOtaUpdateInfo
+
+@brief
+    This struct contains the OTA update information.
+
+@sa
+	tenuWPSTrigger
+*/
+typedef struct {
+    uint32  u8NcfUpgradeVersion;
+    /*!< NCF OTA Upgrade Version */
+    uint32  u8NcfCurrentVersion;
+    /*!< NCF OTA Current firmware version */
+    uint32  u8NcdUpgradeVersion;
+    /*!< NCD (host) upgraded version (if the u8NcdRequiredUpgrade == true) */
+    uint8   u8NcdRequiredUpgrade;
+    /*!< NCD Required upgrade to the above version */
+    uint8   u8DownloadUrlOffset;
+    /*!< Download URL offset in the received packet */
+    uint8   u8DownloadUrlSize;
+    /*!< Download URL size in the received packet */
+    uint8   __PAD8__;
+    /*!< Padding bytes for forcing 4-byte alignment */
+} tstrOtaUpdateInfo;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrOtaUpdateInfo)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrOtaUpdateInfo)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrOtaHostFileGetStatusResp
+
+@brief
+    Host File OTA Information
+*/
+typedef struct {
+    uint32  u32OtaFileSize;
+    /*!<
+    Reports the size of the downloaded file.
+    Valid if u8OtaFileGetStatus=OTA_STATUS_SUCCESS.
+    */
+
+    uint8   u8OtaFileGetStatus;
+    /*!<
+    The status of the File Get operation.
+    See @ref tenuOtaUpdateStatus.
+    */
+    uint8   u8CFHandler;
+    /*!<
+    The file handler stored in the WINC for a valid file.
+    Valid if u8OtaFileGetStatus=OTA_STATUS_SUCCESS.
+     */
+    uint8   __PAD16__[2];
+    /*!< Padding byte for forcing 4-byte alignment */
+} tstrOtaHostFileGetStatusResp;
+
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrOtaHostFileGetStatusResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrOtaHostFileGetStatusResp)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrOtaHostFileReadStatusResp
+
+@brief
+    Host File OTA Information
+*/
+typedef struct {
+    uint16  u16FileBlockSz;
+    /*!<
+    Reports the size of the block of data read via HIF.
+    Valid if u8OtaFileReadStatus=OTA_STATUS_SUCCESS .
+    */
+
+    uint8   u8OtaFileReadStatus;
+    /*!<
+    The status of the File Read operation.
+    See @ref tenuOtaUpdateStatus.
+    */
+    uint8   __PAD8__;
+    /*!< Padding byte for forcing 4-byte alignment */
+    uint8   pFileBuf[MAX_FILE_READ_STEP];
+    /*!<
+    Pointer to the temporary buffer containing the data just read.
+    Max size is @ref MAX_FILE_READ_STEP
+     */
+} tstrOtaHostFileReadStatusResp;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrOtaHostFileReadStatusResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrOtaHostFileReadStatusResp)%4)==0, "Structure alignment error");
+#endif
+#endif
+
+/*!
+@struct \
+    tstrOtaHostFileEraseStatusResp
+
+@brief
+    Host File OTA Information
+*/
+typedef struct {
+    uint8   u8OtaFileEraseStatus;
+    /*!<
+    The status of the File Erase operation.
+    See @ref tenuOtaUpdateStatus.
+    */
+    uint8   __PAD24__[3];
+    /*!< Padding byte for forcing 4-byte alignment */
+} tstrOtaHostFileEraseStatusResp;
+#ifndef _lint
+#ifdef __GNUC__
+_Static_assert((sizeof(tstrOtaHostFileEraseStatusResp)%4)==0, "Structure alignment error");
+#else
+static_assert((sizeof(tstrOtaHostFileEraseStatusResp)%4)==0, "Structure alignment error");
+#endif
+#endif
+/**@}*/     //OTATYPEDEF
+
+#endif
 #endif

--- a/asf/common/components/wifi/winc1500/driver/include/m2m_wifi.h
+++ b/asf/common/components/wifi/winc1500/driver/include/m2m_wifi.h
@@ -4,466 +4,314 @@
  *
  * \brief WINC WLAN Application Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
  */
 
+/**@defgroup m2m_wifi WLAN
+    @{
+        @defgroup   WLANCallbacks   Callbacks
+        @brief
+            Provides detail on the available callbacks for the Wlan APIs.
+
+        @defgroup   WlanDefines     Defines
+        @brief
+            Specifies the macros and defines used by the Wlan APIs.
+
+        @defgroup   WlanEnums       Enumerations and Typedefs
+        @brief
+            Specifies the enums and Data Structures used by the Wlan APIs.
+
+        @defgroup   WLANAPI         Functions
+        @brief
+            Here are listed all the functions that implement the Wlan APIs.
+        @{
+            @defgroup   WLANINIT        Initialization
+            @brief
+                Here are listed all the functions that implement the Wlan Initialization APIs.
+            @defgroup   WLANEVTS        Wlan Events
+            @brief
+                Here are listed all the functions that implement the Wlan Events APIs.
+            @defgroup   WLANCONNECT     Connection
+            @brief
+                Here are listed all the functions that implement the Wifi Connection APIs.
+            @defgroup   WLANSCAN        Scanning
+            @brief
+                Here are listed all the functions that implement the Wifi Scanning APIs.
+            @defgroup   WLANAP          Hot-Spot (Access-Point)
+            @brief
+                Here are listed all the functions that implement the Wifi Hot-Spot (Access-Point) APIs.
+            @defgroup   WLANAP          Hot-Spot (Access-Point)
+            @brief
+                Here are listed all the functions that implement the Wifi Hot-Spot (Access-Point) APIs.
+            @defgroup   WLANETH         Bypass Mode
+            @brief
+                Here are listed all the functions that implement the Bypass Mode APIs.
+            @defgroup   WLANROAMING     Roaming
+            @brief
+                Here are listed all the functions that implement the Wifi Roaming APIs.
+            @defgroup   WLANPS          Power Save
+            @brief
+                Here are listed all the functions that implement the Power-Save APIs.
+            @defgroup   WLANCONF        Configuration
+            @brief
+                Here are listed all the functions that implement the Wlan Configuration APIs.
+            @defgroup   WLANTIME        System Time
+            @brief
+                Here are listed all the functions that implement the System Time APIs.
+            @defgroup   WLANPROVISION   Provisioning
+            @brief
+                Here are listed all the functions that implement the Wifi Provisioning APIs.
+            @defgroup   WLANCRYPTO      Crypto
+            @brief
+                Here are listed all the functions that implement the Wifi Crypto APIs.
+
+            @cond P2P_DOC
+            @defgroup   WLANP2P         P2P
+            @brief
+                Here are listed all the functions that implement the Wifi P2P APIs.
+            @endcond
+            @cond MON_DOC
+            @defgroup   WLANMON         Monitoring Mode
+            @brief
+                Here are listed all the functions that implement the Wifi Monitoring Mode APIs.
+            @endcond
+        @}
+    @}
+ */
+
 #ifndef __M2M_WIFI_H__
 #define __M2M_WIFI_H__
-
-/** \defgroup m2m_wifi WLAN
- *
- */
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 INCLUDES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-
+//#include <compiler.h>
 #include "common/include/nm_common.h"
 #include "driver/include/m2m_types.h"
 #include "driver/source/nmdrv.h"
 
-#ifdef CONF_MGMT
-
-
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 MACROS
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-/**@defgroup  WlanEnums DataTypes
- * @ingroup m2m_wifi
- * @{*/
+
+/**@addtogroup WLANCallbacks
+ * @{
+ */
 /*!
-@enum	\
-	tenuWifiFrameType
-
-@brief
-	Enumeration for Wi-Fi MAC frame type codes (2-bit) 
-	The following types are used to identify the type of frame sent or received.
-	Each frame type constitutes a number of frame subtypes as defined in @ref tenuSubTypes to specify the exact type of frame.
-	Values are defined as per the IEEE 802.11 standard.
-	
-@remarks
-	The following frame types are useful for advanced user usage when monitoring mode is used (defining @ref CONF_MGMT)
-	and the user application requires to monitor the frame transmission and reception.
-@see
-	tenuSubTypes
-*/
-typedef enum {
-	MANAGEMENT            = 0x00,
-	/*!< Wi-Fi Management frame (Probe Req/Resp, Beacon, Association Req/Resp ...etc).
-	*/
-	CONTROL               = 0x04,
-	/*!< Wi-Fi Control frame (eg. ACK frame).
-	*/
-	DATA_BASICTYPE        = 0x08,
-	/*!< Wi-Fi Data frame.
-	*/
-	RESERVED              = 0x0C,
-
-	M2M_WIFI_FRAME_TYPE_ANY	= 0xFF
-/*!< Set monitor mode to receive any of the frames types
-*/
-}tenuWifiFrameType;
-
-
-/*!
-@enum	\
-	tenuSubTypes
-
-@brief
-	Enumeration for Wi-Fi MAC Frame subtype code (6-bit).
-	The frame subtypes fall into one of the three frame type groups as defined in @ref tenuWifiFrameType
-	(MANAGEMENT, CONTROL & DATA).
-	Values are defined as per the IEEE 802.11 standard.
-@remarks
-	The following sub-frame types are useful for advanced user usage when @ref CONF_MGMT is defined
-	and the application developer requires to monitor the frame transmission and reception.
-@see
-    	tenuWifiFrameType
-    	tstrM2MWifiMonitorModeCtrl
-*/
-typedef enum {
-	/*!< Sub-Types related to Management Sub-Types */
-	ASSOC_REQ             = 0x00,
-	ASSOC_RSP             = 0x10,
-	REASSOC_REQ           = 0x20,
-	REASSOC_RSP           = 0x30,
-	PROBE_REQ             = 0x40,
-	PROBE_RSP             = 0x50,
-	BEACON                = 0x80,
-	ATIM                  = 0x90,
-	DISASOC               = 0xA0,
-	AUTH                  = 0xB0,
-	DEAUTH                = 0xC0,
-	ACTION                = 0xD0,
-/**@{*/ 
-	/* Sub-Types related to Control */
-	PS_POLL               = 0xA4,
-	RTS                   = 0xB4,
-	CTS                   = 0xC4,
-	ACK                   = 0xD4,
-	CFEND                 = 0xE4,
-	CFEND_ACK             = 0xF4,
-	BLOCKACK_REQ          = 0x84,
-	BLOCKACK              = 0x94,
-/**@{*/ 
-	/* Sub-Types related to Data */
-	DATA                  = 0x08,
-	DATA_ACK              = 0x18,
-	DATA_POLL             = 0x28,
-	DATA_POLL_ACK         = 0x38,
-	NULL_FRAME            = 0x48,
-	CFACK                 = 0x58,
-	CFPOLL                = 0x68,
-	CFPOLL_ACK            = 0x78,
-	QOS_DATA              = 0x88,
-	QOS_DATA_ACK          = 0x98,
-	QOS_DATA_POLL         = 0xA8,
-	QOS_DATA_POLL_ACK     = 0xB8,
-	QOS_NULL_FRAME        = 0xC8,
-	QOS_CFPOLL            = 0xE8,
-	QOS_CFPOLL_ACK        = 0xF8,
-	M2M_WIFI_FRAME_SUB_TYPE_ANY = 0xFF
-	/*!< Set monitor mode to receive any of the frames types
-	*/
-}tenuSubTypes;
-
-
-/*!
-@enum	\
-	tenuInfoElementId
-
-@brief
-	Enumeration for the Wi-Fi Information Element(IE) IDs, which indicates the specific type of IEs.
-	IEs are management frame information included in management frames.
-	Values are defined as per the IEEE 802.11 standard.
-
-*/
-typedef enum {
-	ISSID               = 0,
-	/*!< Service Set Identifier (SSID)
-	*/
-	ISUPRATES           = 1,
-	/*!< Supported Rates
-	*/
-	IFHPARMS            = 2,
-	/*!< FH parameter set
-	*/
-	IDSPARMS            = 3,
-	/*!< DS parameter set
-	*/
-	ICFPARMS            = 4,
-	/*!< CF parameter set
-	*/
-	ITIM                = 5,
-	/*!< Traffic Information Map
-	*/
-	IIBPARMS            = 6,
-	/*!< IBSS parameter set
-	*/
-	ICOUNTRY            = 7,
-	/*!< Country element.
-	*/
-	IEDCAPARAMS         = 12,
-	/*!< EDCA parameter set
-	*/
-	ITSPEC              = 13,
-	/*!< Traffic Specification
-	*/
-	ITCLAS              = 14,
-	/*!< Traffic Classification
-	*/
-	ISCHED              = 15,
-	/*!< Schedule.
-	*/
-	ICTEXT              = 16,
-	/*!< Challenge Text
-	*/
-	IPOWERCONSTRAINT    = 32,
-	/*!< Power Constraint.
-	*/
-	IPOWERCAPABILITY    = 33,
-	/*!< Power Capability
-	*/
-	ITPCREQUEST         = 34,
-	/*!< TPC Request
-	*/
-	ITPCREPORT          = 35,
-	/*!< TPC Report
-	*/
-	ISUPCHANNEL         = 36,
-	/* Supported channel list
-	*/
-	ICHSWANNOUNC        = 37,
-	/*!< Channel Switch Announcement
-	*/
-	IMEASUREMENTREQUEST = 38,
-	/*!< Measurement request
-	*/
-	IMEASUREMENTREPORT  = 39,
-	/*!< Measurement report
-	*/
-	IQUIET              = 40,
-	/*!< Quiet element Info
-	*/
-	IIBSSDFS            = 41,
-	/*!< IBSS DFS
-	*/
-	IERPINFO            = 42,
-	/*!< ERP Information
-	*/
-	ITSDELAY            = 43,
-	/*!< TS Delay
-	*/
-	ITCLASPROCESS       = 44,
-	/*!< TCLAS Processing
-	*/
-	IHTCAP              = 45,
-	/*!< HT Capabilities
-	*/
-	IQOSCAP             = 46,
-	/*!< QoS Capability
-	*/
-	IRSNELEMENT         = 48,
-	/*!< RSN Information Element
-	*/
-	IEXSUPRATES         = 50,
-	/*!< Extended Supported Rates
-	*/
-	IEXCHSWANNOUNC      = 60,
-	/*!< Extended Ch Switch Announcement
-	*/
-	IHTOPERATION        = 61,
-	/*!< HT Information
-	*/
-	ISECCHOFF           = 62,
-	/*!< Secondary Channel Offset
-	*/
-	I2040COEX           = 72,
-	/*!< 20/40 Coexistence IE
-	*/
-	I2040INTOLCHREPORT  = 73,
-	/*!< 20/40 Intolerant channel report
-	*/
-	IOBSSSCAN           = 74,
-	/*!< OBSS Scan parameters
-	*/
-	IEXTCAP             = 127,
-	/*!< Extended capability
-	*/
-	IWMM                = 221,
-	/*!< WMM parameters
-	*/
-	IWPAELEMENT         = 221
-	/*!< WPA Information Element
-	*/
-}tenuInfoElementId;
-
-
-/*!
-@struct	\
-	tenuWifiCapability
-
-@brief
-	Enumeration for capability Information field bit. 
-	The value of the capability information field from the 802.11 management frames received by the wireless LAN interface. 
-	Defining the capabilities of the Wi-Fi system. Values are defined as per the IEEE 802.11 standard.
-
-@details
-	Capabilities:-
-	ESS/IBSS             : Defines whether a frame is coming from an AP or not.              
-	POLLABLE    		: CF Poll-able                  
-	POLLREQ       		: Request to be polled         
-	PRIVACY      		: WEP encryption supported     
-	SHORTPREAMBLE   : Short Preamble is supported  
-	SHORTSLOT           : Short Slot is supported      
-	PBCC       	        :PBCC                         
-	CHANNELAGILITY :Channel Agility              
-	SPECTRUM_MGMT  :Spectrum Management          
-	DSSS_OFDM      : DSSS-OFDM                    
-*/
-typedef enum{
-	ESS            = 0x01,
-	/*!< ESS capability
-	*/
-	IBSS           = 0x02,
-	/*!< IBSS mode
-	*/
-	POLLABLE       = 0x04,
-	/*!< CF Pollable
-	*/
-	POLLREQ        = 0x08,
-	/*!< Request to be polled
-	*/
-	PRIVACY        = 0x10,
-	/*!< WEP encryption supported
-	*/
-	SHORTPREAMBLE  = 0x20,
-	/*!< Short Preamble is supported
-	*/
-	SHORTSLOT      = 0x400,
-	/*!< Short Slot is supported
-	*/
-	PBCC           = 0x40,
-	/*!< PBCC
-	*/
-	CHANNELAGILITY = 0x80,
-	/*!< Channel Agility
-	*/
-	SPECTRUM_MGMT  = 0x100,
-	/*!< Spectrum Management
-	*/
-	DSSS_OFDM      = 0x2000
-	/*!< DSSS-OFDM
-	*/
-}tenuWifiCapability;
-
-
-#endif
-
-/*!
-@typedef \
-	tpfAppWifiCb
+@typedef void (*tpfAppWifiCb)(uint8 u8MsgType, void* pvMsg);
 
 @brief	
-				Wi-Fi's main callback function handler, for handling the M2M_WIFI events received on the Wi-Fi interface. 
-			       Such notifications are received in response to Wi-Fi/P2P operations such as @ref m2m_wifi_request_scan,
-				@ref m2m_wifi_connect. 
-				Wi-Fi/P2P operations are implemented in an asynchronous mode, and all incoming information/status
+    Wi-Fi's main callback function handler, for handling the M2M_WIFI events received on the 
+    Wi-Fi interface. Such notifications are received in response to Wi-Fi operations such
+    as @ref m2m_wifi_request_scan, @ref m2m_wifi_connect_open, @ref m2m_wifi_connect_wep,
+    @ref m2m_wifi_connect_psk, @ref m2m_wifi_connect_1x_mschap2, @ref m2m_wifi_connect_1x_tls.
+ 
+    Wi-Fi operations are implemented in an asynchronous mode, and all incoming information/status
 				are to be handled through this callback function when the corresponding notification is received.
-				Applications are expected to assign this wi-fi callback function by calling @ref m2m_wifi_init
+		
+    Applications are expected to assign this wi-fi callback function by 
+    calling @ref m2m_wifi_init.
 @param [in]	u8MsgType
-				Type of notifications. Possible types are:
-				/ref M2M_WIFI_RESP_CON_STATE_CHANGED
-				/ref M2M_WIFI_RESP_CONN_INFO
-				/ref M2M_WIFI_REQ_DHCP_CONF
-				/ref M2M_WIFI_REQ_WPS
-				/ref M2M_WIFI_RESP_IP_CONFLICT 
-				/ref M2M_WIFI_RESP_SCAN_DONE
-				/ref M2M_WIFI_RESP_SCAN_RESULT
-				/ref M2M_WIFI_RESP_CURRENT_RSSI
-				/ref M2M_WIFI_RESP_CLIENT_INFO
-				/ref M2M_WIFI_RESP_PROVISION_INFO
-				/ref M2M_WIFI_RESP_DEFAULT_CONNECT
-		
-			In case Ethernet/Bypass mode is defined :
-				@ref M2M_WIFI_RESP_ETHERNET_RX_PACKET
-		
-			In case monitoring mode is used:
-				@ref M2M_WIFI_RESP_WIFI_RX_PACKET
+    Type of notification. Possible types are:
+       - @ref M2M_WIFI_RESP_CON_STATE_CHANGED
+       - @ref M2M_WIFI_RESP_CONN_INFO
+       - @ref M2M_WIFI_REQ_DHCP_CONF
+       - @ref M2M_WIFI_REQ_WPS
+       - @ref M2M_WIFI_RESP_IP_CONFLICT 
+       - @ref M2M_WIFI_RESP_SCAN_DONE
+       - @ref M2M_WIFI_RESP_SCAN_RESULT
+       - @ref M2M_WIFI_RESP_CURRENT_RSSI
+       - @ref M2M_WIFI_RESP_CLIENT_INFO
+       - @ref M2M_WIFI_RESP_PROVISION_INFO
+       - @ref M2M_WIFI_RESP_DEFAULT_CONNECT
+       - @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET (In case Ethernet/Bypass mode is defined)
+       - @ref M2M_WIFI_RESP_WIFI_RX_PACKET (In case monitoring mode is used)
 				
 @param [in]	pvMsg
 				A pointer to a buffer containing the notification parameters (if any). It should be
-				casted to the correct data type corresponding to the notification type.
+    cast to the correct data type corresponding to the notification type.
 
 @see
 	tstrM2mWifiStateChanged
 	tstrM2MWPSInfo
 	tstrM2mScanDone
 	tstrM2mWifiscanResult
+    m2m_wifi_init
 */
 typedef void (*tpfAppWifiCb) (uint8 u8MsgType, void * pvMsg);
 
 /*!
-@typedef \
-	tpfAppEthCb
+@typedef void (*tpfAppEthCb)(uint8 u8MsgType, void* pvMsg, void* pvCtrlBuf);
 
 @brief	
-	ETHERNET (bypass mode) notification callback function receiving Bypass mode events as defined in
-	the Wi-Fi responses enumeration @ref tenuM2mStaCmd. 
+    Ethernet (Bypass mode) notification callback function receiving Bypass mode events as 
+    defined in the Wi-Fi responses enumeration @ref tenuM2mStaCmd. 
+
+    If bypass mode is enabled, applications must ensure this callback function is registered 
+    with the Wi-Fi driver by calling @ref m2m_wifi_init.
 
 @param [in]	u8MsgType
 	Type of notification. Possible types are:
-	- [M2M_WIFI_RESP_ETHERNET_RX_PACKET](@ref M2M_WIFI_RESP_ETHERNET_RX_PACKET)
+        - @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET
 
 @param [in]	pvMsg
-	A pointer to a buffer containing the notification parameters (if any). It should be
-	casted to the correct data type corresponding to the notification type.
+    A pointer to a buffer containing the notification parameters (if any). 
+	It should be cast to the correct data type corresponding to the notification type.
+    
 	For example, it could be a pointer to the buffer holding the received frame in case of @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET
 	event.
 	
 @param [in]	pvControlBuf
 	A pointer to control buffer describing the accompanied message.
-	To be casted to @ref tstrM2mIpCtrlBuf in case of @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET event.
+    To be cast to @ref tstrM2mIpCtrlBuf in case of @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET event.
 
 @warning
-	Make sure that the application defines @ref ETH_MODE.
+	Make sure that the application defines ETH_MODE.
 
 @see
 	m2m_wifi_init
-
 */
 typedef void (*tpfAppEthCb) (uint8 u8MsgType, void * pvMsg,void * pvCtrlBuf);
 
+/**@cond MON_DOC
+ */
 /*!
-@typedef	\
-	tpfAppMonCb
+@typedef void (*tpfAppMonCb)(tstrM2MWifiRxPacketInfo* pstrWifiRxPacket, uint8* pu8Payload, uint16 u16PayloadSize);
 
 @brief	
-	Wi-Fi monitoring mode callback function. This function delivers all received wi-Fi packets through the Wi-Fi interface.
-       Applications requiring to operate in the monitoring should call the asynchronous function m2m_wifi_enable_monitoring_mode
-       and expect to receive the Wi-Fi packets through this callback function, when the event is received.
+    Wi-Fi monitoring mode callback function. This function delivers all received wi-Fi packets 
+    through the Wi-Fi interface. Applications requiring to operate in the monitoring should call the asynchronous 
+    function m2m_wifi_enable_monitoring_mode and expect to receive the Wi-Fi packets through this 
+    callback function, when the event is received.
 	To disable the monitoring mode a call to @ref m2m_wifi_disable_monitoring_mode should be made.
+
 @param [in]	pstrWifiRxPacket
 				Pointer to a structure holding the Wi-Fi packet header parameters.
 
 @param [in]	pu8Payload
-				Pointer to the buffer holding the Wi-Fi packet payload information required by the application starting from the
-				defined OFFSET by the application (when calling m2m_wifi_enable_monitoring_mode).
-				Could hold a value of NULL, if the application does not need any data from the payload.
+    Pointer to the buffer holding the Wi-Fi packet payload information required by the application 
+    starting from the defined OFFSET by the application (when calling 
+    m2m_wifi_enable_monitoring_mode). Could hold a value of NULL, if the application does not need 
+    any data from the payload.
 
 @param [in]	u16PayloadSize
 				The size of the payload in bytes.
 				
 @see
-	m2m_wifi_enable_monitoring_mode,m2m_wifi_init	
+    m2m_wifi_enable_monitoring_mode,
+    m2m_wifi_init	
 	
 @warning
 	u16PayloadSize should not exceed the buffer size given through m2m_wifi_enable_monitoring_mode.
-	
 */
-typedef void (*tpfAppMonCb) (tstrM2MWifiRxPacketInfo *pstrWifiRxPacket, uint8 * pu8Payload, uint16 u16PayloadSize);
+typedef void (*tpfAppMonCb)(tstrM2MWifiRxPacketInfo *pstrWifiRxPacket, uint8 *pu8Payload, uint16 u16PayloadSize);
+/**@endcond*/ //MON_DOC
+/**@}*/     //WLANCallbacks
 
-/**
-@struct 	\
-	tstrEthInitParam
-	
-@brief		
-	Structure to hold Ethernet interface parameters. 
-	Structure is to be defined and have its attributes set,based on the application's functionality before 
-	a call is made to  initialize the Wi-Fi operations by calling the  @ref m2m_wifi_init function.
-	This structure is part of the Wi-Fi configuration structure @ref tstrWifiInitParam.
+/**@addtogroup  WlanEnums
+ * @{
+ */
+/*!
+@enum   \
+    tenuWifiState
+@brief
+    Enumeration for Wi-Fi state
+    The following is used to track the state of the wifi (not initialized, initialized or started)
+
+@remarks
+    This is useful when putting the WINC in "download mode" to access the flash via SPI. By using
+    @ref m2m_wifi_get_state and checking against the desired state, it is possible to validate if
+    the Application should proceed with the SPI Flash access or not.
+*/
+typedef enum {
+    WIFI_STATE_DEINIT,
+    /*!< Wifi is not initialized */
+    WIFI_STATE_INIT,
+    /*!< Wifi has been initialized */
+    WIFI_STATE_START,
+    /*!< Wifi has started */
+} tenuWifiState;
+
+typedef enum {
+    WIFI_CRED_DONTSAVE,
+    /*!< Credentials will not be stored in WINC flash. */
+    WIFI_CRED_SAVE_UNENCRYPTED,
+    /*!< Credentials will be stored unencrypted in WINC flash. */
+    WIFI_CRED_SAVE_ENCRYPTED
+    /*!< Credentials will be stored encrypted in WINC flash.
+            The encryption is not secure; it is merely intended to prevent sensitive information
+            being leaked by an opportunistic read of WINC flash contents.
+            The encryption keys involve WINC efuse contents, so WINC efuses should not be written
+            while this option is in use. */
+} tenuCredStoreOption;
+
+/*!
+@enum   \
+    tenu1xOption
+@brief
+
+@remarks
+
+*/
+typedef enum {
+    WIFI_1X_BYPASS_SERVER_AUTH,
+    /*!< Server authentication for 802.1x connections. Values are of type @ref int.\n
+        0: Authenticate server; Default, Recommended.\n
+        1: Bypass server authentication.\n
+    */
+    WIFI_1X_SESSION_CACHING,
+    /*!< TLS session caching on/off for 802.1x connections. Values are of type @ref int.\n
+        0: Session caching off.\n
+        1: Session caching on; Default.\n
+        Note that the WINC implementation of PEAPv0 does not support session caching; this setting is ignored for PEAPv0 methods.
+    */
+    WIFI_1X_SPECIFIC_ROOTCERT,
+    /*!< SHA1 digest of subject name of the root certificate to be used during server authentication. Values are:\n
+        20-byte arrays: authentication is limited to this particular root certificate; Recommended\n
+        0-byte array: authentication can succeed with any certificate in the WINC root certificate store; Default.\n
+    */
+    WIFI_1X_TIME_VERIF_MODE,
+    /*!< Mode for checking expiry of server certificate chain.
+        Values are of type @ref tenuSslCertExpSettings.
+        Default is @ref SSL_CERT_EXP_CHECK_EN_IF_SYS_TIME.
+    */
+} tenu1xOption;
+
+/*!
+@struct     \
+    tstrEthInitParam
+
+@brief
+    Structure to hold Ethernet interface parameters.
+    Structure is to be defined and have its attributes set, based on the application's functionality
+    before a call is made to initialize the wi-fi operations by calling the
+    @ref m2m_wifi_init function.
+    Part of the wi-fi configuration structure @ref tstrWifiInitParam.
 	Applications shouldn't need to define this structure, if the bypass mode is not defined.
 	
 @see
@@ -472,48 +320,33 @@ typedef void (*tpfAppMonCb) (tstrM2MWifiRxPacketInfo *pstrWifiRxPacket, uint8 * 
 	m2m_wifi_init
 
 @warning
-	Make sure that application defines @ref ETH_MODE before using @ref tstrEthInitParam. 
-
+	Make sure that application defines ETH_MODE before using @ref tstrEthInitParam. 
 */
 typedef struct {
-	tpfAppWifiCb pfAppWifiCb;
-	/*!<
-		Callback for wifi notifications.
-	*/
-	tpfAppEthCb  pfAppEthCb;
-	/*!<
-		Callback for Ethernet interface.
-	*/
-	uint8 * au8ethRcvBuf;
-	/*!<
-		Pointer to Receive Buffer of Ethernet Packet
-	*/
-	uint16 u16ethRcvBufSize;
-	/*!<
-		Size of Receive Buffer for Ethernet Packet
-	*/
-	uint8 u8EthernetEnable;
-	/*!<
-		Enable Ethernet mode flag
-	*/
-	uint8 __PAD8__;
-	/*!<
-		Padding
-	*/
+    tpfAppWifiCb pfAppWifiCb;      /*!< Callback for wifi notifications. */
+    tpfAppEthCb  pfAppEthCb;       /*!< Callback for Ethernet interface. */
+    uint8 * au8ethRcvBuf;          /*!< Pointer to Receive Buffer of Ethernet Packet */
+    uint16	u16ethRcvBufSize;      /*!< Size of Receive Buffer for Ethernet Packet */
+	uint8 u8EthernetEnable;        /*!<	Enable Ethernet mode flag */
+	uint8 __PAD8__;	               /*!< Padding	*/
 } tstrEthInitParam;
+
 /*!
 @struct	\
  	tstrM2mIpCtrlBuf
  	
 @brief		
- 	Structure holding the incoming buffer's data size information, indicating the data size of the buffer and the remaining buffer's data size .
-	The data of the buffer which holds the packet sent to the host when in the bypass mode, is placed in the @ref tstrEthInitParam structure in the 
-	@ref au8ethRcvBuf attribute. This following information is retrieved in the host when an event @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET is received in 
-	the Wi-Fi callback function @ref tpfAppWifiCb. 
+ 	Structure holding the incoming buffer's data size information, indicating the data size of the 
+    buffer and the remaining buffer's data size. The data of the buffer which holds the packet sent 
+    to the host when in the bypass mode, is placed in the @ref tstrEthInitParam::au8ethRcvBuf attribute.
+    This following information is retrieved in the host when an event 
+    @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET is received in the Wi-Fi callback function 
+    @ref tpfAppWifiCb. 
 
 	The application is expected to use this structure's information to determine if there is still incoming data to be received from the firmware.
 	
  @see
+	tpfAppWifiCb     
 	 tpfAppEthCb
 	 tstrEthInitParam
  
@@ -522,16 +355,9 @@ typedef struct {
 
  */
 typedef struct{
-	uint16	u16DataSize;
-	/*!<
-		Size of the received data in bytes.
-	*/
-	uint16	u16RemainigDataSize;
-	/*!<
-		Size of the remaining data bytes to be delivered to host.
-	*/
+    uint16	u16DataSize;          /*!< Size of the received data in bytes. */
+    uint16	u16RemainingDataSize; /*!< Size of the remaining data bytes to be delivered to host. */
 } tstrM2mIpCtrlBuf;
-
 
 /**
 @struct		\
@@ -549,173 +375,440 @@ typedef struct{
 	 tpfAppEthCb
 	 tpfAppMonCb
 	 tstrEthInitParam
-	
 */
 typedef struct {
-	tpfAppWifiCb pfAppWifiCb;
-	/*!<
-		Callback for Wi-Fi notifications.
-	*/
-	tpfAppMonCb  pfAppMonCb;
-	/*!<
-		Callback for monitoring interface.
-	*/
-	tstrEthInitParam strEthInitParam ;
-	/*!<
-		Structure to hold Ethernet interface parameters.
-	*/
-
+    tpfAppWifiCb pfAppWifiCb;     /*!< Callback for Wi-Fi notifications. */
+    tpfAppMonCb  pfAppMonCb;      /*!< Callback for monitoring interface. */
+    tstrEthInitParam strEthInitParam ; /*!< Structure to hold Ethernet interface parameters. */
 } tstrWifiInitParam;
- //@}
+
+typedef struct {
+    uint8           *pu8Bssid;
+    /*!< Pointer to BSSID (6 bytes). Optional (may be NULL).
+            If present, this restricts the connection attempt to APs that have a matching BSSID. */
+    uint8           *pu8Ssid;
+    /*!< Pointer to SSID. Required. */
+    uint8           u8SsidLen;
+    /*!< Length of SSID in bytes. Permitted values are between 0 and 32. */
+    tenuM2mScanCh   enuChannel;
+    /*!< Wi-Fi channel to connect on.
+            If an appropriate AP cannot be found on this channel then connection fails.
+            @ref M2M_WIFI_CH_ALL may be used to allow scanning of all channels. */
+}tstrNetworkId;
+
+/* Legacy Wep param structure. */
+typedef struct {
+    uint8   u8KeyIndx;
+    uint8   u8KeySz;
+    uint8   au8WepKey[WEP_104_KEY_STRING_SIZE + 1];	// NULL terminated
+    uint8   __PAD24__[3];
+}tstrM2mWifiWepParams;
+
+/* Legacy 802.1x MsChapv2 param structure. */
+typedef struct{
+    uint8   au8UserName[21];    // NULL terminated
+    uint8   au8Passwd[41];      // NULL terminated
+}tstr1xAuthCredentials;
+
+typedef struct {
+    uint8   *pu8Psk;
+    /*!< Pointer to PSK, represented as an ASCII string (64 characters, representing 32 bytes).
+            Must be NULL if Passphrase is provided instead. */
+    uint8   *pu8Passphrase;
+    /*!< Pointer to Passphrase (Printable ASCII).
+            Must be NULL if PSK is provided instead. */
+    uint8   u8PassphraseLen;
+    /*!< Length of Passphrase. Permitted values are between 8 and 63.
+            This field is ignored if pu8Passphrase == NULL. */
+}tstrAuthPsk;
+
+typedef struct {
+    uint8   *pu8WepKey;
+    /*!< Pointer to WEP Key, represented as an ASCII string.
+            (10 or 26 characters, representing 5 or 13 bytes.) */
+    uint8   u8KeySz;
+    /*!< Size of WEP Key string.
+            Permitted values are @ref WEP_40_KEY_STRING_SIZE or @ref WEP_104_KEY_STRING_SIZE. */
+    uint8   u8KeyIndx;
+    /*!< WEP Key Index in the range 1 to 4. */
+}tstrAuthWep;
+
+typedef struct {
+    uint8   *pu8Domain;
+    /*!< Pointer to Domain of authentication server (printable ASCII), including '@' or '\'
+            separator character as appropriate. Use NULL if there is no domain information.
+            The Domain will be either prepended or appended to the UserName, depending on the
+            setting of field bPrependDomain. \n
+            Example 1: if [Domain]is "@my_domain" and bPrependDomain is false, then the EAP
+            identity response is "[UserName]@my_domain". \n
+            Example 2: if [Domain]is "my_domain\" and bPrependDomain is true, then the EAP
+            identity response is "my_domain\[UserName]". */
+    uint8   *pu8UserName;
+    /*!< Pointer to UserName (ASCII).
+            This will be sent (encrypted) in the tunneled EAP identity response (if applicable)
+            and used during MSCHAPv2 authentication. If bUnencryptedUserName is true then it will
+            also be sent (unencrypted) in the initial EAP identity response. */
+    uint8   *pu8Password;
+    /*!< Pointer to MSCHAPv2 Password (ASCII).
+            This will be used during MSCHAPv2 authentication. */
+    uint16  u16DomainLen;
+    /*!< Length of Domain (in ASCII characters), including '@' or '\' separator character as
+            appropriate.
+            Permitted values are such that u16DomainLen + u16UserNameLen is between 0 and
+            @ref M2M_AUTH_1X_USER_LEN_MAX. */
+    uint16  u16UserNameLen;
+    /*!< Length of UserName (in ASCII characters).
+            Permitted values are such that u16DomainLen + u16UserNameLen is between 0 and
+            @ref M2M_AUTH_1X_USER_LEN_MAX. */
+    uint16  u16PasswordLen;
+    /*!< Length of Password (in ASCII characters).
+            Permitted values are between 0 and @ref M2M_AUTH_1X_PASSWORD_LEN_MAX. */
+    bool    bUnencryptedUserName;
+    /*!< Determines whether UserName or "anonymous" is sent (unencrypted) in the initial EAP
+            identity response. Domain is sent in both cases. \n
+            true: UserName is sent in the initial EAP identity response (not recommended).
+            false: "anonymous" is sent in the initial EAP identity response. This setting is
+            recommended for tunneled methods. MSCHAPv2 is always a tunneled method. */
+    bool    bPrependDomain;
+    /*!< Determines whether Domain is prepended or appended to UserName in EAP identity responses.
+            true: Domain is prepended to UserName - [Domain][UserName].
+            false: Domain is appended to UserName - [UserName][Domain]. */
+}tstrAuth1xMschap2;
+
+typedef struct {
+    uint8   *pu8Domain;
+    /*!< Pointer to Domain of authentication server (printable ASCII), including '@' or '\'
+            separator character as appropriate. Use NULL if there is no domain information.
+            The Domain will be either prepended or appended to the UserName, depending on the
+            setting of field bPrependDomain. \n
+            Example 1: if [Domain]is "@my_domain" and bPrependDomain is false, then the EAP
+            identity response is "[UserName]@my_domain". \n
+            Example 2: if [Domain]is "my_domain\" and bPrependDomain is true, then the EAP
+            identity response is "my_domain\[UserName]". */
+    uint8   *pu8UserName;
+    /*!< Pointer to UserName (ASCII).
+            This will be sent (encrypted) in the tunneled EAP identity response.
+            If bUnencryptedUserName is true then it will also be sent (unencrypted) in the initial
+            EAP identity response. */
+    uint8   *pu8PrivateKey_Mod;
+    /*!< Pointer to PrivateKey modulus (raw data).
+            This will be used during TLS client authentication. */
+    uint8   *pu8PrivateKey_Exp;
+    /*!< Pointer to PrivateKey exponent (raw data).
+            This will be used during TLS client authentication. */
+    uint8   *pu8Certificate;
+    /*!< Pointer to TLS client certificate corresponding to PrivateKey.
+            This will be used during TLS client authentication. */
+    uint16  u16DomainLen;
+    /*!< Length of Domain (in ASCII characters), including '@' or '\' separator character as
+            appropriate.
+            Permitted values are such that u16DomainLen + u16UserNameLen is between 0 and
+            @ref M2M_AUTH_1X_USER_LEN_MAX. */
+    uint16  u16UserNameLen;
+    /*!< Length of UserName (in ASCII characters).
+            Permitted values are such that u16DomainLen + u16UserNameLen is between 0 and
+            @ref M2M_AUTH_1X_USER_LEN_MAX. */
+    uint16  u16PrivateKeyLen;
+    /*!< Length of PrivateKey_Mod (in bytes).
+            Permitted values are between 0 and @ref M2M_AUTH_1X_PRIVATEKEY_LEN_MAX, typically 128 or 256.
+            PrivateKey_Exp must be the same length as modulus, pre-padded with 0s if necessary. */
+    uint16  u16CertificateLen;
+    /*!< Length of Certificate (in bytes).
+            Permitted values are between 0 and @ref M2M_AUTH_1X_CERT_LEN_MAX. */
+    bool    bUnencryptedUserName;
+    /*!< Determines whether UserName or "anonymous" is sent (unencrypted) in the initial EAP
+            identity response. Domain is sent in both cases. \n
+            true: UserName is sent in the initial EAP identity response (required for EAP-TLS).
+            false: "anonymous" is sent in the initial EAP identity response. This setting is
+            recommended for tunneled methods such as EAP-PEAP/TLS. */
+    bool    bPrependDomain;
+    /*!< Determines whether Domain is prepended or appended to UserName in EAP identity responses.
+            true: Domain is prepended to UserName - [Domain][UserName].
+            false: Domain is appended to UserName - [UserName][Domain]. */
+}tstrAuth1xTls;
+/**@}*/     //WlanEnums
+
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 FUNCTION PROTOTYPES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-/** \defgroup WLANAPI Function
- *   @ingroup m2m_wifi
- */
+
 #ifdef __cplusplus
      extern "C" {
 #endif
- /** @defgroup WiFiDownloadFn m2m_wifi_download_mode
- *  @ingroup WLANAPI
- *   	Synchronous download mode entry function that prepares the WINC board to enter the download mode, ready for the firmware or certificate download.
-*	The WINC board is prepared for download, through initializations for the WINC driver including bus initializations and interrupt enabling, it also halts the chip, to allow for the firmware downloads.
-*	Firmware can be downloaded through a number of interfaces, UART, I2C and SPI.
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API void  m2m_wifi_download_mode(void);
-@brief	Prepares the WINC broard before downloading any data (Firmware, Certificates .. etc)
+@ingroup WLANINIT
+@fn \
+    NMI_API void  m2m_wifi_download_mode(void);
 
-		This function should called before starting to download any data to the WINC board. The WINC board is prepared for download, through initializations for the WINC driver including bus initializations 
-		and interrupt enabling, it also halts the chip, to allow for the firmware downloads Firmware can be downloaded through a number of interfaces, UART, I2C and SPI.
+@brief
+    Prepares the WINC board before downloading any data (Firmware, Certificates, etc).
 
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
+@details
+    This function should be called before attempting to download any data to the WINC board.
+    Performs the appropriate WINC driver initialization, this includes bus initialization,
+    interrupt enabling and it halts the chip to allow for the firmware downloads. Firmware
+    can be downloaded through a number of interfaces, UART, I2C and SPI.
+
+@pre
+    Prior to call m2m_wifi_download_mode, the Application should ensure that the wifi is not
+    initialized. This can be done by calling @ref m2m_wifi_get_state and in case the wifi state
+    differs from @ref WIFI_STATE_DEINIT, a @ref m2m_wifi_deinit needs to be issued.
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
-NMI_API sint8  m2m_wifi_download_mode(void);
+NMI_API sint8 m2m_wifi_download_mode(void);
 
- /**@}*/
- /** @defgroup WifiInitFn m2m_wifi_init
- *  @ingroup WLANAPI
- *  Synchronous initialization function for the WINC driver. This function initializes the driver by, registering the call back function for M2M_WIFI layer(also the call back function for bypass mode/monitoring mode if defined), 
- *  initializing the host interface layer and the bus interfaces. 
- *  Wi-Fi callback registering is essential to allow the handling of the events received, in response to the asynchronous Wi-Fi operations. 
-
-Following are the possible Wi-Fi events that are expected to be received through the call back function(provided by the application) to the M2M_WIFI layer are : 
-
-		@ref M2M_WIFI_RESP_CON_STATE_CHANGED \n
-		@ref M2M_WIFI_RESP_CONN_INFO \n
-		@ref M2M_WIFI_REQ_DHCP_CONF \n
-		@ref M2M_WIFI_REQ_WPS \n
-		@ref M2M_WIFI_RESP_IP_CONFLICT \n 
-		@ref M2M_WIFI_RESP_SCAN_DONE \n
-		@ref M2M_WIFI_RESP_SCAN_RESULT \n
-		@ref M2M_WIFI_RESP_CURRENT_RSSI \n
-		@ref M2M_WIFI_RESP_CLIENT_INFO \n
-		@ref M2M_WIFI_RESP_PROVISION_INFO  \n
-		@ref M2M_WIFI_RESP_DEFAULT_CONNECT \n
-	Example: \n
-	In case Bypass mode is defined : \n
-		@ref M2M_WIFI_RESP_ETHERNET_RX_PACKET
-		
-	In case Monitoring mode is used: \n
-		@ref M2M_WIFI_RESP_WIFI_RX_PACKET
-		
-	Any application using the WINC driver must call this function at the start of its main function.
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8  m2m_wifi_init(tstrWifiInitParam * pWifiInitParam);
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_init(tstrWifiInitParam * pWifiInitParam);
+
+@brief
+    Synchronous API to initialize the WINC driver.
+
+@details
+    This function initializes the WINC driver by registering the callback function for the M2M_WIFI layer
+    (also the callback function for bypass mode/monitoring mode if defined), initializing the host
+    interface layer and the bus interfaces. Wi-Fi callback registering is essential to allow the
+    handling of the events received, in response to the asynchronous Wi-Fi operations.
+
+    The possible Wi-Fi events that are expected to be received through the callback
+    function (provided by the application) to the M2M_WIFI layer are listed below:
+
+     - @ref M2M_WIFI_RESP_CON_STATE_CHANGED
+     - @ref M2M_WIFI_RESP_CONN_INFO
+     - @ref M2M_WIFI_REQ_DHCP_CONF
+     - @ref M2M_WIFI_REQ_WPS
+     - @ref M2M_WIFI_RESP_IP_CONFLICT
+     - @ref M2M_WIFI_RESP_SCAN_DONE
+     - @ref M2M_WIFI_RESP_SCAN_RESULT
+     - @ref M2M_WIFI_RESP_CURRENT_RSSI
+     - @ref M2M_WIFI_RESP_CLIENT_INFO
+     - @ref M2M_WIFI_RESP_PROVISION_INFO
+     - @ref M2M_WIFI_RESP_DEFAULT_CONNECT
+     - @ref M2M_WIFI_RESP_ETHERNET_RX_PACKET (if bypass mode is enabled)
+     - @ref M2M_WIFI_RESP_WIFI_RX_PACKET (if monitoring mode is enabled)
+
+    Any application using the WINC driver must call this function at the start of its main function.
 
 @param [in]	pWifiInitParam
-	This is a pointer to the @ref tstrWifiInitParam structure which holds the pointer to the application WIFI layer call back function,
-	monitoring mode call back and @ref tstrEthInitParam structure containing bypass mode parameters.
-
-@brief Initialize the WINC host driver.
-	  This function initializes the driver by, registering the call back function for M2M_WIFI layer(also the call back function for bypass mode/monitoring mode if defined), 
- 	  initializing the host interface layer and the bus interfaces. 
+    This is a pointer to a structure of type @ref tstrWifiInitParam which contains pointers to the
+	application WIFI layer callback function, monitoring mode callback and @ref tstrEthInitParam 
+	structure (which contains initialization settings for bypass mode).
  
+@return		
+    The function returns @ref M2M_SUCCESS for successful operations  and a negative value otherwise.
+
 @pre 
-	Prior to this function call, The application should initialize the BSP using "nm_bsp_init". 
-	Also,application users must provide a call back function responsible for receiving all the WI-FI events that are received on the M2M_WIFI layer.
+    Prior to this function call, The application should initialize the BSP using @ref nm_bsp_init.
+    Also, application users must provide a call back function responsible for receiving all the
+    wi-fi events that are received on the M2M_WIFI layer.
 	
 @warning
-	Failure to successfully complete function indicates that the driver couldn't be initialized and a fatal error will prevent the application from proceeding. 
+    Failure to successfully complete indicates that the driver could not be initialized and
+    a fatal error will prevent the application from proceeding, proper error handling should be
+    implemented by the application.
 	
 @see
-	nm_bsp_init
 	m2m_wifi_deinit
+    m2m_wifi_init_hold
+    m2m_wifi_init_start
+    tstrWifiInitParam
 	tenuM2mStaCmd
-
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+	tenuM2mStaCmd
 */
 NMI_API sint8  m2m_wifi_init(tstrWifiInitParam * pWifiInitParam);
- /**@}*/
- /** @defgroup WifiDeinitFn m2m_wifi_deinit
- *  @ingroup WLANAPI
- *   Synchronous de-initialization function to the WINC1500 driver. De-initializes the host interface and frees any resources used by the M2M_WIFI layer. 
- *   This function must be called in the application closing phase to ensure that all resources have been correctly released. No arguments are expected to be passed in. 
- */
-/**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8  m2m_wifi_deinit(void * arg);
-	
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_deinit(void * arg);
+
+@brief
+    De-initialize the WINC driver and host interface.
+
+@details
+    Synchronous de-initialization function for the WINC driver.
+	De-initializes the host interface and frees any resources used by the M2M_WIFI layer. 
+    This function must be called in the application closing phase to ensure that all
+    resources have been correctly released.
+	No arguments are expected to be passed in. 
+
 @param [in]	arg
-		Generic argument. Not used in the current implementation.
-@brief	Deinitilize the WINC driver and host enterface. 
-		This function must be called at the De-initilization stage of the application. Generally This function should be the last function before switching off the chip
-		and it should be followed only by "nm_bsp_deinit" function call. Every function call of "nm_wifi_init" should be matched with a call to nm_wifi_deinit.
-@see
-	nm_bsp_deinit
-	nm_wifi_init
-	
+        Opaque argument, not used in current implementation. Application should use null.
+
 @return		
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC, 
+	and a negative value otherwise.
+
+@note
+    This function must be called at the de-initialization stage of the application.
+    Generally this function should be the last function before switching off the chip
+    and it should be followed only by @ref nm_bsp_deinit function call.
+    Every function call of @ref m2m_wifi_init should be matched with a call to m2m_wifi_deinit.
+
+@see
+    nm_bsp_deinit
+    m2m_wifi_init
+    m2m_wifi_init_hold
+    m2m_wifi_download_mode
 */
 NMI_API sint8  m2m_wifi_deinit(void * arg);
 
- /**@}*/
-/** @defgroup WifiHandleEventsFn m2m_wifi_handle_events
-*  @ingroup WLANAPI
-* 	Synchronous M2M event handler function, responsible for handling interrupts received from the WINC firmware.
-*     Application developers should call this function periodically in-order to receive the events that are to be handled by the
-*     callback functions implemented by the application.
-
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_handle_events(void * arg);
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_init_hold(void);
+
+@brief
+    First part of @ref m2m_wifi_init, up to the point of initializing SPI for flash access.
+
+@see
+    m2m_wifi_init
+    m2m_wifi_init_start
+*/
+NMI_API sint8 m2m_wifi_init_hold(void);
+
+/*!
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_init_start(tstrWifiInitParam * pWifiInitParam);
+
+@brief
+    Second part of @ref m2m_wifi_init, continuing from where @ref m2m_wifi_init_hold left off.
+
+@param [in] pWifiInitParam
+    This is a pointer to a variable of type @ref tstrWifiInitParam which contains pointers to the
+    application WIFI layer callback function (see @ref tpfAppWifiCb), monitoring mode callback
+    (see @ref tpfAppEthCb) and @ref tstrEthInitParam structure (which contains initialization
+    settings for bypass mode).
+
+@see
+    m2m_wifi_init
+    tstrWifiInitParam
+*/
+NMI_API sint8 m2m_wifi_init_start(tstrWifiInitParam * pWifiInitParam);
+
+/*!
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_reinit(tstrWifiInitParam * pWifiInitParam);
+
+@brief
+    De-initialize and then initialize wifi. Resets the WINC.
+
+@param [in] pWifiInitParam
+    This is a pointer to a variable of type @ref tstrWifiInitParam which contains pointers to the
+    application WIFI layer callback function (see @ref tpfAppWifiCb), monitoring mode callback
+    (see @ref tpfAppEthCb) and @ref tstrEthInitParam structure (which contains initialization
+    settings for bypass mode).
+
+@note
+    m2m_wifi_reinit wraps a call to @ref m2m_wifi_deinit and to @ref m2m_wifi_init.
+
+@see
+    m2m_wifi_deinit
+    m2m_wifi_init
+    tstrWifiInitParam
+*/
+NMI_API sint8 m2m_wifi_reinit(tstrWifiInitParam * pWifiInitParam);
+
+/*!
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_reinit_hold(void);
+
+@brief
+    First part of @ref m2m_wifi_reinit, up to the point of initializing SPI for flash access.
+
+@note
+    m2m_wifi_reinit_hold wraps a call to @ref m2m_wifi_deinit and to @ref m2m_wifi_init_hold.
+
+@see
+    m2m_wifi_deinit
+    m2m_wifi_reinit
+    m2m_wifi_init_hold
+*/
+NMI_API sint8 m2m_wifi_reinit_hold(void);
+
+/*!
+@ingroup WLANINIT
+@fn \
+    NMI_API sint8 m2m_wifi_reinit_start(tstrWifiInitParam * pWifiInitParam);
+
+@brief
+    Second part of @ref m2m_wifi_reinit, continuing from where m2m_wifi_reinit_hold left off.
+
+@param [in] pWifiInitParam
+                This is a pointer to the @ref tstrWifiInitParam structure which contains pointers to the
+    application WIFI layer callback function (see @ref tpfAppWifiCb), monitoring mode callback
+    (see @ref tpfAppEthCb) and @ref tstrEthInitParam structure (which contains initialization
+    settings for bypass mode).
+
+@see
+    m2m_wifi_reinit
+    m2m_wifi_init_start
+    tstrWifiInitParam
+*/
+NMI_API sint8 m2m_wifi_reinit_start(tstrWifiInitParam * pWifiInitParam);
+
+/*!
+@ingroup WLANEVTS
+@fn \
+    NMI_API void m2m_wifi_yield(void);
+
+@brief
+    Yield from processing more synchronous M2M events.
+
+@details 
+    This function causes the synchronous M2M event handler function to yield from processing further
+    events and return control to the caller.
 
 @pre
-	Prior to receiving events, the WINC driver should have been successfully initialized by calling the @ref m2m_wifi_init function.
-
-@brief 	Handle the varios events received from the WINC board.
-		Whenever an event happen in the WINC board (e.g. Connection, Disconnection , DHCP .. etc), WINC will interrupt the host to let it know that a new 
-		event has occured. The host driver will attempt to handle these events whenever the host driver decides to do that by calling the "m2m_wifi_handle_events" function.
-		It's mandatory to call this function periodically and independantly of any other condition. It's ideal to include this function in the main and the most frequent loop of the 
-		host application.
+    Prior to receiving  Wi-Fi interrupts, the WINC driver should have been successfully initialized 
+	by calling the @ref m2m_wifi_init function.
+     
 @warning
-	Failure to successfully complete this function indicates bus errors and hence a fatal error that will prevent the application from proceeding.
+    Failure to successfully complete this function indicates bus errors and hence a fatal error that will
+    prevent the application from proceeding.
+*/
+NMI_API void m2m_wifi_yield(void);
+
+/*!
+@ingroup WLANEVTS
+@fn \
+    NMI_API sint8 m2m_wifi_handle_events(void * arg);
+
+@brief 	
+    Synchronous M2M event handler function.
+
+@details
+	This function is responsible for handling interrupts received from the WINC firmware.
+	Applications should call this function periodically in-order to receive the events that are to 
+	be handled by the callback functions implemented by the application.
+
+	Handle the various events received from the WINC board.
+    Whenever an event happens in the WINC board (e.g. Connection, Disconnection, DHCP, etc),
+    the WINC will interrupt the host to let it know that a new event has occurred. The host driver
+    will attempt to handle these events whenever the application decides to do so by calling
+    the m2m_wifi_handle_events function.
+    It is mandatory to call this function periodically and independently of any other condition.
+    It is ideal to include this function in the main and the most frequent loop of the
+		host application.
+
+@pre
+    Prior to receiving events, the WINC driver should have been successfully initialized by calling the @ref m2m_wifi_init function.
+
+@warning
+    Failure to successfully complete this function indicates bus errors and hence a fatal error that will prevent the application from proceeding.
 
 @return		
-	The function returns @ref M2M_SUCCESS for successful interrupt handling and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS for successful interrupt handling and a negative value otherwise.
 */
-
 NMI_API sint8 m2m_wifi_handle_events(void * arg);
 
- /**@}*/
-/** @defgroup WifiSendCRLFn m2m_wifi_send_crl
-*  @ingroup WLANAPI
-* 	Asynchronous API that notifies the WINC with the Certificate Revocation List to be used for TLS.
-
- */
- /**@{*/
 /*!
 @fn	\
 	sint8 m2m_wifi_send_crl(tstrTlsCrlInfo* pCRL);
@@ -727,375 +820,900 @@ NMI_API sint8 m2m_wifi_handle_events(void * arg);
 	Pointer to the structure containing certificate revocation list details.
 
 @return
-	The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC, 
-	and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 */
-
 sint8 m2m_wifi_send_crl(tstrTlsCrlInfo* pCRL);
 
- /**@}*/
-/** @defgroup WifiDefaultConnectFn m2m_wifi_default_connect
- *  @ingroup WLANAPI
- *   Asynchronous Wi-Fi connection function. An application calling this function will cause the firmware to correspondingly connect to the last successfully connected AP from the cached connections. 
- *   A failure to connect will result in a response of @ref M2M_WIFI_RESP_DEFAULT_CONNECT indicating the connection error as defined in the structure @ref tstrM2MDefaultConnResp.
- *   Possible errors are: 
- *   The connection list is empty @ref M2M_DEFAULT_CONN_EMPTY_LIST or a mismatch for the saved AP name @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
- *    only difference between this function and @ref m2m_wifi_connect, is the connection parameters. 
- *   Connection using this function is expected to connect using cached connection parameters. 
-
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_default_connect(void);
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_delete_sc(char *pcSsid, uint8 u8SsidLen);
+
+@brief
+	Asynchronous API that deletes connection credentials (PSK, WEP key, 802.1X password) from WINC
+	flash. Either deletes all credentials, or for a specific SSID.
+
+@details
+	Causes WINC to delete connection credentials. If the parameter is NULL, then WINC will delete
+	all credentials from flash. Otherwise WINC will only delete credentials for matching SSID.
+    Callback will report the status of the operation (success or not).
+
+@param [in]	pcSsid
+	SSID to match on when deleting credentials.
+	SSID must not contain '\0'.
+	NULL is a valid argument here, in which case all credentials are deleted.
+
+@param [in]	u8SsidLen
+	Length of SSID provided in pcSsid. Must be less than @ref M2M_MAX_SSID_LEN.
+	This parameter is ignored if pcSsid is NULL.
 
 @pre 
-	Prior to connecting, the WINC driver should have been successfully initialized by calling the @ref m2m_wifi_init function.
+	Prior to deleting credentials, the WINC driver should have been successfully initialized by calling the 
+	@ref m2m_wifi_init function.
 
-@brief	Connect to the last successfully connected AP from the cached connections. 
+@warning
+    The option to delete for a specific SSID is currently not supported; all credentials are
+    deleted regardless of the input parameters.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+*/
+sint8 m2m_wifi_delete_sc(char *pcSsid, uint8 u8SsidLen);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_default_connect(void);
+
+@brief
+	Asynchronous API that attempts to reconnect to the last-associated access point.
+
+@details
+	Asynchronous Wi-Fi connection function. An application calling this function will cause
+	the firmware to correspondingly connect to the last successfully connected AP from the 
+    cached connections.\n
+ 	A failure to connect will result in a response of @ref M2M_WIFI_RESP_DEFAULT_CONNECT 
+	indicating the connection error as defined in the structure @ref tstrM2MDefaultConnResp.
+	
+	Possible errors are: 
+	The connection list is empty @ref M2M_DEFAULT_CONN_EMPTY_LIST or a mismatch for the 
+	saved AP name @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
+
+@pre 
+    Prior to connecting, the WINC driver should have been successfully initialized by calling the 
+	@ref m2m_wifi_init function.
 
 @warning
  This function must be called in station mode only.
- It's important to note that successful completion of a call to m2m_wifi_default_connect() does not guarantee success of the WIFI connection, 
- and a negative return value indicates only locally-detected errors.
-	
-@see
-	m2m_wifi_connect
-	
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    It is important to note that successful completion of a call to m2m_wifi_default_connect()
+    does not guarantee success of the WIFI connection; a negative return value indicates only
+    locally-detected errors.
 
+@see
+    m2m_wifi_connect
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_default_connect(void);
- /**@}*/
-/** @defgroup WifiConnectFn m2m_wifi_connect
- *   @ingroup WLANAPI
- *   Asynchronous wi-fi connection function to a specific AP. Prior to a successful connection, the application must define the SSID of the AP, the security type,
- *   the authentication information parameters and the channel number to which the connection will be established.
- *  The connection status is known when a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED is received based on the states defined in @ref tenuM2mConnState,
- *  successful connection is defined by @ref M2M_WIFI_CONNECTED
-*   
- *   The only difference between this function and @ref m2m_wifi_default_connect, is the connection parameters. 
- *   Connection using this function is expected to be made to a specific AP and to a specified channel.
- */
- /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_wifi_connect(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch);
 
-@param [in]	pcSsid
-				A buffer holding the SSID corresponding to the requested AP.
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_connect_open(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId);
+
+@brief
+    Asynchronous API to connect to an access point using open authentication.
+
+@details
+    Asynchronous Wi-Fi connection function. An application calling this function will cause the
+    firmware to attempt to connect to an access point matching the details in pstrNetworkId, with
+    open authentication.
+    On successful connection, the connection details may be saved in WINC's flash, according to
+    the option selected in enuCredStoreOption.
+    Once connection has been attempted (whether successful or otherwise), a response event
+    @ref M2M_WIFI_RESP_CON_STATE_CHANGED will be sent to the callback function @ref tpfAppWifiCb
+    provided during initialization @ref m2m_wifi_init.
+
+    Possible results indicated by the response event are:
+    - @ref M2M_WIFI_DISCONNECTED if the connection attempt failed.
+    - @ref M2M_WIFI_CONNECTED if the connection attempt succeeded.
+
+@pre
+    Prior to attempting connection, the WINC driver must have been initialized by calling the
+    @ref m2m_wifi_init function.
+
+@warning
+    This function is handled in station mode only.
+
+@param[in]  enuCredStoreOption
+    Option to specify whether connection details (i.e. the contents
+    of pstrNetworkId) are stored in WINC's flash and, if so,
+    whether they are encrypted before storing.
+
+@param[in]  pstrNetworkId
+    Structure specifying SSID/BSSID and Wi-Fi channel.
+
+@return
+    The function returns @ref M2M_SUCCESS if the connect request has been successfully passed to the firmware and a negative value otherwise.
+*/
+sint8 m2m_wifi_connect_open(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_connect_wep(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuthWep *pstrAuthWep);
+
+@brief
+    Asynchronous API to connect to an access point using WEP authentication.
 				
-@param [in]	u8SsidLen
-				Length of the given SSID (not including the NULL termination).
-				A length less than ZERO or greater than the maximum defined SSID @ref M2M_MAX_SSID_LEN will result in a negative error 
-				@ref M2M_ERR_FAIL.
+@details
+    Asynchronous Wi-Fi connection function. An application calling this function will cause the
+    firmware to attempt to connect to an access point matching the details in pstrNetworkId, with
+    the WEP key provided in pstrAuthWep.
+    On successful connection, the connection details may be saved in WINC's flash, according to
+    the option selected in enuCredStoreOption.
+    Once connection has been attempted (whether successful or otherwise), a response event
+    @ref M2M_WIFI_RESP_CON_STATE_CHANGED will be sent to the callback function @ref tpfAppWifiCb
+    provided during initialization @ref m2m_wifi_init.
+	
+    Possible results indicated by the response event are:
+    - @ref M2M_WIFI_DISCONNECTED if the connection attempt failed.
+    - @ref M2M_WIFI_CONNECTED if the connection attempt succeeded.
+
+@pre
+    Prior to attempting connection, the WINC driver must have been initialized by calling the
+    @ref m2m_wifi_init function.
+
+@warning
+    This function is handled in station mode only.
+
+@param[in]  enuCredStoreOption
+    Option to specify whether connection details (i.e. the contents
+    of pstrNetworkId and pstrAuthWep) are stored in WINC's flash
+    and, if so, whether they are encrypted before storing.
+
+@param[in]  pstrNetworkId
+    Structure specifying SSID/BSSID and Wi-Fi channel.
+
+@param[in]  pstrAuthWep
+    Structure specifying the WEP key.
+	
+@return
+    The function returns @ref M2M_SUCCESS if the connect request has been successfully passed to the firmware and a negative value otherwise.
+*/
+sint8 m2m_wifi_connect_wep(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuthWep *pstrAuthWep);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_connect_psk(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuthPsk *pstrAuthPsk);
+
+@brief
+    Asynchronous API to connect to an access point using WPA(2) PSK authentication.
+
+@details
+    Asynchronous Wi-Fi connection function. An application calling this function will cause the
+    firmware to attempt to connect to an access point matching the details in pstrNetworkId, with
+    the PSK passphrase provided in pstrAuthPsk.
+    On successful connection, the connection details may be saved in WINC's flash, according to
+    the option selected in enuCredStoreOption.
+    Once connection has been attempted (whether successful or otherwise), a response event
+    @ref M2M_WIFI_RESP_CON_STATE_CHANGED will be sent to the callback function @ref tpfAppWifiCb
+    provided during initialization @ref m2m_wifi_init.
+
+    Possible results indicated by the response event are:
+    - @ref M2M_WIFI_DISCONNECTED if the connection attempt failed.
+    - @ref M2M_WIFI_CONNECTED if the connection attempt succeeded.
+
+@pre
+    Prior to attempting connection, the WINC driver must have been initialized by calling the
+    @ref m2m_wifi_init function.
+
+@warning
+    This function is handled in station mode only.
+
+@param[in]  enuCredStoreOption
+    Option to specify whether connection details (i.e. the contents
+    of pstrNetworkId and pstrAuthPsk) are stored in WINC's flash
+    and, if so, whether they are encrypted before storing.
+
+@param[in]  pstrNetworkId
+    Structure specifying SSID/BSSID and Wi-Fi channel.
+
+@param[in]  pstrAuthPsk
+    Structure specifying the Passphrase/PSK.
+
+@return
+    The function returns @ref M2M_SUCCESS if the connect request has been successfully passed to the firmware and a negative value otherwise.
+*/
+sint8 m2m_wifi_connect_psk(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuthPsk *pstrAuthPsk);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_1x_set_option(tenu1xOption enuOptionName, const void *pOptionValue, size_t OptionLen);
+
+@brief
+    API to set (write) options relating to Wi-Fi connection using WPA(2) Enterprise authentication.
+
+@details
+    The following options can be set:\n
+        @ref WIFI_1X_BYPASS_SERVER_AUTH\n
+        @ref WIFI_1X_SESSION_CACHING\n
+        @ref WIFI_1X_SPECIFIC_ROOTCERT\n
+        @ref WIFI_1X_TIME_VERIF_MODE\n
+    The setting applies to all subsequent connection attempts via @ref m2m_wifi_connect_1x_mschap2
+    or @ref m2m_wifi_connect_1x_tls.\n
+    Connection attempts via @ref m2m_wifi_default_connect use the
+    settings which were in place at the time of the original connection.
+
+@param[in]  enuOptionName
+    The option to set.
+
+@param[in]  pOptionValue
+    Pointer to a buffer containing the value to set. The buffer must be at least as long as OptionLen.
+    If OptionLen is 0, then pOptionValue may be NULL.
+
+@param[in]  OptionLen
+    The length of the option value being set.
+
+@return
+    The function returns @ref M2M_SUCCESS if the parameters are valid and @ref M2M_ERR_INVALID_ARG otherwise.
+*/
+sint8 m2m_wifi_1x_set_option(tenu1xOption enuOptionName, const void *pOptionValue, size_t OptionLen);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_1x_get_option(tenu1xOption enuOptionName, void *pOptionValue, size_t *pOptionLen);
+
+@brief
+    API to get (read) options relating to Wi-Fi connection using WPA(2) Enterprise authentication.
+
+@details
+    The following options can be read:\n
+        @ref WIFI_1X_BYPASS_SERVER_AUTH\n
+        @ref WIFI_1X_SESSION_CACHING\n
+        @ref WIFI_1X_SPECIFIC_ROOTCERT\n
+        @ref WIFI_1X_TIME_VERIF_MODE\n
+
+@param[in]      enuOptionName
+    The option to get.
+
+@param[out]     pOptionValue
+    Pointer to a buffer containing the value to set. The buffer must be at least as long as OptionLen.
+    If OptionLen is 0, then pOptionValue may be NULL.
+
+@param[inout]  pOptionLen
+    Pointer to a length.
+    When calling the function, this length must be the length of the buffer available for reading the option value.
+    When the function returns, this length is the length of the data that has been populated by the function.
+
+@return
+    The function returns @ref M2M_SUCCESS if the parameters are valid and @ref M2M_ERR_INVALID_ARG otherwise.
+*/
+sint8 m2m_wifi_1x_get_option(tenu1xOption enuOptionName, void *pOptionValue, size_t *pOptionLen);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_connect_1x_mschap2(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuth1xMschap2 *pstrAuth1xMschap2);
+
+@brief
+    Asynchronous API to connect to an access point using WPA(2) Enterprise authentication with
+    MS-CHAP-V2 credentials.
 				
-@param [in]	u8SecType
-				Wi-Fi security type security for the network. It can be one of the following types:
-				-@ref M2M_WIFI_SEC_OPEN
-				-@ref M2M_WIFI_SEC_WEP
-				-@ref M2M_WIFI_SEC_WPA_PSK
-				-@ref M2M_WIFI_SEC_802_1X
-				A value outside these possible values will result in a negative return error @ref M2M_ERR_FAIL.
+@details
+    Asynchronous Wi-Fi connection function. An application calling this function will cause the
+    firmware to attempt to connect to an access point matching the details in pstrNetworkId, with
+    the Enterprise MS-CHAP-V2 credentials provided in pstrAuth1xMschap2.
+    On successful connection, the connection details may be saved in WINC's flash, according to
+    the option selected in enuCredStoreOption.
+    Once connection has been attempted (whether successful or otherwise), a response event
+    @ref M2M_WIFI_RESP_CON_STATE_CHANGED will be sent to the callback function tpfAppWifiCb
+    provided during initialization @ref m2m_wifi_init.
+	
+    Possible results indicated by the response event are:
+    - @ref M2M_WIFI_DISCONNECTED if the connection attempt failed.
+    - @ref M2M_WIFI_CONNECTED if the connection attempt succeeded.
+
+@pre
+    Prior to attempting connection, the WINC driver must have been initialized by calling the
+    @ref m2m_wifi_init function.
+
+@warning
+    This function is handled in station mode only.
+
+@param[in]  enuCredStoreOption
+    Option to specify whether connection details (i.e. the contents
+    of pstrNetworkId and pstrAuth1xMschap2) are stored in WINC's
+    flash and, if so, whether they are encrypted before storing.
+
+@param[in]  pstrNetworkId
+    Structure specifying SSID/BSSID and Wi-Fi channel.
+
+@param[in]  pstrAuth1xMschap2
+    Structure specifying the MS-CHAP-V2 credentials.
+	
+@return
+    The function returns @ref M2M_SUCCESS if the connect request has been successfully passed to the firmware and a negative value otherwise.
+*/
+sint8 m2m_wifi_connect_1x_mschap2(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuth1xMschap2 *pstrAuth1xMschap2);
+	
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_connect_1x_tls(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuth1xTls *pstrAuth1xTls);
+
+@brief
+    Asynchronous API to connect to an access point using WPA(2) Enterprise authentication with
+    MS-CHAP-V2 credentials.
+
+@details
+    Asynchronous Wi-Fi connection function. An application calling this function will cause the
+    firmware to attempt to connect to an access point matching the details in pstrNetworkId, with
+    the Enterprise TLS credentials provided in pstrAuth1xTls.
+    On successful connection, the connection details may be saved in WINC's flash, according to
+    the option selected in enuCredStoreOption.
+    Once connection has been attempted (whether successful or otherwise), a response event
+    @ref M2M_WIFI_RESP_CON_STATE_CHANGED will be sent to the callback function @ref tpfAppWifiCb
+    provided during initialization @ref m2m_wifi_init.
+
+    Possible results indicated by the response event are:
+    - @ref M2M_WIFI_DISCONNECTED if the connection attempt failed.
+    - @ref M2M_WIFI_CONNECTED if the connection attempt succeeded.
+
+@pre
+    Prior to attempting connection, the WINC driver must have been initialized by calling the
+    @ref m2m_wifi_init function.
+
+@warning
+    This function is handled in station mode only.
+
+@param[in]  enuCredStoreOption
+    Option to specify whether connection details (i.e. the contents
+    of pstrNetworkId and pstrAuth1xTls) are stored in WINC's
+    flash and, if so, whether they are encrypted before storing.
+
+@param[in]  pstrNetworkId
+    Structure specifying SSID/BSSID and Wi-Fi channel.
+
+@param[in]  pstrAuth1xTls
+    Structure specifying the EAP-TLS credentials.
+
+@return
+    The function returns @ref M2M_SUCCESS if the connect request has been successfully passed to the firmware and a negative value otherwise.
+*/
+sint8 m2m_wifi_connect_1x_tls(tenuCredStoreOption enuCredStoreOption, tstrNetworkId *pstrNetworkId, tstrAuth1xTls *pstrAuth1xTls);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_connect(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch);
+
+@brief
+    DEPRECATED in v19.6.1 - Kept only for legacy purposes.\n
+    Legacy asynchronous API to request connection to a specified access point.
+
+@details
+    Prior to a successful connection, the application must define the SSID of the AP, the security
+    type, the authentication information parameters and the channel number to which the connection
+    will be established.
+
+    The connection status is known when a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED is
+    received based on the states defined in @ref tenuM2mConnState, successful connection is defined
+    by @ref M2M_WIFI_CONNECTED
+
+    The only difference between this function and @ref m2m_wifi_default_connect, is the set of connection parameters.
+    Connection using this function is expected to be made to a specific AP and to a specified channel.
+
+@param[in]  pcSsid
+    A buffer holding the SSID corresponding to the requested AP.
+    SSID must not contain '\0'.
+
+@param[in]  u8SsidLen
+    Length of the given SSID (not including the NULL termination).
+    A length greater than the maximum defined SSID @ref M2M_MAX_SSID_LEN will result in a negative error
+    @ref M2M_ERR_FAIL.
+
+@param[in]  u8SecType
+    Wi-Fi security type security for the network. It can be one of the following types:
+    -@ref M2M_WIFI_SEC_OPEN
+    -@ref M2M_WIFI_SEC_WEP
+    -@ref M2M_WIFI_SEC_WPA_PSK
+    -@ref M2M_WIFI_SEC_802_1X
+    A value outside these possible values will result in a negative return error @ref M2M_ERR_FAIL.
 
 @param [in]	pvAuthInfo
-				Authentication parameters required for completing the connection. It is type is based on the Security type.
-				If the authentication parameters are NULL or are greater than the maximum length of the authentication parameters length as defined by
-				@ref M2M_MAX_PSK_LEN a negative error will return @ref M2M_ERR_FAIL(-12) indicating connection failure.
+    Authentication parameters required for completing the connection. Its type is based on the
+    security type. If the authentication parameters are NULL or are greater than the maximum length
+    of the authentication parameters length as defined by @ref M2M_MAX_PSK_LEN a negative error will
+    return @ref M2M_ERR_FAIL(-12) indicating connection failure.
 
 @param [in]	u16Ch
-				Wi-Fi channel number as defined in @ref tenuM2mScanCh enumeration.
-				Channel number greater than @ref M2M_WIFI_CH_14 returns a negative error @ref M2M_ERR_FAIL(-12).
-				Except if the value is M2M_WIFI_CH_ALL(255), since this indicates that the firmware should scan all channels to find the SSID requested to connect to.
-				Failure to find the connection match will return a negative error @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
+    Wi-Fi channel number as defined in @ref tenuM2mScanCh enumeration. Specifying a channel number
+    greater than @ref M2M_WIFI_CH_14 returns a negative error @ref M2M_ERR_FAIL(-12), unless
+    the value is @ref M2M_WIFI_CH_ALL, since this indicates that the firmware should scan all channels
+    to find the SSID specified in parameter pcSsid.
+
+    Failure to find the connection match will return a negative error
+    @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
+
 @pre
-  		Prior to a successful connection request, the Wi-Fi driver must have been successfully initialized through the call of the @ref @m2m_wifi_init function
-@see
-	tuniM2MWifiAuth
-	tstr1xAuthCredentials
-	tstrM2mWifiWepParams
-	
+        Prior to a successful connection request, the wi-fi driver must have been successfully initialized
+        through the call of the @ref m2m_wifi_init function
+
 @warning
-	-This function must be called in station mode only.
-	-Successful completion of this function does not guarantee success of the WIFI connection, and
-	a negative return value indicates only locally-detected errors.
-	
-@return	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-	
+    If there is a '\0' character within the first u8SsidLen characters, then this function will assume
+    that the input u8SsidLen was incorrect, set length to strlen(pcSsid) and continue.\n
+    This function has been deprecated since v19.6.1 and will no longer be supported afterwards.
+    The following should be used instead:
+    @ref m2m_wifi_connect_open
+    @ref m2m_wifi_connect_wep
+    @ref m2m_wifi_connect_psk
+    @ref m2m_wifi_connect_1x_mschap2
+    @ref m2m_wifi_connect_1x_tls
+
+    Additionally:
+    - This function must be called in station mode only.
+    - Successful completion of this function does not guarantee success of the WIFI connection, and
+    a negative return value indicates only locally-detected errors.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+    tstr1xAuthCredentials
+    tstrM2mWifiWepParams
 */
 NMI_API sint8 m2m_wifi_connect(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch);
- /**@}*/
-/** @defgroup WifiConnectFn m2m_wifi_connect_sc
- *   @ingroup WLANAPI
- *   Asynchronous wi-fi connection function to a specific AP. Prior to a successful connection, the application developers must know the SSID of the AP, the security type,
- *   the authentication information parameters and the channel number to which the connection will be established.this API allows the user to choose
- *   whether to
- *  The connection status is known when a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED is received based on the states defined in @ref tenuM2mConnState,
- *  successful connection is defined by @ref M2M_WIFI_CONNECTED
- *   The only difference between this function and @ref m2m_wifi_connect, is the option to save the acess point info ( SSID, password...etc) or not.
- *   Connection using this function is expected to be made to a specific AP and to a specified channel.
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_connect_sc(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch,uint8 u8SaveCred);
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_connect_sc(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch, uint8 u8NoSaveCred);
+
+@brief
+    DEPRECATED in v19.6.1 - Kept only for legacy purposes.\n
+    Legacy asynchronous API to request connection to a specific AP with the option to save credentials in Flash.
+
+@details
+    Prior to a successful connection, the application developers must know the SSID of the AP, the security
+    type, the authentication information parameters and the channel number to which the connection will
+    be established.
+
+    The connection status is known when a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED is received based
+    on the states defined in @ref tenuM2mConnState, successful connection is defined by @ref M2M_WIFI_CONNECTED
+    The only difference between this function and @ref m2m_wifi_connect, is the option to save the access point
+    info (SSID, password...etc) or not.
+    Connection using this function is expected to be made to a specific AP and to a specified channel.
 
 @param [in]	pcSsid
-				A buffer holding the SSID corresponding to the requested AP.
-				
+    A buffer holding the SSID corresponding to the requested AP.
+    SSID must not contain '\0'.
+
 @param [in]	u8SsidLen
-				Length of the given SSID (not including the NULL termination).
-				A length less than ZERO or greater than the maximum defined SSID @ref M2M_MAX_SSID_LEN will result in a negative error 
-				@ref M2M_ERR_FAIL.
-				
+    Length of the given SSID (not including the NULL termination).
+    A length greater than the maximum defined SSID @ref M2M_MAX_SSID_LEN will result in a negative error
+    @ref M2M_ERR_FAIL.
+
 @param [in]	u8SecType
-				Wi-Fi security type security for the network. It can be one of the following types:
-				-@ref M2M_WIFI_SEC_OPEN
-				-@ref M2M_WIFI_SEC_WEP
-				-@ref M2M_WIFI_SEC_WPA_PSK
-				-@ref M2M_WIFI_SEC_802_1X
-				A value outside these possible values will result in a negative return error @ref M2M_ERR_FAIL.
+    Wi-Fi security type security for the network see @ref tenuM2mSecType. It can be one of the following types:
+    -@ref M2M_WIFI_SEC_OPEN
+    -@ref M2M_WIFI_SEC_WEP
+    -@ref M2M_WIFI_SEC_WPA_PSK
+    -@ref M2M_WIFI_SEC_802_1X
+    A value outside these possible values will result in a negative return error @ref M2M_ERR_FAIL.
 
 @param [in]	pvAuthInfo
-				Authentication parameters required for completing the connection. It is type is based on the Security type.
-				If the authentication parameters are NULL or are greater than the maximum length of the authentication parameters length as defined by
-				@ref M2M_MAX_PSK_LEN a negative error will return @ref M2M_ERR_FAIL(-12) indicating connection failure.
+    Authentication parameters required for completing the connection. Its type is based on the
+    security type. If the authentication parameters are NULL or are greater than the maximum length
+    of the authentication parameters length as defined by @ref M2M_MAX_PSK_LEN a negative error will
+    return @ref M2M_ERR_FAIL(-12) indicating connection failure.
 
 @param [in]	u16Ch
-				Wi-Fi channel number as defined in @ref tenuM2mScanCh enumeration.
-				Channel number greater than @ref M2M_WIFI_CH_14 returns a negative error @ref M2M_ERR_FAIL(-12).
-				Except if the value is M2M_WIFI_CH_ALL(255), since this indicates that the firmware should scan all channels to find the SSID requested to connect to.
-				Failure to find the connection match will return a negative error @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
-				
+    Wi-Fi channel number as defined in @ref tenuM2mScanCh enumeration. Specification of a channel
+    number greater than @ref M2M_WIFI_CH_14 returns a negative error @ref M2M_ERR_FAIL(-12) unless
+    the value is @ref M2M_WIFI_CH_ALL. A channel number of @ref M2M_WIFI_CH_ALL indicates that the
+    firmware should scan all channels to find the SSID specified in parameter pcSsid.
+
+    Failure to find the connection match will return a negative error
+    @ref M2M_DEFAULT_CONN_SCAN_MISMATCH.
+
 @param [in] u8NoSaveCred
-				Option to store the acess point SSID and password into the WINC flash memory or not.
-				
+    Option to store the access point SSID and password into the WINC flash memory or not.
+
 @pre
-  		Prior to a successful connection request, the wi-fi driver must have been successfully initialized through the call of the @ref @m2m_wifi_init function
-@see
-	tuniM2MWifiAuth
-	tstr1xAuthCredentials
-	tstrM2mWifiWepParams
+    Prior to a successful connection request, the wi-fi driver must have been successfully initialized through the call of the @ref m2m_wifi_init function.
 	
 @warning
-	-This function must be called in station mode only.
-	-Successful completion of this function does not guarantee success of the WIFI connection, and
-	a negative return value indicates only locally-detected errors.
-	
-@return	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-	
+    If there is a '\0' character within the first u8SsidLen characters, then this function will assume
+    that the input u8SsidLen was incorrect, set length to strlen(pcSsid) and continue.\n
+    This function has been deprecated since v19.6.1 and will no longer be supported afterwards.
+    The following should be used instead:
+    @ref m2m_wifi_connect_open
+    @ref m2m_wifi_connect_wep
+    @ref m2m_wifi_connect_psk
+    @ref m2m_wifi_connect_1x_mschap2
+    @ref m2m_wifi_connect_1x_tls
+
+    Additionally:
+    - This function must be called in station mode only.
+    - Successful completion of this function does not guarantee success of the WIFI connection, and
+    a negative return value indicates only locally-detected errors.
+
+@see
+    tenuM2mSecType
+    tstr1xAuthCredentials
+    tstrM2mWifiWepParams
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 */
- NMI_API sint8 m2m_wifi_connect_sc(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch, uint8 u8SaveCred);
- /**@}*/
-/** @defgroup WifiDisconnectFn m2m_wifi_disconnect
- *   @ingroup WLANAPI
- *   Synchronous wi-fi disconnection function, requesting a Wi-Fi disconnection from the currently connected AP.
- */
- /**@{*/
+NMI_API sint8 m2m_wifi_connect_sc(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch, uint8 u8NoSaveCred);
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_disconnect(void);
-	
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_disconnect(void);
+
+@brief
+    Synchronous API to request disconnection from a network.
+
+@details
+    Request a Wi-Fi disconnect from the currently connected AP.
+    After the disconnect is complete the driver should receive a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED based on the states defined
+    in @ref tenuM2mConnState, successful disconnection is defined by @ref M2M_WIFI_DISCONNECTED .
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
 @pre 
 	Disconnection request must be made to a successfully connected AP. If the WINC is not in the connected state, a call to this function will hold insignificant.
 
-@brief  Request a Wi-Fi disconnect from the currently connected AP.
-		After the Disconnect is complete the driver should recieve a response of @ref M2M_WIFI_RESP_CON_STATE_CHANGED based on the states defined
-		in @ref tenuM2mConnState, successful disconnection is defined by @ref M2M_WIFI_DISCONNECTED .
 @warning
 	This function must be called in station mode only.
 	
 @see
-	m2m_wifi_connect
+    m2m_wifi_connect_open
+	m2m_wifi_connect_wep
+	m2m_wifi_connect_psk
+	m2m_wifi_connect_1x_mschap2
+	m2m_wifi_connect_1x_tls
 	m2m_wifi_default_connect
-	
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_disconnect(void);
  
- /**@}*/
-/** @defgroup StartProvisionModeFn m2m_wifi_start_provision_mode
- *   @ingroup WLANAPI
- *    Asynchronous Wi-Fi provisioning function, which starts the WINC HTTP PROVISIONING mode.
-	The function triggers the WINC to activate the Wi-Fi AP (HOTSPOT) mode with the passed configuration parameters and then starts the
-	HTTP Provision WEB Server. 
-	The provisioning status is returned in an event @ref M2M_WIFI_RESP_PROVISION_INFO
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_start_provision_mode(tstrM2MAPConfig *pstrAPConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect);
-	
-@param [in]	pstrAPConfig
-				AP configuration parameters as defined in @ref tstrM2MAPConfig configuration structure.
-				A NULL value passed in, will result in a negative error @ref M2M_ERR_FAIL.
-				
-@param [in]	pcHttpServerDomainName
-				Domain name of the HTTP Provision WEB server which others will use to load the provisioning Home page.
-				The domain name can have one of the following 3 forms:
-				1- "wincprov.com"
-				2- "http://wincprov.com"
-				3- "https://wincprov.com"
-				The forms 1 and 2 are equivalent, they both will start a plain http server, while form 3
-				will start a secure HTTP provisioning Session (HTTP over SSL connection).
+@ingroup WLANPROVISION
+@fn \
+    NMI_API sint8 m2m_wifi_start_provision_mode(tstrM2MAPConfig *pstrAPConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect);
+
+@brief
+    Asynchronous API for control of Wi-Fi provisioning functionality.
+
+@details
+    Asynchronous Wi-Fi provisioning function, which starts the WINC HTTP PROVISIONING mode.
+    The function triggers the WINC to activate the Wi-Fi AP (HOTSPOT) mode with the passed
+    configuration parameters and then starts the HTTP Provision WEB Server.
+
+    Provisioning status is returned in an event @ref M2M_WIFI_RESP_PROVISION_INFO.
+
+@param[in]  pstrAPConfig
+    AP configuration parameters as defined in @ref tstrM2MAPConfig configuration structure.
+    If a NULL value is passed in, the call will result in a negative error @ref M2M_ERR_FAIL.
+
+@param[in]  pcHttpServerDomainName
+    Domain name of the HTTP Provision WEB server which others will use to load the provisioning Home page.
+    The domain name can have one of the following 3 forms:
+    - 1. "wincprov.com"
+    - 2. "http://wincprov.com"
+    - 3. "https://wincprov.com"
+
+    Forms 1 and 2 are equivalent, they will both start a plain http server, while form 3
+    will start a secure HTTP provisioning Session (HTTP over SSL connection).
 
 @param [in]	bEnableHttpRedirect
-				A flag to enable/disable the HTTP redirect feature. If Secure provisioning is enabled (i.e. the server
-				domain name uses "https" prefix) this flag is ignored (no meaning for redirect in HTTPS).
-				Possible values are:
-				- ZERO  			DO NOT Use HTTP Redirect. In this case the associated device could open the provisioning page ONLY when
-									the HTTP Provision URL of the WINC HTTP Server is correctly written on the browser.
-				- Non-Zero value	Use HTTP Redirect. In this case, all http traffic (http://URL) from the associated
-									device (Phone, PC, ...etc) will be redirected to the WINC HTTP Provisioning Home page.
+    A flag to enable/disable the HTTP redirect feature. If Secure provisioning is enabled (i.e. the server
+    domain name uses "https" prefix) this flag is ignored (no meaning for redirect in HTTPS).
+    Possible values are:
+    - ZERO value, which means DO NOT use HTTP Redirect. In this case, the associated device could open the provisioning
+                  page ONLY when the HTTP Provision URL of the WINC HTTP Server is correctly written on the browser.
+    - Non-Zero value, means use HTTP Redirect. In this case, all http traffic (http://URL) from the associated
+                  device (Phone, PC, etc) will be redirected to the WINC HTTP Provisioning Home page.
 
 @pre	
 	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at startup. Registering the callback
 	  is done through passing it to the initialization @ref m2m_wifi_init function.
 	- The event @ref M2M_WIFI_RESP_CONN_INFO must be handled in the callback to receive the requested connection info.
-	
-@see
-	tpfAppWifiCb
-	m2m_wifi_init
-	M2M_WIFI_RESP_PROVISION_INFO
-	m2m_wifi_stop_provision_mode
-	tstrM2MAPConfig
 
 @warning
-		DO Not use ".local" in the pcHttpServerDomainName.
-		
+    DO NOT use ".local" in the pcHttpServerDomainName.
+
 @return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 
-\section Example
-  The example demonstrates a code snippet for how provisioning is triggered and the response event received accordingly. 
+@see
+    tpfAppWifiCb
+    m2m_wifi_init
+    M2M_WIFI_RESP_PROVISION_INFO
+    m2m_wifi_stop_provision_mode
+    tstrM2MAPConfig
+
+\section WIFIExample1 Example
+  The example demonstrates a code snippet for how provisioning is triggered and the response event
+  received accordingly.
+
 @code
-	#include "m2m_wifi.h"
-	#include "m2m_types.h"
+    #include "m2m_wifi.h"
+    #include "m2m_types.h"
 
+    void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
+    {
+        switch(u8WiFiEvent)
+        {
+        case M2M_WIFI_RESP_PROVISION_INFO:
+            {
+                tstrM2MProvisionInfo    *pstrProvInfo = (tstrM2MProvisionInfo*)pvMsg;
+                if(pstrProvInfo->u8Status == M2M_SUCCESS)
+                {
+                    tstrNetworkId   strNetworkId = {NULL, pstrProvInfo->au8SSID, (uint8)strlen((char*)(pstrProvInfo->au8SSID)), M2M_WIFI_CH_ALL};
+                    tstrAuthPsk     strAuthPsk = {NULL, pstrProvInfo->au8Password, (uint8)strlen((char*)(pstrProvInfo->au8Password))};
+                    m2m_wifi_connect_psk(WIFI_CRED_SAVE_ENCRYPTED, &strNetworkId, &strAuthPsk);
 
-	void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
-	{
-		switch(u8WiFiEvent)
-		{
-		case M2M_WIFI_RESP_PROVISION_INFO:
-			{
-				tstrM2MProvisionInfo	*pstrProvInfo = (tstrM2MProvisionInfo*)pvMsg;
-				if(pstrProvInfo->u8Status == M2M_SUCCESS)
-				{
-					m2m_wifi_connect((char*)pstrProvInfo->au8SSID, (uint8)strlen(pstrProvInfo->au8SSID), pstrProvInfo->u8SecType, 
-							pstrProvInfo->au8Password, M2M_WIFI_CH_ALL);
+                    printf("PROV SSID : %s\n",pstrProvInfo->au8SSID);
+                    printf("PROV PSK  : %s\n",pstrProvInfo->au8Password);
+                }
+                else
+                {
+                    printf("(ERR) Provisioning Failed\n");
+                }
+            }
+            break;
 
-					printf("PROV SSID : %s\n",pstrProvInfo->au8SSID);
-					printf("PROV PSK  : %s\n",pstrProvInfo->au8Password);
-				}
-				else
-				{
-					printf("(ERR) Provisioning Failed\n");
-				}
-			}
-			break;
+            default:
+            break;
+        }
+    }
 
-			default:
-			break;
-		}
-	}
+    int main()
+    {
+        tstrWifiInitParam   param;
 
-	int main()
-	{
-		tstrWifiInitParam 	param;
-		
-		param.pfAppWifiCb	= wifi_event_cb;
-		if(!m2m_wifi_init(&param))
-		{
-			tstrM2MAPConfig		apConfig;
-			uint8				bEnableRedirect = 1;
-			
-			strcpy(apConfig.au8SSID, "WINC_SSID");
-			apConfig.u8ListenChannel 	= 1;
-			apConfig.u8SecType			= M2M_WIFI_SEC_OPEN;
-			apConfig.u8SsidHide			= 0;
-			
-			// IP Address
-			apConfig.au8DHCPServerIP[0]	= 192;
-			apConfig.au8DHCPServerIP[1]	= 168;
-			apConfig.au8DHCPServerIP[2]	= 1;
-			apConfig.au8DHCPServerIP[0]	= 1;
+        param.pfAppWifiCb   = wifi_event_cb;
+        if(!m2m_wifi_init(&param))
+        {
+            tstrM2MAPConfig     apConfig;
+            uint8               bEnableRedirect = 1;
 
-			m2m_wifi_start_provision_mode(&apConfig, "atmelwincconf.com", bEnableRedirect);
-						
-			while(1)
-			{
-				m2m_wifi_handle_events(NULL);
-			}
-		}
-	}
-	
+            strcpy(apConfig.au8SSID, "WINC_SSID");
+            apConfig.u8ListenChannel    = 1;
+            apConfig.u8SecType          = M2M_WIFI_SEC_OPEN;
+            apConfig.u8SsidHide         = 0;
+
+            // IP Address
+            apConfig.au8DHCPServerIP[0] = 192;
+            apConfig.au8DHCPServerIP[1] = 168;
+            apConfig.au8DHCPServerIP[2] = 1;
+            apConfig.au8DHCPServerIP[3] = 1;
+
+            m2m_wifi_start_provision_mode(&apConfig, "atmelwincconf.com", bEnableRedirect);
+
+            while(1)
+            {
+                m2m_wifi_handle_events(NULL);
+            }
+        }
+    }
 @endcode
 */
 NMI_API sint8 m2m_wifi_start_provision_mode(tstrM2MAPConfig *pstrAPConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect);
- /**@}*/
-/** @defgroup StopProvisioningModeFn m2m_wifi_stop_provision_mode
- *   @ingroup WLANAPI
- *  Synchronous provision termination function which stops the provision mode if it is active.
- */
- /**@{*/
-/*!
-@fn	\
-	sint8 m2m_wifi_stop_provision_mode(void);
 
-@pre
-	An active provisioning session must be active before it is terminated through this function.
-@see
-	m2m_wifi_start_provision_mode
-	
-@return
-	The function returns ZERO for success and a negative value otherwise.
-*/
-NMI_API sint8 m2m_wifi_stop_provision_mode(void);
- /**@}*/
-/** @defgroup GetConnectionInfoFn m2m_wifi_get_connection_info
- *   @ingroup WLANAPI
- *  Asynchronous connection status retrieval function, retrieves the status information of the currently connected AP. The result is passed to the Wi-Fi notification callback
-*    through the event @ref M2M_WIFI_RESP_CONN_INFO. Connection information is retrieved from the structure @ref tstrM2MConnInfo.
- */
- /**@{*/
 /*!
-@fn	\
-	sint8 m2m_wifi_get_connection_info(void);
+@ingroup WLANPROVISION
+@fn \
+    NMI_API sint8 m2m_wifi_start_provision_mode_ext(tstrM2MAPModeConfig *pstrAPModeConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect);
 
 @brief
-	Retrieve the current Connection information. The result is passed to the Wi-Fi notification callback
-	with [M2M_WIFI_RESP_CONN_INFO](@ref M2M_WIFI_RESP_CONN_INFO).
-@pre	
-	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at startup. Registering the callback
-	is done through passing it to the initialization @ref m2m_wifi_init function.
-	- The event @ref M2M_WIFI_RESP_CONN_INFO must be handled in the callback to receive the requested connection info.
+    Asynchronous API for control of Wi-Fi provisioning functionality with extended options.
+
+@details
+    Asynchronous Wi-Fi provisioning function, which starts the WINC HTTP PROVISIONING mode.
+    The function triggers the WINC to activate the Wi-Fi AP (HOTSPOT) mode with the passed
+    configuration parameters and then starts the HTTP Provision WEB Server.
+
+    Provisioning status is returned in an event @ref M2M_WIFI_RESP_PROVISION_INFO.
+
+@param[in]  pstrAPModeConfig
+    AP configuration parameters as defined in @ref tstrM2MAPModeConfig configuration structure.
+    A NULL value passed in, will result in a negative error @ref M2M_ERR_FAIL.
+
+@param[in]  pcHttpServerDomainName
+    Domain name of the HTTP Provision WEB server which others will use to load the provisioning Home page.
+    The domain name can have one of the following 3 forms:
+    - 1. "wincprov.com"
+    - 2. "http://wincprov.com"
+    - 3. "https://wincprov.com"
+
+    The forms 1 and 2 are equivalent, they both will start a plain http server, while form 3
+    will start a secure HTTP provisioning Session (HTTP over SSL connection).
+
+@param[in]  bEnableHttpRedirect
+    A flag to enable/disable the HTTP redirect feature. If Secure provisioning is enabled (i.e. the server
+    domain name uses "https" prefix) this flag is ignored (no meaning for redirect in HTTPS).
+    Possible values are:
+    - ZERO value, which means DO NOT use HTTP Redirect. In this case, the associated device could open the provisioning
+                  page ONLY when the HTTP Provision URL of the WINC HTTP Server is correctly written on the browser.
+    - Non-Zero value, means use HTTP Redirect. In this case, all http traffic (http://URL) from the associated
+                  device (Phone, PC, etc) will be redirected to the WINC HTTP Provisioning Home page.
+
+@pre
+    - A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at startup. Registering the callback
+      is done through passing it to the initialization @ref m2m_wifi_init function.
+    - The event @ref M2M_WIFI_RESP_CONN_INFO must be handled in the callback to receive the requested connection info.
+
+@warning
+    DO Not use ".local" in the pcHttpServerDomainName.
+
+@see
+    tpfAppWifiCb
+    m2m_wifi_init
+    M2M_WIFI_RESP_PROVISION_INFO
+    m2m_wifi_stop_provision_mode
+    tstrM2MAPModeConfig
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+\section WIFIExample1b Example
+  The example demonstrates a code snippet for how provisioning is triggered and the response event
+  received accordingly.
+
+@code
+    #include "m2m_wifi.h"
+    #include "m2m_types.h"
+
+    void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
+    {
+        switch(u8WiFiEvent)
+        {
+        case M2M_WIFI_RESP_PROVISION_INFO:
+            {
+                tstrM2MProvisionInfo    *pstrProvInfo = (tstrM2MProvisionInfo*)pvMsg;
+                if(pstrProvInfo->u8Status == M2M_SUCCESS)
+                {
+                    tstrNetworkId   strNetworkId = {NULL, pstrProvInfo->au8SSID, (uint8)strlen((char*)(pstrProvInfo->au8SSID)), M2M_WIFI_CH_ALL};
+                    tstrAuthPsk     strAuthPsk = {NULL, pstrProvInfo->au8Password, (uint8)strlen((char*)(pstrProvInfo->au8Password))};
+                    m2m_wifi_connect_psk(WIFI_CRED_SAVE_ENCRYPTED, &strNetworkId, &strAuthPsk);
+
+                    printf("PROV SSID : %s\n",pstrProvInfo->au8SSID);
+                    printf("PROV PSK  : %s\n",pstrProvInfo->au8Password);
+                }
+                else
+                {
+                    printf("(ERR) Provisioning Failed\n");
+                }
+            }
+            break;
+
+            default:
+            break;
+        }
+    }
+
+    int main()
+    {
+        tstrWifiInitParam   param;
+
+        param.pfAppWifiCb   = wifi_event_cb;
+        if(!m2m_wifi_init(&param))
+        {
+            tstrM2MAPModeConfig	apModeConfig;
+            uint8				bEnableRedirect = 1;
+            
+            strcpy(apModeConfig.strApConfig.au8SSID, "WINC_SSID");
+            apModeConfig.strApConfig.u8ListenChannel 	= 1;
+            apModeConfig.strApConfig.u8SecType			= M2M_WIFI_SEC_OPEN;
+            apModeConfig.strApConfig.u8SsidHide			= 0;
+            
+            // IP Address
+            apModeConfig.strApConfig.au8DHCPServerIP[0]	= 192;
+            apModeConfig.strApConfig.au8DHCPServerIP[1]	= 168;
+            apModeConfig.strApConfig.au8DHCPServerIP[2]	= 1;
+            apModeConfig.strApConfig.au8DHCPServerIP[3]	= 1;
+
+            // Default router IP
+			m2m_memcpy(apModeConfig.strApConfigExt.au8DefRouterIP, apModeConfig.strApConfig.au8DHCPServerIP, 4);
+
+            // DNS Server IP
+			m2m_memcpy(apModeConfig.strApConfigExt.au8DNSServerIP, apModeConfig.strApConfig.au8DHCPServerIP, 4);
+			
+			// Subnet mask
+            apModeConfig.strApConfigExt.au8SubnetMask[0]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[1]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[2]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[3]    = 0;
+
+            m2m_wifi_start_provision_mode_ext(&apModeConfig, "atmelwincconf.com", bEnableRedirect);
+                        
+            while(1)
+            {
+                m2m_wifi_handle_events(NULL);
+            }
+        }
+    }
+@endcode
+*/
+NMI_API sint8 m2m_wifi_start_provision_mode_ext(tstrM2MAPModeConfig *pstrAPModeConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect);
+
+/*!
+@ingroup WLANPROVISION
+@fn \
+    sint8 m2m_wifi_stop_provision_mode(void);
+
+@brief
+    Synchronous API for terminating provisioning mode on the WINC IC.
+
+@details	
+    This function will terminate any currently active provisioning mode on the WINC IC, returning the 
+	IC to idle.
+	
+@pre
+	An active provisioning session must be active before it is terminated through this function.
+	
+@return
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+    m2m_wifi_start_provision_mode
+*/
+NMI_API sint8 m2m_wifi_stop_provision_mode(void);
+
+/*!
+@ingroup WLANCONNECT
+@fn \
+    sint8 m2m_wifi_get_connection_info(void);
+
+@brief
+    Asynchronous API for retrieving the WINC IC's connection status.
+
+@details
+	Asynchronous connection status retrieval function, retrieves the status information of the 
+	currently connected AP. 
+	The result is passed to the Wi-Fi notification callback through the event 
+	@ref M2M_WIFI_RESP_CONN_INFO. Connection information is retrieved from 
+	the structure @ref tstrM2MConnInfo.
 	
 	Connection Information retrieved:
-
-	
 	-Connection Security
 	-Connection RSSI
 	-Remote MAC address
 	-Remote IP address
 
-	and in case of WINC station mode the SSID of the AP is also retrieved.
+    In case the WINC is operating in station mode, the SSID of the AP is also retrieved.
+
+@pre	
+	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at 
+	startup. Registering the callback is done through passing it to the initialization 
+	@ref m2m_wifi_init function.
+	- The event @ref M2M_WIFI_RESP_CONN_INFO must be handled in the callback to receive the 
+	requested connection info.
+	
 @warning
-	-In case of WINC AP mode or P2P mode, ignore the SSID field (NULL string).
-@sa
+    - In case the WINC is operating in AP mode, the SSID field will be returned as a NULL string.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
 	M2M_WIFI_RESP_CONN_INFO,
 	tstrM2MConnInfo
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
+\section WIFIExample2 Example
   The code snippet shows an example of how wi-fi connection information is retrieved .
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
-
 
 	void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
 	{
@@ -1141,62 +1759,67 @@ NMI_API sint8 m2m_wifi_stop_provision_mode(void);
 			}
 		}
 	}
-	
 @endcode
 */
 NMI_API sint8 m2m_wifi_get_connection_info(void);
- /**@}*/
-/** @defgroup WifiSetMacAddFn m2m_wifi_set_mac_address
- *   @ingroup WLANAPI
- *  Synchronous MAC address assigning to the NMC1500. It is used for non-production SW. Assign MAC address to the WINC device. 
- */
- /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
 
-@brief 	Assign a MAC address to the WINC board.
+/*!
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
+
+@brief
+    Synchronous API for assigning a MAC address to the WINC IC.
+
+@details
 		This function override the already assigned MAC address of the WINC board with a user provided one. This is for experimental 
 		use only and should never be used in the production SW.
 
 @param [in]	au8MacAddress
-				MAC Address to be set to the WINC.
+    MAC Address to be provisioned to the WINC.
 
-@return		
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
  
- /**@}*/
-/** @defgroup WifiWpsFn m2m_wifi_wps
- *   @ingroup WLANAPI
- *   Asynchronous WPS triggering function.
- *   This function is called for the WINC to enter the WPS (Wi-Fi Protected Setup) mode. The result is passed to the Wi-Fi notification callback
-*	with the event @ref M2M_WIFI_REQ_WPS.
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_wps(uint8 u8TriggerType,const char * pcPinNumber);
+@ingroup WLANWPS
+@fn \
+    NMI_API sint8 m2m_wifi_wps(uint8 u8TriggerType,const char * pcPinNumber);
+
+@brief
+    Asynchronous API to engage the WINC IC's Wi-Fi Protected Setup (enrollee) function.
+
+@details
+	This function is called for the WINC to enter the WPS (Wi-Fi Protected Setup) mode. The result 
+	is passed to the Wi-Fi notification callback with the event @ref M2M_WIFI_REQ_WPS.
 
 @param [in]	u8TriggerType
-				WPS Trigger method. Could be:
-				- [WPS_PIN_TRIGGER](@ref WPS_PIN_TRIGGER)   Push button method
-				- [WPS_PBC_TRIGGER](@ref WPS_PBC_TRIGGER)	Pin method
-				
-@param [in]	pcPinNumber
-				PIN number for WPS PIN method. It is not used if the trigger type is WPS_PBC_TRIGGER. It must follow the rules
-				stated by the WPS standard.
+    WPS Trigger method. This may be:
+    - @ref WPS_PIN_TRIGGER   Push button method
+    - @ref WPS_PBC_TRIGGER   Pin method
+
+@param[in]  pcPinNumber
+    PIN number for WPS PIN method. It is not used if the trigger type is WPS_PBC_TRIGGER. It must follow the rules
+    stated by the WPS standard.
+
+@pre	
+	- A Wi-Fi notification callback of type (@ref tpfAppWifiCb MUST be implemented and registered at 
+    startup. Registering the callback is done through passing it to @ref m2m_wifi_init.
+    - The event @ref M2M_WIFI_REQ_WPS must be handled in the callback to receive
+	  the WPS status.
+    - The WINC device MUST be in IDLE or STA mode. If AP mode is active, the WPS will not be
+	  performed. 
+    - The @ref m2m_wifi_handle_events MUST be called periodically to receive
+	  the responses in the callback.
 
 @warning
-	This function is not allowed in AP or P2P modes.
-	
-@pre	
-	- A Wi-Fi notification callback of type (@ref tpfAppWifiCb MUST be implemented and registered at startup. Registering the callback
-	  is done through passing it to the [m2m_wifi_init](@ref m2m_wifi_init).
-	- The event [M2M_WIFI_REQ_WPS](@ref M2M_WIFI_REQ_WPS) must be handled in the callback to receive the WPS status.
-	- The WINC device MUST be in IDLE or STA mode. If AP or P2P mode is active, the WPS will not be performed. 
-	- The [m2m_wifi_handle_events](@ref m2m_wifi_handle_events) MUST be called periodically to receive the responses in the callback.
+    This function is not allowed in AP mode.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
 @see
 	tpfAppWifiCb
 	m2m_wifi_init
@@ -1204,12 +1827,9 @@ NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
 	tenuWPSTrigger
 	tstrM2MWPSInfo
 
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
-  The code snippet shows an example of how Wi-Fi WPS is triggered .
+\section WIFIExample3 Example
+  The code snippet shows an example of how wi-fi WPS is triggered .
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
 
@@ -1222,14 +1842,22 @@ NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
 				tstrM2MWPSInfo	*pstrWPS = (tstrM2MWPSInfo*)pvMsg;
 				if(pstrWPS->u8AuthType != 0)
 				{
+                    // establish Wi-Fi connection
+                    tstrNetworkId   strNetworkId = {NULL, pstrWPS->au8SSID, (uint8)strlen((char*)(pstrWPS->au8SSID)), pstrWPS->u8Ch};
+                    if(pstrWPS->u8AuthType == M2M_WIFI_SEC_OPEN)
+                    {
+                        m2m_wifi_connect_open(WIFI_CRED_SAVE_ENCRYPTED, &strNetworkId);
+                    }
+                    else
+                    {
+                        tstrAuthPsk     strAuthPsk = {NULL, pstrWPS->au8PSK, (uint8)strlen((char*)(pstrWPS->au8PSK))};
+                        m2m_wifi_connect_psk(WIFI_CRED_SAVE_ENCRYPTED, &strNetworkId, &strAuthPsk);
+                    }
+
 					printf("WPS SSID           : %s\n",pstrWPS->au8SSID);
 					printf("WPS PSK            : %s\n",pstrWPS->au8PSK);
 					printf("WPS SSID Auth Type : %s\n",pstrWPS->u8AuthType == M2M_WIFI_SEC_OPEN ? "OPEN" : "WPA/WPA2");
-					printf("WPS Channel        : %d\n",pstrWPS->u8Ch + 1);
-					
-					// establish Wi-Fi connection
-					m2m_wifi_connect((char*)pstrWPS->au8SSID, (uint8)m2m_strlen(pstrWPS->au8SSID),
-						pstrWPS->u8AuthType, pstrWPS->au8PSK, pstrWPS->u8Ch);
+                    printf("WPS Channel        : %d\n",pstrWPS->u8Ch);
 				}
 				else
 				{
@@ -1259,164 +1887,79 @@ NMI_API sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6]);
 			}
 		}
 	}
-	
 @endcode
 */
 NMI_API sint8 m2m_wifi_wps(uint8 u8TriggerType,const char  *pcPinNumber);
- /**@}*/
-/** @defgroup WifiWpsDisableFn m2m_wifi_wps_disable
- *   @ingroup WLANAPI
- * Disable the WINC1500 WPS operation.
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_wps_disable(void);
+@ingroup WLANWPS
+@fn \
+    NMI_API sint8 m2m_wifi_wps_disable(void);
 
-@pre	WINC should be already in WPS mode using @ref m2m_wifi_wps 
+@brief	
+    Stops the ongoing WPS session.
 
-@brief	Stops the WPS ongoing session.
+@pre	
+    WINC should be already in WPS mode using @ref m2m_wifi_wps.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 
 @see 
 	m2m_wifi_wps
-	
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_wps_disable(void);
- 
- /**@}*/
-/** @defgroup WifiP2PFn m2m_wifi_p2p
- *   @ingroup WLANAPI
- *    Asynchronous  Wi-Fi direct (P2P) enabling mode function.
-	The WINC supports P2P in device listening mode ONLY (intent is ZERO).
-	The WINC P2P implementation does not support P2P GO (Group Owner) mode.
-	Active P2P devices (e.g. phones) could find the WINC in the search list. When a device is connected to WINC, a Wi-Fi notification event
-	@ref M2M_WIFI_RESP_CON_STATE_CHANGED is triggered. After a short while, the DHCP IP Address is obtained 
-	and an event @ref M2M_WIFI_REQ_DHCP_CONF is triggered. Refer to the code examples for a more illustrative example.
+
+/**@cond P2P_DOC
  */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_p2p(uint8 u8Channel);
-
-@param [in]	u8Channel
-				P2P Listen RF channel. According to the P2P standard It must hold only one of the following values 1, 6 or 11.
-
-@pre
-	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
-	  is done through passing it to the @ref m2m_wifi_init.
-	- The events @ref M2M_WIFI_RESP_CON_STATE_CHANGED and @ref M2M_WIFI_REQ_DHCP_CONF 
-	  must be handled in the callback.
-	- The @ref m2m_wifi_handle_events MUST be called to receive the responses in the callback.
+@ingroup WLANP2P
+@fn \
+    NMI_API sint8 m2m_wifi_p2p(uint8 u8Channel);
 
 @warning
-	This function is not allowed in AP or STA modes.
-
-@see
-	tpfAppWifiCb
-	m2m_wifi_init
-	M2M_WIFI_RESP_CON_STATE_CHANGED
-	M2M_WIFI_REQ_DHCP_CONF
-	tstrM2mWifiStateChanged
-
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
-  The code snippet shown an example of how the p2p mode operates.
-@code
-	#include "m2m_wifi.h"
-	#include "m2m_types.h"
-	
-	void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
-	{
-		switch(u8WiFiEvent)
-		{
-		case M2M_WIFI_RESP_CON_STATE_CHANGED:
-			{
-				tstrM2mWifiStateChanged *pstrWifiState = (tstrM2mWifiStateChanged*)pvMsg;
-				M2M_INFO("Wifi State :: %s :: ErrCode %d\n", pstrWifiState->u8CurrState? "CONNECTED":"DISCONNECTED",pstrWifiState->u8ErrCode);
-				
-				// Do something
-			}
-			break;
-			
-		case M2M_WIFI_REQ_DHCP_CONF:
-			{
-				uint8	*pu8IPAddress = (uint8*)pvMsg;
-
-				printf("P2P IP Address \"%u.%u.%u.%u\"\n",pu8IPAddress[0],pu8IPAddress[1],pu8IPAddress[2],pu8IPAddress[3]);
-			}
-			break;
-			
-		default:
-			break;
-		}
-	}
-	
-	int main()
-	{
-		tstrWifiInitParam 	param;
-		
-		param.pfAppWifiCb	= wifi_event_cb;
-		if(!m2m_wifi_init(&param))
-		{
-			// Trigger P2P
-			m2m_wifi_p2p(M2M_WIFI_CH_1);
-			
-			while(1)
-			{
-				m2m_wifi_handle_events(NULL);
-			}
-		}
-	}
-	
-@endcode
-
+    P2P has been deprecated from version 19.5.3!
 */
 NMI_API sint8 m2m_wifi_p2p(uint8 u8Channel);
- /**@}*/
-/** @defgroup WifiP2PDisconnectFn m2m_wifi_p2p_disconnect
- *   @ingroup WLANAPI
- * Disable the WINC1500 device Wi-Fi direct mode (P2P). 
- */
- /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_wifi_p2p_disconnect(void);
-@pre 
-	The p2p mode must have be enabled and active before a disconnect can be called.
-	
-@see
-         m2m_wifi_p2p
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-*/
-NMI_API sint8 m2m_wifi_p2p_disconnect(void);
- /**@}*/
-/** @defgroup WifiEnableApFn m2m_wifi_enable_ap
- *   @ingroup WLANAPI
- * 	Asynchronous Wi-FI hot-spot enabling function. 
- *    The WINC supports AP mode operation with the following limitations:
-	- Only 1 STA could be associated at a time.
-	- Open and WEP are the only supported security types
- */
- /**@{*/
-/*!
-@fn	\
-	NMI_API sint8 m2m_wifi_enable_ap(CONST tstrM2MAPConfig* pstrM2MAPConfig);
 
-@param [in]	pstrM2MAPConfig
-				A structure holding the AP configurations.
+/*!
+@ingroup WLANP2P
+@fn \
+    NMI_API sint8 m2m_wifi_p2p_disconnect(void);
 
 @warning
-	This function is not allowed in P2P or STA modes.
-	
+    P2P has been deprecated from version 19.5.3!
+*/
+NMI_API sint8 m2m_wifi_p2p_disconnect(void);
+/**@endcond*/ //P2P_DOC
+
+/*!
+@ingroup WLANAP
+@fn \
+    NMI_API sint8 m2m_wifi_enable_ap(CONST tstrM2MAPConfig* pstrM2MAPConfig);
+
+@brief
+    Asynchronous API to enable access point (AKA "hot-spot") mode on the WINC IC.
+
+@details
+    The WINC IC supports the ability to operate as an access point with the following limitations:
+      - Only 1 station may be associated at any given time.
+      - Open system and WEP are the only security suites supported.
+
+@param[in]  pstrM2MAPConfig
+    A structure holding the AP configurations.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
 @pre
 	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
-	  is done through passing it to the [m2m_wifi_init](@ref m2m_wifi_init).
+    is done through passing it to the @ref m2m_wifi_init.
 	- The event @ref M2M_WIFI_REQ_DHCP_CONF must be handled in the callback.
 	- The @ref m2m_wifi_handle_events MUST be called to receive the responses in the callback.
+
+@warning
+    This function is not allowed in STA mode.
 
 @see
 	tpfAppWifiCb
@@ -1426,9 +1969,7 @@ NMI_API sint8 m2m_wifi_p2p_disconnect(void);
 	tstrM2mWifiStateChanged
 	tstrM2MAPConfig
 
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
+\section WIFIExample5 Example
   The code snippet demonstrates how the AP mode is enabled after the driver is initialized in the application's main function and the handling
   of the event @ref M2M_WIFI_REQ_DHCP_CONF, to indicate successful connection.
 @code
@@ -1470,7 +2011,7 @@ NMI_API sint8 m2m_wifi_p2p_disconnect(void);
 			apConfig.au8DHCPServerIP[0]	= 192;
 			apConfig.au8DHCPServerIP[1]	= 168;
 			apConfig.au8DHCPServerIP[2]	= 1;
-			apConfig.au8DHCPServerIP[0]	= 1;
+            apConfig.au8DHCPServerIP[3]	= 1;
 			
 			// Trigger AP
 			m2m_wifi_enable_ap(&apConfig);
@@ -1483,195 +2024,354 @@ NMI_API sint8 m2m_wifi_p2p_disconnect(void);
 	}
 
 @endcode
-
 */
 NMI_API sint8 m2m_wifi_enable_ap(CONST tstrM2MAPConfig* pstrM2MAPConfig);
- /**@}*/
-/** @defgroup WifiDisableApFn m2m_wifi_disable_ap
- *   @ingroup WLANAPI
- *    Synchronous Wi-Fi hot-spot disabling function. Must be called only when the AP is enabled through the @ref m2m_wifi_enable_ap
- *   function. Otherwise the call to this function will not be useful.
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_disable_ap(void);
+@ingroup WLANAP
+@fn \
+    NMI_API sint8 m2m_wifi_enable_ap_ext(CONST tstrM2MAPModeConfig* pstrM2MAPModeConfig);
+
+@brief
+    Asynchronous API to enable access point (AKA "hot-spot") mode on the WINC IC with extended options.
+
+@details
+    The WINC IC supports the ability to operate as an access point with the following limitations:
+    - Only 1 station may be associated at any given time.
+    - Open system and WEP are the only security suites supported.
+
+@param [in]	pstrM2MAPModeConfig
+    A structure holding the AP configurations.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@pre
+    - A Wi-Fi notification callback of type @ref tpfAppWifiCb  MUST be implemented and registered at initialization. Registering the callback
+    is done through passing it to the @ref m2m_wifi_init.
+    - The event @ref M2M_WIFI_REQ_DHCP_CONF must be handled in the callback.
+    - The @ref m2m_wifi_handle_events MUST be called to receive the responses in the callback.
+
+@warning
+    This function is not allowed in STA mode.
+
+@see
+    tpfAppWifiCb
+    tenuM2mSecType
+    m2m_wifi_init
+    M2M_WIFI_REQ_DHCP_CONF
+    tstrM2mWifiStateChanged
+    tstrM2MAPModeConfig
+    tstrM2MAPConfigExt
+
+\section WIFIExample5b Example
+  The code snippet demonstrates how the AP mode is enabled after the driver is initialized in the application's main function and the handling
+  of the event @ref M2M_WIFI_REQ_DHCP_CONF, to indicate successful connection.
+@code
+    #include "m2m_wifi.h"
+    #include "m2m_types.h"
+    
+    void wifi_event_cb(uint8 u8WiFiEvent, void * pvMsg)
+    {
+        switch(u8WiFiEvent)
+        {
+        case M2M_WIFI_REQ_DHCP_CONF:
+            {
+                uint8	*pu8IPAddress = (uint8*)pvMsg;
+
+                printf("Associated STA has IP Address \"%u.%u.%u.%u\"\n",pu8IPAddress[0],pu8IPAddress[1],pu8IPAddress[2],pu8IPAddress[3]);
+            }
+            break;
+            
+        default:
+            break;
+        }
+    }
+    
+    int main()
+    {
+        tstrWifiInitParam 	param;
+        
+        param.pfAppWifiCb	= wifi_event_cb;
+        if(!m2m_wifi_init(&param))
+        {
+            tstrM2MAPModeConfig		apModeConfig;
+            
+            strcpy(apConfig.strApConfig.au8SSID, "WINC_SSID");
+            apModeConfig.strApConfig.u8ListenChannel 	= 1;
+            apModeConfig.strApConfig.u8SecType			= M2M_WIFI_SEC_OPEN;
+            apModeConfig.strApConfig.u8SsidHide			= 0;
+            
+            // IP Address
+            apModeConfig.strApConfig.au8DHCPServerIP[0]	= 192;
+            apModeConfig.strApConfig.au8DHCPServerIP[1]	= 168;
+            apModeConfig.strApConfig.au8DHCPServerIP[2]	= 1;
+            apModeConfig.strApConfig.au8DHCPServerIP[3]	= 1;
+
+            // Default router IP
+			m2m_memcpy(apModeConfig.strApConfigExt.au8DefRouterIP, apModeConfig.strApConfig.au8DHCPServerIP, 4);
+
+            // DNS Server IP
+			m2m_memcpy(apModeConfig.strApConfigExt.au8DNSServerIP, apModeConfig.strApConfig.au8DHCPServerIP, 4);
+			
+			// Subnet mask
+            apModeConfig.strApConfigExt.au8SubnetMask[0]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[1]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[2]    = 255;
+            apModeConfig.strApConfigExt.au8SubnetMask[3]    = 0;
+
+            // Trigger AP
+            m2m_wifi_enable_ap_ext(&apModeConfig);
+            
+            while(1)
+            {
+                m2m_wifi_handle_events(NULL);
+            }
+        }
+    }
+@endcode
+*/
+NMI_API sint8 m2m_wifi_enable_ap_ext(CONST tstrM2MAPModeConfig* pstrM2MAPModeConfig);
+
+/*!
+@ingroup WLANAP
+@fn \
+    NMI_API sint8 m2m_wifi_disable_ap(void);
+
+@brief
+    Synchronous API to disable access point mode on the WINC IC.
+
+@details
+    Must be called only when the AP is enabled through the @ref m2m_wifi_enable_ap
+    function. Otherwise the call to this function will not be useful.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
 @see
          m2m_wifi_enable_ap
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_disable_ap(void);
- /**@}*/
-/** @defgroup SetStaticIPFn m2m_wifi_set_static_ip
- *   @ingroup WLANAPI
- *   Synchronous static IP Address configuration function. 
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_set_static_ip(tstrM2MIPConfig * pstrStaticIPConf);
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_set_static_ip(tstrM2MIPConfig * pstrStaticIPConf);
+
+@brief
+    Synchronous API to manually assign a (static) IP address to the WINC IC.
+
+@details
+	Assign a static IP address to the WINC board.
+	This function assigns a static IP address in case the AP doesn't have a DHCP 
+	server or in case the application wants to assign a predefined known IP 
+    address. The user must keep in mind that assigning a static IP address might
+	result in an IP address conflict. In case of an IP address conflict observed 
+	by the WINC board the user will get a response of @ref M2M_WIFI_RESP_IP_CONFLICT 
+	in the wifi callback. The application is then responsible to either solve the 
+	conflict or assign another IP address. 
+
+@pre
+    The application must disable auto DHCP using @ref m2m_wifi_enable_dhcp 
+	before assigning a static IP address. 
+
+@warning
+	Normally this function should not be used. 
+	DHCP configuration is requested automatically after successful Wi-Fi connection is established.
 
 @param [in]	pstrStaticIPConf
-				Pointer to a structure holding the static IP Configurations (IP,
-				Gateway, subnet mask and DNS address).
+    Pointer to a structure holding the static IP configuration (IP, Gateway, subnet mask and
+    DNS address).
 
-@pre 	The application must disable auto DHCP using @ref m2m_wifi_enable_dhcp before assigning a static IP address. 
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 
-@brief	Assign a static IP address to the WINC board.
-		This function assigns a static IP address in case the AP doesn't have a DHCP server or in case the application wants to assign 
-		a predefined known IP address. The user must take in mind that assigning a static IP address might result in an IP address 
-		conflict. In case of an IP address conflict observed by the WINC board the user will get a response of @ref M2M_WIFI_RESP_IP_CONFLICT 
-		in the wifi callback. The application is then responsible to either solve the conflict or assign another IP address. 
-@warning
-	Normally this function normally should not be used. DHCP configuration is requested automatically after successful Wi-Fi connection is established.
-	
 @see
 	tstrM2MIPConfig
-	
-	
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_set_static_ip(tstrM2MIPConfig * pstrStaticIPConf);
  
- /**@}*/
-/** @defgroup RequestDHCPClientFn m2m_wifi_request_dhcp_client
- *   @ingroup WLANAPI
- * 	Starts the DHCP client operation(DHCP requested by the firmware automatically in STA/AP/P2P mode).
- *    
- */
- /**@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_request_dhcp_client(void);
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_request_dhcp_client(void);
+
+@brief
+    Legacy (deprecated) Asynchronous API for starting a DHCP client on the WINC IC.
 	
+@details
+    This is a legacy API and is no longer supported. Calls to this API will not result in any 
+	changes being made to the state of the WINC IC. 
+
 @warning
-	This function is legacy and exists only for compatability with older applications. DHCP configuration is requested automatically after successful Wi-Fi connection is established.
+    This function has been deprecated. DHCP is used automatically when the WINC IC connects.
 
 @return
-	The function returns @ref M2M_SUCCESS always.
+    This function always returns @ref M2M_SUCCESS.
 */
 NMI_API sint8 m2m_wifi_request_dhcp_client(void);
- /**@}*/
-/** @defgroup RequestDHCPServerFn m2m_wifi_request_dhcp_server
- *   @ingroup WLANAPI
- *   Dhcp requested by the firmware automatically in STA/AP/P2P mode).
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_request_dhcp_server(uint8* addr);
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_request_dhcp_server(uint8* addr);
+
+@brief
+    Dhcp requested by the firmware automatically in STA/AP mode).
 
 @warning
-	This function is legacy and exists only for compatability with older applications. DHCP server is started automatically when enabling the AP mode.
-
+    This function is legacy and exists only for compatibility with older applications. 
+	DHCP server is started automatically when enabling the AP mode.
 
 @return
-	The function returns @ref M2M_SUCCESS always.
+    This function always returns @ref M2M_SUCCESS.
 */
 NMI_API sint8 m2m_wifi_request_dhcp_server(uint8* addr);
- /**@}*/
-/** @defgroup WifiDHCPEnableFn m2m_wifi_enable_dhcp
- *   @ingroup WLANAPI
- *   Synchronous Wi-Fi DHCP enable function. This function Enable/Disable DHCP protocol.
- */
- /**@{*/
+
 /*!
-@fn	\
-	NMI_API  sint8 m2m_wifi_enable_dhcp(uint8  u8DhcpEn );
-	
+@ingroup WLANCONNECT
+@fn \
+    NMI_API  sint8 m2m_wifi_enable_dhcp(uint8 u8DhcpEn);
+
 @brief
 	Enable/Disable the DHCP client after connection.
 
-@param [in]	 u8DhcpEn 
-				Possible values:
-				1: Enable DHCP client after connection.
-				0: Disable DHCP client after connection.
-@warnings
-	-DHCP client is enabled by default
-	-This Function should be called before using m2m_wifi_set_static_ip()
+@details
+    Synchronous Wi-Fi DHCP enable function. This function will Enable/Disable the DHCP protocol.
 
-	
-@sa
-	m2m_wifi_set_static_ip()
+@param [in]	 u8DhcpEn 
+    The state of the DHCP client feature after successful association with an access point:
+    - 1: Enables DHCP client after connection.
+    - 0: Disables DHCP client after connection.
 	
 @return
 	The function SHALL return @ref M2M_SUCCESS  for successful operation and a negative value otherwise.
+
+@warning
+    DHCP client is enabled by default.
+    This Function should be called before using @ref m2m_wifi_set_static_ip
+    
+@see
+    m2m_wifi_set_static_ip
 */
 NMI_API sint8 m2m_wifi_enable_dhcp(uint8  u8DhcpEn );
- /**@}*/
-/** @defgroup WifiSetScanOptionFn m2m_wifi_set_scan_options
- *   @ingroup WLANAPI
- *   Synchronous Wi-Fi scan settings function. This function sets the time configuration parameters for the scan operation.
- */
 
 /*!
-@fn	\
-	sint8 m2m_wifi_set_scan_options(tstrM2MScanOption* ptstrM2MScanOption)
+@ingroup WLANSCAN
+@fn \
+    sint8 m2m_wifi_set_scan_options(tstrM2MScanOption* ptstrM2MScanOption);
+
+@brief
+    Synchronous API for configuring the behaviour of the WINC IC's network scanning functions.
+
+@details
+    This function sets the configuration parameters for the scan operation.
 
 @param [in]	ptstrM2MScanOption;
 	Pointer to the structure holding the Scan Parameters.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 
 @see
 	tenuM2mScanCh
 	m2m_wifi_request_scan
 	tstrM2MScanOption
-	
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_set_scan_options(tstrM2MScanOption* ptstrM2MScanOption);
- /**@}*/
-/** @defgroup WifiSetScanRegionFn m2m_wifi_set_scan_region
- *   @ingroup WLANAPI
- *  Synchronous wi-fi scan region setting function.
- *   This function sets the scan region, which will affect the range of possible scan channels. 
- *   For 2.5GHz supported in the current release, the requested scan region can't exceed the maximum number of channels (14).
- *@{*/
-/*!
-@fn	\
-	sint8 m2m_wifi_set_scan_region(uint16 ScanRegion)
 
-@param [in]	ScanRegion;
+/*!
+@ingroup WLANSCAN
+@fn \
+    sint8 m2m_wifi_set_stop_scan_on_first(uint8 u8StopScanOption);
+
+@brief
+    Synchronous API for enabling/disabling the stop scan on first result of the WINC IC's network scanning functions.
+
+@details
+    Allows for enabling/disabling of stop scan on first result. When enabled, the WINC will stop the scan as soon as
+    it detects a network and return the results to the host. Setting is persistent and will need to be explicitly
+    reverted back by the application if it no longer wishes for it to be enabled.
+
+@param[in]  u8StopScanOption;
+    Setting for enabling or disabling Stopping Scan on first result.
+    1 = Enabled, 0 = Disabled (Default)
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+    tenuM2mScanCh
+    tstrM2MScanOption
+    tstrM2MStopScanOption
+    m2m_wifi_request_scan
+    m2m_wifi_set_scan_options
+*/
+NMI_API sint8 m2m_wifi_set_stop_scan_on_first(uint8 u8StopScanOption);
+
+/*!
+@ingroup WLANSCAN
+@fn \
+    sint8 m2m_wifi_set_scan_region(uint16 ScanRegion);
+
+@brief
+    Synchronous API for configuring the regulatory restrictions that may affect the WINC ICs 
+	scanning behaviour.
+
+@details
+    This function sets a property called the scan region, a parameter that affects the range of 
+	channels that the WINC IC may legally scan given a geographic region.
+
+    For 2.4GHz, supported in the current release, the requested scan region can't exceed the
+    maximum number of channels (14).
+
+@param [in]	ScanRegion
 		ASIA
 		NORTH_AMERICA
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
 @see
 	tenuM2mScanCh
 	m2m_wifi_request_scan
-	
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-
 */
 NMI_API sint8 m2m_wifi_set_scan_region(uint16  ScanRegion);
- /**@}*/
-/** @defgroup WifiRequestScanFn m2m_wifi_request_scan
-*   @ingroup WLANAPI
-*    Asynchronous Wi-FI scan request on the given channel. The scan status is delivered in the wifi event callback and then the application
-*    is supposed to read the scan results sequentially. 
-*    The number of  APs found (N) is returned in event @ref M2M_WIFI_RESP_SCAN_DONE with the number of found
-*     APs.
-*	The application reads the list of APs by calling the function @ref m2m_wifi_req_scan_result N times.
-* 
-*@{*/
+
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_request_scan(uint8 ch);
+@ingroup WLANSCAN
+@fn \
+    NMI_API sint8 m2m_wifi_request_scan(uint8 ch);
+
+@brief
+    Asynchronous API to request the WINC IC to scan for networks.
+
+@details
+    Scan statuses are delivered to the application via the Wi-Fi event callback (@ref tpfAppWifiCb) in
+    three stages. The first step involves the event @ref M2M_WIFI_RESP_SCAN_DONE which, if successful,
+    provides the number of detected networks (access points). The application must then read the list
+    of access points via multiple calls to the asynchronous @ref m2m_wifi_req_scan_result API. For
+    each call to this function, the application will receive (step three) the event
+    @ref M2M_WIFI_RESP_SCAN_RESULT.
 
 @param [in]	ch
-		      RF Channel ID for SCAN operation. It should be set according to tenuM2mScanCh. 
-		      With a value of M2M_WIFI_CH_ALL(255)), means to scan all channels.
+    RF Channel ID for SCAN operation. It should be set according to @ref tenuM2mScanCh, with a
+    value of @ref M2M_WIFI_CH_ALL to scan all channels.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@pre
+    - A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at
+      initialization. Registration of the callback is done via @ref m2m_wifi_init.
+    - The events @ref M2M_WIFI_RESP_SCAN_DONE and @ref M2M_WIFI_RESP_SCAN_RESULT must be handled in
+      the (tpfAppWifiCb) callback.
+    - The @ref m2m_wifi_handle_events function MUST be called to receive the responses in the
+      callback.
 
 @warning
-	This function is not allowed in P2P or AP modes. It works only for STA mode (both connected or disconnected states).
-				
-@pre
-	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
-	  is done through passing it to the @ref m2m_wifi_init.
-	- The events @ref M2M_WIFI_RESP_SCAN_DONE and @ref M2M_WIFI_RESP_SCAN_RESULT.
-	  must be handled in the callback.
-	- The @ref m2m_wifi_handle_events function MUST be called to receive the responses in the callback.
+    This API is valid only for STA mode, it may be called regardless of connection state (connected
+    or disconnected states).
 
 @see
 	M2M_WIFI_RESP_SCAN_DONE
@@ -1683,13 +2383,10 @@ NMI_API sint8 m2m_wifi_set_scan_region(uint16  ScanRegion);
 	m2m_wifi_handle_events
 	m2m_wifi_req_scan_result
 
-@return
-	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
+\section WIFIExample6 Example
   The code snippet demonstrates an example of how the scan request is called from the application's main function and the handling of
   the events received in response.
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
 	
@@ -1767,31 +2464,27 @@ NMI_API sint8 m2m_wifi_set_scan_region(uint16  ScanRegion);
 			}
 		}
 	}
-	
 @endcode
 */
 NMI_API sint8 m2m_wifi_request_scan(uint8 ch);
 
-  /**@}*/
-/** @defgroup WifiRequestScanFn m2m_wifi_request_scan_passive
-*   @ingroup WLANAPI
-*    Same as m2m_wifi_request_scan but perform passive scanning while the other one perform active scanning.
-
-* 
-*@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
+@ingroup WLANSCAN
+@fn \
+    NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
+
+@brief
+    Similar to @ref m2m_wifi_request_scan but performs passive scanning instead of active scanning.
 
 @param [in]	ch
-		      RF Channel ID for SCAN operation. It should be set according to tenuM2mScanCh. 
-		      With a value of M2M_WIFI_CH_ALL(255)), means to scan all channels.
+    RF Channel ID for SCAN operation. It should be set according to @ref tenuM2mScanCh.
+    With a value of @ref M2M_WIFI_CH_ALL, means to scan all channels.
 
 @param [in]	scan_time
-		      The time in ms that passive scan is listening to beacons on each channel per one slot, enter 0 for deafult setting.
+    The time in ms that passive scan is listening for beacons on each channel per one slot, enter 0 for default setting.
 
 @warning
-	This function is not allowed in P2P or AP modes. It works only for STA mode (both connected or disconnected states).
+    This function is not allowed in AP mode. It works only for STA mode (both connected or disconnected states).
 				
 @pre
 	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
@@ -1801,50 +2494,51 @@ NMI_API sint8 m2m_wifi_request_scan(uint8 ch);
 	- The @ref m2m_wifi_handle_events function MUST be called to receive the responses in the callback.
 
 @see
-	m2m_wifi_request_scan
 	M2M_WIFI_RESP_SCAN_DONE
 	M2M_WIFI_RESP_SCAN_RESULT
 	tpfAppWifiCb
 	tstrM2mWifiscanResult
 	tenuM2mScanCh
 	m2m_wifi_init
+    m2m_wifi_request_scan
 	m2m_wifi_handle_events
 	m2m_wifi_req_scan_result
 
 @return
 	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-
 */
 NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
 
-  
- /**@}*/
-/** @defgroup WifiRequestScanFn m2m_wifi_request_scan_ssid_list
-*   @ingroup WLANAPI
-*    Asynchronous wi-fi scan request on the given channel and the hidden scan list. The scan status is delivered in the wi-fi event callback and then the application
-*    is to read the scan results sequentially. 
-*    The number of  APs found (N) is returned in event @ref M2M_WIFI_RESP_SCAN_DONE with the number of found
-*     APs.
-*	The application could read the list of APs by calling the function @ref m2m_wifi_req_scan_result N times.
-* 
-*@{*/
 /*!
-@fn	\
-	NMI_API sint8 m2m_wifi_request_scan_ssid_list(uint8 ch,uint8 * u8SsidList);
+@ingroup WLANSCAN
+@fn \
+    NMI_API sint8 m2m_wifi_request_scan_ssid_list(uint8 ch,uint8 * u8SsidList);
+
+@brief
+    Asynchronous wi-fi scan request on the given channel and the hidden scan list.
+
+@details
+	The scan status is delivered in the wi-fi event callback and then the application
+	is to read the scan results sequentially. 
+	The number of  APs found (N) is returned in event @ref M2M_WIFI_RESP_SCAN_DONE with the number of found
+	APs.
+	The application could read the list of APs by calling the function @ref m2m_wifi_req_scan_result N times.
 
 @param [in]	ch
-		      RF Channel ID for SCAN operation. It should be set according to tenuM2mScanCh. 
-		      With a value of M2M_WIFI_CH_ALL(255)), means to scan all channels.
+    RF Channel ID for SCAN operation. It should be set according to @ref tenuM2mScanCh.
+    With a value of @ref M2M_WIFI_CH_ALL, means to scan all channels.
+
 @param [in]	u8SsidList
               u8SsidList is a buffer containing a list of hidden SSIDs to 
 			  include during the scan. The first byte in the buffer, u8SsidList[0], 
 			  is the number of SSIDs encoded in the string. The number of hidden SSIDs 
-			  cannot exceed MAX_HIDDEN_SITES. All SSIDs are concatenated in the following 
+    cannot exceed @ref MAX_HIDDEN_SITES. All SSIDs are concatenated in the following
 			  bytes and each SSID is prefixed with a one-byte header containing its length.  
 			  The total number of bytes in u8SsidList buffer, including length byte, cannot 
 			  exceed 133 bytes (MAX_HIDDEN_SITES SSIDs x 32 bytes each, which is max SSID length).
               For instance, encoding the two hidden SSIDs "DEMO_AP" and "TEST" 
 			  results in the following buffer content: 
+
 @code
               uint8 u8SsidList[14];
               u8SsidList[0] = 2; // Number of SSIDs is 2
@@ -1854,8 +2548,8 @@ NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
               memcpy(&u8SsidList[10], "TEST", 4);  // Bytes index 10-13 containing the string TEST
 @endcode
 
-@warning
-	This function is not allowed in P2P. It works only for STA/AP mode (connected or disconnected).
+@note
+    It works with STA/AP mode (connected or disconnected).
 				
 @pre
 	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
@@ -1876,11 +2570,11 @@ NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
 
 @return
 	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
+
+\section WIFIExample6b Example
   The code snippet demonstrates an example of how the scan request is called from the application's main function and the handling of
   the events received in response.
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
 
@@ -1917,7 +2611,6 @@ NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
 				}
 			}
 			break;
-		
 		case M2M_WIFI_RESP_SCAN_RESULT:
 			{
 				tstrM2mWifiscanResult		*pstrScanResult =(tstrM2mWifiscanResult*)pvMsg;
@@ -1966,45 +2659,52 @@ NMI_API sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time);
 		if(!m2m_wifi_init(&param))
 		{
 			request_scan_hidden_demo_ap();
-
 			while(1)
 			{
 				m2m_wifi_handle_events(NULL);
 			}
 		}
 	}
-	
 @endcode
 */
 NMI_API sint8 m2m_wifi_request_scan_ssid_list(uint8 ch,uint8 * u8Ssidlist);
 
-/**@}*/
-/** @defgroup WifiGetNumAPFoundFn m2m_wifi_get_num_ap_found
- *   @ingroup WLANAPI
-*  Synchronous function to retrieve the number of AP's found in the last scan request, The function reads the number of APs from global variable which was updated in the Wi-Fi callback function through the M2M_WIFI_RESP_SCAN_DONE event.
-*  Function used only in STA mode only. 
- */
- /**@{*/
 /*!
-@fn        NMI_API uint8 m2m_wifi_get_num_ap_found(void);
+@ingroup WLANSCAN
+@fn \
+    NMI_API uint8 m2m_wifi_get_num_ap_found(void);
 
-@see       m2m_wifi_request_scan 
+@brief
+	Synchronous function to retrieve the number of AP's found during the last scan operation.
+
+@details
+	The function reads the number of APs from global variable which was updated in the Wi-Fi 
+    callback function through the @ref M2M_WIFI_RESP_SCAN_DONE event.
+	Function used only in STA mode only. 
+
+@see       
+	m2m_wifi_request_scan 
 		   M2M_WIFI_RESP_SCAN_DONE
 		   M2M_WIFI_RESP_SCAN_RESULT         
-@pre         m2m_wifi_request_scan need to be called first	
+
+@pre
+    m2m_wifi_request_scan must be called first to ensure up to date results are available.
 		- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at initialization. Registering the callback
 		   is done through passing it to the @ref m2m_wifi_init.
 		- The event @ref M2M_WIFI_RESP_SCAN_DONE must be handled in the callback to receive the requested scan information. 
-@warning   This function must be called only in the wi-fi callback function when the events @ref M2M_WIFI_RESP_SCAN_DONE or @ref M2M_WIFI_RESP_SCAN_RESULT
-		   are received.
+
+@warning   
+	This function must be called only in the wi-fi callback function when the events 
+	@ref M2M_WIFI_RESP_SCAN_DONE or @ref M2M_WIFI_RESP_SCAN_RESULT are received.
 		   Calling this function in any other place will result in undefined/outdated numbers.
-@return    Return the number of AP's found in the last Scan Request.
 		  
-\section Example
+@return
+	Return the number of AP's found in the last Scan Request.
+		  
+\section WIFIExample7 Example
   The code snippet demonstrates an example of how the scan request is called from the application's main function and the handling of
   the events received in response.
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
 	
@@ -2082,40 +2782,53 @@ NMI_API sint8 m2m_wifi_request_scan_ssid_list(uint8 ch,uint8 * u8Ssidlist);
 			}
 		}
 	}
-	
 @endcode			 
 */
 NMI_API uint8 m2m_wifi_get_num_ap_found(void);
-/**@}*/
-/** @defgroup WifiReqScanResult m2m_wifi_req_scan_result
-*   @ingroup WLANAPI
-*   Synchronous call to read the AP information from the SCAN Result list with the given index.
-*   This function is expected to be called when the response events M2M_WIFI_RESP_SCAN_RESULT or
-*   M2M_WIFI_RESP_SCAN_DONE are received in the wi-fi callback function.
-*   The response information received can be obtained through the casting to the @ref tstrM2mWifiscanResult structure 	
- */
- /**@{*/
-/*!
-@fn          NMI_API sint8 m2m_wifi_req_scan_result(uint8 index);
-@param [in]  index 
-		      Index for the requested result, the index range start from 0 till number of AP's found
 
-@see          tstrM2mWifiscanResult
+/*!
+@ingroup WLANSCAN
+@fn \
+    NMI_API sint8 m2m_wifi_req_scan_result(uint8 index);
+
+@brief
+    Synchronous call to read the AP information from the SCAN Result list.
+
+@details
+	Synchronous call to read the AP information from the SCAN Result list with the given index.
+    This function is expected to be called when the response events @ref M2M_WIFI_RESP_SCAN_RESULT or
+    @ref M2M_WIFI_RESP_SCAN_DONE are received in the wi-fi callback function.
+	The response information received can be obtained through the casting to the 
+    @ref tstrM2mWifiscanResult structure.
+
+@param [in]  index 
+    Index for the requested result, the index range start from 0 till number of AP's found.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	tstrM2mWifiscanResult
 		   m2m_wifi_get_num_ap_found
 		   m2m_wifi_request_scan             
 		   
-@pre         @ref m2m_wifi_request_scan needs to be called first, then m2m_wifi_get_num_ap_found 
-		   to get the number of AP's found	
-			- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered at startup. Registering the callback
-			is done through passing it to the @ref m2m_wifi_init function.
-			- The event @ref M2M_WIFI_RESP_SCAN_RESULT must be handled in the callback to receive the requested scan information.
-@warning     Function used  in STA mode only. the scan results are updated only if the scan request is called.
-		     Calling this function only without a scan request will lead to firmware errors. 
-		     Refrain from introducing a large delay  between the scan request and the scan result request, to prevent
-		     errors occurring.
+@pre         
+	- @ref m2m_wifi_request_scan needs to be called first, then m2m_wifi_get_num_ap_found 
+      to get the number of AP's found.
+	- A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered 
+      at startup. Registering the callback is done through passing it to the @ref m2m_wifi_init function.
+	- The event @ref M2M_WIFI_RESP_SCAN_RESULT must be handled in the callback to receive the 
+ 	  requested scan information.
 			 
-@return      The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
-\section Example
+@warning
+    - Function used in STA mode only. the scan results are updated only if the scan request 
+	  is called.
+	- Calling this function only without a scan request will lead to 
+ 	  firmware errors. 
+	- Application code should refrain from introducing a large delay  between the scan request and the scan result 
+	  request, to prevent errors occurring.
+
+\section WIFIExample8 Example
   The code snippet demonstrates an example of how the scan request is called from the application's main function and the handling of
   the events received in response.
 @code
@@ -2196,27 +2909,34 @@ NMI_API uint8 m2m_wifi_get_num_ap_found(void);
 			}
 		}
 	}
-	
 @endcode 
 */
 NMI_API sint8 m2m_wifi_req_scan_result(uint8 index);
-/**@}*/
-/** @defgroup WifiReqCurrentRssiFn m2m_wifi_req_curr_rssi
- *   @ingroup WLANAPI
- *   Asynchronous request for the current RSSI of the connected AP.
- *   The response received in through the @ref M2M_WIFI_RESP_CURRENT_RSSI event.
- */
- /**@{*/
+
 /*!
-@fn          NMI_API sint8 m2m_wifi_req_curr_rssi(void);
-@pre	   - A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered before initialization. Registering the callback
-			is done through passing it to the [m2m_wifi_init](@ref m2m_wifi_init) through the @ref tstrWifiInitParam initialization structure.
-		   - The event @ref M2M_WIFI_RESP_CURRENT_RSSI must be handled in the callback to receive the requested Rssi information.       
-@return      The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.	
-\section Example
+@ingroup WLANCONNECT
+@fn \
+    NMI_API sint8 m2m_wifi_req_curr_rssi(void);
+
+@brief
+    Asynchronous API to request the current Receive Signal Strength (RSSI) of the current connection.
+
+@details
+    This function will result in the application receiving the RSSI via a
+    @ref M2M_WIFI_RESP_CURRENT_RSSI event.
+
+@pre
+    - A Wi-Fi notification callback of type @ref tpfAppWifiCb MUST be implemented and registered
+      during initialization. Registration of the callback is done through passing it to @ref m2m_wifi_init
+      via the @ref tstrWifiInitParam initialization structure.
+    - The event @ref M2M_WIFI_RESP_CURRENT_RSSI must be handled in the callback to receive the requested Rssi information.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+\section WIFIExample9 Example
   The code snippet demonstrates how the RSSI request is called in the application's main function and the handling of the event received in the callback. 
 @code
-
 	#include "m2m_wifi.h"
 	#include "m2m_types.h"
 	
@@ -2253,240 +2973,382 @@ NMI_API sint8 m2m_wifi_req_scan_result(uint8 index);
 			}
 		}
 	}
-
 @endcode	
-
 */
 NMI_API sint8 m2m_wifi_req_curr_rssi(void);
-/**@}*/
-/** @defgroup WifiGetOtpMacAddFn m2m_wifi_get_otp_mac_address
-*   @ingroup WLANAPI
-*   Request the MAC address stored on the One Time Programmable(OTP) memory of the device.
-*   The function is blocking until the response is received.
-*/
- /**@{*/
+
 /*!
-@fn          NMI_API sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8 * pu8IsValid);
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8 * pu8IsValid);
+
+@brief
+    Synchronous API to query the MAC address programmed into the WINC ICs OTP memory.
+
+@details
+    This function attempts to read the device's MAC address from the One Time Programmable (OTP)
+	memory on the IC. The presence (yes or no) of a MAC address in the OTP memory and, in the case
+    of it being present, its value is returned via RAM pointed to by the input arguments.
+
+    Request the MAC address stored on the One Time Programmable(OTP) memory of the device.
+    The function is blocking until the response is received.
+
+@pre
+    Prior call to @ref m2m_wifi_init is required before any WIFI/socket function.
 
 @param [out] pu8MacAddr
-			Output MAC address buffer of 6 bytes size. Valid only if *pu8Valid=1.
+    Output MAC address buffer 6 bytes in size. Valid only if *pu8Valid=1.
+
 @param [out] pu8IsValid
-		     Output boolean value to indicate the validity of pu8MacAddr in OTP. 
-		     Output zero if the OTP memory is not programmed, non-zero otherwise.
-@pre         m2m_wifi_init required to be called before any WIFI/socket function
-@see         m2m_wifi_get_mac_address             
+    A boolean value set by the callee to indicate the validity of pu8MacAddr in OTP. If no MAC has
+    been programmed in the OTP the value of this parameter will be zero; otherwise it will be non-zero.
 
-@return      The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
+@return
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 
+@see         
+    m2m_wifi_get_mac_address             
 */
 NMI_API sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8 * pu8IsValid);
-/**@}*/
-/** @defgroup WifiGetMacAddFn m2m_wifi_get_mac_address
-*   @ingroup WLANAPI
-*   Function to retrieve the current MAC address. The function is blocking until the response is received.
-*/
-/**@{*/
-/*!
-@fn          NMI_API sint8 m2m_wifi_get_mac_address(uint8 *pu8MacAddr)	
-@param [out] pu8MacAddr
-			 Output MAC address buffer of 6 bytes size.	
-@pre         m2m_wifi_init required to be called before any WIFI/socket function
-@see         m2m_wifi_get_otp_mac_address             
-@return      The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 
+/*!
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_get_mac_address(uint8 *pu8MacAddr)
+
+@brief
+    Synchronous API to retrieve the MAC address currently in use by the device.
+
+@details
+	Function to retrieve the current MAC address. 
+	The function is blocking until the response is received.
+
+@pre         
+    Prior call to @ref m2m_wifi_init is required before any WIFI/socket function.
+
+@param [out] pu8MacAddr
+    Pointer to a buffer in memory containing a 6-byte MAC address (provided function returns 
+    @ref M2M_SUCCESS).
+
+@return
+	The function returns @ref M2M_SUCCESS for successful operation and a negative value otherwise.
+
+@see
+	m2m_wifi_get_otp_mac_address             
 */
 NMI_API sint8 m2m_wifi_get_mac_address(uint8 *pu8MacAddr);
-/**@}*/
-/** @defgroup SetSleepModeFn m2m_wifi_set_sleep_mode
- *   @ingroup WLANAPI
- *  This is one of the two synchronous power-save setting functions that
- *  allow the host MCU application to tweak the system power consumption. Such tweaking can be done through one of two ways:
-*  1) Changing the power save mode, to one of the allowed power save modes @ref tenuPowerSaveModes. This is done by setting the first parameter
-*  2) Configuring DTIM monitoring: Configuring beacon monitoring parameters by enabling or disabling the reception of broadcast/multicast data. 
-*   this is done by setting the second parameter.
- */
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn);
+@ingroup WLANPS
+@fn \
+    NMI_API sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn);
+
+@brief
+    Synchronous API to set the power-save mode of the WINC IC.
+
+@details
+    This is one of the two synchronous power-save setting functions that allow the host MCU application
+    to tweak the system power consumption. Such tweaking can be done through one of two ways:
+    - 1) Changing the power save mode, to one of the allowed power save modes (see @ref tenuPowerSaveModes). This is done by setting the first parameter.
+    - 2) Configuring DTIM monitoring: Configuring beacon monitoring parameters by enabling or disabling the reception of broadcast/multicast data.
+         This is done by setting the second parameter.
+
 @param [in]	PsTyp
 			Desired power saving mode. Supported types are enumerated in @ref tenuPowerSaveModes.
+
 @param [in]	BcastEn
 			Broadcast reception enable flag. 
-			If it is 1, the WINC1500 will be awake each DTIM beacon for receiving broadcast traffic.
-			If it is 0, the WINC1500: disable broadcast traffic. Through this flag the WINC1500 will not wakeup at the DTIM beacon, but it will wakeup depends only 
-			on the the configured Listen Interval. 
+    If it is 1, the WINC will be awake for each DTIM beacon in order to check for and receive broadcast traffic.
+    If it is 0, the WINC will ignore broadcast traffic. Through this flag the WINC will not wakeup at the DTIM beacon,
+    but instead it will wakeup only based on the configured Listen Interval.
 
-@warning    The function called once after initialization.
+@warning
+	The function called once after initialization.
 
-@see	   tenuPowerSaveModes
+@return
+	The function returns @ref M2M_SUCCESS for successful operation and a negative value otherwise.
+
+@see
+	tenuPowerSaveModes
 		   m2m_wifi_get_sleep_mode
 		   m2m_wifi_set_lsn_int
-
-@return    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn);
-/**@}*/
-/** @defgroup WifiRequestSleepFn m2m_wifi_request_sleep
- *   @ingroup WLANAPI
- *  	Synchronous power-save sleep request function, which requests from the WINC1500 device to sleep in the currenlty configured power save mode as defined
- *   	by the @ref m2m_wifi_set_sleep_mode, for a specific time as defined by the passed in parameter.
- *  	This function should be used in the @ref M2M_PS_MANUAL power save mode only.
- *    A wake up request is automatically performed by the WINC1500 device when any host driver API function, e.g. Wi-Fi or socket operation is called.
- */
- /**@{*/
-/*!
-@fn	       	NMI_API sint8 m2m_wifi_request_sleep(uint32 u32SlpReqTime);
-@param [in]	u32SlpReqTime
-			Request sleep time in ms 
-			The best recommended sleep duration is left to be determined by the application. Taking into account that if the application sends notifications very rarely, 
-			sleeping for a long time can be a power-efficient decision. In contrast applications that are senstive for long periods of absence can experience  
-			performance degradation in the connection if long sleeping times are used.
-@warning 	The function should be called in @ref M2M_PS_MANUAL power save mode only. As enumerated in @ref tenuPowerSaveModes
-			It's also important to note that during the sleeping time while in the M2M_PS_MANUAL mode, AP beacon monitoring is bypassed and the wifi-connection may drop if 
-			the sleep period is enlongated.
-@see     		tenuPowerSaveModes 
-		  	m2m_wifi_set_sleep_mode
 
-@return    	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+/*!
+@ingroup WLANPS
+@fn \
+    NMI_API sint8 m2m_wifi_request_sleep(uint32 u32SlpReqTime);
+
+@brief
+    API to place the WINC IC into sleep mode for a specified period of time.
+
+@details
+    Synchronous power-save sleep request function, which requests the WINC device to sleep in the currently configured
+    power save mode, as set using @ref m2m_wifi_set_sleep_mode, for a specific time as defined by the passed in parameter.
+	This function should be used in the @ref M2M_PS_MANUAL power save mode only.
+    A wake up request is automatically performed by the WINC device when any host driver API function, e.g. Wi-Fi or socket operation is called.
+
+@param [in]	u32SlpReqTime
+    Request sleep time in ms.\n
+	The best recommended sleep duration is left to be determined by the application. 
+	Taking into account that if the application sends notifications very rarely, 
+	sleeping for a long time can be a power-efficient decision. 
+    In contrast, applications that are sensitive for long periods of absence can experience
+			performance degradation in the connection if long sleeping times are used.
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operation and a negative value otherwise.
+
+@warning 
+    The function should be called in @ref M2M_PS_MANUAL power save mode only. As enumerated in @ref tenuPowerSaveModes.
+    It's also important to note that during the sleeping time while in the M2M_PS_MANUAL mode, AP beacon monitoring is
+    bypassed and the wifi-connection may drop if the sleep period is elongated.
+
+@see
+	tenuPowerSaveModes 
+	m2m_wifi_set_sleep_mode
 */
 NMI_API sint8 m2m_wifi_request_sleep(uint32 u32SlpReqTime);
-/**@}*/
-/** @defgroup GetSleepModeFn m2m_wifi_get_sleep_mode
- *   @ingroup WLANAPI
- *  Synchronous power save mode retrieval function.
- */
- /**@{*/
+
 /*!
-@fn		    NMI_API uint8 m2m_wifi_get_sleep_mode(void);
-@see	    tenuPowerSaveModes 
+@ingroup WLANPS
+@fn \
+    NMI_API uint8 m2m_wifi_get_sleep_mode(void);
+
+@brief
+	Synchronous power save mode retrieval function.
+
+@return	    
+    The current operating power saving mode based on the enumerated sleep modes @ref tenuPowerSaveModes.
+
+@see
+	tenuPowerSaveModes 
 		    m2m_wifi_set_sleep_mode
-@return	    The current operating power saving mode based on the enumerated sleep modes @ref tenuPowerSaveModes.
 */
 NMI_API uint8 m2m_wifi_get_sleep_mode(void);
-/**@}*/
-/** @defgroup WifiReqClientCtrlFn m2m_wifi_req_client_ctrl
- *   @ingroup WLANAPI
- *  Asynchronous command sending function to the PS Client (An WINC1500 board running the ps_firmware)
-*   if the PS client send any command it will be received through the @ref M2M_WIFI_RESP_CLIENT_INFO event
- */
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_req_client_ctrl(uint8 cmd);
+@fn \
+    NMI_API sint8 m2m_wifi_req_client_ctrl(uint8 cmd);
+
 @brief		
+    Asynchronous command sending function to the PS Client.
+
+@details
+    Asynchronous command sending function to the PS Client (a WINC board running the ps_firmware)
+    if the PS client sends any command, it will be received through the @ref M2M_WIFI_RESP_CLIENT_INFO event.
+
 @param [in]	cmd
 			Control command sent from PS Server to PS Client (command values defined by the application)
-@pre		@ref m2m_wifi_req_server_init should be called first
-@warning	       This mode is not supported in the current release.
-@see		m2m_wifi_req_server_init
+
+@pre
+    @ref m2m_wifi_req_server_init should be called first.
+
+@warning	
+	This mode is not supported in the current release.
+
+@see
+	m2m_wifi_req_server_init
 			M2M_WIFI_RESP_CLIENT_INFO
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+
+@return		
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_req_client_ctrl(uint8 cmd);
-/**@}*/
-/** @defgroup WifiReqServerInit m2m_wifi_req_server_init
- *   @ingroup WLANAPI
- *  Synchronous function to initialize the PS Server.
- *  The WINC1500 supports non secure communication with another WINC1500, 
-*   (SERVER/CLIENT) through one byte command (probe request and probe response) without any connection setup.
-*   The server mode can't be used with any other modes (STA/P2P/AP)
-*/
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_req_server_init(uint8 ch);
+@fn \
+    NMI_API sint8 m2m_wifi_req_server_init(uint8 ch);
+
+@brief
+	Synchronous function to initialize the PS Server.
+
+@details
+    The WINC supports non secure communication with another WINC,
+	(SERVER/CLIENT) through one byte command (probe request and probe response) without any connection setup.
+    The server mode can't be used with any other modes (STA/AP)
+
 @param [in]	ch
 			Server listening channel
-@see		m2m_wifi_req_client_ctrl
-@warning	       This mode is not supported in the current release.
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+
+@see
+	m2m_wifi_req_client_ctrl
+
+@warning
+	This mode is not supported in the current release.
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_req_server_init(uint8 ch);
-/**@}*/
-/** @defgroup WifiSetDeviceNameFn m2m_wifi_set_device_name
- *   @ingroup WLANAPI
- *  Sets the WINC device name. The name string is used as a device name in both (P2P) WiFi-Direct mode as well as DHCP hostname (option 12).
- *  For P2P devices to communicate a device name must be present. If it is not set through this function a default name is assigned.
- *  The default name is WINC-XX-YY, where XX and YY are the last 2 octets of the OTP MAC address. If OTP (eFuse) is programmed, 
- *  then the default name is WINC-00-00.
- */
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength);		
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength);
+
+@brief
+    Asynchronous API to set the "Device Name" of the WINC IC.
+
+@details
+    Sets the WINC device name. The name string is used as a device name in DHCP
+    hostname (option 12).
+    If a device is not set through this function a default name is assigned.
+	The default name is WINC-XX-YY, where XX and YY are the last 2 octets of the OTP 
+	MAC address. If OTP (eFuse) is programmed, then the default name is WINC-00-00.
+
+@warning	
+    The function called once after initialization.\n
+    Used for DHCP client hostname option (12).\n
+	Device name shall contain only characters allowed in valid internet host name as 
+	defined in RFC 952 and 1123.
+
 @param [in]	pu8DeviceName
-			A Buffer holding the device name. Device name is a null terminated C string.
+	Buffer holding the device name. Device name is a null terminated C string.
+
 @param [in]	u8DeviceNameLength
-			The length of the device name. Should not exceed the maximum device name's length @ref M2M_DEVICE_NAME_MAX (including null character).
-@warning	The function called once after initialization. 
-			Used for the Wi-Fi Direct (P2P) as well as DHCP client hostname option (12). 
-@warning    Device name shall contain only characters allowed in valid internet host name as defined in RFC 952 and 1123.
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+	Length of the device name. Should not exceed the maximum device name's 
+	length @ref M2M_DEVICE_NAME_MAX (including null character).
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
 */
 NMI_API sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength);
-/**@}*/
-/** @defgroup WifiSetLsnIntFn m2m_wifi_set_lsn_int
- *   @ingroup WLANAPI
-*	This is one of the two synchronous power-save setting functions that
-*  	allow the host MCU application to tweak the system power consumption. Such tweaking can be done by modifying the 
-*	the Wi-Fi listen interval. The listen interval is how many beacon periods the station can sleep before it wakes up to receive data buffer in AP.  
-*     It is represented in units of AP beacon periods(100ms).  
-*/
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt * pstrM2mLsnInt);
+@ingroup WLANTIME
+@fn \
+    NMI_API sint8 m2m_wifi_configure_sntp(uint8 *pu8NTPServerName, uint8 u8NTPServerNameLength, tenuSNTPUseDHCP useDHCP);
+
+@brief
+	Configures what NTP server the SNTP client should use.
+
+@details
+    Configures what NTP server the SNTP client should use. Only 1 server name can be provided, if the configured server name begins with an asterisk then it will be treated as a server pool.
+    The SNTP client can also use the NTP server provided by the DHCP server through option 42.
+    By default the NTP server provided by DHCP will be tried first, then the built-in default NTP server (time.nist.gov) will be used.
+
+@param [in]	pu8NTPServerName
+	Buffer holding the NTP server name. If the first character is an asterisk (*) then it will be treated as a server pool, where the asterisk will
+	be replaced with an incrementing value from 0 to 3 each time a server fails (example: *.pool.ntp.org).
+
+@param [in]	u8NTPServerNameLength
+    Length of the NTP server name. Should not exceed the maximum NTP server name length of @ref M2M_NTP_MAX_SERVER_NAME_LENGTH.
+
+@param[in]  useDHCP
+    Explicity tell the WINC if it should use the NTP server provided by the DHCP server or not.
+
+@warning
+    SNTP should be configured before the connection takes place. If SNTP is configured after the device connects to a
+    network, the new configuration can take a minimum of 24h to be applied. However, it can take even longer since it is
+    triggered by DHCP renewal.
+    Currently there is also a known issue in which if the WINC obtains the NTP server from DHCP and then connects to a
+    different network, it will still use the NTP from the previous network.
+    Configuring a server name will overwrite the built-in default server until next reboot.
+
+@return
+    The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
+*/
+NMI_API sint8 m2m_wifi_configure_sntp(uint8 *pu8NTPServerName, uint8 u8NTPServerNameLength, tenuSNTPUseDHCP useDHCP);
+
+/*!
+@ingroup WLANPS
+@fn \
+    NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt * pstrM2mLsnInt);
+
+@brief
+	API to set Wi-Fi listen interval for power save operation. 
+
+@details
+	This is one of the two synchronous power-save setting functions that
+	allow the host MCU application to tweak the system power consumption. Such tweaking can be done by modifying the 
+    Wi-Fi listen interval. The listen interval is how many beacon periods the station can sleep before it wakes up to receive data buffered in the AP.
+	It is represented in units of AP beacon periods(100ms).  
+
+@warning
+	The function should be called once after initialization. 
 
 @param [in]	pstrM2mLsnInt
-			Structure holding the listen interval configurations.
-@pre		Function @m2m_wifi_set_sleep_mode shall be called first, to set the power saving mode required.
-@warning     	The function should be called once after initialization. 
-@see		tstrM2mLsnInt
-                     m2m_wifi_set_sleep_mode
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    Structure holding the listen interval configuration.
 
+@pre
+	The function @ref m2m_wifi_set_sleep_mode shall be called first, to set the power saving mode required.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	tstrM2mLsnInt
+	m2m_wifi_set_sleep_mode
 */
 NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt *pstrM2mLsnInt);
-/**@}*/
-/** @defgroup WifiEnableMonitorModeFn m2m_wifi_enable_monitoring_mode
- *   @ingroup WLANAPI
- *     Asynchronous Wi-Fi monitoring mode (Promiscuous mode) enabling function. This function enables the monitoring mode, thus allowing two operations to be performed:
- *    1) Transmission of manually configured frames, through using the @ref m2m_wifi_send_wlan_pkt function.
- *    2) Reception of frames based on a defined filtering criteria
- *    When the monitoring mode is enabled, reception of all frames that satisfy the filter criteria passed in as a parameter is allowed, on the current wireless channel \n.
- *    All packets that meet the filtering criteria are passed to the application layer, to be handled by the assigned monitoring callback function \n.
- *    The monitoring callback function must be implemented before starting the monitoring mode, in-order to handle the packets received \n.
- *    Registering of the implemented callback function is through the callback pointer @ref tpfAppMonCb in the @ref tstrWifiInitParam structure\n.
- *    passed to @ref m2m_wifi_init function at initialization.
- *    
+
+/**@cond MON_DOC
  */
- /**@{*/
 /*!
- * @fn             NMI_API sint8 m2m_wifi_enable_monitoring_mode(tstrM2MWifiMonitorModeCtrl *, uint8 *, uint16 , uint16);
- * @param [in]     pstrMtrCtrl
- *                 		Pointer to @ref tstrM2MWifiMonitorModeCtrl structure holding the filtering parameters.
- * @param [in]     pu8PayloadBuffer
- * 				   Pointer to a buffer allocated by the application. The buffer SHALL hold the Data field of 
- *				   the WIFI RX Packet (Or a part from it). If it is set to NULL, the WIFI data payload will 
- *				   be discarded by the monitoring driver.
- * @param [in]     u16BufferSize
- *				   The total size of the pu8PayloadBuffer in bytes.
- * @param [in]     u16DataOffset
- *				   Starting offset in the DATA FIELD of the received WIFI packet. The application may be interested
- *				   in reading specific information from the received packet. It must assign the offset to the starting
- *				   position of it relative to the DATA payload start.\n
- *				   \e Example, \e if \e the \e SSID \e is \e needed \e to \e be \e read \e from \e a \e PROBE \e REQ \e packet, \e the \e u16Offset \e MUST \e be \e set \e to \e 0.
- * @warning        When This mode is enabled, you can not be connected in any mode (Station, Access Point, or P2P).\n 
- * @see             tstrM2MWifiMonitorModeCtrl
+@ingroup WLANMON
+@fn \
+    NMI_API sint8 m2m_wifi_enable_monitoring_mode(tstrM2MWifiMonitorModeCtrl *, uint8 *, uint16 , uint16);
+
+@brief
+	Asynchronous call to enable Wi-Fi monitoring (promiscuous receive) mode.
+
+@details
+	Asynchronous Wi-Fi monitoring mode (Promiscuous mode) enabling function. 
+	This function enables the monitoring mode, thus allowing two operations to be 
+	performed:
+	1) Transmission of manually configured frames, through using the 
+		@ref m2m_wifi_send_wlan_pkt function.
+    2) Reception of frames based on a defined filtering criteria.
+
+	When the monitoring mode is enabled, reception of all frames that satisfy the 
+	filter criteria passed in as a parameter is allowed, on the current wireless channel.
+	All packets that meet the filtering criteria are passed to the application layer, to 
+	be handled by the assigned monitoring callback function.
+	The monitoring callback function must be implemented before starting the monitoring mode, 
+	in-order to handle the packets received.
+	Registering of the implemented callback function is through the callback pointer 
+	@ref tpfAppMonCb in the @ref tstrWifiInitParam structure passed to @ref m2m_wifi_init function at initialization.
+
+@param [in]     pstrMtrCtrl
+	Pointer to @ref tstrM2MWifiMonitorModeCtrl structure holding the filtering parameters.
+
+@param [in]     pu8PayloadBuffer
+	Pointer to a Buffer allocated by the application. The buffer SHALL hold the Data field of 
+	the WIFI RX Packet (Or a part from it). If it is set to NULL, the WIFI data payload will 
+	be discarded by the monitoring driver.
+	
+@param [in]     u16BufferSize
+	The total size of the pu8PayloadBuffer in bytes.
+	
+@param [in]     u16DataOffset
+	Starting offset in the DATA FIELD of the received WIFI packet. The application may be interested
+	in reading specific information from the received packet. It must assign the offset to the starting
+	position of it relative to the DATA payload start.\n
+	\e Example, \e if \e the \e SSID \e is \e needed \e to \e be \e read \e from \e a \e PROBE \e REQ 
+	\e packet, \e the \e u16Offset \e MUST \e be \e set \e to \e 0.
+
+@warning
+    When this mode is enabled, you cannot be connected in any mode (Station or Access Point).
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	tstrM2MWifiMonitorModeCtrl
  			   tstrM2MWifiRxPacketInfo
  			   tstrWifiInitParam
  			   tenuM2mScanCh
  			   m2m_wifi_disable_monitoring_mode  
  			   m2m_wifi_send_wlan_pkt
  			   m2m_wifi_send_ethernet_pkt
- * @return       The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 
-*\section Example
-*  The example demonstrates the main function where-by the monitoring enable function is called after the initialization of the driver and the packets are
-*   handled in the callback function.
-* @code
+\section WIFIExample10 Example
+	The example demonstrates the main function where-by the monitoring enable function is called after 
+	the initialization of the driver and the packets are handled in the callback function.
 			
+@code
 			#include "m2m_wifi.h"
 			#include "m2m_types.h"
 
@@ -2498,6 +3360,7 @@ NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt *pstrM2mLsnInt);
 			{
 				; 
 			}
+
 			void wifi_monitoring_cb(tstrM2MWifiRxPacketInfo *pstrWifiRxPacket, uint8 *pu8Payload, uint16 u16PayloadSize)
 			{
 				if((NULL != pstrWifiRxPacket) && (0 != u16PayloadSize)) {
@@ -2534,152 +3397,231 @@ NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt *pstrM2mLsnInt);
 				}
 				return 0;
 			}
- * @endcode
+@endcode
  */
 NMI_API sint8 m2m_wifi_enable_monitoring_mode(tstrM2MWifiMonitorModeCtrl *pstrMtrCtrl, uint8 *pu8PayloadBuffer, 
 										   uint16 u16BufferSize, uint16 u16DataOffset);
-/**@}*/
-/** @defgroup WifiDisableMonitorModeFn m2m_wifi_disable_monitoring_mode
- *   @ingroup WLANAPI
- *   Synchronous function to disable Wi-Fi monitoring mode (Promiscuous mode). Expected to be called, if the enable monitoring mode is set, but if it was called without enabling
- *   no negative impact will reside.
- */
- /**@{*/
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_disable_monitoring_mode(void);
- * @see           m2m_wifi_enable_monitoring_mode               
- * @return      The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+@ingroup WLANMON
+@fn \
+    NMI_API sint8 m2m_wifi_disable_monitoring_mode(void);
+
+@brief
+    API to disable Wi-Fi monitoring (promiscuous receive) mode.
+
+@details
+	Synchronous function to disable Wi-Fi monitoring mode (Promiscuous mode). Expected to be called, if the enable monitoring mode is set, but if it was called without enabling
+	no negative impact will reside.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_monitoring_mode               
  */
 NMI_API sint8 m2m_wifi_disable_monitoring_mode(void);
- /**@}*/
- /** @defgroup SendWlanPktFn m2m_wifi_send_wlan_pkt
- *   @ingroup WLANAPI
- *   Synchronous function to transmit a WIFI RAW packet while the implementation of this packet is left to the application developer.
- */
- /**@{*/
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_send_wlan_pkt(uint8 *, uint16, uint16);
+@ingroup WLANMON
+@fn \
+    NMI_API sint8 m2m_wifi_send_wlan_pkt(uint8 *, uint16, uint16);
  
- * @param [in]     pu8WlanPacket
- *                 	     Pointer to a buffer holding the whole WIFI frame.
- * @param [in]     u16WlanHeaderLength
- * 			      The size of the WIFI packet header ONLY.
- * @param [in]     u16WlanPktSize
- *			     The size of the whole bytes in packet. 
- * @see             m2m_wifi_enable_monitoring_mode
+@brief
+	Synchronous function to transmit a WIFI RAW packet while the implementation of this packet is left to the application developer.
+
+@pre
+	Enable Monitoring mode first using @ref m2m_wifi_enable_monitoring_mode
+
+@note
+	Packets are user's responsibility.
+
+@warning
+    This function available in monitoring mode ONLY.
+
+@param [in]     pu8WlanPacket
+                 	     Pointer to a buffer holding the whole WIFI frame.
+
+@param [in]     u16WlanHeaderLength
+ 			      The size of the WIFI packet header ONLY.
+
+@param [in]     u16WlanPktSize
+    The size of the whole packet in bytes.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_monitoring_mode
  			   m2m_wifi_disable_monitoring_mode
- * @pre              Enable Monitoring mode first using @ref m2m_wifi_enable_monitoring_mode
- * @warning        This function available in monitoring mode ONLY.\n  
- * @note             Packets are user's responsibility.
- * @return     	    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
  */
 NMI_API sint8 m2m_wifi_send_wlan_pkt(uint8 *pu8WlanPacket, uint16 u16WlanHeaderLength, uint16 u16WlanPktSize);
-/**@}*/
-/** @defgroup WifiSendEthernetPktFn m2m_wifi_send_ethernet_pkt
- *   @ingroup WLANAPI
- *   Synchronous function to transmit an Ethernet packet. Transmit a packet directly in ETHERNET/bypass mode where the TCP/IP stack is disabled and the implementation of this packet is left to the application developer. 
- *   The Ethernet packet composition is left to the application developer. 
- */
- /**@{*/
-/*!
- * @fn           NMI_API sint8 m2m_wifi_send_ethernet_pkt(uint8* pu8Packet,uint16 u16PacketSize)
- * @param [in]     pu8Packet
- *                        Pointer to a buffer holding the whole Ethernet frame.
- * @param [in]     u16PacketSize
- * 		            The size of the whole bytes in packet.    
-  * @warning     This function available in ETHERNET/Bypass mode ONLY. Make sure that application defines @ref ETH_MODE.\n  
- * @note            Packets are the user's responsibility.
- *  @sa  		   m2m_wifi_enable_mac_mcast,m2m_wifi_set_receive_buffer	
- * @return         The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+/**@endcond*/ //MON_DOC
 
+/*!
+@ingroup WLANETH
+@fn \
+    NMI_API sint8 m2m_wifi_send_ethernet_pkt(uint8* pu8Packet,uint16 u16PacketSize);
+
+@brief
+	Synchronous function to transmit an Ethernet packet.
+
+@details
+	Transmit a packet directly in ETHERNET/bypass mode where the TCP/IP stack is disabled 
+	and the implementation of this packet is left to the application developer. 
+	The Ethernet packet composition is left to the application developer. 
+
+@note
+	Packets are the user's responsibility.
+
+@warning
+    This function available in ETHERNET/Bypass mode ONLY. Make sure that application defines ETH_MODE.
+
+@param [in]     pu8Packet
+	Pointer to a buffer holding the whole Ethernet frame.
+
+@param [in]     u16PacketSize
+    The size of the whole packet in bytes.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_mac_mcast
+	m2m_wifi_set_receive_buffer
  */
 NMI_API sint8 m2m_wifi_send_ethernet_pkt(uint8* pu8Packet,uint16 u16PacketSize);
-/**@}*/
-/** @defgroup WifiEnableSntpFn m2m_wifi_enable_sntp
- *   @ingroup WLANAPI
- *  	Synchronous function to enable/disable the native Simple Network Time Protocol(SNTP) client in the WINC1500 firmware.\n
- *    The SNTP is enabled by default at start-up.The SNTP client at firmware is used to synchronize the system clock to the UTC time from the well known time
- *  	servers (e.g. "time-c.nist.gov"). The SNTP client uses a default update cycle of 1 day.
- *  	The UTC is important for checking the expiration date of X509 certificates used while establishing
- *  	TLS (Transport Layer Security) connections.
- *  	It is highly recommended to use it if there is no other means to get the UTC time. If there is a RTC
- *  	on the host MCU, the SNTP could be disabled and the host should set the system time to the firmware 
- *  	using the @ref m2m_wifi_set_system_time function.
- */
- /**@{*/
+
 /*!
- * @fn                  NMI_API sint8 m2m_wifi_enable_sntp(uint8);
- * @param [in]     bEnable
-*				Enabling/Disabling flag
- *                        '0' :disable SNTP
- *                        '1' :enable SNTP  
- * @see             m2m_wifi_set_sytem_time       
- * @return        The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+@ingroup WLANTIME
+@fn \
+    NMI_API sint8 m2m_wifi_enable_sntp(uint8);
+
+@brief
+    Synchronous function to enable/disable the native Simple Network Time Protocol(SNTP) client in the WINC15x0 firmware.
+
+@details
+	The SNTP is enabled by default at start-up.The SNTP client at firmware is used to 
+	synchronize the system clock to the UTC time from the well known time servers (e.g. "time-c.nist.gov").
+	The SNTP client uses a default update cycle of 1 day.
+	
+	The UTC is important for checking the expiration date of X509 certificates used while establishing
+	TLS (Transport Layer Security) connections.
+
+	It is highly recommended to use it if there is no other means to get the UTC time. If there is a RTC
+	on the host MCU, the SNTP could be disabled and the host should set the system time to the firmware 
+	using the @ref m2m_wifi_set_system_time function.
+
+@param [in]     bEnable
+    Enables or disables the SNTP service
+		'0' :disable SNTP
+		'1' :enable SNTP  
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_set_system_time
  */
 NMI_API sint8 m2m_wifi_enable_sntp(uint8 bEnable);
-/**@}*/
-/** @defgroup WifiSetSystemTime m2m_wifi_set_sytem_time
- *   @ingroup WLANAPI
- *    Synchronous function for setting the system time in time/date format (@ref uint32).\n
- *    The @ref tstrSystemTime structure can be used as a reference to the time values that should be set and pass its value as @ref uint32
- */
- /**@{*/
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_set_sytem_time(uint32);   
- * @param [in]     u32UTCSeconds
- *                    Seconds elapsed since January 1, 1900 (NTP Timestamp).  
- * @see            m2m_wifi_enable_sntp
- *			  tstrSystemTime   
-  * @note         If there is an RTC on the host MCU, the SNTP could be disabled and the host should set the system time to the firmware 
- *		         using the API @ref m2m_wifi_set_sytem_time.
- * @return        The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+@ingroup WLANTIME
+@fn \
+    NMI_API sint8 m2m_wifi_set_system_time(uint32);
+
+@brief
+    Function for setting the system time within the WINC IC.
+
+@details
+	Synchronous function for setting the system time in time/date format (@ref uint32).
+	The @ref tstrSystemTime structure can be used as a reference to the time values that 
+    should be set and pass its value as @ref uint32.
+
+@param [in]     u32UTCSeconds
+ 	Seconds elapsed since January 1, 1900 (NTP Timestamp). 
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_sntp
+ 	tstrSystemTime
+
+@note
+	If there is an RTC on the host MCU, the SNTP may be disabled and the host may set the system 
+	time within the firmware using the API @ref m2m_wifi_set_system_time.
  */
-NMI_API sint8 m2m_wifi_set_sytem_time(uint32 u32UTCSeconds);
-/**@}*/
-/** @defgroup WifiGetSystemTime m2m_wifi_get_sytem_time
- *   @ingroup WLANAPI
- *    Asynchronous function used to retrieve the system time through the use of the response @ref M2M_WIFI_RESP_GET_SYS_TIME.
- *    Response time retrieved is parsed into the members defined in the structure @ref tstrSystemTime.
- */
- /**@{*/
+NMI_API sint8 m2m_wifi_set_system_time(uint32 u32UTCSeconds);
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_get_sytem_time(void);   
- * @see            m2m_wifi_enable_sntp
+@ingroup WLANTIME
+@fn \
+    NMI_API sint8 m2m_wifi_get_system_time(void);
+
+@brief 
+    Asynchronous API to obtain the system time in use by the WINC IC.
+
+@details
+	Asynchronous function used to retrieve the system time through the use of the 
+	response @ref M2M_WIFI_RESP_GET_SYS_TIME.
+	Response time retrieved is parsed into the members defined in the 
+	structure @ref tstrSystemTime.
+
+@note
+	Get the system time from the SNTP client using the API @ref m2m_wifi_get_system_time.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_sntp
  			  tstrSystemTime   
- * @note         Get the system time from the SNTP client
- *		        using the API @ref m2m_wifi_get_sytem_time.
- * @return        The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
  */
-NMI_API sint8 m2m_wifi_get_sytem_time(void);
-/**@}*/
-/** @defgroup WifiSetCustInfoElementFn m2m_wifi_set_cust_InfoElement
- *   @ingroup WLANAPI
- *   Synchronous function to Add/Remove user-defined Information Element to the WIFIBeacon and Probe Response frames while chip mode is Access Point Mode.\n
- *   According to the information element layout shown bellow, if it is required to set new data for the information elements, pass in the buffer with the
- *   information according to the sizes and ordering defined bellow. However, if it's required to delete these IEs, fill the buffer with zeros.
- */
- /**@{*/
+NMI_API sint8 m2m_wifi_get_system_time(void);
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_set_cust_InfoElement(uint8*);
- * @param [in]     pau8M2mCustInfoElement
- *                        Pointer to Buffer containing the IE to be sent. It is the application developer's responsibility to ensure on the correctness  of the information element's ordering passed in. 
- * @warning	       - Size of All elements combined must not exceed 255 byte.\n
- *			       - Used in Access Point Mode \n
- * @note              IEs Format will be follow the following layout:\n
- * @verbatim 
-               --------------- ---------- ---------- ------------------- -------- -------- ----------- ----------------------  
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_cust_InfoElement(uint8*);
+
+@brief
+    API to add or remove a user-defined Information Element 
+
+@details
+	Synchronous function to Add/Remove user-defined Information Element to the WIFIBeacon and Probe Response frames while chip mode is Access Point Mode.\n
+	According to the information element layout shown bellow, if it is required to set new data for the information elements, pass in the buffer with the
+	information according to the sizes and ordering defined bellow. However, if it's required to delete these IEs, fill the buffer with zeros.
+
+@param [in]     pau8M2mCustInfoElement
+	Pointer to Buffer containing the IE to be sent. It is the application developer's 
+	responsibility to ensure on the correctness  of the information element's ordering 
+	passed in. 
+
+@warning
+	Size of All elements combined must not exceed 255 byte.
+    Used in Access Point Mode.
+
+@note
+	IEs Format will be follow the following layout:
+
+@verbatim 
+    --------------- ---------- ---------- ------------------- -------- -------- ----------- -----------------------
               | Byte[0]       | Byte[1]  | Byte[2]  | Byte[3:length1+2] | ..... | Byte[n] | Byte[n+1] | Byte[n+2:lengthx+2]  | 
-              |---------------|----------|----------|-------------------|-------- --------|-----------|------------------| 
+    |---------------|----------|----------|-------------------|-------- --------|-----------|---------------------|
               | #of all Bytes | IE1 ID   | Length1  | Data1(Hex Coded)  | ..... | IEx ID  | Lengthx   | Datax(Hex Coded)     | 
-               --------------- ---------- ---------- ------------------- -------- -------- ----------- ---------------------- 
- * @endverbatim
- * @see             m2m_wifi_enable_sntp
- *                      tstrSystemTime               
- * @return        The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
- \section Example
+    --------------- ---------- ---------- ------------------- -------- -------- ----------- -----------------------
+@endverbatim
+
+@return
+     The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_sntp
+
+ \section WIFIExample11 Example
    The example demonstrates how the information elements are set using this function.
- *@code
- *
+@code
             char elementData[21];
             static char state = 0; // To Add, Append, and Delete
             if(0 == state) {	//Add 3 IEs
@@ -2708,173 +3650,394 @@ NMI_API sint8 m2m_wifi_get_sytem_time(void);
                 elementData[0]=0;
             }
             m2m_wifi_set_cust_InfoElement(elementData);	
- * @endcode
+@endcode
  */
 NMI_API sint8 m2m_wifi_set_cust_InfoElement(uint8* pau8M2mCustInfoElement);
- /**@}*/
-/** @defgroup WifiSetPowerProfile m2m_wifi_set_power_profile
- *   @ingroup WLANAPI
- *    Change the power profile mode
- */
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode);
-@brief		 
-@param [in]	u8PwrMode
-			Change the WINC1500 power profile to different mode based on the enumeration
-			@ref  tenuM2mPwrMode
-@pre		Must be called after the initializations and before any connection request and can't be changed in run time.
-@sa			tenuM2mPwrMode
+@ingroup WLANPS
+@fn \
+    NMI_API sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode);
+
+@brief
+    Change the power profile mode
+
+@param [in] u8PwrMode
+    Change the WINC power profile to different mode based on the enumeration @ref tenuM2mPwrMode.
+
+@warning
+    May only be called after initialization, before any connection request, and may not be used to change 
+	the power mode thereafter. 
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+	tenuM2mPwrMode
 			m2m_wifi_init
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.    
 */
 sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode);
-  /**@}*/
-  /** @defgroup WifiSetTxPower m2m_wifi_set_tx_power
- *   @ingroup WLANAPI
- *	Set the TX power tenuM2mTxPwrLevel
- */
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel);
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel);
+
+@brief	
+    Set the TX power tenuM2mTxPwrLevel.
+
 @param [in]	u8TxPwrLevel
-			change the TX power based on the enumeration tenuM2mTxPwrLevel
-@pre		Must be called after the initialization and before any connection request and can't be changed in runtime.
-@sa			tenuM2mTxPwrLevel
+    Change the TX power based on the enumeration \ref tenuM2mTxPwrLevel.
+
+@pre
+	Must be called after the initialization and before any connection request and can't be changed in runtime.
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+	tenuM2mTxPwrLevel
 			m2m_wifi_init
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.    
 */
 sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel);
- /**@}*/
-/** @defgroup WifiEnableFirmware m2m_wifi_enable_firmware_logs
-*   @ingroup WLANAPI
-*	Enable or Disable logs in run time (Disabling Firmware logs will 
-*	enhance the firmware start-up time and performance)
-*/
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable);
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_gain_table_idx(uint8 u8GainTableIdx);
+
+@brief
+    Set the Gain table index corresponding to specific WiFi region.
+
+@param [in]	u8GainTableIdx
+	change the gain table index based on the WiFi region it is suppose to be used.
+
+@pre
+	Must be called after the initialization and before any connection request. 
+	The corresponding gain tables must be present in the flash.
+
+@return	
+	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.    
+	
+@see			
+	m2m_wifi_init
+*/
+sint8 m2m_wifi_set_gain_table_idx(uint8 u8GainTableIdx);
+
+/*!
+@ingroup WLANLOG
+@fn \
+    NMI_API sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable);
+
+@brief
+    Enable or Disable logs in run time.
+
+@details
+    Enable or Disable logs in run time (Disable Firmware logs will enhance the firmware start-up time and performance).
+
 @param [in]	u8Enable
-			Set 1 to enable the logs, 0 for disable
-@pre   		Must be called after intialization through the following function @ref m2m_wifi_init
-@sa			__DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
+    Set 1 to enable the logs, 0 for disable.
+
+@pre
+    Must be called after initialization through the following function @ref m2m_wifi_init().
+
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+	__DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
 			m2m_wifi_init
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.     
 */
 sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable);
-  /**@}*/
- /** @defgroup WifiSetBatteryVoltage m2m_wifi_set_battery_voltage
-*   @ingroup WLANAPI
-*   Set the battery voltage to update the firmware calculations
-*/
- /**@{*/
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_battery_voltage(uint8 u8BattVolt)
-@brief		Set the battery voltage to update the firmware calculations
+@ingroup WLANCONF
+@fn \
+    NMI_API sint8 m2m_wifi_set_battery_voltage(uint8 u8BattVolt);
+
+@brief
+    Set the battery voltage to update the firmware calculations.
+
+@pre
+    Must be called after initialization through the following function @ref m2m_wifi_init().
+
 @param [in]	dbBattVolt
-			Battery Volt in double
-@pre		Must be called after intialization through the following function @ref m2m_wifi_init
-@sa       		m2m_wifi_init
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    Battery Voltage as double.
+	
+@return
+    The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+	m2m_wifi_init
 */
 sint8 m2m_wifi_set_battery_voltage(uint16 u16BattVoltx100);
-  /**@}*/
- /** @defgroup WifiSetGains m2m_wifi_set_gains
-*   @ingroup WLANAPI
-*   Set the chip gains mainly (PPA for 11b/11gn)
-*/
- /**@{*/
+
 /*!
-@fn			sint8 m2m_wifi_set_gains(tstrM2mWifiGainsParams* pstrM2mGain);
-@brief		Set the chip PPA gain for 11b/11gn
+@ingroup WLANCONF
+@fn \
+    sint8 m2m_wifi_set_gains(tstrM2mWifiGainsParams* pstrM2mGain);
+
+@brief		
+    Set the chip PPA gain for 11b/11gn.
+
 @param [in]	pstrM2mGain
-			tstrM2mWifiGainsParams contain gain parmaters as implemnted in rf document 
-@pre		Must be called after intialization through the following function @ref m2m_wifi_init
-@sa       		m2m_wifi_init
-@return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+    @ref tstrM2mWifiGainsParams contain gain parameters as implemented in rf document.
+
+@pre
+    Must be called after initialization through the following function @ref m2m_wifi_init.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_init
 */
 sint8 m2m_wifi_set_gains(tstrM2mWifiGainsParams* pstrM2mGain);
- /**@}*/
-/** @defgroup WifiGetFirmwareVersion m2m_wifi_get_firmware_version
-*   @ingroup WLANAPI
-*  Get Firmware version info as defined in the structure @ref tstrM2mRev.
-*/
- /**@{*/
+
+#ifdef ETH_MODE
 /*!
-@fn		m2m_wifi_get_firmware_version(tstrM2mRev* pstrRev)
-@param [out]	M2mRev
-		       Pointer to the structure @ref tstrM2mRev that contains the firmware version parameters
-@pre		Must be called after intialization through the following function @ref m2m_wifi_init
+@ingroup WLANETH
+@fn \
+    NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8 *, uint8);
+
+@brief
+	Synchronous function for filtering received MAC addresses
+
+@details
+	Synchronous function for filtering received MAC addresses from certain MAC address groups.
+	This function allows the addition/removal of certain MAC addresses, used in the multicast filter.
+
+@param [in]     pu8MulticastMacAddress
+	Pointer to MAC address
+
+@param [in]     u8AddRemove
+	A flag to add or remove the MAC ADDRESS, based on the following values:
+	  -  0 : remove MAC address
+	  -  1 : add MAC address    
+
+@note
+	Maximum number of MAC addresses that could be added is 8.
+
+@warning
+	This function is available in ETHERNET/bypass mode ONLY. 
+	Make sure that the application defines ETH_MODE.
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_set_receive_buffer
+	m2m_wifi_send_ethernet_pkt
+ */
+NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8* pu8MulticastMacAddress, uint8 u8AddRemove);
+
+/*!
+@ingroup WLANETH
+@fn \
+    NMI_API sint8 m2m_wifi_set_receive_buffer(void *, uint16);
+     
+@brief
+    Synchronous function for setting or modifying the receiver buffer's length.
+
+@details
+	Synchronous function for setting or modifying the receiver buffer's length. 
+	In the ETHERNET/bypass mode the application should define a callback of type 
+	@ref tpfAppEthCb, through which the application handles the received 
+	ethernet frames. It is through this callback function that the user can 
+	dynamically modify the length of the currently used receiver buffer.
+
+ @param [in]     pvBuffer
+	Pointer to Buffer to receive data.
+	NULL pointer causes a negative error @ref M2M_ERR_FAIL.
+
+ @param [in]     u16BufferLen
+                 Length of data to be received.  Maximum length of data should not exceed the size defined by TCP/IP
+      	     defined as @ref SOCKET_BUFFER_MAX_LENGTH
+		     
+@warning
+	This function is available in the Ethernet/bypass mode ONLY. Make sure that the application defines ETH_MODE.\n 
+
+@return
+    The function returns @ref M2M_SUCCESS if the command has been successfully queued to the WINC and a negative value otherwise.
+
+@see
+	m2m_wifi_enable_mac_mcast
+	m2m_wifi_send_ethernet_pkt	
+ */
+NMI_API sint8 m2m_wifi_set_receive_buffer(void* pvBuffer,uint16 u16BufferLen);
+
+#endif /* ETH_MODE */
+
+/*!
+@ingroup WLANCRYPTO
+@fn \
+    sint8 m2m_wifi_prng_get_random_bytes(uint8* pu8PrngBuff,uint16 u16PrngSize);
+
+@brief
+    Asynchronous function for retrieving from the firmware a pseudo-random set of bytes.
+
+@details
+    Asynchronous function for retrieving from the firmware a pseudo-random set of bytes as specified in the size passed in as a parameter.
+    The registered wifi-cb function retrieves the random bytes through the response @ref M2M_WIFI_RESP_GET_PRNG
+
+@param [in] pu8PrngBuff
+    Pointer to a buffer to receive data.
+
+@param [in] u16PrngSize
+    Requested size in bytes. Maximum 1580.
+
+@warning
+    Size greater than the maximum specified (1580) causes a negative error @ref M2M_ERR_FAIL.
+
+@return      
+	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+ */
+sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PrngBuff,uint16 u16PrngSize);
+
+/*!
+@ingroup WLANCONF
+@fn \
+     NMI_API sint8 m2m_wifi_conf_auto_rate(tstrConfAutoRate * pstrConfAutoRate);
+
+@brief
+	Configures WLAN automatic TX rate adaptation algorithm.
+
+@details
+	Allow the host MCU app to configure auto TX rate selection algorithm. The application can use this 
+	API to tweak the algorithm performance. Moreover, it allows the application to force a specific WLAN 
+	PHY rate for transmitted data packets to favor range vs. throughput needs.
+
+@param [in]	pstrConfAutoRate
+	The Auto rate configuration parameters as listed in tstrConfAutoRate.
+
+@return
+	The function SHALL return @ref M2M_SUCCESS for success and a negative value otherwise.
+
+@see
+	tstrConfAutoRate
+*/
+NMI_API sint8 m2m_wifi_conf_auto_rate(tstrConfAutoRate * pstrConfAutoRate);
+
+/*!
+@ingroup WLANROAMING
+@fn \
+    sint8 m2m_wifi_enable_roaming(uint8 bEnableDhcp);
+
+@brief
+    Enable WiFi STA roaming.
+
+@details
+	m2m_wifi_enable_roaming enables the firmware to trigger the roaming algorithm/steps on link loss with the current AP.
+	If roaming is successful, 
+        the @ref M2M_WIFI_RESP_CON_STATE_CHANGED message with state as @ref M2M_WIFI_ROAMED is sent to host.
+        Additionally a @ref M2M_WIFI_REQ_DHCP_CONF message with new DHCP lease details is sent to host (only if bEnableDhcp=1).
+	If roaming is unsuccessful,
+        @ref M2M_WIFI_RESP_CON_STATE_CHANGED message with state as @ref M2M_WIFI_DISCONNECTED is sent to host.
+	
+@param [in]    bEnableDhcp
+    0 : Disables DHCP client execution after roaming to new AP
+    1 : Enables DHCP client execution after roaming to new AP
+
+@pre
+    Must be called after the initialization.
+    The roaming algorithm/procedure is internal to the firmware.
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.    
+    
+@see            
+    m2m_wifi_init
+*/
+sint8 m2m_wifi_enable_roaming(uint8 bEnableDhcp);
+/*!
+@ingroup WLANROAMING
+@fn \
+    sint8 m2m_wifi_disable_roaming(void);
+
+@brief
+    Disable WiFi STA roaming.
+
+@pre
+    Must be called after the initialization.
+
+@return    
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.    
+    
+@see            
+    m2m_wifi_init
+*/
+sint8 m2m_wifi_disable_roaming(void);
+
+/*!
+@ingroup WLANINIT
+@fn \
+    NMI_API uint8 m2m_wifi_get_state(void);
+
+@brief
+    Get the wifi state.
+
+@return
+    The function returns the current wifi state (see @ref tenuWifiState for the possible states).
+
+@note
+    Check the WINC state. See @ref tenuWifiState for possible states.\n
+    @ref WIFI_STATE_INIT state represents WINC initialized but not started, this is a suitable state
+    for safe flash access.
+
+@sa
+    m2m_wifi_init
+    m2m_wifi_download_mode
+*/
+NMI_API uint8 m2m_wifi_get_state(void);
+
+/** @defgroup VERSION Version
+    @brief
+        Describes the APIs for reading the version information of the WINC firmware.
+@{
+    @defgroup   VERSIONDEF  Defines
+    @brief
+       Specifies the macros and defines used by the version APIs.
+
+    @defgroup   VERSIONAPI  Functions
+    @brief
+       Lists the APIs for reading the version information of the WINC firmware.
+@}
+ */
+
+/*!
+@ingroup        VERSIONAPI
+@fn             NMI_API m2m_wifi_get_firmware_version(tstrM2mRev* pstrRev);
+@brief          Get Firmware version info.
+@details        Get the Firmware version info from the active partition, as defined in the structure tstrM2mRev.
+@param [out]	pstrRev
+                    Pointer to the structure tstrM2mRev that contains the firmware version parameters.
+@pre            Must be called after initialization through the following function @ref m2m_wifi_init.
 @sa       		m2m_wifi_init
 @return		The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
 */
-sint8 m2m_wifi_get_firmware_version(tstrM2mRev *pstrRev);
-/**@}*/
-#ifdef ETH_MODE
-/** @defgroup WifiEnableMacMcastFn m2m_wifi_enable_mac_mcast
- *   @ingroup WLANAPI
- *   Synchronous function for filtering received MAC addresses from certain MAC address groups.
- *   This function allows the addtion/removal of certain MAC addresses, used in the multicast filter.
- */
- /**@{*/
+NMI_API sint8 m2m_wifi_get_firmware_version(tstrM2mRev* pstrRev);
+
 /*!
- * @fn             NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8 *, uint8);
- * @brief        
- * @param [in]     pu8MulticastMacAddress
- *                        Pointer to MAC address
- * @param [in]     u8AddRemove
- *                        A flag to add or remove the MAC ADDRESS, based on the following values:
- *                        -  0 : remove MAC address
- *                        -  1 : add MAC address    
- * @warning    This function is available in ETHERNET/bypass mode ONLY. Make sure that the application defines @ref ETH_MODE.\n  
- * @note         Maximum number of MAC addresses that could be added is 8.
- * @sa		m2m_wifi_set_receive_buffer, m2m_wifi_send_ethernet_pkt
- * @return       The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
- */
-NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8* pu8MulticastMacAddress, uint8 u8AddRemove);
-/**@}*/
-/** @defgroup SetReceiveBufferFn m2m_wifi_set_receive_buffer
- *   @ingroup WLANAPI
- *    Synchronous function for setting or modifying the receiver buffer's length. 
- *    In the ETHERNET/bypass mode the application should define a callback of type @ref tpfAppEthCb, through which the application handles the received 
- *    ethernet frames. It is through this callback function that the user can dynamically modify the length of the currently used receiver buffer.
- *@{*/
-/*!
- * @fn             NMI_API sint8 m2m_wifi_set_receive_buffer(void *, uint16);
-     
- * @param [in]     pvBuffer
- *                 Pointer to Buffer to receive data.
- *		     NULL pointer causes a negative error @ref M2M_ERR_FAIL.
- *
- * @param [in]     u16BufferLen
- *                 Length of data to be received.  Maximum length of data should not exceed the size defined by TCP/IP
- *      	     defined as @ref SOCKET_BUFFER_MAX_LENGTH
- *		     
- * @warning      This function is available in the Ethernet/bypass mode ONLY. Make sure that the application defines @ref ETH_MODE.\n 
- * @sa		m2m_wifi_enable_mac_mcast,m2m_wifi_send_ethernet_pkt	
- * @return       The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
- */
-NMI_API sint8 m2m_wifi_set_receive_buffer(void* pvBuffer,uint16 u16BufferLen);
-/**@}*/
-#endif /* ETH_MODE */
-/** @defgroup GetPrngBytes m2m_wifi_prng_get_random_bytes
- *   @ingroup WLANAPI
- *    Asynchronous function for retrieving from the firmware a pseudo-random set of bytes as specifed in the size passed in as a parameter.
- *    The registered wifi-cb function retrieves the random bytes through the response @ref M2M_WIFI_RESP_GET_PRNG 
- *@{*/
-/*!
- * @fn                  sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PRNGBuff,uint16 u16PRNGSize)
- * @param [out]      pu8PrngBuff
- *                 		Pointer to a buffer to receive data.
- * @param [in]      u16PrngSize
- *				Request size in bytes  
- *@warning 		Size greater than the maximum specified (@ref M2M_BUFFER_MAX_SIZE - sizeof(tstrPrng))
- *				causes a negative error @ref M2M_ERR_FAIL.
- *@see  			tstrPrng	
- * @return       	The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
- */
-sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PrngBuff,uint16 u16PrngSize);
-/**@}*/
+@ingroup WLANPS
+@fn \
+    sint8 m2m_wifi_enable_XO_during_sleep(uint8 bXOSleepEnable);
+
+@brief
+    Specifies whether the crystal oscillator is left on or off during deep sleep (defaults to off).
+
+@details
+    m2m_wifi_enable_XO_during_sleep controls the state of the crystal oscillator during deep sleep.
+    
+@param[in]  bXOSleepEnable
+    0 : The XO will be switched off during deep sleep
+    1 : The XO will be kept on during deep sleep
+
+@return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+
+*/
+sint8 m2m_wifi_enable_XO_during_sleep(uint8 bXOSleepEnable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_ate_mode.c
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_ate_mode.c
@@ -2,38 +2,31 @@
  *
  * \file
  *
- * \brief NMC1500 Peripherials Application Interface.
+ * \brief WINC1500 Peripherials Application Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -103,6 +96,7 @@ volatile static uint32	gaAteFwTxRates[M2M_ATE_MAX_NUM_OF_RATES] =
 	0x06, 0x09, 0x0C, 0x12, 0x18, 0x24, 0x30, 0x36,	/*G-Rats*/
 	0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87	/*N-Rats*/
 };
+
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 STATIC FUNCTIONS
@@ -392,7 +386,6 @@ sint8 m2m_ate_start_tx(tstrM2mAteTx * strM2mAteTx)
 	}
 	
 
-	
 	s8Ret += nm_write_reg(rBurstTx_NMI_USE_PMU, strM2mAteTx->use_pmu);
 	s8Ret += nm_write_reg(rBurstTx_NMI_TX_PHY_CONT, strM2mAteTx->phy_burst_tx);
 	s8Ret += nm_write_reg(rBurstTx_NMI_NUM_TX_FRAMES, strM2mAteTx->num_frames);

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_crypto.c
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_crypto.c
@@ -4,36 +4,29 @@
  *
  * \brief WINC Crypto module.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -758,7 +751,7 @@ static void m2m_crypto_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
 		}
 
 	}
-	else if(u8OpCode == M2M_CRYPTO_RESP_SHA256_FINSIH)
+	else if(u8OpCode == M2M_CRYPTO_RESP_SHA256_FINISH)
 	{
 		tstrCyptoResp strResp;
 		if (hif_receive(u32Addr + sizeof(tstrM2mSha256Ctxt), (uint8*) &strResp,sizeof(tstrCyptoResp), 0) == M2M_SUCCESS)
@@ -851,7 +844,7 @@ sint8 m2m_crypto_sha256_hash_init(tstrM2mSha256Ctxt *psha256Ctxt)
 				Buffer holding the data submitted to the hash.
 				
 @param [in]	u16DataLength
-				Size of the data bufefr in bytes.
+				Size of the data buffer in bytes.
 */
 sint8 m2m_crypto_sha256_hash_update(tstrM2mSha256Ctxt *psha256Ctxt, uint8 *pu8Data, uint16 u16DataLength)
 {
@@ -883,7 +876,7 @@ sint8 m2m_crypto_sha256_hash_finish(tstrM2mSha256Ctxt *psha256Ctxt, uint8 *pu8Sh
 	if((!gstrCryptoCtxt.u8CryptoBusy) && (psha256Ctxt != NULL) && (pu8Sha256Digest != NULL))
 	{
 		gstrCryptoCtxt.pu8Digest = pu8Sha256Digest;
-		ret = hif_send(M2M_REQ_GROUP_CRYPTO,M2M_CRYPTO_REQ_SHA256_FINSIH|M2M_REQ_DATA_PKT,(uint8*)psha256Ctxt,sizeof(tstrM2mSha256Ctxt),NULL,0,0);
+		ret = hif_send(M2M_REQ_GROUP_CRYPTO,M2M_CRYPTO_REQ_SHA256_FINISH|M2M_REQ_DATA_PKT,(uint8*)psha256Ctxt,sizeof(tstrM2mSha256Ctxt),NULL,0,0);
 	}
 	return ret;
 }
@@ -980,7 +973,7 @@ sint8 m2m_crypto_rsa_sign_verify(uint8 *pu8N, uint16 u16NSize, uint8 *pu8E, uint
 				The length of the hash digest.
 				
 @param[out] pu8RsaSignature
-				Pointer to a user buffer allocated by teh caller shall hold the generated signature.
+				Pointer to a user buffer allocated by the caller shall hold the generated signature.
 */
 sint8 m2m_crypto_rsa_sign_gen(uint8 *pu8N, uint16 u16NSize, uint8 *pu8d, uint16 u16dSize, uint8 *pu8SignedMsgHash, 
 					   uint16 u16HashLength, uint8 *pu8RsaSignature)

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_hif.h
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_hif.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains M2M host interface APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -135,7 +128,7 @@ NMI_API sint8 hif_send(uint8 u8Gid,uint8 u8Opcode,uint8 *pu8CtrlBuf,uint16 u16Ct
 					   uint8 *pu8DataBuf,uint16 u16DataSize, uint16 u16DataOffset);
 /*
 *	@fn		hif_receive
-*	@brief	Host interface interrupt serviece routine
+*	@brief	Host interface interrupt service routine
 *	@param [in]	u32Addr
 *				Receive start address
 *	@param [out] pu8Buf
@@ -233,6 +226,13 @@ NMI_API uint8 hif_get_sleep_mode(void);
 */
 NMI_API sint8 hif_Resp_handler(uint8 *pu8Buffer, uint16 u16BufferSize);
 #endif
+
+/**
+*	@fn		hif_yield(void)
+*	@brief
+			Yields control from interrupt event handler.
+*/
+NMI_API void hif_yield(void);
 
 /**
 *	@fn		hif_handle_isr(void)

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_ota.c
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_ota.c
@@ -4,36 +4,29 @@
  *
  * \brief NMC1500 IoT OTA Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -48,44 +41,53 @@ INCLUDES
 #include "driver/include/m2m_types.h"
 #include "driver/include/m2m_ota.h"
 #include "driver/source/m2m_hif.h"
+#include "spi_flash/include/spi_flash.h"
+#include "driver/include/m2m_wifi.h"
+#include "spi_flash/include/flexible_flash.h"
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 MACROS
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 DATA TYPES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 static tpfOtaUpdateCb gpfOtaUpdateCb = NULL;
 static tpfOtaNotifCb  gpfOtaNotifCb = NULL;
+static tpfFileGetCb   gpfHFDGetCb    = NULL;
+static tpfFileReadCb  gpfHFDReadCb   = NULL;
+static tpfFileEraseCb gpfHFDEraseCb  = NULL;
 
+typedef struct {
+    uint32 u32Offset;
+    uint32 u32Size;
+}FileBlockDescriptor;
+
+static FileBlockDescriptor FileBlock;
+
+static uint8  gu8CurrFileHandlerID  = HFD_INVALID_HANDLER;
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 FUNCTION PROTOTYPES
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
+
 /**
-*	@fn			m2m_wifi_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr, uint8 grp)
-*	@brief		WiFi call back function
-*	@param [in]	u8OpCode
-*					HIF Opcode type.
-*	@param [in]	u16DataSize
-*					HIF data length.
-*	@param [in]	u32Addr
-*					HIF address.
-*	@param [in]	grp
-*					HIF group type.
-*	@author
-*	@date
-*	@version	1.0
+@fn         m2m_ota_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
+@brief      Internal OTA call back function.
+@param[in]  u8OpCode
+                HIF Opcode type.
+@param[in]  u16DataSize
+                HIF data length.
+@param[in]  u32Addr
+                HIF address.
 */
 static void m2m_ota_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
 {
-	sint8 ret = M2M_SUCCESS;
+	sint8 s8Ret = M2M_SUCCESS;
 	if(u8OpCode == M2M_OTA_RESP_NOTIF_UPDATE_INFO)
 	{
 		tstrOtaUpdateInfo strOtaUpdateInfo;
 		m2m_memset((uint8*)&strOtaUpdateInfo,0,sizeof(tstrOtaUpdateInfo));
-		ret = hif_receive(u32Addr,(uint8*)&strOtaUpdateInfo,sizeof(tstrOtaUpdateInfo),0);
-		if(ret == M2M_SUCCESS)
+		s8Ret = hif_receive(u32Addr,(uint8*)&strOtaUpdateInfo,sizeof(tstrOtaUpdateInfo),0);
+		if(s8Ret == M2M_SUCCESS)
 		{
 			if(gpfOtaNotifCb)
 				gpfOtaNotifCb(&strOtaUpdateInfo);
@@ -95,34 +97,76 @@ static void m2m_ota_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
 	{
 		tstrOtaUpdateStatusResp strOtaUpdateStatusResp;
 		m2m_memset((uint8*)&strOtaUpdateStatusResp,0,sizeof(tstrOtaUpdateStatusResp));
-		ret = hif_receive(u32Addr, (uint8*) &strOtaUpdateStatusResp,sizeof(tstrOtaUpdateStatusResp), 0);
-		if(ret == M2M_SUCCESS)
+		s8Ret = hif_receive(u32Addr, (uint8*) &strOtaUpdateStatusResp,sizeof(tstrOtaUpdateStatusResp), 0);
+		if(s8Ret == M2M_SUCCESS)
 		{
 			if(gpfOtaUpdateCb)
 				gpfOtaUpdateCb(strOtaUpdateStatusResp.u8OtaUpdateStatusType,strOtaUpdateStatusResp.u8OtaUpdateStatus);
 		}
 	}
+    else if (u8OpCode == M2M_OTA_RESP_HOST_FILE_STATUS)
+    {
+        tstrOtaHostFileGetStatusResp strOtaHostFileGetStatusResp = {0};
+        s8Ret = hif_receive(u32Addr, (uint8*)&strOtaHostFileGetStatusResp, sizeof(tstrOtaHostFileGetStatusResp), 1);
+        if(M2M_SUCCESS == s8Ret)
+        {
+            if(strOtaHostFileGetStatusResp.u8OtaFileGetStatus == OTA_STATUS_SUCCESS) {
+                gu8CurrFileHandlerID = strOtaHostFileGetStatusResp.u8CFHandler;
+            }
+        }
+    }
+    else if (u8OpCode == M2M_OTA_RESP_HOST_FILE_DOWNLOAD)
+    {
+        tstrOtaHostFileGetStatusResp strOtaHostFileGetStatusResp = {0};
+        s8Ret = hif_receive(u32Addr, (uint8*)&strOtaHostFileGetStatusResp, sizeof(tstrOtaHostFileGetStatusResp), 1);
+        if(M2M_SUCCESS == s8Ret)
+        {
+            if(strOtaHostFileGetStatusResp.u8OtaFileGetStatus == OTA_STATUS_SUCCESS) {
+                gu8CurrFileHandlerID = strOtaHostFileGetStatusResp.u8CFHandler;
+                M2M_INFO("Generated HostFileHandlerID is %u\n", gu8CurrFileHandlerID);
+            }
+
+            if(gpfHFDGetCb) {
+                gpfHFDGetCb(strOtaHostFileGetStatusResp.u8OtaFileGetStatus, gu8CurrFileHandlerID, strOtaHostFileGetStatusResp.u32OtaFileSize);
+                gpfHFDGetCb = NULL;
+            }
+        }
+    }
+    else if (u8OpCode == M2M_OTA_RESP_HOST_FILE_READ)
+    {
+        tstrOtaHostFileReadStatusResp strOtaHostFileReadStatusResp;
+        m2m_memset((uint8*)&strOtaHostFileReadStatusResp, 0, sizeof(tstrOtaHostFileReadStatusResp));
+        s8Ret = hif_receive(u32Addr, (uint8*)&strOtaHostFileReadStatusResp, sizeof(tstrOtaHostFileReadStatusResp), 1);
+        if(M2M_SUCCESS == s8Ret)
+            if(gpfHFDReadCb)
+                gpfHFDReadCb(strOtaHostFileReadStatusResp.u8OtaFileReadStatus, strOtaHostFileReadStatusResp.pFileBuf, strOtaHostFileReadStatusResp.u16FileBlockSz);
+    }
+    else if(u8OpCode == M2M_OTA_RESP_HOST_FILE_ERASE)
+    {
+        tstrOtaHostFileEraseStatusResp strOtaHostFileEraseStatusResp = {0};
+        s8Ret = hif_receive(u32Addr, (uint8*)&strOtaHostFileEraseStatusResp, sizeof(tstrOtaHostFileEraseStatusResp), 1);
+        if(M2M_SUCCESS == s8Ret)
+        {
+            if(gpfHFDEraseCb)
+            {
+                gpfHFDEraseCb(strOtaHostFileEraseStatusResp.u8OtaFileEraseStatus);
+                gpfHFDEraseCb = NULL;
+            }
+        }
+    }
 	else
 	{
-		M2M_ERR("Invaild OTA resp %d ?\n",u8OpCode);
+		M2M_ERR("Invalid OTA resp %d ?\n",u8OpCode);
 	}
-
 }
 /*!
-@fn	\
-	NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNotifCb);
-
-@brief
-	Initialize the OTA layer.
-
-@param [in]	pfOtaUpdateCb
-				OTA Update callback function
-
-@param [in]	pfOtaNotifCb
-				OTA notify callback function
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNotifCb)
+@brief      Initialize the OTA layer.
+@param[in]  pfOtaUpdateCb
+                OTA Update callback function.
+@param[in]  pfOtaNotifCb
+                OTA Notify callback function.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNotifCb)
 {
@@ -131,37 +175,32 @@ NMI_API sint8  m2m_ota_init(tpfOtaUpdateCb pfOtaUpdateCb, tpfOtaNotifCb pfOtaNot
 	if(pfOtaUpdateCb){
 		gpfOtaUpdateCb = pfOtaUpdateCb;
 	}else{
-		M2M_ERR("Invaild Ota update cb\n");
+		M2M_ERR("Invalid Ota update cb\n");
 	}
 	if(pfOtaNotifCb){
 		gpfOtaNotifCb = pfOtaNotifCb;
 	}else{
-		M2M_ERR("Invaild Ota notify cb\n");
+		M2M_ERR("Invalid Ota notify cb\n");
 	}
 
 	hif_register_cb(M2M_REQ_GROUP_OTA,m2m_ota_cb);
+	ret = hif_send(M2M_REQ_GROUP_OTA, M2M_OTA_REQ_HOST_FILE_STATUS, NULL, 0, NULL, 0, 0);
 
 	return ret;
 }
 /*!
-@fn	\
-	NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url);
-
-@brief
-	Set the OTA url
-
-@param [in]	u8Url
-			 The url server address
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url)
+@brief      Set the OTA url.
+@param[in]  u8Url
+                The url server address.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url)
 {
 	sint8 ret = M2M_SUCCESS;
 	uint16 u16UrlSize = m2m_strlen(u8Url) + 1;
-	/*Todo: we may change it to data pkt but we need to give it higer priority
-			but the priorty is not implemnted yet in data pkt
+	/*Todo: we may change it to data pkt but we need to give it higher priority
+			but the priority is not implemented yet in data pkt
 	*/
 	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_NOTIF_SET_URL,u8Url,u16UrlSize,NULL,0,0);
 	return ret;
@@ -169,14 +208,9 @@ NMI_API sint8  m2m_ota_notif_set_url(uint8 * u8Url)
 }
 
 /*!
-@fn	\
-	NMI_API sint8  m2m_ota_notif_check_for_update(void);
-
-@brief
-	check for ota update
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8  m2m_ota_notif_check_for_update(void)
+@brief      Check for OTA update.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8  m2m_ota_notif_check_for_update(void)
 {
@@ -186,17 +220,11 @@ NMI_API sint8  m2m_ota_notif_check_for_update(void)
 }
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period);
-
-@brief
-	Schedule OTA update
-
-@param [in]	u32Period
-	Period in days
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period)
+@brief      Schedule OTA update.
+@param[in]  u32Period
+                Period in days
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period)
 {
@@ -206,61 +234,27 @@ NMI_API sint8 m2m_ota_notif_sched(uint32 u32Period)
 }
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_start_update(uint8 * u8DownloadUrl);
-
-@brief
-	Request OTA start update using the downloaded url
-
-@param [in]	u8DownloadUrl
-		The download firmware url, you get it from device info
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
+@fn         NMI_API sint8 m2m_ota_start_update(unsigned char * pcDownloadUrl)
+@brief      Request OTA start update using the downloaded URL.
+@param[in]  pcDownloadUrl
+                The download firmware URL, you get it from device info.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
-NMI_API sint8 m2m_ota_start_update(uint8 * u8DownloadUrl)
+NMI_API sint8 m2m_ota_start_update(unsigned char * pcDownloadUrl)
 {
 	sint8 ret = M2M_SUCCESS;
-	uint16 u16DurlSize = m2m_strlen(u8DownloadUrl) + 1;
-	/*Todo: we may change it to data pkt but we need to give it higer priority
-			but the priorty is not implemnted yet in data pkt
+	uint16 u16DurlSize = m2m_strlen(pcDownloadUrl) + 1;
+	/*Todo: we may change it to data pkt but we need to give it higher priority
+			but the priority is not implemented yet in data pkt
 	*/
-	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_START_FW_UPDATE,u8DownloadUrl,u16DurlSize,NULL,0,0);
-	return ret;
-}
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_start_update_crt(uint8 * u8DownloadUrl);
-
-@brief
-	Request OTA start for the Cortus app image.
-
-@param [in]	u8DownloadUrl
-		The cortus application image url.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-
-*/
-NMI_API sint8 m2m_ota_start_update_crt(uint8 * u8DownloadUrl)
-{
-	sint8 ret = M2M_SUCCESS;
-	uint16 u16DurlSize = m2m_strlen(u8DownloadUrl) + 1;
-	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_START_CRT_UPDATE,u8DownloadUrl,u16DurlSize,NULL,0,0);
+	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_START_FW_UPDATE,pcDownloadUrl,u16DurlSize,NULL,0,0);
 	return ret;
 }
 
-
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_rollback(void);
-
-@brief
-	Request OTA Rollback image
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8 m2m_ota_rollback(void)
+@brief      Request OTA Rollback image.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_rollback(void)
 {
@@ -268,32 +262,11 @@ NMI_API sint8 m2m_ota_rollback(void)
 	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_ROLLBACK_FW,NULL,0,NULL,0,0);
 	return ret;
 }
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_rollback_crt(void);
-
-@brief
-	Request Cortus application OTA Rollback image
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_rollback_crt(void)
-{
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_ROLLBACK_CRT,NULL,0,NULL,0,0);
-	return ret;
-}
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_abort(void);
-
-@brief
-	Request OTA Abort
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8 m2m_ota_abort(void)
+@brief      Request OTA Abort.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_abort(void)
 {
@@ -302,16 +275,10 @@ NMI_API sint8 m2m_ota_abort(void)
 	return ret;
 }
 
-
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_switch_firmware(void);
-
-@brief
-	Switch to the upgraded Firmware
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8 m2m_ota_switch_firmware(void)
+@brief      Switch to the upgraded Firmware.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_switch_firmware(void)
 {
@@ -319,32 +286,11 @@ NMI_API sint8 m2m_ota_switch_firmware(void)
 	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_SWITCH_FIRMWARE,NULL,0,NULL,0,0);
 	return ret;
 }
-/*!
-@fn	\
-	NMI_API sint8 m2m_ota_switch_crt(void);
-
-@brief
-	Switch to the upgraded cortus application.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
-*/
-NMI_API sint8 m2m_ota_switch_crt(void)
-{
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_OTA,M2M_OTA_REQ_SWITCH_CRT_IMG,NULL,0,NULL,0,0);
-	return ret;
-}
 
 /*!
-@fn	\
-	NMI_API sint8 m2m_ota_get_firmware_version(tstrM2mRev * pstrRev);
-
-@brief
-	Get the OTA Firmware version.
-
-@return
-	The function SHALL return 0 for success and a negative value otherwise.
+@fn         NMI_API sint8 m2m_ota_get_firmware_version(tstrM2mRev * pstrRev)
+@brief      Get the OTA Firmware version.
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
 */
 NMI_API sint8 m2m_ota_get_firmware_version(tstrM2mRev * pstrRev)
 {
@@ -409,3 +355,164 @@ NMI_API sint8 m2m_ota_test(void)
 }
 #endif
 
+/*!
+@fn         NMI_API m2m_ota_host_file_get(unsigned char *pcDownloadUrl, tpfFileGetCb pfHFDGetCb)
+@brief      Download a file from a remote location and store it in the WINC's Flash.
+@param[in]  pcDownloadUrl
+                Url pointing to the remote file. HTTP/HTTPS only.
+
+@param[in]  pfHFDGetCb
+                Pointer to a callback to be executed when the download finishes.
+@return     Status of the get operation.
+@warning    Providing a callback is mandatory.
+*/
+NMI_API sint8 m2m_ota_host_file_get(unsigned char *pcDownloadUrl, tpfFileGetCb pfHFDGetCb)
+{
+    sint8 s8Ret = M2M_ERR_FAIL;
+    uint16 u16DUrlSize = m2m_strlen(pcDownloadUrl);
+
+    if((NULL == pfHFDGetCb) || (0 == u16DUrlSize))
+    {
+        M2M_ERR("Invalid parameters.\n");
+        goto EXIT;
+    }
+
+    if('\0' != pcDownloadUrl[u16DUrlSize])
+        pcDownloadUrl[u16DUrlSize] = '\0';
+    else
+        u16DUrlSize++;
+
+    M2M_INFO("GetHostFile - URL: %s, urlSize: %u\n", pcDownloadUrl, u16DUrlSize);
+
+    s8Ret = hif_send(M2M_REQ_GROUP_OTA, M2M_OTA_REQ_HOST_FILE_DOWNLOAD, pcDownloadUrl, u16DUrlSize, NULL, 0, 0);
+    if(s8Ret == M2M_SUCCESS)
+    {
+        gpfHFDGetCb = pfHFDGetCb;
+        gu8CurrFileHandlerID = HFD_INVALID_HANDLER;
+    }
+
+EXIT:
+    return s8Ret;
+}
+
+/*!
+@fn         NMI_API m2m_ota_host_file_read_hif(uint8 u8Handler, uint32 u32Offset, uint32 u32Size, tpfFileReadCb pfHFDReadCb)
+@brief      Read a certain amount of bytes from a file in WINC's Flash using HIF transfer.
+@param[in]  u8Handler
+                ID of the file we are trying to read from. Must be valid.
+
+@param[in]  u32Offset
+                Offset from start of the file to read from (in bytes).
+
+@param[in]  u32Size
+                The amount of data to read (in bytes).
+
+@param[in]  pfHFDReadCb
+                Callback to be executed when the read operation completes.
+@return     Status of the read operation.
+@warning    Providing a callback is mandatory.
+*/
+NMI_API sint8 m2m_ota_host_file_read_hif(uint8 u8Handler, uint32 u32Offset, uint32 u32Size, tpfFileReadCb pfHFDReadCb)
+{
+    sint8 s8Ret         = M2M_ERR_INVALID_ARG;
+    FileBlock.u32Offset = u32Offset;
+    FileBlock.u32Size   = u32Size;
+
+    if((u8Handler != gu8CurrFileHandlerID) || (HFD_INVALID_HANDLER == gu8CurrFileHandlerID) || (NULL == pfHFDReadCb)) goto EXIT; 
+    s8Ret = hif_send(M2M_REQ_GROUP_OTA, M2M_OTA_REQ_HOST_FILE_READ, (uint8 *) &FileBlock, sizeof(FileBlockDescriptor), NULL, 0, 0);
+
+    if(M2M_SUCCESS == s8Ret)
+        gpfHFDReadCb = pfHFDReadCb;
+EXIT:
+    return s8Ret;
+}
+
+/*!
+@fn         NMI_API m2m_ota_host_file_read_spi(uint8 u8Handler, uint8 *pu8Buff, uint32 u32Offset, uint32 u32Size)
+@brief      Read a certain amount of bytes from a file in WINC's Flash using SPI transfer.
+@param[in]  u8Handler
+                ID of the file we are trying to read from. Must be valid.
+
+@param[in]  pu8Buff
+                Pointer to a buffer to store the data being read. Must be valid.
+
+@param[in]  u32Offset
+                Offset from start of the file to read from (in bytes).
+
+@param[in]  u32Size
+                The amount of data to read (in Bytes).
+@return     Status of the read operation.
+@warning    Before using m2m_ota_host_file_read_spi, the WINC needs to be put in a special
+            mode to allow for a safe access to the Flash. This can be done by calling
+            @ref m2m_wifi_download_mode or @ref m2m_wifi_reinit_hold before trying to read.
+*/
+NMI_API sint8 m2m_ota_host_file_read_spi(uint8 u8Handler, uint8 *pu8Buff, uint32 u32Offset, uint32 u32Size)
+{
+    static uint32 u32FlashHFDStart = 0;
+    static uint32 u32FlashHFDSize  = 0;
+    sint8 s8Ret = M2M_ERR_INVALID_ARG;
+    if((u8Handler == HFD_INVALID_HANDLER) || (NULL == pu8Buff)) goto EXIT;
+
+    if(WIFI_STATE_INIT != m2m_wifi_get_state())
+    {
+        s8Ret = M2M_ERR_FAIL;
+        M2M_ERR("WINC is not in an appropriate state for this operation!\n");
+        goto EXIT;
+    }
+
+    if((u32FlashHFDStart == 0) || (u32FlashHFDSize == 0))
+    {
+        s8Ret = spi_flexible_flash_find_section(ENTRY_ID_HOSTFILE, &u32FlashHFDStart, &u32FlashHFDSize);
+        if(M2M_SUCCESS != s8Ret) goto EXIT;
+    }
+
+    s8Ret = spi_flash_read(pu8Buff, u32FlashHFDStart, 4);
+
+    if((M2M_SUCCESS != s8Ret) || (pu8Buff[0] != u8Handler)) goto EXIT;
+
+    if((u32Offset >= u32FlashHFDSize) ||
+            (u32Size   >  u32FlashHFDSize) ||
+            ((u32Offset + u32Size) >= u32FlashHFDSize))
+    {
+        s8Ret = M2M_ERR_FAIL;
+        goto EXIT;
+    }
+
+    s8Ret = spi_flash_read(pu8Buff, u32FlashHFDStart + FLASH_SECTOR_SZ + u32Offset, u32Size);
+
+    if(M2M_SUCCESS != s8Ret)
+        M2M_ERR("Unable to read SPI Flash\n");
+
+EXIT:
+    return s8Ret;
+}
+
+/*!
+@fn         NMI_API m2m_ota_host_file_erase(uint8 u8Handler, tpfFileEraseCb pfHFDEraseCb)
+@brief      Erase any traces of an existing file, this means from host driver and WINC firmware.
+@param[in]  u8Handler
+                ID of the file we are trying to erase. Must be valid.
+@param[in]  pfHFDEraseCb
+                Pointer to callback to execute when the file erase in the WINC completes.
+@return     Status of the erase operation.
+@note       Providing a callback is optional.
+            If the current handler is invalid at this point, it means one of the three:
+                1. The file never existed;
+                2. The file has already been already deleted;
+                3. The request to get the file hasn't fully completed.
+            For 1. and 2. there is no need to signal the WINC to erase the file in Flash.
+            For 3. the Flash can't be erased while a file download is ongoing.
+*/
+NMI_API sint8 m2m_ota_host_file_erase(uint8 u8Handler, tpfFileEraseCb pfHFDEraseCb)
+{
+    sint8 s8Ret = M2M_ERR_INVALID;
+    if((u8Handler != gu8CurrFileHandlerID) || (HFD_INVALID_HANDLER == gu8CurrFileHandlerID)) goto EXIT;
+
+    gu8CurrFileHandlerID = HFD_INVALID_HANDLER;
+    gpfHFDReadCb  = NULL;
+    gpfHFDEraseCb = pfHFDEraseCb;
+
+    s8Ret = hif_send(M2M_REQ_GROUP_OTA, M2M_OTA_REQ_HOST_FILE_ERASE, NULL, 0, NULL, 0, 0);
+EXIT:
+    return s8Ret;
+}

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_periph.c
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_periph.c
@@ -4,36 +4,29 @@
  *
  * \brief NMC1500 Peripherials Application Interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -63,99 +56,52 @@ DATA TYPES
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 STATIC FUNCTIONS
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
-static sint8 get_gpio_idx(uint8 u8GpioNum)
-{
-	if(u8GpioNum >= M2M_PERIPH_GPIO_MAX) return -1;
-	if(u8GpioNum == M2M_PERIPH_GPIO15) { return 15;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO16) { return 16;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO18) { return 18;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO3) { return 3;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO4) { return 4;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO5) { return 5;
-	} else if(u8GpioNum == M2M_PERIPH_GPIO6) { return 6;
-	} else {
-		return -2;
-	}
-}
 /*
  * GPIO read/write skeleton with wakeup/sleep capability.
  */
 static sint8 gpio_ioctl(uint8 op, uint8 u8GpioNum, uint8 u8InVal, uint8 * pu8OutVal)
 {
-	sint8 ret, gpio;
+    sint8 s8Ret = hif_chip_wake();
+    if(s8Ret != M2M_SUCCESS) goto _EXIT;
 
-	ret = hif_chip_wake();
-	if(ret != M2M_SUCCESS) goto _EXIT;
+    if(u8GpioNum >= M2M_PERIPH_GPIO_MAX) goto _EXIT1;
 
-	gpio = get_gpio_idx(u8GpioNum);
-	if(gpio < 0) goto _EXIT1;
-
-	if(op == GPIO_OP_DIR) {
-		ret = set_gpio_dir((uint8)gpio, u8InVal);
-	} else if(op == GPIO_OP_SET) {
-		ret = set_gpio_val((uint8)gpio, u8InVal);
-	} else if(op == GPIO_OP_GET) {
-		ret = get_gpio_val((uint8)gpio, pu8OutVal);
-	}
-	if(ret != M2M_SUCCESS) goto _EXIT1;
+    if(op == GPIO_OP_DIR) {
+        s8Ret = set_gpio_dir(u8GpioNum, u8InVal);
+    } else if(op == GPIO_OP_SET) {
+        s8Ret = set_gpio_val(u8GpioNum, u8InVal);
+    } else if(op == GPIO_OP_GET) {
+        s8Ret = get_gpio_val(u8GpioNum, pu8OutVal);
+    }
 
 _EXIT1:
-	ret = hif_chip_sleep();
+    s8Ret = hif_chip_sleep();
+
 _EXIT:
-	return ret;
+    return s8Ret;
 }
+
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 FUNCTION IMPLEMENTATION
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 
-
-sint8 m2m_periph_init(tstrPerphInitParam * param)
-{
-	return M2M_SUCCESS;
-}
-
 sint8 m2m_periph_gpio_set_dir(uint8 u8GpioNum, uint8 u8GpioDir)
 {
-	return gpio_ioctl(GPIO_OP_DIR, u8GpioNum, u8GpioDir, NULL);
+    return gpio_ioctl(GPIO_OP_DIR, u8GpioNum, u8GpioDir, NULL);
 }
 
 sint8 m2m_periph_gpio_set_val(uint8 u8GpioNum, uint8 u8GpioVal)
 {
-	return gpio_ioctl(GPIO_OP_SET, u8GpioNum, u8GpioVal, NULL);
+    return gpio_ioctl(GPIO_OP_SET, u8GpioNum, u8GpioVal, NULL);
 }
 
 sint8 m2m_periph_gpio_get_val(uint8 u8GpioNum, uint8 * pu8GpioVal)
 {
-	return gpio_ioctl(GPIO_OP_GET, u8GpioNum, 0, pu8GpioVal);
+    return gpio_ioctl(GPIO_OP_GET, u8GpioNum, 0, pu8GpioVal);
 }
-
-sint8 m2m_periph_gpio_pullup_ctrl(uint8 u8GpioNum, uint8 u8PullupEn)
-{
-	/* TBD */
-	return M2M_SUCCESS;
-}
-
-sint8 m2m_periph_i2c_master_init(tstrI2cMasterInitParam * param)
-{
-	/* TBD */
-	return M2M_SUCCESS;
-}
-
-sint8 m2m_periph_i2c_master_write(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint8 flags)
-{
-	/* TBD */
-	return M2M_SUCCESS;
-}
-
-sint8 m2m_periph_i2c_master_read(uint8 u8SlaveAddr, uint8 * pu8Buf, uint16 u16BufLen, uint16 * pu16ReadLen, uint8 flags)
-{
-	/* TBD */
-	return M2M_SUCCESS;
-}
-
 
 sint8 m2m_periph_pullup_ctrl(uint32 pinmask, uint8 enable)
 {
-	return pullup_ctrl(pinmask, enable);
+    return pullup_ctrl(pinmask, enable);
 }
 #endif /* CONF_PERIPH */

--- a/asf/common/components/wifi/winc1500/driver/source/m2m_wifi.c
+++ b/asf/common/components/wifi/winc1500/driver/source/m2m_wifi.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains M2M Wi-Fi APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -42,17 +35,44 @@
 #include "driver/include/m2m_wifi.h"
 #include "driver/source/m2m_hif.h"
 #include "driver/source/nmasic.h"
+#include <string.h>
+#include <stdbool.h>
+#include <stdlib.h>
 
 /**
  * \defgroup winc1500_group WINC1500 (Wi-Fi)
  *
  * \{
  */
+ 
+/* Require authentication of server. */
+#define WIFI_1X_TLS_HS_FLAGS_PEER_AUTH          NBIT1
+/* Enable expiry checking of server certificate chain. */
+#define WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK NBIT2
+/* Require local system time to be known (i.e. fail expiry checking if time is not known locally). */
+#define WIFI_1X_TLS_HS_FLAGS_REQUIRE_TIME       NBIT3
+/* Enable TLS session caching. */
+#define WIFI_1X_TLS_HS_FLAGS_SESSION_CACHING    NBIT4
+/* Reserved, this bit must be clear. */
+#define WIFI_1X_TLS_HS_FLAGS_RSV5               NBIT5
+/* Require server authentication to be against a specified root certificate. */
+#define WIFI_1X_TLS_HS_FLAGS_SPECIFY_ROOTCERT   NBIT6
+/* Reserved, this bit must be clear. */
+#define WIFI_1X_TLS_HS_FLAGS_RSV7               NBIT7
+
+#define WIFI_1X_TLS_HS_FLAGS_DEFAULT    (           \
+            WIFI_1X_TLS_HS_FLAGS_PEER_AUTH          \
+        |   WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK \
+        |   WIFI_1X_TLS_HS_FLAGS_SESSION_CACHING    \
+)
 
 static volatile uint8 gu8ChNum;
+static volatile uint8 gu8WifiState      = WIFI_STATE_DEINIT;
+static tpfAppWifiCb gpfAppWifiCb        = NULL;
 static volatile uint8 gu8scanInProgress = 0;
-static tpfAppWifiCb gpfAppWifiCb = NULL;
 
+static uint32   gu321xTlsHsFlags      = WIFI_1X_TLS_HS_FLAGS_DEFAULT;
+static uint8    gau81xRootSha1[20]    = {0};
 
 #ifdef ETH_MODE
 static tpfAppEthCb  gpfAppEthCb  = NULL;
@@ -60,32 +80,17 @@ static uint8* 	        gau8ethRcvBuf=NULL;
 static uint16 	        gu16ethRcvBufSize ;
 #endif
 
-
-//#define CONF_MGMT
-#ifdef CONF_MGMT
-static tpfAppMonCb  gpfAppMonCb  = NULL;
-static struct _tstrMgmtCtrl
-{
-	uint8* pu8Buf;
-	uint16 u16Offset;
-	uint16 u16Sz;
-}
-gstrMgmtCtrl = {NULL, 0 , 0};
-#endif
 /**
-*	@fn			m2m_wifi_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr, uint8 grp)
-*	@brief		WiFi call back function
-*	@param [in]	u8OpCode
-*					HIF Opcode type.
-*	@param [in]	u16DataSize
-*					HIF data length.
-*	@param [in]	u32Addr
-*					HIF address.
-*	@param [in]	grp
-*					HIF group type.
-*	@author
-*	@date
-*	@version	1.0
+@fn         void m2m_wifi_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr, uint8 grp)
+@brief      Internal WiFi callback function.
+@param[in]  u8OpCode
+                HIF Opcode type.
+@param[in]  u16DataSize
+                HIF data length.
+@param[in]  u32Addr
+                HIF address.
+@param[in]  grp
+                HIF group type.
 */
 static void m2m_wifi_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
 {
@@ -120,1307 +125,1916 @@ static void m2m_wifi_cb(uint8 u8OpCode, uint16 u16DataSize, uint32 u32Addr)
 	else if (u8OpCode == M2M_WIFI_RESP_MEMORY_RECOVER)
 	{
 #if 0
-		if (hif_receive(u32Addr, rx_buf, 4, 1) == M2M_SUCCESS)
-		{
-			tstrM2mWifiStateChanged strState;
-			m2m_memcpy((uint8*) &strState, rx_buf,sizeof(tstrM2mWifiStateChanged));
-			if (app_wifi_recover_cb)
-				app_wifi_recover_cb(strState.u8CurrState);
-		}
+        if(hif_receive(u32Addr, rx_buf, 4, 1) == M2M_SUCCESS)
+        {
+            tstrM2mWifiStateChanged strState;
+            m2m_memcpy((uint8 *) &strState, rx_buf, sizeof(tstrM2mWifiStateChanged));
+            if(app_wifi_recover_cb)
+                app_wifi_recover_cb(strState.u8CurrState);
+        }
 #endif
-	}
-	else if (u8OpCode == M2M_WIFI_REQ_DHCP_CONF)
-	{
-		tstrM2MIPConfig strIpConfig;
-		if (hif_receive(u32Addr, (uint8 *)&strIpConfig, sizeof(tstrM2MIPConfig), 0) == M2M_SUCCESS)
-		{
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_REQ_DHCP_CONF, (uint8 *)&strIpConfig);
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_REQ_WPS)
-	{
-		tstrM2MWPSInfo strWps;
-		m2m_memset((uint8*)&strWps,0,sizeof(tstrM2MWPSInfo));
-		if(hif_receive(u32Addr, (uint8*)&strWps, sizeof(tstrM2MWPSInfo), 0) == M2M_SUCCESS)
-		{
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_REQ_WPS, &strWps);
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_RESP_IP_CONFLICT)
-	{
-		uint32  u32ConflictedIP;
-		if(hif_receive(u32Addr, (uint8 *)&u32ConflictedIP, sizeof(u32ConflictedIP), 0) == M2M_SUCCESS)
-		{
-			M2M_INFO("Conflicted IP \" %u.%u.%u.%u \" \n", 
-				BYTE_0(u32ConflictedIP),BYTE_1(u32ConflictedIP),BYTE_2(u32ConflictedIP),BYTE_3(u32ConflictedIP));
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_IP_CONFLICT, NULL);
-
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_RESP_SCAN_DONE)
-	{
-		tstrM2mScanDone strState;
-		gu8scanInProgress = 0;
-		if(hif_receive(u32Addr, (uint8*)&strState, sizeof(tstrM2mScanDone), 0) == M2M_SUCCESS)
-		{
-			gu8ChNum = strState.u8NumofCh;
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_SCAN_DONE, &strState);
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_RESP_SCAN_RESULT)
-	{
-		tstrM2mWifiscanResult strScanResult;
-		if(hif_receive(u32Addr, (uint8*)&strScanResult, sizeof(tstrM2mWifiscanResult), 0) == M2M_SUCCESS)
-		{
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_SCAN_RESULT, &strScanResult);
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_RESP_CURRENT_RSSI)
-	{
-		if (hif_receive(u32Addr, rx_buf, 4, 0) == M2M_SUCCESS)
-		{
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_CURRENT_RSSI, rx_buf);
-		}
-	}
-	else if (u8OpCode == M2M_WIFI_RESP_CLIENT_INFO)
-	{
-		if (hif_receive(u32Addr, rx_buf, 4, 0) == M2M_SUCCESS)
-		{
-			if (gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_CLIENT_INFO, rx_buf);
-		}
-	}
-	else if(u8OpCode == M2M_WIFI_RESP_PROVISION_INFO)
-	{
-		tstrM2MProvisionInfo	strProvInfo;
-		if(hif_receive(u32Addr, (uint8*)&strProvInfo, sizeof(tstrM2MProvisionInfo), 1) == M2M_SUCCESS)
-		{
-			if(gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_PROVISION_INFO, &strProvInfo);
-		}
-	}
-	else if(u8OpCode == M2M_WIFI_RESP_DEFAULT_CONNECT)
-	{
-		tstrM2MDefaultConnResp	strResp;
-		if(hif_receive(u32Addr, (uint8*)&strResp, sizeof(tstrM2MDefaultConnResp), 1) == M2M_SUCCESS)
-		{
-			if(gpfAppWifiCb)
-				gpfAppWifiCb(M2M_WIFI_RESP_DEFAULT_CONNECT, &strResp);
-		}
-	}
-	
-	else if(u8OpCode == M2M_WIFI_RESP_GET_PRNG)
-	{
-		tstrPrng strPrng;
-		if(hif_receive(u32Addr, (uint8*)&strPrng,sizeof(tstrPrng), 0) == M2M_SUCCESS)
-		{
-			if(hif_receive(u32Addr + sizeof(tstrPrng),strPrng.pu8RngBuff,strPrng.u16PrngSize, 1) == M2M_SUCCESS)
-			{
-				if(gpfAppWifiCb)
-					gpfAppWifiCb(M2M_WIFI_RESP_GET_PRNG,&strPrng);
-			}
-		}
-	}
+    }
+    else if(u8OpCode == M2M_WIFI_REQ_DHCP_CONF)
+    {
+        tstrM2MIPConfig strIpConfig;
+        if(hif_receive(u32Addr, (uint8 *)&strIpConfig, sizeof(tstrM2MIPConfig), 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_REQ_DHCP_CONF, (uint8 *)&strIpConfig);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_REQ_DHCP_FAILURE)
+    {
+        if(hif_receive(u32Addr, NULL, 0, 1) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_REQ_DHCP_FAILURE, NULL);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_REQ_WPS)
+    {
+        tstrM2MWPSInfo strWps;
+        m2m_memset((uint8 *)&strWps, 0, sizeof(tstrM2MWPSInfo));
+        if(hif_receive(u32Addr, (uint8 *)&strWps, sizeof(tstrM2MWPSInfo), 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_REQ_WPS, &strWps);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_IP_CONFLICT)
+    {
+        uint32  u32ConflictedIP;
+        if(hif_receive(u32Addr, (uint8 *)&u32ConflictedIP, sizeof(u32ConflictedIP), 0) == M2M_SUCCESS)
+        {
+            M2M_INFO("Conflicted IP \" %u.%u.%u.%u \" \n",
+                     BYTE_0(u32ConflictedIP), BYTE_1(u32ConflictedIP), BYTE_2(u32ConflictedIP), BYTE_3(u32ConflictedIP));
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_IP_CONFLICT, NULL);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_SCAN_DONE)
+    {
+        tstrM2mScanDone strState;
+        gu8scanInProgress = 0;
+        if(hif_receive(u32Addr, (uint8 *)&strState, sizeof(tstrM2mScanDone), 0) == M2M_SUCCESS)
+        {
+            gu8ChNum = strState.u8NumofCh;
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_SCAN_DONE, &strState);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_SCAN_RESULT)
+    {
+        tstrM2mWifiscanResult strScanResult;
+        if(hif_receive(u32Addr, (uint8 *)&strScanResult, sizeof(tstrM2mWifiscanResult), 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_SCAN_RESULT, &strScanResult);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_CURRENT_RSSI)
+    {
+        if(hif_receive(u32Addr, rx_buf, 4, 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_CURRENT_RSSI, rx_buf);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_CLIENT_INFO)
+    {
+        if(hif_receive(u32Addr, rx_buf, 4, 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_CLIENT_INFO, rx_buf);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_PROVISION_INFO)
+    {
+        tstrM2MProvisionInfo    strProvInfo;
+        if(hif_receive(u32Addr, (uint8 *)&strProvInfo, sizeof(tstrM2MProvisionInfo), 1) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_PROVISION_INFO, &strProvInfo);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_DEFAULT_CONNECT)
+    {
+        tstrM2MDefaultConnResp  strResp;
+        if(hif_receive(u32Addr, (uint8 *)&strResp, sizeof(tstrM2MDefaultConnResp), 1) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_RESP_DEFAULT_CONNECT, &strResp);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_REQRSP_DELETE_APID)
+    {
+        tstrM2MGenericResp strResp;
+        if(hif_receive(u32Addr, (uint8 *)&strResp, sizeof(tstrM2MGenericResp), 0) == M2M_SUCCESS)
+        {
+            if(gpfAppWifiCb)
+                gpfAppWifiCb(M2M_WIFI_REQRSP_DELETE_APID, &strResp);
+        }
+    }
+    else if(u8OpCode == M2M_WIFI_RESP_GET_PRNG)
+    {
+        tstrPrng strPrng;
+        if(hif_receive(u32Addr, (uint8 *)&strPrng, sizeof(tstrPrng), 0) == M2M_SUCCESS)
+        {
+            if(hif_receive(u32Addr + sizeof(tstrPrng), strPrng.pu8RngBuff, strPrng.u16PrngSize, 1) == M2M_SUCCESS)
+            {
+                if(gpfAppWifiCb)
+                    gpfAppWifiCb(M2M_WIFI_RESP_GET_PRNG, &strPrng);
+            }
+        }
+    }
 #ifdef ETH_MODE
-	else if(u8OpCode == M2M_WIFI_RESP_ETHERNET_RX_PACKET)
-		{
-			uint8 u8SetRxDone;
-			tstrM2mIpRsvdPkt strM2mRsvd;
-			if(hif_receive(u32Addr, &strM2mRsvd ,sizeof(tstrM2mIpRsvdPkt), 0) == M2M_SUCCESS)
-			{
-				tstrM2mIpCtrlBuf  strM2mIpCtrlBuf;
-				uint16 u16Offset = strM2mRsvd.u16PktOffset;
-				strM2mIpCtrlBuf.u16RemainigDataSize = strM2mRsvd.u16PktSz;
-				if((gpfAppEthCb) && (gau8ethRcvBuf) && (gu16ethRcvBufSize > 0))
-				{
-					do
-					{
-						u8SetRxDone = 1;
-						if(strM2mIpCtrlBuf.u16RemainigDataSize > gu16ethRcvBufSize)
-						{
-							u8SetRxDone = 0;
-							strM2mIpCtrlBuf.u16DataSize = gu16ethRcvBufSize;
-						}
-						else
-						{
-							strM2mIpCtrlBuf.u16DataSize = strM2mIpCtrlBuf.u16RemainigDataSize;
-						}
+    else if(u8OpCode == M2M_WIFI_RESP_ETHERNET_RX_PACKET)
+    {
+        uint8 u8SetRxDone;
+        tstrM2mIpRsvdPkt strM2mRsvd;
+        if(hif_receive(u32Addr, (uint8 *)&strM2mRsvd, sizeof(tstrM2mIpRsvdPkt), 0) == M2M_SUCCESS)
+        {
+            tstrM2mIpCtrlBuf  strM2mIpCtrlBuf;
+            uint16 u16Offset = strM2mRsvd.u16PktOffset;
+            strM2mIpCtrlBuf.u16RemainingDataSize = strM2mRsvd.u16PktSz;
+            if((gpfAppEthCb) && (gau8ethRcvBuf) && (gu16ethRcvBufSize > 0))
+            {
+                do
+                {
+                    u8SetRxDone = 1;
+                    if(strM2mIpCtrlBuf.u16RemainingDataSize > gu16ethRcvBufSize)
+                    {
+                        u8SetRxDone = 0;
+                        strM2mIpCtrlBuf.u16DataSize = gu16ethRcvBufSize;
+                    }
+                    else
+                    {
+                        strM2mIpCtrlBuf.u16DataSize = strM2mIpCtrlBuf.u16RemainingDataSize;
+                    }
 
-						if(hif_receive(u32Addr + u16Offset, gau8ethRcvBuf, strM2mIpCtrlBuf.u16DataSize, u8SetRxDone) == M2M_SUCCESS)
-						{
-							strM2mIpCtrlBuf.u16RemainigDataSize -= strM2mIpCtrlBuf.u16DataSize;							
-							u16Offset += strM2mIpCtrlBuf.u16DataSize;
-							gpfAppEthCb(M2M_WIFI_RESP_ETHERNET_RX_PACKET, gau8ethRcvBuf, &(strM2mIpCtrlBuf));
-						}
-						else
-						{
-							break;
-						}
-					}while (strM2mIpCtrlBuf.u16RemainigDataSize > 0);
-				}
-			}
-		}
-#endif	/* ETH_MODE */
-#ifdef CONF_MGMT
-	else if(u8OpCode == M2M_WIFI_RESP_WIFI_RX_PACKET)
-	{
-		
-		tstrM2MWifiRxPacketInfo		strRxPacketInfo;
-		if(u16DataSize >= sizeof(tstrM2MWifiRxPacketInfo)) {
-			if(hif_receive(u32Addr, (uint8*)&strRxPacketInfo, sizeof(tstrM2MWifiRxPacketInfo), 0) == M2M_SUCCESS)
-			{
-				u16DataSize -= sizeof(tstrM2MWifiRxPacketInfo);
-				if(u16DataSize > 0 && gstrMgmtCtrl.pu8Buf != NULL)
-				{
-					if(u16DataSize > (gstrMgmtCtrl.u16Sz + gstrMgmtCtrl.u16Offset))
-					{
-						u16DataSize = gstrMgmtCtrl.u16Sz;
-					}
-					u32Addr += sizeof(tstrM2MWifiRxPacketInfo) + gstrMgmtCtrl.u16Offset;
-					if(hif_receive(u32Addr , gstrMgmtCtrl.pu8Buf, u16DataSize, 1) != M2M_SUCCESS) return;
-				}
-				if(gpfAppMonCb)
-					gpfAppMonCb(&strRxPacketInfo, gstrMgmtCtrl.pu8Buf,u16DataSize);
-			}
-		} else {
-			M2M_ERR("Incorrect mon data size %u\n", u16DataSize);
-		}
-	}
-#endif
-	else
-	{
-		M2M_ERR("REQ Not defined %d\n",u8OpCode);
-	}
+                    if(hif_receive(u32Addr + u16Offset, gau8ethRcvBuf, strM2mIpCtrlBuf.u16DataSize, u8SetRxDone) == M2M_SUCCESS)
+                    {
+                        strM2mIpCtrlBuf.u16RemainingDataSize -= strM2mIpCtrlBuf.u16DataSize;
+                        u16Offset += strM2mIpCtrlBuf.u16DataSize;
+                        gpfAppEthCb(M2M_WIFI_RESP_ETHERNET_RX_PACKET, gau8ethRcvBuf, &(strM2mIpCtrlBuf));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                } while(strM2mIpCtrlBuf.u16RemainingDataSize > 0);
+            }
+        }
+    }
+#endif  /* ETH_MODE */
+    else
+    {
+        M2M_ERR("REQ Not defined %d\n", u8OpCode);
+    }
 }
 
 sint8 m2m_wifi_download_mode()
 {
-	sint8 ret = M2M_SUCCESS;
-	/* Apply device specific initialization. */
-	ret = nm_drv_init_download_mode();
-	if(ret != M2M_SUCCESS) 	goto _EXIT0;
+    sint8 ret = M2M_SUCCESS;
+    /* Apply device specific initialization. */
+    ret = nm_drv_init_download_mode();
+    if(ret != M2M_SUCCESS)  goto _EXIT0;
 
-
-
-	enable_interrupts();
+    enable_interrupts();
+    gu8WifiState = WIFI_STATE_INIT;
 
 _EXIT0:
-	return ret;
+    return ret;
 }
 
-static sint8 m2m_validate_ap_parameters(CONST tstrM2MAPConfig* pstrM2MAPConfig)
+static sint8 m2m_validate_ap_parameters(CONST tstrM2MAPModeConfig *pstrM2MAPModeConfig)
 {
-	sint8 s8Ret = M2M_SUCCESS;
-	/* Check for incoming pointer */
-	if(pstrM2MAPConfig == NULL)
-	{
-		M2M_ERR("INVALID POINTER\n");
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
-	/* Check for SSID */
-	if((m2m_strlen((uint8 *)pstrM2MAPConfig->au8SSID) <= 0) || (m2m_strlen((uint8 *)pstrM2MAPConfig->au8SSID) >= M2M_MAX_SSID_LEN))
-	{
-		M2M_ERR("INVALID SSID\n");
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
-	/* Check for Channel */
-	if(pstrM2MAPConfig->u8ListenChannel > M2M_WIFI_CH_14 || pstrM2MAPConfig->u8ListenChannel < M2M_WIFI_CH_1)
-	{
-		M2M_ERR("INVALID CH\n");
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
-	/* Check for DHCP Server IP address */
-	if(!(pstrM2MAPConfig->au8DHCPServerIP[0] || pstrM2MAPConfig->au8DHCPServerIP[1]))
-	{
-		if(!(pstrM2MAPConfig->au8DHCPServerIP[2]))
-		{
-			M2M_ERR("INVALID DHCP SERVER IP\n");
-			s8Ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-	}
-	/* Check for Security */
-	if(pstrM2MAPConfig->u8SecType == M2M_WIFI_SEC_OPEN)
-	{
-		goto ERR1;
-	}
-	else if(pstrM2MAPConfig->u8SecType == M2M_WIFI_SEC_WEP)
-	{
-		/* Check for WEP Key index */
-		if((pstrM2MAPConfig->u8KeyIndx <= 0) || (pstrM2MAPConfig->u8KeyIndx > WEP_KEY_MAX_INDEX))
-		{
-			M2M_ERR("INVALID KEY INDEX\n");
-			s8Ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-		/* Check for WEP Key size */
-		if(	(pstrM2MAPConfig->u8KeySz != WEP_40_KEY_STRING_SIZE) &&
-			(pstrM2MAPConfig->u8KeySz != WEP_104_KEY_STRING_SIZE)
-		)
-		{
-			M2M_ERR("INVALID KEY STRING SIZE\n");
-			s8Ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
+    sint8 s8Ret = M2M_SUCCESS;
+    /* Check for incoming pointer */
+    if(pstrM2MAPModeConfig == NULL)
+    {
+        M2M_ERR("INVALID POINTER\n");
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR1;
+    }
+    /* Check for SSID */
+    if((m2m_strlen((uint8 *)pstrM2MAPModeConfig->strApConfig.au8SSID) <= 0) || (m2m_strlen((uint8 *)pstrM2MAPModeConfig->strApConfig.au8SSID) >= M2M_MAX_SSID_LEN))
+    {
+        M2M_ERR("INVALID SSID\n");
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR1;
+    }
+    /* Check for Channel */
+    if(pstrM2MAPModeConfig->strApConfig.u8ListenChannel > M2M_WIFI_CH_14 || pstrM2MAPModeConfig->strApConfig.u8ListenChannel < M2M_WIFI_CH_1)
+    {
+        M2M_ERR("INVALID CH\n");
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR1;
+    }
+    /* Check for DHCP Server IP address */
+    if(!(pstrM2MAPModeConfig->strApConfig.au8DHCPServerIP[0] || pstrM2MAPModeConfig->strApConfig.au8DHCPServerIP[1]))
+    {
+        if(!(pstrM2MAPModeConfig->strApConfig.au8DHCPServerIP[2]))
+        {
+            M2M_ERR("INVALID DHCP SERVER IP\n");
+            s8Ret = M2M_ERR_FAIL;
+            goto ERR1;
+        }
+    }
+    /* Check for Security */
+    if(pstrM2MAPModeConfig->strApConfig.u8SecType == M2M_WIFI_SEC_OPEN)
+    {
+        goto ERR1;
+    }
+    else if(pstrM2MAPModeConfig->strApConfig.u8SecType == M2M_WIFI_SEC_WEP)
+    {
+        /* As of 19.7.5 the WEP protocol is deprecated */
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR1;
+    }
+    else if(pstrM2MAPModeConfig->strApConfig.u8SecType == M2M_WIFI_SEC_WPA_PSK)
+    {
+        /* Check for WPA Key size */
+        if(((pstrM2MAPModeConfig->strApConfig.u8KeySz + 1) < M2M_MIN_PSK_LEN) || ((pstrM2MAPModeConfig->strApConfig.u8KeySz + 1) > M2M_MAX_PSK_LEN))
+        {
+            M2M_ERR("INVALID WPA KEY SIZE\n");
+            s8Ret = M2M_ERR_FAIL;
+            goto ERR1;
+        }
+    }
+    else
+    {
+        M2M_ERR("INVALID AUTHENTICATION MODE\n");
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR1;
+    }
 
-		if((m2m_strlen((uint8 *)pstrM2MAPConfig->au8WepKey) <= 0) || (m2m_strlen((uint8 *)pstrM2MAPConfig->au8WepKey) > WEP_104_KEY_STRING_SIZE))
-		{
-			M2M_ERR("INVALID KEY SIZE\n");
-			s8Ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-	}
-	else if(pstrM2MAPConfig->u8SecType == M2M_WIFI_SEC_WPA_PSK)
-	{
-		/* Check for WPA Key size */
-		if(	((pstrM2MAPConfig->u8KeySz + 1) < M2M_MIN_PSK_LEN) || ((pstrM2MAPConfig->u8KeySz + 1) > M2M_MAX_PSK_LEN))
-		{
-			M2M_ERR("INVALID WPA KEY SIZE\n");
-			s8Ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-	}
-	else
-	{
-		M2M_ERR("INVALID AUTHENTICATION MODE\n");
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
-	
 ERR1:
-	return s8Ret;
+    return s8Ret;
 }
-static sint8 m2m_validate_scan_options(tstrM2MScanOption* ptstrM2MScanOption)
+
+static sint8 m2m_validate_scan_options(tstrM2MScanOption *ptstrM2MScanOption)
 {
-	sint8 s8Ret = M2M_SUCCESS;
-	/* Check for incoming pointer */
-	if(ptstrM2MScanOption == NULL)
-	{
-		M2M_ERR("INVALID POINTER\n");
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR;
-	}	
-	/* Check for valid No of slots */
-	if(ptstrM2MScanOption->u8NumOfSlot == 0)
-	{
-		M2M_ERR("INVALID No of scan slots! %d\n",ptstrM2MScanOption->u8NumOfSlot);
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR;
-	}	
-	/* Check for valid time of slots */
-	if(ptstrM2MScanOption->u8SlotTime < 10 || ptstrM2MScanOption->u8SlotTime > 250)
-	{
-		M2M_ERR("INVALID scan slot time! %d\n",ptstrM2MScanOption->u8SlotTime);
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR;
-	}	
-	/* Check for valid No of probe requests per slot */
-	if((ptstrM2MScanOption->u8ProbesPerSlot == 0)||(ptstrM2MScanOption->u8ProbesPerSlot > M2M_SCAN_DEFAULT_NUM_PROBE))
-	{
-		M2M_ERR("INVALID No of probe requests per scan slot %d\n",ptstrM2MScanOption->u8ProbesPerSlot);
-		s8Ret = M2M_ERR_FAIL;
-		goto ERR;
-	}	
-	/* Check for valid RSSI threshold */
-	if((ptstrM2MScanOption->s8RssiThresh  < -99) || (ptstrM2MScanOption->s8RssiThresh >= 0))
-	{
-		M2M_ERR("INVALID RSSI threshold %d \n",ptstrM2MScanOption->s8RssiThresh);
-		s8Ret = M2M_ERR_FAIL;
-	}
+    sint8 s8Ret = M2M_SUCCESS;
+    /* Check for incoming pointer */
+    if(ptstrM2MScanOption == NULL)
+    {
+        M2M_ERR("INVALID POINTER\n");
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR;
+    }
+    /* Check for valid No of slots */
+    if(ptstrM2MScanOption->u8NumOfSlot == 0)
+    {
+        M2M_ERR("INVALID No of scan slots! %d\n", ptstrM2MScanOption->u8NumOfSlot);
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR;
+    }
+    /* Check for valid time of slots */
+    if(ptstrM2MScanOption->u8SlotTime < 10 || ptstrM2MScanOption->u8SlotTime > 250)
+    {
+        M2M_ERR("INVALID scan slot time! %d\n", ptstrM2MScanOption->u8SlotTime);
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR;
+    }
+    /* Check for valid No of probe requests per slot */
+    if((ptstrM2MScanOption->u8ProbesPerSlot == 0) || (ptstrM2MScanOption->u8ProbesPerSlot > M2M_SCAN_DEFAULT_NUM_PROBE))
+    {
+        M2M_ERR("INVALID No of probe requests per scan slot %d\n", ptstrM2MScanOption->u8ProbesPerSlot);
+        s8Ret = M2M_ERR_FAIL;
+        goto ERR;
+    }
+    /* Check for valid RSSI threshold */
+    if(ptstrM2MScanOption->s8RssiThresh >= 0)
+    {
+        M2M_ERR("INVALID RSSI threshold %d \n", ptstrM2MScanOption->s8RssiThresh);
+        s8Ret = M2M_ERR_FAIL;
+    }
 
 ERR:
-	return s8Ret;
+    return s8Ret;
 }
 
-sint8 m2m_wifi_send_crl(tstrTlsCrlInfo* pCRL)
+sint8 m2m_wifi_send_crl(tstrTlsCrlInfo *pCRL)
 {
-	sint8 s8Ret = M2M_ERR_FAIL;
-	s8Ret = hif_send(M2M_REQ_GROUP_SSL, M2M_SSL_IND_CRL|M2M_REQ_DATA_PKT, NULL, 0, (uint8*)pCRL, sizeof(tstrTlsCrlInfo), 0);
-	return s8Ret;
+    sint8 s8Ret = M2M_ERR_FAIL;
+    s8Ret = hif_send(M2M_REQ_GROUP_SSL, M2M_SSL_IND_CRL|M2M_REQ_DATA_PKT, NULL, 0, (uint8 *)pCRL, sizeof(tstrTlsCrlInfo), 0);
+    return s8Ret;
 }
 
-sint8 m2m_wifi_init(tstrWifiInitParam * param)
+sint8 m2m_wifi_init_hold(void)
 {
-	tstrM2mRev strtmp;
-	sint8 ret = M2M_SUCCESS;
-	uint8 u8WifiMode = M2M_WIFI_MODE_NORMAL;
-	
-	if(param == NULL) {
-		ret = M2M_ERR_FAIL;
-		goto _EXIT0;
-	}
-	
-	gpfAppWifiCb = param->pfAppWifiCb;
+    sint8 ret = M2M_ERR_FAIL;
+
+    /* Apply device specific initialization. */
+    ret = nm_drv_init_hold();
+
+    if(M2M_SUCCESS == ret)
+        gu8WifiState = WIFI_STATE_INIT;
+
+    return ret;
+}
+
+sint8 m2m_wifi_init_start(tstrWifiInitParam *pWifiInitParam)
+{
+    tstrM2mRev strtmp;
+    sint8 ret = M2M_SUCCESS;
+    uint8 u8WifiMode = M2M_WIFI_MODE_NORMAL;
+
+    if(pWifiInitParam == NULL) {
+        ret = M2M_ERR_FAIL;
+        goto _EXIT0;
+    }
+
+    gpfAppWifiCb = pWifiInitParam->pfAppWifiCb;
 
 #ifdef ETH_MODE
-	gpfAppEthCb  	    = param->strEthInitParam.pfAppEthCb;
-	gau8ethRcvBuf       = param->strEthInitParam.au8ethRcvBuf;
-	gu16ethRcvBufSize	= param->strEthInitParam.u16ethRcvBufSize;
-	u8WifiMode = param->strEthInitParam.u8EthernetEnable;
+    gpfAppEthCb       = pWifiInitParam->strEthInitParam.pfAppEthCb;
+    gau8ethRcvBuf     = pWifiInitParam->strEthInitParam.au8ethRcvBuf;
+    gu16ethRcvBufSize = pWifiInitParam->strEthInitParam.u16ethRcvBufSize;
+	if (pWifiInitParam->strEthInitParam.u8EthernetEnable)		
+		u8WifiMode = M2M_WIFI_MODE_ETHERNET;
 #endif /* ETH_MODE */
 
-#ifdef CONF_MGMT
-	gpfAppMonCb  = param->pfAppMonCb;
-#endif
-	gu8scanInProgress = 0;
-	/* Apply device specific initialization. */
-	ret = nm_drv_init(&u8WifiMode);
-	if(ret != M2M_SUCCESS) 	goto _EXIT0;
-	/* Initialize host interface module */
-	ret = hif_init(NULL);
-	if(ret != M2M_SUCCESS) 	goto _EXIT1;
+    gu8scanInProgress = 0;
+    /* Apply device specific initialization. */
+    ret = nm_drv_init_start(&u8WifiMode);
+    if(ret != M2M_SUCCESS) goto _EXIT0;
 
-	hif_register_cb(M2M_REQ_GROUP_WIFI,m2m_wifi_cb);
+    gu8WifiState = WIFI_STATE_START;
 
-	ret = nm_get_firmware_full_info(&strtmp);
+    /* Initialize host interface module */
+    ret = hif_init(NULL);
+    if(ret != M2M_SUCCESS) goto _EXIT1;
+
+    hif_register_cb(M2M_REQ_GROUP_WIFI, m2m_wifi_cb);
+
+    ret = nm_get_firmware_full_info(&strtmp);
 
 	M2M_INFO("Firmware ver   : %u.%u.%u Svnrev %u\n", strtmp.u8FirmwareMajor, strtmp.u8FirmwareMinor, strtmp.u8FirmwarePatch,strtmp.u16FirmwareSvnNum);
 	M2M_INFO("Firmware Build %s Time %s\n",strtmp.BuildDate,strtmp.BuildTime);
 	M2M_INFO("Firmware Min driver ver : %u.%u.%u\n", strtmp.u8DriverMajor, strtmp.u8DriverMinor, strtmp.u8DriverPatch);
-	M2M_INFO("Driver ver: %u.%u.%u\n", M2M_RELEASE_VERSION_MAJOR_NO, M2M_RELEASE_VERSION_MINOR_NO, M2M_RELEASE_VERSION_PATCH_NO);
+	M2M_INFO("Driver ver: %u.%u.%u \n", M2M_RELEASE_VERSION_MAJOR_NO, M2M_RELEASE_VERSION_MINOR_NO, M2M_RELEASE_VERSION_PATCH_NO);
 	M2M_INFO("Driver built at %s\t%s\n",__DATE__,__TIME__);
 	if(M2M_ERR_FW_VER_MISMATCH == ret)
 	{
-		M2M_ERR("Mismatch Firmawre Version\n");
+		M2M_ERR("Mismatch Firmware Version\n");
 	}
 
-	goto _EXIT0;
+    goto _EXIT0;
 
 _EXIT1:
-	nm_drv_deinit(NULL);
+    gu8WifiState = WIFI_STATE_DEINIT;
+    nm_drv_deinit(NULL);
+
 _EXIT0:
-	return ret;
+
+    return ret;
 }
 
-sint8  m2m_wifi_deinit(void * arg)
+sint8 m2m_wifi_init(tstrWifiInitParam *pWifiInitParam)
 {
+    sint8 ret = M2M_SUCCESS;
 
-	hif_deinit(NULL);
-
-	nm_drv_deinit(NULL);
-
-	return M2M_SUCCESS;
+    ret = m2m_wifi_init_hold();
+    if(ret == M2M_SUCCESS)
+    {
+        ret = m2m_wifi_init_start(pWifiInitParam);
+    }
+    return ret;
 }
 
-
-sint8 m2m_wifi_handle_events(void * arg)
+sint8  m2m_wifi_deinit(void *arg)
 {
-	return hif_handle_isr();
+    gu8WifiState = WIFI_STATE_DEINIT;
+    hif_deinit(NULL);
+
+    nm_drv_deinit(NULL);
+
+    return M2M_SUCCESS;
+}
+
+void m2m_wifi_yield(void)
+{
+    hif_yield();
+}
+
+sint8 m2m_wifi_handle_events(void *arg)
+{
+    return hif_handle_isr();
+}
+
+sint8 m2m_wifi_delete_sc(char *pcSsid, uint8 u8SsidLen)
+{
+    tstrM2mWifiApId strApId;
+    m2m_memset((uint8 *)&strApId, 0, sizeof(strApId));
+#if 0
+    if(pcSsid != NULL)
+    {
+        if(u8SsidLen >= M2M_MAX_SSID_LEN)
+            return M2M_ERR_INVALID_ARG;
+        strApId.au8SSID[0] = u8SsidLen;
+        m2m_memcpy(&strApId.au8SSID[1], (uint8 *)pcSsid, u8SsidLen);
+    }
+    else
+#endif
+        strApId.au8SSID[0] = 0xFF;  // Special value used to cause fw to delete all entries.
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQRSP_DELETE_APID, (uint8 *)&strApId, sizeof(tstrM2mWifiApId), NULL, 0, 0);
 }
 
 sint8 m2m_wifi_default_connect(void)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DEFAULT_CONNECT, NULL, 0,NULL, 0,0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DEFAULT_CONNECT, NULL, 0, NULL, 0, 0);
+}
+
+/*************************************************************************************************/
+/*                                WIFI CONNECT INTERNAL FUNCTIONS                                */
+/*************************************************************************************************/
+static sint8 m2m_wifi_connect_prepare_msg(
+    tenuCredStoreOption enuCredStoreOption,
+    tenuM2mSecType      enuAuthType,
+    uint16              u16AuthSize,
+    tstrNetworkId       *pstrNetworkId,
+    tstrM2mWifiConnHdr  *pstrWifiConn
+)
+{
+    sint8   ret = M2M_ERR_FAIL;
+    uint16  u16CredSize = sizeof(tstrM2mConnCredCmn) + u16AuthSize;
+
+    /* Check application params. */
+    if(
+        (pstrNetworkId == NULL)
+        || (pstrNetworkId->pu8Ssid == NULL)
+        || (pstrNetworkId->u8SsidLen >= M2M_MAX_SSID_LEN)
+    )
+        goto INVALID_ARG;
+
+    if(pstrWifiConn != NULL)
+    {
+        tstrM2mConnCredHdr  *pstrHdr = &pstrWifiConn->strConnCredHdr;
+        tstrM2mConnCredCmn  *pstrCmn = &pstrWifiConn->strConnCredCmn;
+
+        m2m_memset((uint8 *)pstrWifiConn, 0, sizeof(tstrM2mWifiConnHdr));
+
+        pstrHdr->u16CredSize = u16CredSize;
+        switch(enuCredStoreOption)
+        {
+        case WIFI_CRED_SAVE_ENCRYPTED:
+            pstrHdr->u8CredStoreFlags |= M2M_CRED_ENCRYPT_FLAG;
+        // intentional fall through...
+        case WIFI_CRED_SAVE_UNENCRYPTED:
+            pstrHdr->u8CredStoreFlags |= M2M_CRED_STORE_FLAG;
+        // intentional fall through...
+        case WIFI_CRED_DONTSAVE:
+            break;
+        default:
+            goto INVALID_ARG;
+        }
+
+        if(pstrNetworkId->enuChannel == M2M_WIFI_CH_ALL)
+            pstrHdr->u8Channel = (uint8)(pstrNetworkId->enuChannel);
+        else if((pstrNetworkId->enuChannel <= M2M_WIFI_CH_14) && (pstrNetworkId->enuChannel >= M2M_WIFI_CH_1))
+            pstrHdr->u8Channel = (uint8)(pstrNetworkId->enuChannel) - 1;
+        else
+            goto INVALID_ARG;
+
+        if((enuAuthType == M2M_WIFI_SEC_INVALID) || (enuAuthType >= M2M_WIFI_NUM_AUTH_TYPES))
+            goto INVALID_ARG;
+        pstrCmn->u8AuthType = (uint8)enuAuthType;
+
+        pstrCmn->u8SsidLen = pstrNetworkId->u8SsidLen;
+        m2m_memcpy(pstrCmn->au8Ssid, pstrNetworkId->pu8Ssid, pstrNetworkId->u8SsidLen);
+        if(pstrNetworkId->pu8Bssid != NULL)
+        {
+            pstrCmn->u8Options = M2M_WIFI_CONN_BSSID_FLAG;
+            m2m_memcpy(pstrCmn->au8Bssid, pstrNetworkId->pu8Bssid, M2M_MAC_ADDRES_LEN);
+        }
+        /* Everything is ok, set return value. */
+        ret = M2M_SUCCESS;
+    }
+    return ret;
+INVALID_ARG:
+    return M2M_ERR_INVALID_ARG;
+}
+
+/*************************************************************************************************/
+/*                                        WIFI CONNECT APIS                                      */
+/*************************************************************************************************/
+sint8 m2m_wifi_connect_open(
+    tenuCredStoreOption enuCredStoreOption,
+    tstrNetworkId      *pstrNetworkId
+)
+{
+    sint8               ret = M2M_ERR_INVALID_ARG;
+    tstrM2mWifiConnHdr  strConnHdr;
+
+    ret = m2m_wifi_connect_prepare_msg(enuCredStoreOption, M2M_WIFI_SEC_OPEN, 0, pstrNetworkId, &strConnHdr);
+    if(ret == M2M_SUCCESS)
+    {
+        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONN,
+                       (uint8 *)&strConnHdr, sizeof(strConnHdr),
+                       NULL, 0, 0);
+    }
+    return ret;
+}
+
+sint8 m2m_wifi_connect_wep(
+    tenuCredStoreOption enuCredStoreOption,
+    tstrNetworkId       *pstrNetworkId,
+    tstrAuthWep         *pstrAuthWep
+)
+{
+    /* As of 19.7.5 the WEP protocol is deprecated */
+    return M2M_ERR_INVALID;
+}
+
+sint8 m2m_wifi_connect_psk(
+    tenuCredStoreOption enuCredStoreOption,
+    tstrNetworkId       *pstrNetworkId,
+    tstrAuthPsk         *pstrAuthPsk
+)
+{
+    sint8   ret = M2M_ERR_INVALID_ARG;
+
+    if(pstrAuthPsk != NULL)
+    {
+        tstrM2mWifiConnHdr  strConnHdr;
+
+        ret = m2m_wifi_connect_prepare_msg(enuCredStoreOption,
+                                           M2M_WIFI_SEC_WPA_PSK,
+                                           sizeof(tstrM2mWifiPsk),
+                                           pstrNetworkId,
+                                           &strConnHdr);
+
+        if(ret == M2M_SUCCESS)
+        {
+            tstrM2mWifiPsk  *pstrPsk = (tstrM2mWifiPsk *)malloc(sizeof(tstrM2mWifiPsk));
+            if(pstrPsk != NULL)
+            {
+                m2m_memset((uint8 *)pstrPsk, 0, sizeof(tstrM2mWifiPsk));
+                if(pstrAuthPsk->pu8Psk != NULL)
+                {
+                    if(pstrAuthPsk->pu8Passphrase != NULL)
+                        ret = M2M_ERR_INVALID_ARG;
+                    else
+                    {
+                        pstrPsk->u8PassphraseLen = M2M_MAX_PSK_LEN-1;
+                        /* Use hexstr_2_bytes to verify pu8Psk input. */
+                        if(M2M_SUCCESS != hexstr_2_bytes(pstrPsk->au8Passphrase, pstrAuthPsk->pu8Psk, pstrPsk->u8PassphraseLen/2))
+                            ret = M2M_ERR_INVALID_ARG;
+                        m2m_memcpy(pstrPsk->au8Passphrase, pstrAuthPsk->pu8Psk, pstrPsk->u8PassphraseLen);
+                    }
+                }
+                else if(pstrAuthPsk->pu8Passphrase != NULL)
+                {
+                    if(pstrAuthPsk->u8PassphraseLen > M2M_MAX_PSK_LEN-1)
+                        ret = M2M_ERR_INVALID_ARG;
+                    else
+                    {
+                        pstrPsk->u8PassphraseLen = pstrAuthPsk->u8PassphraseLen;
+                        m2m_memcpy(pstrPsk->au8Passphrase, pstrAuthPsk->pu8Passphrase, pstrPsk->u8PassphraseLen);
+                    }
+                }
+                else
+                    ret = M2M_ERR_INVALID_ARG;
+                if(ret == M2M_SUCCESS)
+                {
+                    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONN | M2M_REQ_DATA_PKT,
+                                   (uint8 *)&strConnHdr, sizeof(tstrM2mWifiConnHdr),
+                                   (uint8 *)pstrPsk, sizeof(tstrM2mWifiPsk), sizeof(tstrM2mWifiConnHdr));
+                }
+                free(pstrPsk);
+            }
+            else
+                ret = M2M_ERR_MEM_ALLOC;
+        }
+    }
+    return ret;
+}
+
+sint8 m2m_wifi_1x_set_option(tenu1xOption enuOptionName, const void *pOptionValue, size_t OptionLen)
+{
+    if((pOptionValue == NULL) && (OptionLen > 0))
+        return M2M_ERR_INVALID_ARG;
+    switch(enuOptionName)
+    {
+    case WIFI_1X_BYPASS_SERVER_AUTH:
+        if(OptionLen != sizeof(int))
+            return M2M_ERR_INVALID_ARG;
+        switch(*(int*)pOptionValue)
+        {
+        case 1:
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_PEER_AUTH;
+            break;
+        case 0:
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_PEER_AUTH;
+            break;
+        default:
+            return M2M_ERR_INVALID_ARG;
+        }
+        break;
+    case WIFI_1X_TIME_VERIF_MODE:
+        if(OptionLen != sizeof(tenuSslCertExpSettings))
+            return M2M_ERR_INVALID_ARG;
+        switch(*(tenuSslCertExpSettings*)pOptionValue)
+        {
+        case SSL_CERT_EXP_CHECK_DISABLE:
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK;
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_REQUIRE_TIME;
+            break;
+        case SSL_CERT_EXP_CHECK_ENABLE:
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK;
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_REQUIRE_TIME;
+            break;
+        case SSL_CERT_EXP_CHECK_EN_IF_SYS_TIME:
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK;
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_REQUIRE_TIME;
+            break;
+        default:
+            return M2M_ERR_INVALID_ARG;
+        }
+        break;
+    case WIFI_1X_SESSION_CACHING:
+        if(OptionLen != sizeof(int))
+            return M2M_ERR_INVALID_ARG;
+        switch(*(int*)pOptionValue)
+        {
+        case 1:
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_SESSION_CACHING;
+            break;
+        case 0:
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_SESSION_CACHING;
+            break;
+        default:
+            return M2M_ERR_INVALID_ARG;
+        }
+        break;
+    case WIFI_1X_SPECIFIC_ROOTCERT:
+        switch(OptionLen)
+        {
+        case 20:
+            gu321xTlsHsFlags |= WIFI_1X_TLS_HS_FLAGS_SPECIFY_ROOTCERT;
+            m2m_memcpy(gau81xRootSha1, (uint8*)pOptionValue, sizeof(gau81xRootSha1));
+            break;
+        case 0:
+            gu321xTlsHsFlags &= ~WIFI_1X_TLS_HS_FLAGS_SPECIFY_ROOTCERT;
+            m2m_memset(gau81xRootSha1, 0, sizeof(gau81xRootSha1));
+            break;
+        default:
+            return M2M_ERR_INVALID_ARG;
+        }
+        break;
+    default:
+        return M2M_ERR_INVALID_ARG;
+    }
+    return M2M_SUCCESS;
+}
+
+sint8 m2m_wifi_1x_get_option(tenu1xOption enuOptionName, void *pOptionValue, size_t *pOptionLen)
+{
+    if(pOptionValue == NULL)
+        return M2M_ERR_INVALID_ARG;
+    switch(enuOptionName)
+    {
+    case WIFI_1X_BYPASS_SERVER_AUTH:
+        if(*pOptionLen < sizeof(int))
+            return M2M_ERR_INVALID_ARG;
+        *pOptionLen = sizeof(int);
+        *(int*)pOptionValue = (gu321xTlsHsFlags & WIFI_1X_TLS_HS_FLAGS_PEER_AUTH) ? 0 : 1;
+        break;
+    case WIFI_1X_TIME_VERIF_MODE:
+        if(*pOptionLen < sizeof(tenuSslCertExpSettings))
+            return M2M_ERR_INVALID_ARG;
+        *pOptionLen = sizeof(tenuSslCertExpSettings);
+        if(!(gu321xTlsHsFlags & WIFI_1X_TLS_HS_FLAGS_PEER_CERTTIMECHECK))
+            *(tenuSslCertExpSettings*)pOptionValue = SSL_CERT_EXP_CHECK_DISABLE;
+        else if(gu321xTlsHsFlags & WIFI_1X_TLS_HS_FLAGS_REQUIRE_TIME)
+            *(tenuSslCertExpSettings*)pOptionValue = SSL_CERT_EXP_CHECK_ENABLE;
+        else
+            *(tenuSslCertExpSettings*)pOptionValue = SSL_CERT_EXP_CHECK_EN_IF_SYS_TIME;
+        break;
+    case WIFI_1X_SESSION_CACHING:
+        if(*pOptionLen < sizeof(int))
+            return M2M_ERR_INVALID_ARG;
+        *pOptionLen = sizeof(int);
+        *(int*)pOptionValue = (gu321xTlsHsFlags & WIFI_1X_TLS_HS_FLAGS_SESSION_CACHING) ? 1 : 0;
+        break;
+    case WIFI_1X_SPECIFIC_ROOTCERT:
+        if(gu321xTlsHsFlags & WIFI_1X_TLS_HS_FLAGS_SPECIFY_ROOTCERT)
+        {
+            if(*pOptionLen < sizeof(gau81xRootSha1))
+                return M2M_ERR_INVALID_ARG;
+            *pOptionLen = sizeof(gau81xRootSha1);
+            m2m_memcpy((uint8*)pOptionValue, gau81xRootSha1, sizeof(gau81xRootSha1));
+        }
+        else
+            *pOptionLen = 0;
+        break;
+    default:
+        return M2M_ERR_INVALID_ARG;
+    }
+    return M2M_SUCCESS;
+}
+
+sint8 m2m_wifi_connect_1x_mschap2(
+    tenuCredStoreOption enuCredStoreOption,
+    tstrNetworkId       *pstrNetworkId,
+    tstrAuth1xMschap2   *pstrAuth1xMschap2
+)
+{
+    sint8 ret = M2M_ERR_INVALID_ARG;
+    if(pstrAuth1xMschap2 != NULL)
+    {
+        if(pstrAuth1xMschap2->pu8Domain == NULL)
+            pstrAuth1xMschap2->u16DomainLen = 0;
+        if(
+            (pstrAuth1xMschap2->pu8UserName != NULL)
+            && (pstrAuth1xMschap2->pu8Password != NULL)
+            && ((uint32)(pstrAuth1xMschap2->u16DomainLen) + pstrAuth1xMschap2->u16UserNameLen <= M2M_AUTH_1X_USER_LEN_MAX)
+            && (pstrAuth1xMschap2->u16PasswordLen <= M2M_AUTH_1X_PASSWORD_LEN_MAX)
+        )
+        {
+            tstrM2mWifiConnHdr  strConnHdr;
+            uint16              u16AuthSize =   sizeof(tstrM2mWifi1xHdr) +
+                                                pstrAuth1xMschap2->u16DomainLen +
+                                                pstrAuth1xMschap2->u16UserNameLen +
+                                                pstrAuth1xMschap2->u16PasswordLen;
+
+            ret = m2m_wifi_connect_prepare_msg(enuCredStoreOption,
+                                               M2M_WIFI_SEC_802_1X,
+                                               u16AuthSize,
+                                               pstrNetworkId,
+                                               &strConnHdr);
+
+            if(ret == M2M_SUCCESS)
+            {
+                tstrM2mWifi1xHdr    *pstr1xHdr = (tstrM2mWifi1xHdr *)malloc(u16AuthSize);
+                if(pstr1xHdr != NULL)
+                {
+                    uint8   *pu8AuthPtr = pstr1xHdr->au81xAuthDetails;
+                    m2m_memset((uint8 *)pstr1xHdr, 0, u16AuthSize);
+
+                    pstr1xHdr->u8Flags = M2M_802_1X_MSCHAP2_FLAG;
+                    if(pstrAuth1xMschap2->bUnencryptedUserName == true)
+                        pstr1xHdr->u8Flags |= M2M_802_1X_UNENCRYPTED_USERNAME_FLAG;
+                    if(pstrAuth1xMschap2->bPrependDomain == true)
+                        pstr1xHdr->u8Flags |= M2M_802_1X_PREPEND_DOMAIN_FLAG;
+
+                    pstr1xHdr->u8HdrLength = sizeof(tstrM2mWifi1xHdr);
+                    pstr1xHdr->u32TlsHsFlags = gu321xTlsHsFlags;
+                    m2m_memcpy(pstr1xHdr->au8TlsSpecificRootNameSha1, gau81xRootSha1, sizeof(gau81xRootSha1));
+
+                    pstr1xHdr->u8DomainLength = 0;
+                    if(pstrAuth1xMschap2->pu8Domain != NULL)
+                    {
+                        pstr1xHdr->u8DomainLength = (uint8)(pstrAuth1xMschap2->u16DomainLen);
+                        m2m_memcpy(pu8AuthPtr, pstrAuth1xMschap2->pu8Domain, pstr1xHdr->u8DomainLength);
+                        pu8AuthPtr += pstr1xHdr->u8DomainLength;
+                    }
+
+                    pstr1xHdr->u8UserNameLength = (pstrAuth1xMschap2->u16UserNameLen);
+                    m2m_memcpy(pu8AuthPtr, pstrAuth1xMschap2->pu8UserName, pstr1xHdr->u8UserNameLength);
+                    pu8AuthPtr += pstr1xHdr->u8UserNameLength;
+
+                    pstr1xHdr->u16PrivateKeyOffset = pu8AuthPtr - pstr1xHdr->au81xAuthDetails;
+                    pstr1xHdr->u16PrivateKeyLength = pstrAuth1xMschap2->u16PasswordLen;
+                    m2m_memcpy(pu8AuthPtr, pstrAuth1xMschap2->pu8Password, pstr1xHdr->u16PrivateKeyLength);
+
+                    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONN | M2M_REQ_DATA_PKT,
+                                   (uint8 *)&strConnHdr, sizeof(tstrM2mWifiConnHdr),
+                                   (uint8 *)pstr1xHdr, u16AuthSize,
+                                   sizeof(tstrM2mWifiConnHdr));
+                    free(pstr1xHdr);
+                }
+                else
+                    ret = M2M_ERR_MEM_ALLOC;
+            }
+        }
+    }
+    return ret;
+}
+
+sint8 m2m_wifi_connect_1x_tls(
+    tenuCredStoreOption enuCredStoreOption,
+    tstrNetworkId       *pstrNetworkId,
+    tstrAuth1xTls       *pstrAuth1xTls
+)
+{
+    sint8 ret = M2M_ERR_INVALID_ARG;
+    if(pstrAuth1xTls != NULL)
+    {
+        if(pstrAuth1xTls->pu8Domain == NULL)
+            pstrAuth1xTls->u16DomainLen = 0;
+        if(
+            (pstrAuth1xTls->pu8UserName != NULL)
+            && (pstrAuth1xTls->pu8PrivateKey_Mod != NULL)
+            && (pstrAuth1xTls->pu8PrivateKey_Exp != NULL)
+            && (pstrAuth1xTls->pu8Certificate != NULL)
+            && ((uint32)(pstrAuth1xTls->u16DomainLen) + pstrAuth1xTls->u16UserNameLen <= M2M_AUTH_1X_USER_LEN_MAX)
+            && (pstrAuth1xTls->u16PrivateKeyLen <= M2M_AUTH_1X_PRIVATEKEY_LEN_MAX)
+            && (pstrAuth1xTls->u16CertificateLen <= M2M_AUTH_1X_CERT_LEN_MAX)
+        )
+        {
+            tstrM2mWifiConnHdr  strConnHdr;
+            uint16              u16AuthSize =   sizeof(tstrM2mWifi1xHdr) +
+                                                pstrAuth1xTls->u16DomainLen +
+                                                pstrAuth1xTls->u16UserNameLen +
+                                                (2 * pstrAuth1xTls->u16PrivateKeyLen) +
+                                                pstrAuth1xTls->u16CertificateLen;
+
+            ret = m2m_wifi_connect_prepare_msg(enuCredStoreOption,
+                                               M2M_WIFI_SEC_802_1X,
+                                               u16AuthSize,
+                                               pstrNetworkId,
+                                               &strConnHdr);
+
+            if(ret == M2M_SUCCESS)
+            {
+                uint16              u16Payload1Size = u16AuthSize - pstrAuth1xTls->u16CertificateLen;
+                tstrM2mWifi1xHdr    *pstr1xHdr = (tstrM2mWifi1xHdr *)malloc(u16Payload1Size);
+                if(pstr1xHdr != NULL)
+                {
+                    tstrM2mWifiAuthInfoHdr strInfoHdr = {0};
+
+                    uint8   *pu8AuthPtr = pstr1xHdr->au81xAuthDetails;
+                    m2m_memset((uint8 *)pstr1xHdr, 0, u16Payload1Size);
+
+                    pstr1xHdr->u8Flags = M2M_802_1X_TLS_FLAG;
+                    if(pstrAuth1xTls->bUnencryptedUserName == true)
+                        pstr1xHdr->u8Flags |= M2M_802_1X_UNENCRYPTED_USERNAME_FLAG;
+                    if(pstrAuth1xTls->bPrependDomain == true)
+                        pstr1xHdr->u8Flags |= M2M_802_1X_PREPEND_DOMAIN_FLAG;
+
+                    pstr1xHdr->u8HdrLength = sizeof(tstrM2mWifi1xHdr);
+                    pstr1xHdr->u32TlsHsFlags = gu321xTlsHsFlags;
+                    m2m_memcpy(pstr1xHdr->au8TlsSpecificRootNameSha1, gau81xRootSha1, sizeof(gau81xRootSha1));
+
+                    pstr1xHdr->u8DomainLength = 0;
+                    if(pstrAuth1xTls->pu8Domain != NULL)
+                    {
+                        pstr1xHdr->u8DomainLength = (uint8)(pstrAuth1xTls->u16DomainLen);
+                        m2m_memcpy(pu8AuthPtr, pstrAuth1xTls->pu8Domain, pstr1xHdr->u8DomainLength);
+                        pu8AuthPtr += pstr1xHdr->u8DomainLength;
+                    }
+
+                    pstr1xHdr->u8UserNameLength = (pstrAuth1xTls->u16UserNameLen);
+                    m2m_memcpy(pu8AuthPtr, pstrAuth1xTls->pu8UserName, pstr1xHdr->u8UserNameLength);
+                    pu8AuthPtr += pstr1xHdr->u8UserNameLength;
+
+                    pstr1xHdr->u16PrivateKeyOffset = pu8AuthPtr - pstr1xHdr->au81xAuthDetails;
+                    pstr1xHdr->u16PrivateKeyLength = pstrAuth1xTls->u16PrivateKeyLen;
+                    m2m_memcpy(pu8AuthPtr, pstrAuth1xTls->pu8PrivateKey_Mod, pstr1xHdr->u16PrivateKeyLength);
+                    pu8AuthPtr += pstr1xHdr->u16PrivateKeyLength;
+                    m2m_memcpy(pu8AuthPtr, pstrAuth1xTls->pu8PrivateKey_Exp, pstr1xHdr->u16PrivateKeyLength);
+                    pu8AuthPtr += pstr1xHdr->u16PrivateKeyLength;
+
+                    pstr1xHdr->u16CertificateOffset = pu8AuthPtr - pstr1xHdr->au81xAuthDetails;
+                    pstr1xHdr->u16CertificateLength = pstrAuth1xTls->u16CertificateLen;
+
+                    strInfoHdr.u8Type = M2M_802_1X_TLS_CLIENT_CERTIFICATE;
+                    strInfoHdr.u16InfoPos = pstr1xHdr->u16CertificateOffset;
+                    strInfoHdr.u16InfoLen = pstr1xHdr->u16CertificateLength;
+                    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_IND_CONN_PARAM | M2M_REQ_DATA_PKT,
+                                   (uint8 *)&strInfoHdr, sizeof(tstrM2mWifiAuthInfoHdr),
+                                   pstrAuth1xTls->pu8Certificate, pstrAuth1xTls->u16CertificateLen,
+                                   sizeof(tstrM2mWifiAuthInfoHdr));
+
+                    if(ret == M2M_SUCCESS)
+                    {
+                        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONN | M2M_REQ_DATA_PKT,
+                                       (uint8 *)&strConnHdr, sizeof(tstrM2mWifiConnHdr),
+                                       (uint8 *)pstr1xHdr, u16Payload1Size,
+                                       sizeof(tstrM2mWifiConnHdr));
+                    }
+                    free(pstr1xHdr);
+                }
+                else
+                    ret = M2M_ERR_MEM_ALLOC;
+            }
+        }
+    }
+    return ret;
 }
 
 sint8 m2m_wifi_connect(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch)
 {
-	return m2m_wifi_connect_sc(pcSsid, u8SsidLen, u8SecType, pvAuthInfo,  u16Ch,0);
+    return m2m_wifi_connect_sc(pcSsid, u8SsidLen, u8SecType, pvAuthInfo,  u16Ch, 0);
 }
+
 sint8 m2m_wifi_connect_sc(char *pcSsid, uint8 u8SsidLen, uint8 u8SecType, void *pvAuthInfo, uint16 u16Ch, uint8 u8NoSaveCred)
 {
-	sint8				ret = M2M_SUCCESS;
-	tstrM2mWifiConnect	strConnect;
-	tstrM2MWifiSecInfo	*pstrAuthInfo;
+    sint8               s8Ret              = M2M_ERR_INVALID_ARG;
+    tstrNetworkId       strNetworkId       = {NULL, (uint8 *)pcSsid, u8SsidLen, (tenuM2mScanCh)u16Ch};
+    tenuCredStoreOption enuCredStoreOption = u8NoSaveCred ? WIFI_CRED_DONTSAVE : WIFI_CRED_SAVE_ENCRYPTED;
 
-	if(u8SecType != M2M_WIFI_SEC_OPEN)
-	{
-		if(pvAuthInfo == NULL)
-		{
-			M2M_ERR("Key is not valid\n");
-			ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-		if((u8SecType == M2M_WIFI_SEC_WPA_PSK) && (m2m_strlen(pvAuthInfo) == (M2M_MAX_PSK_LEN-1)))
-		{
-			uint8 i = 0;
-			uint8* pu8Psk = (uint8*)pvAuthInfo;
-			while(i < (M2M_MAX_PSK_LEN-1))
-			{
-				if(pu8Psk[i]<'0' || (pu8Psk[i]>'9' && pu8Psk[i] < 'A')|| (pu8Psk[i]>'F' && pu8Psk[i] < 'a') || pu8Psk[i] > 'f')
-				{
-					M2M_ERR("Invalid Key\n");
-					ret = M2M_ERR_FAIL;
-					goto ERR1;
-				}
-				i++;
-			}
-		}
-	}
-	if((u8SsidLen<=0)||(u8SsidLen>=M2M_MAX_SSID_LEN))
-	{
-		M2M_ERR("SSID LEN INVALID\n");
-		ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
+    /* This API does not support SSIDs which contain '\0'. If there is a '\0' character within the
+     * first u8SsidLen characters, then assume that the input u8SsidLen was incorrect - set length
+     * to strlen(pcSsid) and continue. This is to avoid a change from the behaviour of previously
+     * released drivers. */
+    if(u8SsidLen < M2M_MAX_SSID_LEN)
+        while(u8SsidLen--)
+            if(strNetworkId.pu8Ssid[u8SsidLen] == 0)
+                strNetworkId.u8SsidLen = u8SsidLen;
 
-	if(u16Ch < M2M_WIFI_CH_1|| u16Ch > M2M_WIFI_CH_14)
-	{
-		if(u16Ch!=M2M_WIFI_CH_ALL)
-		{
-			M2M_ERR("CH INVALID\n");
-			ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-	}
+    switch((tenuM2mSecType)u8SecType)
+    {
+    case M2M_WIFI_SEC_OPEN:
+        s8Ret = m2m_wifi_connect_open(enuCredStoreOption, &strNetworkId);
+        break;
+    case M2M_WIFI_SEC_WPA_PSK:
+        if(pvAuthInfo != NULL)
+        {
+            tstrAuthPsk strAuthPsk = {NULL, NULL, 0};
+            uint16      len        = m2m_strlen((uint8 *)pvAuthInfo);
 
+            if(len == M2M_MAX_PSK_LEN-1)
+            {
+                strAuthPsk.pu8Psk = (uint8 *)pvAuthInfo;
+            }
+            else
+            {
+                strAuthPsk.pu8Passphrase   = (uint8 *)pvAuthInfo;
+                strAuthPsk.u8PassphraseLen = len;
+            }
+            s8Ret = m2m_wifi_connect_psk(enuCredStoreOption, &strNetworkId, &strAuthPsk);
+        }
+        break;
+    case M2M_WIFI_SEC_WEP:
+        if(pvAuthInfo != NULL)
+        {
+            tstrM2mWifiWepParams    *pstrWepParams = (tstrM2mWifiWepParams *)pvAuthInfo;
+            tstrAuthWep             strAuthWep     = {pstrWepParams->au8WepKey, pstrWepParams->u8KeySz-1, pstrWepParams->u8KeyIndx};
 
-	m2m_memcpy(strConnect.au8SSID, (uint8*)pcSsid, u8SsidLen);
-	strConnect.au8SSID[u8SsidLen]	= 0;
-	strConnect.u16Ch				= NM_BSP_B_L_16(u16Ch);
-	/* Credentials will be Not be saved if u8NoSaveCred is set */ 
-	strConnect.u8NoSaveCred 			= u8NoSaveCred ? 1:0;
-	pstrAuthInfo = &strConnect.strSec;
-	pstrAuthInfo->u8SecType		= u8SecType;
+            s8Ret = m2m_wifi_connect_wep(enuCredStoreOption, &strNetworkId, &strAuthWep);
+        }
+        break;
+    case M2M_WIFI_SEC_802_1X:
+        if(pvAuthInfo != NULL)
+        {
+            tstr1xAuthCredentials   *pstr1xParams    = (tstr1xAuthCredentials *)pvAuthInfo;
+            tstrAuth1xMschap2       strAuth1xMschap2 = {NULL,
+                                                        pstr1xParams->au8UserName,
+                                                        pstr1xParams->au8Passwd,
+                                                        0,
+                                                        m2m_strlen(pstr1xParams->au8UserName),
+                                                        m2m_strlen(pstr1xParams->au8Passwd),
+                                                        false};
 
-	if(u8SecType == M2M_WIFI_SEC_WEP)
-	{
-		tstrM2mWifiWepParams	* pstrWepParams = (tstrM2mWifiWepParams*)pvAuthInfo;
-		tstrM2mWifiWepParams	*pstrWep = &pstrAuthInfo->uniAuth.strWepInfo;
-		pstrWep->u8KeyIndx =pstrWepParams->u8KeyIndx-1;
-
-		if(pstrWep->u8KeyIndx >= WEP_KEY_MAX_INDEX)
-		{
-			M2M_ERR("Invalid Wep key index %d\n", pstrWep->u8KeyIndx);
-			ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-		pstrWep->u8KeySz = pstrWepParams->u8KeySz-1;
-		if ((pstrWep->u8KeySz != WEP_40_KEY_STRING_SIZE)&& (pstrWep->u8KeySz != WEP_104_KEY_STRING_SIZE))
-		{
-			M2M_ERR("Invalid Wep key length %d\n", pstrWep->u8KeySz);
-			ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-		m2m_memcpy((uint8*)pstrWep->au8WepKey,(uint8*)pstrWepParams->au8WepKey, pstrWepParams->u8KeySz);
-		pstrWep->au8WepKey[pstrWepParams->u8KeySz] = 0;
-
-	}
-
-
-	else if(u8SecType == M2M_WIFI_SEC_WPA_PSK)
-	{
-		uint16	u16KeyLen = m2m_strlen((uint8*)pvAuthInfo);
-		if((u16KeyLen <= 0)||(u16KeyLen >= M2M_MAX_PSK_LEN))
-		{
-			M2M_ERR("Incorrect PSK key length\n");
-			ret = M2M_ERR_FAIL;
-			goto ERR1;
-		}
-		m2m_memcpy(pstrAuthInfo->uniAuth.au8PSK, (uint8*)pvAuthInfo, u16KeyLen + 1);
-	}
-	else if(u8SecType == M2M_WIFI_SEC_802_1X)
-	{
-		m2m_memcpy((uint8*)&pstrAuthInfo->uniAuth.strCred1x, (uint8*)pvAuthInfo, sizeof(tstr1xAuthCredentials));
-	}
-	else if(u8SecType == M2M_WIFI_SEC_OPEN)
-	{
-
-	}
-	else
-	{
-		M2M_ERR("undefined sec type\n");
-		ret = M2M_ERR_FAIL;
-		goto ERR1;
-	}
-
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONNECT, (uint8*)&strConnect, sizeof(tstrM2mWifiConnect),NULL, 0,0);
-
-ERR1:
-	return ret;
+            s8Ret = m2m_wifi_connect_1x_mschap2(enuCredStoreOption, &strNetworkId, &strAuth1xMschap2);
+        }
+        break;
+    default:
+        break;
+    }
+    return s8Ret;
 }
 
 sint8 m2m_wifi_disconnect(void)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISCONNECT, NULL, 0, NULL, 0,0);
-}
-sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6])
-{
-	tstrM2mSetMacAddress strTmp;
-	m2m_memcpy((uint8*) strTmp.au8Mac, (uint8*) au8MacAddress, 6);
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_MAC_ADDRESS,
-		(uint8*) &strTmp, sizeof(tstrM2mSetMacAddress), NULL, 0,0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISCONNECT, NULL, 0, NULL, 0, 0);
 }
 
-sint8 m2m_wifi_set_static_ip(tstrM2MIPConfig * pstrStaticIPConf)
+sint8 m2m_wifi_set_mac_address(uint8 au8MacAddress[6])
 {
-	pstrStaticIPConf->u32DNS = NM_BSP_B_L_32(pstrStaticIPConf->u32DNS);
-	pstrStaticIPConf->u32Gateway = NM_BSP_B_L_32(pstrStaticIPConf->u32Gateway);
-	pstrStaticIPConf->u32StaticIP = NM_BSP_B_L_32(
-		pstrStaticIPConf->u32StaticIP);
-	pstrStaticIPConf->u32SubnetMask = NM_BSP_B_L_32(
-		pstrStaticIPConf->u32SubnetMask);
-	return hif_send(M2M_REQ_GROUP_IP, M2M_IP_REQ_STATIC_IP_CONF,
-		(uint8*) pstrStaticIPConf, sizeof(tstrM2MIPConfig), NULL, 0,0);
+    tstrM2mSetMacAddress strTmp;
+    m2m_memcpy((uint8 *) strTmp.au8Mac, (uint8 *) au8MacAddress, 6);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_MAC_ADDRESS,
+                    (uint8 *) &strTmp, sizeof(tstrM2mSetMacAddress), NULL, 0, 0);
+}
+
+sint8 m2m_wifi_set_static_ip(tstrM2MIPConfig *pstrStaticIPConf)
+{
+    pstrStaticIPConf->u32DNS = NM_BSP_B_L_32(pstrStaticIPConf->u32DNS);
+    pstrStaticIPConf->u32Gateway = NM_BSP_B_L_32(pstrStaticIPConf->u32Gateway);
+    pstrStaticIPConf->u32StaticIP = NM_BSP_B_L_32(
+                                        pstrStaticIPConf->u32StaticIP);
+    pstrStaticIPConf->u32SubnetMask = NM_BSP_B_L_32(
+                                          pstrStaticIPConf->u32SubnetMask);
+    return hif_send(M2M_REQ_GROUP_IP, M2M_IP_REQ_STATIC_IP_CONF,
+                    (uint8 *) pstrStaticIPConf, sizeof(tstrM2MIPConfig), NULL, 0, 0);
 }
 
 sint8 m2m_wifi_request_dhcp_client(void)
 {
-	/*legacy API should be removed */
-	return 0;
+    /*legacy API should be removed */
+    return 0;
 }
-sint8 m2m_wifi_request_dhcp_server(uint8* addr)
+
+sint8 m2m_wifi_request_dhcp_server(uint8 *addr)
 {
     /*legacy API should be removed */
-	return 0;
+    return 0;
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt * pstrM2mLsnInt);
-@brief		Set the Wi-Fi listen interval for power save operation. It is represented in units
-			of AP Beacon periods.
-@param [in]	pstrM2mLsnInt
-			Structure holding the listen interval configurations.
-@return		The function SHALL return 0 for success and a negative value otherwise.
-@sa			tstrM2mLsnInt , m2m_wifi_set_sleep_mode
-@pre		m2m_wifi_set_sleep_mode shall be called first
-@warning	The Function called once after initialization. 
+@fn         NMI_API sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt * pstrM2mLsnInt);
+@brief      Set the Wi-Fi listen interval for power save operation. It is represented in units
+            of AP Beacon periods.
+@param [in] pstrM2mLsnInt
+            Structure holding the listen interval configurations.
+@return     The function SHALL return 0 for success and a negative value otherwise.
+@sa         tstrM2mLsnInt , m2m_wifi_set_sleep_mode
+@pre        m2m_wifi_set_sleep_mode shall be called first
+@warning    The Function called once after initialization.
 */
-sint8 m2m_wifi_enable_dhcp(uint8  u8DhcpEn )
+sint8 m2m_wifi_enable_dhcp(uint8  u8DhcpEn)
 {
-
-	uint8	u8Req;
-	u8Req = u8DhcpEn ? M2M_IP_REQ_ENABLE_DHCP : M2M_IP_REQ_DISABLE_DHCP;
-	return hif_send(M2M_REQ_GROUP_IP, u8Req, NULL, 0, NULL, 0, 0);
-
-
+    uint8 u8Req;
+    u8Req = u8DhcpEn ? M2M_IP_REQ_ENABLE_DHCP : M2M_IP_REQ_DISABLE_DHCP;
+    return hif_send(M2M_REQ_GROUP_IP, u8Req, NULL, 0, NULL, 0, 0);
 }
 
-sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt* pstrM2mLsnInt)
+sint8 m2m_wifi_set_lsn_int(tstrM2mLsnInt *pstrM2mLsnInt)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_LSN_INT, (uint8*)pstrM2mLsnInt, sizeof(tstrM2mLsnInt), NULL, 0, 0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_LSN_INT, (uint8 *)pstrM2mLsnInt, sizeof(tstrM2mLsnInt), NULL, 0, 0);
 }
 
-sint8 m2m_wifi_set_cust_InfoElement(uint8* pau8M2mCustInfoElement)
+sint8 m2m_wifi_set_cust_InfoElement(uint8 *pau8M2mCustInfoElement)
 {
-
-	sint8  ret = M2M_ERR_FAIL;
-	if(pau8M2mCustInfoElement != NULL)
-	{
-		if((pau8M2mCustInfoElement[0] + 1) < M2M_CUST_IE_LEN_MAX)
-		{
-			ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CUST_INFO_ELEMENT|M2M_REQ_DATA_PKT, (uint8*)pau8M2mCustInfoElement, pau8M2mCustInfoElement[0]+1, NULL, 0, 0);
-		}
-	}
-	return ret;
+    sint8  ret = M2M_ERR_FAIL;
+    if(pau8M2mCustInfoElement != NULL)
+    {
+        if((pau8M2mCustInfoElement[0] + 1) < M2M_CUST_IE_LEN_MAX)
+        {
+            ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CUST_INFO_ELEMENT|M2M_REQ_DATA_PKT, (uint8 *)pau8M2mCustInfoElement, pau8M2mCustInfoElement[0]+1, NULL, 0, 0);
+        }
+    }
+    return ret;
 }
 
-sint8 m2m_wifi_set_scan_options(tstrM2MScanOption* ptstrM2MScanOption)
+sint8 m2m_wifi_set_scan_options(tstrM2MScanOption *ptstrM2MScanOption)
 {
-	sint8	s8Ret = M2M_ERR_FAIL;
-	if(m2m_validate_scan_options (ptstrM2MScanOption) == M2M_SUCCESS)
-	{
-		s8Ret =  hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SCAN_OPTION, (uint8*)ptstrM2MScanOption, sizeof(tstrM2MScanOption),NULL, 0,0);
-	}
-	return s8Ret;
+    sint8   s8Ret = M2M_ERR_FAIL;
+    if(m2m_validate_scan_options(ptstrM2MScanOption) == M2M_SUCCESS)
+    {
+        s8Ret =  hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SCAN_OPTION, (uint8 *)ptstrM2MScanOption, sizeof(tstrM2MScanOption), NULL, 0, 0);
+    }
+    return s8Ret;
 }
+
+sint8 m2m_wifi_set_stop_scan_on_first(uint8 u8StopScanOption)
+{
+    sint8   s8Ret = M2M_ERR_FAIL;
+
+    tstrM2MStopScanOption StopScanOption = { 0 };
+
+    if(1 >= u8StopScanOption)
+    {
+        StopScanOption.u8StopOnFirstResult = u8StopScanOption;
+
+        s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_STOP_SCAN_OPTION, (uint8 *)&StopScanOption, sizeof(tstrM2MStopScanOption), NULL, 0, 0);
+
+        M2M_INFO("Scan will %s stop on first result.\n", StopScanOption.u8StopOnFirstResult ? "" : "NOT");
+    }
+    else
+    {
+        s8Ret = M2M_ERR_INVALID_ARG;
+    }
+
+    return s8Ret;
+}
+
 sint8 m2m_wifi_set_scan_region(uint16  ScanRegion)
 {
-	sint8	s8Ret = M2M_ERR_FAIL;
-	tstrM2MScanRegion strScanRegion;
-	strScanRegion.u16ScanRegion = ScanRegion;
-	s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SCAN_REGION, (uint8*)&strScanRegion, sizeof(tstrM2MScanRegion),NULL, 0,0);
-	return s8Ret;
+    sint8   s8Ret = M2M_ERR_FAIL;
+    tstrM2MScanRegion strScanRegion;
+    strScanRegion.u16ScanRegion = ScanRegion;
+    s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SCAN_REGION, (uint8 *)&strScanRegion, sizeof(tstrM2MScanRegion), NULL, 0, 0);
+    return s8Ret;
 }
 sint8 m2m_wifi_request_scan(uint8 ch)
 {
-	sint8	s8Ret = M2M_SUCCESS;
+    sint8   s8Ret = M2M_SUCCESS;
 
-	if(!gu8scanInProgress)
-	{
-		if(((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))
-		{
-			tstrM2MScan strtmp;
-			strtmp.u8ChNum = ch;
-			s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN, (uint8*)&strtmp, sizeof(tstrM2MScan),NULL, 0,0);
-			if(s8Ret == M2M_SUCCESS)
-			{
-				gu8scanInProgress = 1;
-			}
-		}
-		else
-		{
-			s8Ret = M2M_ERR_INVALID_ARG;
-		}
-	}
-	else
-	{
-		s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
-	}
-	return s8Ret;
+    if(!gu8scanInProgress)
+    {
+        if(((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))
+        {
+            tstrM2MScan strtmp;
+            strtmp.u8ChNum = ch;
+            s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN, (uint8 *)&strtmp, sizeof(tstrM2MScan), NULL, 0, 0);
+            if(s8Ret == M2M_SUCCESS)
+            {
+                gu8scanInProgress = 1;
+            }
+        }
+        else
+        {
+            s8Ret = M2M_ERR_INVALID_ARG;
+        }
+    }
+    else
+    {
+        s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
+    }
+    return s8Ret;
 }
 
 sint8 m2m_wifi_request_scan_passive(uint8 ch, uint16 scan_time)
 {
-	sint8	s8Ret = M2M_SUCCESS;
+    sint8 s8Ret = M2M_SUCCESS;
 
-	if(!gu8scanInProgress)
-	{
-		if(((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))
-		{
-			tstrM2MScan strtmp;
-			strtmp.u8ChNum = ch;
-			
-			strtmp.u16PassiveScanTime = scan_time;
-			
-			s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_PASSIVE_SCAN, (uint8*)&strtmp, sizeof(tstrM2MScan),NULL, 0,0);
-			if(s8Ret == M2M_SUCCESS)
-			{
-				gu8scanInProgress = 1;
-			}
-		}
-		else
-		{
-			s8Ret = M2M_ERR_INVALID_ARG;
-		}
-	}
-	else
-	{
-		s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
-	}
-	return s8Ret;
+    if(!gu8scanInProgress)
+    {
+        if(((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))
+        {
+            tstrM2MScan strtmp;
+            strtmp.u8ChNum = ch;
+
+            strtmp.u16PassiveScanTime = scan_time;
+
+            s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_PASSIVE_SCAN, (uint8 *)&strtmp, sizeof(tstrM2MScan), NULL, 0, 0);
+            if(s8Ret == M2M_SUCCESS)
+            {
+                gu8scanInProgress = 1;
+            }
+        }
+        else
+        {
+            s8Ret = M2M_ERR_INVALID_ARG;
+        }
+    }
+    else
+    {
+        s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
+    }
+    return s8Ret;
 }
 
-sint8 m2m_wifi_request_scan_ssid_list(uint8 ch,uint8 * u8Ssidlist)
+sint8 m2m_wifi_request_scan_ssid_list(uint8 ch, uint8 *u8Ssidlist)
 {
-	sint8	s8Ret = M2M_ERR_INVALID_ARG;
+    sint8   s8Ret = M2M_ERR_INVALID_ARG;
 
-	if(!gu8scanInProgress)
-	{
-		if((((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))&&(u8Ssidlist != NULL))
-		{
-			tstrM2MScan strtmp;
-			uint16 u16Lsize = 0;
-			uint8 u8Apnum = u8Ssidlist[u16Lsize];
-			if(u8Apnum <= MAX_HIDDEN_SITES)
-			{
-				u16Lsize++;
-				while(u8Apnum)
-				{
-					if(u8Ssidlist[u16Lsize] >= M2M_MAX_SSID_LEN){ 
-						goto EXIT;
-					}else {
-						u16Lsize += u8Ssidlist[u16Lsize] + 1;
-						u8Apnum--;
-					}
-				}
-				strtmp.u8ChNum = ch;
-				s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN_SSID_LIST|M2M_REQ_DATA_PKT, (uint8*)&strtmp, sizeof(tstrM2MScan),u8Ssidlist, u16Lsize,sizeof(tstrM2MScan));
-				if(s8Ret == M2M_SUCCESS)
-				{
-					gu8scanInProgress = 1;
-				}
-			}
-		}
-	}
-	else
-	{
-		s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
-	}
+    if(!gu8scanInProgress)
+    {
+        if((((ch >= M2M_WIFI_CH_1) && (ch <= M2M_WIFI_CH_14)) || (ch == M2M_WIFI_CH_ALL))&&(u8Ssidlist != NULL))
+        {
+            tstrM2MScan strtmp;
+            uint16 u16Lsize = 0;
+            uint8 u8Apnum = u8Ssidlist[u16Lsize];
+            if(u8Apnum <= MAX_HIDDEN_SITES)
+            {
+                u16Lsize++;
+                while(u8Apnum)
+                {
+                    if(u8Ssidlist[u16Lsize] >= M2M_MAX_SSID_LEN) {
+                        goto EXIT;
+                    } else {
+                        u16Lsize += u8Ssidlist[u16Lsize] + 1;
+                        u8Apnum--;
+                    }
+                }
+                strtmp.u8ChNum = ch;
+                s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN_SSID_LIST|M2M_REQ_DATA_PKT, (uint8 *)&strtmp, sizeof(tstrM2MScan), u8Ssidlist, u16Lsize, sizeof(tstrM2MScan));
+                if(s8Ret == M2M_SUCCESS)
+                {
+                    gu8scanInProgress = 1;
+                }
+            }
+        }
+    }
+    else
+    {
+        s8Ret = M2M_ERR_SCAN_IN_PROGRESS;
+    }
 EXIT:
-	return s8Ret;
+    return s8Ret;
 }
-sint8 m2m_wifi_wps(uint8 u8TriggerType,const char  *pcPinNumber)
+sint8 m2m_wifi_wps(uint8 u8TriggerType, const char  *pcPinNumber)
 {
-	tstrM2MWPSConnect strtmp;
+    tstrM2MWPSConnect strtmp;
 
-	/* Stop Scan if it is ongoing.
-	*/
-	gu8scanInProgress = 0;
-	strtmp.u8TriggerType = u8TriggerType;
-	/*If WPS is using PIN METHOD*/
-	if (u8TriggerType == WPS_PIN_TRIGGER)
-		m2m_memcpy ((uint8*)strtmp.acPinNumber,(uint8*) pcPinNumber,8);
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_WPS, (uint8*)&strtmp,sizeof(tstrM2MWPSConnect), NULL, 0,0);
+    /* Stop Scan if it is ongoing.
+    */
+    gu8scanInProgress = 0;
+    strtmp.u8TriggerType = u8TriggerType;
+    /*If WPS is using PIN METHOD*/
+    if(u8TriggerType == WPS_PIN_TRIGGER)
+        m2m_memcpy((uint8 *)strtmp.acPinNumber, (uint8 *) pcPinNumber, 8);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_WPS, (uint8 *)&strtmp, sizeof(tstrM2MWPSConnect), NULL, 0, 0);
 }
 sint8 m2m_wifi_wps_disable(void)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_WPS, NULL,0, NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_WPS, NULL, 0, NULL, 0, 0);
+    return ret;
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_req_client_ctrl(uint8 cmd);
-@brief		Send a command to the PS Client (An WINC1500 board running the ps_firmware), 
-			if the PS client send any commands it will be received in wifi_cb M2M_WIFI_RESP_CLIENT_INFO
-@param [in]	cmd
-			Control command sent from PS Server to PS Client (command values defined by the application)
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
-@sa			m2m_wifi_req_server_init, M2M_WIFI_RESP_CLIENT_INFO
-@pre		m2m_wifi_req_server_init should be called first
-@warning	
+@fn         NMI_API sint8 m2m_wifi_req_client_ctrl(uint8 cmd)
+@brief      Send a command to the PS Client (An WINC board running the ps_firmware),
+            if the PS client send any commands it will be received in wifi_cb @ref M2M_WIFI_RESP_CLIENT_INFO.
+@param[in]  cmd
+                Control command sent from PS Server to PS Client (command values defined by the application).
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
+@sa         m2m_wifi_req_server_init, M2M_WIFI_RESP_CLIENT_INFO
+@pre        m2m_wifi_req_server_init should be called first
 */
 sint8 m2m_wifi_req_client_ctrl(uint8 u8Cmd)
 {
-
-	sint8 ret = M2M_SUCCESS;
+    sint8 ret = M2M_SUCCESS;
 #ifdef _PS_SERVER_
-	tstrM2Mservercmd	strCmd;
-	strCmd.u8cmd = u8Cmd;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CLIENT_CTRL, (uint8*)&strCmd, sizeof(tstrM2Mservercmd), NULL, 0, 0);
+    tstrM2Mservercmd    strCmd;
+    strCmd.u8cmd = u8Cmd;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CLIENT_CTRL, (uint8 *)&strCmd, sizeof(tstrM2Mservercmd), NULL, 0, 0);
 #else
-	M2M_ERR("_PS_SERVER_ is not defined\n");
+    M2M_ERR("_PS_SERVER_ is not defined\n");
 #endif
-	return ret;
+    return ret;
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_req_server_init(uint8 ch);
-@brief		Initialize the PS Server, The WINC1500 support Non secure communication with another WINC1500, 
-			(SERVER/CLIENT) through one byte command (probe request and probe response) without any connection setup
-@param [in]	ch
-			Server listening channel
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise
-@sa			m2m_wifi_req_client_ctrl
-@warning	The server mode can't be used with any other modes (STA/P2P/AP)
+@fn         NMI_API sint8 m2m_wifi_req_server_init(uint8 ch)
+@brief      Initialize the PS Server, The WINC support non secure communication with another WINC,
+            (SERVER/CLIENT) through one byte command (probe request and probe response) without any connection setup.
+@param[in]  ch
+                Server listening channel
+@return     The function returns @ref M2M_SUCCESS for success and a negative value otherwise.
+@sa         m2m_wifi_req_client_ctrl
+@warning    The server mode can't be used with any other modes (STA/AP).
 */
 sint8 m2m_wifi_req_server_init(uint8 ch)
 {
-	sint8 ret = M2M_SUCCESS;
+    sint8 ret = M2M_SUCCESS;
 #ifdef _PS_SERVER_
-	tstrM2mServerInit strServer;
-	strServer.u8Channel = ch;
-	ret = hif_send(M2M_REQ_GROUP_WIFI,M2M_WIFI_REQ_SERVER_INIT, (uint8*)&strServer, sizeof(tstrM2mServerInit), NULL, 0, 0);
+    tstrM2mServerInit strServer;
+    strServer.u8Channel = ch;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SERVER_INIT, (uint8 *)&strServer, sizeof(tstrM2mServerInit), NULL, 0, 0);
 #else
-	M2M_ERR("_PS_SERVER_ is not defined\n");
+    M2M_ERR("_PS_SERVER_ is not defined\n");
 #endif
-	return ret;
-}
-sint8 m2m_wifi_p2p(uint8 u8Channel)
-{
-	sint8 ret = M2M_SUCCESS;
-	if((u8Channel == M2M_WIFI_CH_1) || (u8Channel == M2M_WIFI_CH_6) || (u8Channel == M2M_WIFI_CH_11))
-	{
-		tstrM2MP2PConnect strtmp;
-		strtmp.u8ListenChannel = u8Channel;
-		ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ENABLE_P2P, (uint8*)&strtmp, sizeof(tstrM2MP2PConnect), NULL, 0,0);
-	}
-	else
-	{
-		M2M_ERR("Listen channel should only be M2M_WIFI_CH_1/6/11 \n");
-		ret = M2M_ERR_FAIL;
-	}
-	return ret;
-}
-sint8 m2m_wifi_p2p_disconnect(void)
-{
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_P2P, NULL, 0, NULL, 0, 0);
-	return ret;
-}
-sint8 m2m_wifi_enable_ap(CONST tstrM2MAPConfig* pstrM2MAPConfig)
-{
-	sint8 ret = M2M_ERR_FAIL;
-	if(M2M_SUCCESS == m2m_validate_ap_parameters(pstrM2MAPConfig))
-	{
-		ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ENABLE_AP, (uint8 *)pstrM2MAPConfig, sizeof(tstrM2MAPConfig), NULL, 0, 0);	
-	}
-	return ret;
+    return ret;
 }
 
-sint8 m2m_wifi_set_gains(tstrM2mWifiGainsParams* pstrM2mGain)
+sint8 m2m_wifi_p2p(uint8 u8Channel)
 {
-	sint8 ret = M2M_ERR_FAIL;
-	if(pstrM2mGain != NULL)
-	{
-		ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_GAINS, (uint8 *)pstrM2mGain, sizeof(tstrM2mWifiGainsParams), NULL, 0, 0);	
-	}
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    if((u8Channel == M2M_WIFI_CH_1) || (u8Channel == M2M_WIFI_CH_6) || (u8Channel == M2M_WIFI_CH_11))
+    {
+        tstrM2MP2PConnect strtmp;
+        strtmp.u8ListenChannel = u8Channel;
+        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ENABLE_P2P, (uint8 *)&strtmp, sizeof(tstrM2MP2PConnect), NULL, 0, 0);
+    }
+    else
+    {
+        M2M_ERR("Listen channel should only be M2M_WIFI_CH_1/6/11 \n");
+        ret = M2M_ERR_FAIL;
+    }
+    return ret;
 }
+
+sint8 m2m_wifi_p2p_disconnect(void)
+{
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_P2P, NULL, 0, NULL, 0, 0);
+    return ret;
+}
+
+sint8 m2m_wifi_enable_ap(CONST tstrM2MAPConfig *pstrM2MAPConfig)
+{
+    tstrM2MAPModeConfig strM2MAPModeConfig;
+
+    m2m_memcpy((uint8 *)&strM2MAPModeConfig.strApConfig, (uint8 *)pstrM2MAPConfig, sizeof(tstrM2MAPConfig));
+    m2m_memcpy(strM2MAPModeConfig.strApConfigExt.au8DefRouterIP, (uint8 *)pstrM2MAPConfig->au8DHCPServerIP, 4);
+    m2m_memcpy(strM2MAPModeConfig.strApConfigExt.au8DNSServerIP, (uint8 *)pstrM2MAPConfig->au8DHCPServerIP, 4);
+
+    strM2MAPModeConfig.strApConfigExt.au8SubnetMask[0] = 0;
+
+    return m2m_wifi_enable_ap_ext(&strM2MAPModeConfig);
+}
+
+sint8 m2m_wifi_enable_ap_ext(CONST tstrM2MAPModeConfig *pstrM2MAPModeConfig)
+{
+    sint8 ret = M2M_ERR_FAIL;
+    if(M2M_SUCCESS == m2m_validate_ap_parameters(pstrM2MAPModeConfig))
+    {
+        ret = hif_send(M2M_REQ_GROUP_WIFI, (M2M_REQ_DATA_PKT|M2M_WIFI_REQ_ENABLE_AP), NULL, 0, (uint8 *)pstrM2MAPModeConfig, sizeof(tstrM2MAPModeConfig), 0);
+    }
+    return ret;
+}
+
+sint8 m2m_wifi_set_gains(tstrM2mWifiGainsParams *pstrM2mGain)
+{
+    sint8 ret = M2M_ERR_FAIL;
+    if(pstrM2mGain != NULL)
+    {
+        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_GAINS, (uint8 *)pstrM2mGain, sizeof(tstrM2mWifiGainsParams), NULL, 0, 0);
+    }
+    return ret;
+}
+
 sint8 m2m_wifi_disable_ap(void)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_AP, NULL, 0, NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_AP, NULL, 0, NULL, 0, 0);
+    return ret;
 }
+
 /*!
 @fn          NMI_API sint8 m2m_wifi_req_curr_rssi(void);
-@brief       Request the current RSSI for the current connected AP, 
-			 the response received in wifi_cb M2M_WIFI_RESP_CURRENT_RSSI	
-@sa          M2M_WIFI_RESP_CURRENT_RSSI              
+@brief       Request the current RSSI for the current connected AP,
+             the response received in wifi_cb M2M_WIFI_RESP_CURRENT_RSSI
+@sa          M2M_WIFI_RESP_CURRENT_RSSI
 @return      The function shall return M2M_SUCCESS for success and a negative value otherwise.
 */
 sint8 m2m_wifi_req_curr_rssi(void)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CURRENT_RSSI, NULL, 0, NULL,0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CURRENT_RSSI, NULL, 0, NULL, 0, 0);
+    return ret;
 }
-sint8 m2m_wifi_send_ethernet_pkt(uint8* pu8Packet,uint16 u16PacketSize)
+sint8 m2m_wifi_send_ethernet_pkt(uint8 *pu8Packet, uint16 u16PacketSize)
 {
-	sint8	s8Ret = -1;
-	if((pu8Packet != NULL)&&(u16PacketSize>0))
-	{
-		tstrM2MWifiTxPacketInfo		strTxPkt;
+    sint8   s8Ret = -1;
+    if((pu8Packet != NULL)&&(u16PacketSize>0))
+    {
+        tstrM2MWifiTxPacketInfo     strTxPkt;
 
-		strTxPkt.u16PacketSize		= u16PacketSize;
-		strTxPkt.u16HeaderLength	= M2M_ETHERNET_HDR_LEN;
-		s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SEND_ETHERNET_PACKET | M2M_REQ_DATA_PKT,
-		(uint8*)&strTxPkt, sizeof(tstrM2MWifiTxPacketInfo), pu8Packet, u16PacketSize,  M2M_ETHERNET_HDR_OFFSET - M2M_HIF_HDR_OFFSET);
-	}
-	return s8Ret;
+        strTxPkt.u16PacketSize      = u16PacketSize;
+        strTxPkt.u16HeaderLength    = M2M_ETHERNET_HDR_LEN;
+        s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SEND_ETHERNET_PACKET | M2M_REQ_DATA_PKT,
+                         (uint8 *)&strTxPkt, sizeof(tstrM2MWifiTxPacketInfo), pu8Packet, u16PacketSize,  M2M_ETHERNET_HDR_OFFSET - M2M_HIF_HDR_OFFSET);
+    }
+    return s8Ret;
 }
+
 /*!
 @fn          NMI_API sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8 * pu8IsValid);
 @brief       Request the MAC address stored on the OTP (one time programmable) memory of the device.
-			 (the function is Blocking until response received)	
+             (the function is Blocking until response received)
 @param [out] pu8MacAddr
-			 Output MAC address buffer of 6 bytes size. Valid only if *pu8Valid=1.
+             Output MAC address buffer of 6 bytes size. Valid only if *pu8Valid=1.
 @param [out] pu8IsValid
-		     A output boolean value to indicate the validity of pu8MacAddr in OTP. 
-		     Output zero if the OTP memory is not programmed, non-zero otherwise.	
+             A output boolean value to indicate the validity of pu8MacAddr in OTP.
+             Output zero if the OTP memory is not programmed, non-zero otherwise.
 @return      The function shall return M2M_SUCCESS for success and a negative value otherwise.
-@sa          m2m_wifi_get_mac_address             
+@sa          m2m_wifi_get_mac_address
 @pre         m2m_wifi_init required to call any WIFI/socket function
 */
-sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8* pu8IsValid)
+sint8 m2m_wifi_get_otp_mac_address(uint8 *pu8MacAddr, uint8 *pu8IsValid)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_chip_wake();
-	if(ret == M2M_SUCCESS)
-	{
-		ret = nmi_get_otp_mac_address(pu8MacAddr, pu8IsValid);
-		if(ret == M2M_SUCCESS)
-		{
-			ret = hif_chip_sleep();
-		}
-	}
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_chip_wake();
+    if(ret == M2M_SUCCESS)
+    {
+        ret = nmi_get_otp_mac_address(pu8MacAddr, pu8IsValid);
+        if(ret == M2M_SUCCESS)
+        {
+            ret = hif_chip_sleep();
+        }
+    }
+    return ret;
 }
+
 /*!
 @fn          NMI_API sint8 m2m_wifi_get_mac_address(uint8 *pu8MacAddr)
 @brief       Request the current MAC address of the device (the working mac address).
-			 (the function is Blocking until response received)	
+             (the function is Blocking until response received)
 @param [out] pu8MacAddr
-			 Output MAC address buffer of 6 bytes size.	
+             Output MAC address buffer of 6 bytes size.
 @return      The function shall return M2M_SUCCESS for success and a negative value otherwise.
-@sa          m2m_wifi_get_otp_mac_address             
+@sa          m2m_wifi_get_otp_mac_address
 @pre         m2m_wifi_init required to call any WIFI/socket function
 */
 sint8 m2m_wifi_get_mac_address(uint8 *pu8MacAddr)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_chip_wake();
-	if(ret == M2M_SUCCESS)
-	{
-		ret = nmi_get_mac_address(pu8MacAddr);
-		if(ret == M2M_SUCCESS)
-		{
-			ret = hif_chip_sleep();
-		}
-	}
-
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_chip_wake();
+    if(ret == M2M_SUCCESS)
+    {
+        ret = nmi_get_mac_address(pu8MacAddr);
+        if(ret == M2M_SUCCESS)
+        {
+            ret = hif_chip_sleep();
+        }
+    }
+    return ret;
 }
+
 /*!
 @fn          NMI_API sint8 m2m_wifi_req_scan_result(uint8 index);
-@brief       Reads the AP information from the Scan Result list with the given index, 
-			 the response received in wifi_cb M2M_WIFI_RESP_SCAN_RESULT, 
-			 the response pointer should be casted with tstrM2mWifiscanResult structure 	
-@param [in]  index 
-			 Index for the requested result, the index range start from 0 till number of AP's found 
-@sa          tstrM2mWifiscanResult,m2m_wifi_get_num_ap_found,m2m_wifi_request_scan             
-@return      The function shall return M2M_SUCCESE for success and a negative value otherwise
-@pre         m2m_wifi_request_scan need to be called first, then m2m_wifi_get_num_ap_found 
-			 to get the number of AP's found
+@brief       Reads the AP information from the Scan Result list with the given index,
+             the response received in wifi_cb M2M_WIFI_RESP_SCAN_RESULT,
+             the response pointer should be casted with tstrM2mWifiscanResult structure
+@param [in]  index
+             Index for the requested result, the index range start from 0 till number of AP's found
+@sa          tstrM2mWifiscanResult,m2m_wifi_get_num_ap_found,m2m_wifi_request_scan
+@return      The function shall return M2M_SUCCESS for success and a negative value otherwise
+@pre         m2m_wifi_request_scan need to be called first, then m2m_wifi_get_num_ap_found
+             to get the number of AP's found
 @warning     Function used only in STA mode only. the scan result updated only if scan request called,
-			 else it will be cashed in firmware for the host scan request result, 
-			 which mean if large delay occur between the scan request and the scan result request, 
-			 the result will not be up-to-date
+             else it will be cashed in firmware for the host scan request result,
+             which mean if large delay occur between the scan request and the scan result request,
+             the result will not be up-to-date
 */
-
 sint8 m2m_wifi_req_scan_result(uint8 index)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mReqScanResult strReqScanRlt;
-	strReqScanRlt.u8Index = index;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN_RESULT, (uint8*) &strReqScanRlt, sizeof(tstrM2mReqScanResult), NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mReqScanResult strReqScanRlt;
+    strReqScanRlt.u8Index = index;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SCAN_RESULT, (uint8 *) &strReqScanRlt, sizeof(tstrM2mReqScanResult), NULL, 0, 0);
+    return ret;
 }
+
 /*!
 @fn          NMI_API uint8 m2m_wifi_get_num_ap_found(void);
-@brief       Reads the number of AP's found in the last Scan Request, 
-			 The function read the number of AP's from global variable which updated in the 
-			 wifi_cb in M2M_WIFI_RESP_SCAN_DONE.			 
-@sa          m2m_wifi_request_scan               
+@brief       Reads the number of AP's found in the last Scan Request,
+             The function read the number of AP's from global variable which updated in the
+             wifi_cb in M2M_WIFI_RESP_SCAN_DONE.
+@sa          m2m_wifi_request_scan
 @return      Return the number of AP's found in the last Scan Request.
-@pre         m2m_wifi_request_scan need to be called first 
-@warning     That function need to be called in the wifi_cb in M2M_WIFI_RESP_SCAN_DONE, 
-			 calling that function in any other place will return undefined/undated numbers.
-			 Function used only in STA mode only.
+@pre         m2m_wifi_request_scan need to be called first
+@warning     That function need to be called in the wifi_cb in M2M_WIFI_RESP_SCAN_DONE,
+             calling that function in any other place will return undefined/undated numbers.
+             Function used only in STA mode only.
 */
 uint8 m2m_wifi_get_num_ap_found(void)
 {
-	return gu8ChNum;
+    return gu8ChNum;
 }
+
 /*!
-@fn		    NMI_API uint8 m2m_wifi_get_sleep_mode(void);
-@brief	    Get the current Power save mode.
-@return	    The current operating power saving mode.
-@sa		    tenuPowerSaveModes , m2m_wifi_set_sleep_mode
+@fn         NMI_API uint8 m2m_wifi_get_sleep_mode(void);
+@brief      Get the current Power save mode.
+@return     The current operating power saving mode.
+@sa         tenuPowerSaveModes , m2m_wifi_set_sleep_mode
 */
 uint8 m2m_wifi_get_sleep_mode(void)
 {
-	return hif_get_sleep_mode();
+    return hif_get_sleep_mode();
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn);
-@brief      Set the power saving mode for the WINC1500. 
-@param [in]	PsTyp
-			Desired power saving mode. Supported types are defined in tenuPowerSaveModes.
-@param [in]	BcastEn
-			Broadcast reception enable flag. 
-			If it is 1, the WINC1500 must be awake each DTIM Beacon for receiving Broadcast traffic.
-			If it is 0, the WINC1500 will not wakeup at the DTIM Beacon, but its wakeup depends only 
-			on the the configured Listen Interval. 
+@fn         NMI_API sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn);
+@brief      Set the power saving mode for the WINC1500.
+@param [in] PsTyp
+            Desired power saving mode. Supported types are defined in tenuPowerSaveModes.
+@param [in] BcastEn
+            Broadcast reception enable flag.
+            If it is 1, the WINC1500 must be awake each DTIM Beacon for receiving Broadcast traffic.
+            If it is 0, the WINC1500 will not wakeup at the DTIM Beacon, but its wakeup depends only
+            on the the configured Listen Interval.
 @return     The function SHALL return 0 for success and a negative value otherwise.
-@sa			tenuPowerSaveModes
-@warning    The function called once after initialization.  
+@sa         tenuPowerSaveModes
+@warning    The function called once after initialization.
 */
 sint8 m2m_wifi_set_sleep_mode(uint8 PsTyp, uint8 BcastEn)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mPsType strPs;
-	strPs.u8PsType = PsTyp;
-	strPs.u8BcastEn = BcastEn;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SLEEP, (uint8*) &strPs,sizeof(tstrM2mPsType), NULL, 0, 0);
-	M2M_INFO("POWER SAVE %d\n",PsTyp);
-	hif_set_sleep_mode(PsTyp);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mPsType strPs;
+    strPs.u8PsType = PsTyp;
+    strPs.u8BcastEn = BcastEn;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SLEEP, (uint8 *) &strPs, sizeof(tstrM2mPsType), NULL, 0, 0);
+    M2M_INFO("POWER SAVE %d\n", PsTyp);
+    hif_set_sleep_mode(PsTyp);
+    return ret;
 }
+
 /*!
-@fn	        NMI_API sint8 m2m_wifi_request_sleep(void)
-@brief	    Request from WINC1500 device to Sleep for specific time in the M2M_PS_MANUAL Power save mode (only).
-@param [in]	u32SlpReqTime
-			Request Sleep in ms 
+@fn         NMI_API sint8 m2m_wifi_request_sleep(void)
+@brief      Request from WINC device to Sleep for specific time in the M2M_PS_MANUAL Power save mode (only).
+@param [in] u32SlpReqTime
+            Request Sleep in ms
 @return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
 @sa         tenuPowerSaveModes , m2m_wifi_set_sleep_mode
-@warning	the Function should be called in M2M_PS_MANUAL power save only 
+@warning    the Function should be called in M2M_PS_MANUAL power save only
 */
 sint8 m2m_wifi_request_sleep(uint32 u32SlpReqTime)
 {
-	sint8 ret = M2M_SUCCESS;
-	uint8 psType;
-	psType = hif_get_sleep_mode();
-	if(psType == M2M_PS_MANUAL)
-	{
-		tstrM2mSlpReqTime strPs;
-		strPs.u32SleepTime = u32SlpReqTime;
-		ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DOZE, (uint8*) &strPs,sizeof(tstrM2mSlpReqTime), NULL, 0, 0);
-	}
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    uint8 psType;
+    psType = hif_get_sleep_mode();
+    if(psType == M2M_PS_MANUAL)
+    {
+        tstrM2mSlpReqTime strPs;
+        strPs.u32SleepTime = u32SlpReqTime;
+        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DOZE, (uint8 *) &strPs, sizeof(tstrM2mSlpReqTime), NULL, 0, 0);
+    }
+    return ret;
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength);
-@brief		Set the WINC1500 device name which is used as P2P device name.
-@param [in]	pu8DeviceName
-			Buffer holding the device name.
-@param [in]	u8DeviceNameLength
-			Length of the device name.
-@return		The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
-@warning	The Function called once after initialization. 
+@fn         NMI_API sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength);
+@brief      Sets the WINC device name. The name string is used as a device name in DHCP hostname (option 12).
+@param [in] pu8DeviceName
+            Buffer holding the device name.
+@param [in] u8DeviceNameLength
+            Length of the device name.
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@warning    The Function called once after initialization.
 */
 sint8 m2m_wifi_set_device_name(uint8 *pu8DeviceName, uint8 u8DeviceNameLength)
 {
-	tstrM2MDeviceNameConfig strDeviceName;
-	if(u8DeviceNameLength >= M2M_DEVICE_NAME_MAX)
-	{
-		u8DeviceNameLength = M2M_DEVICE_NAME_MAX;
-	}
-	//pu8DeviceName[u8DeviceNameLength] = '\0';
-	u8DeviceNameLength ++;
-	m2m_memcpy(strDeviceName.au8DeviceName, pu8DeviceName, u8DeviceNameLength);
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_DEVICE_NAME,
-		(uint8*)&strDeviceName, sizeof(tstrM2MDeviceNameConfig), NULL, 0,0);
+    tstrM2MDeviceNameConfig strDeviceName;
+    if(u8DeviceNameLength >= M2M_DEVICE_NAME_MAX)
+    {
+        u8DeviceNameLength = M2M_DEVICE_NAME_MAX;
+    }
+    //pu8DeviceName[u8DeviceNameLength] = '\0';
+    u8DeviceNameLength ++;
+    m2m_memcpy(strDeviceName.au8DeviceName, pu8DeviceName, u8DeviceNameLength);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_DEVICE_NAME,
+                    (uint8 *)&strDeviceName, sizeof(tstrM2MDeviceNameConfig), NULL, 0, 0);
 }
+
+/*!
+@fn         NMI_API sint8 m2m_wifi_configure_sntp(uint8 *pu8NTPServerName, uint8 u8NTPServerNameLength, tenuSNTPUseDHCP useDHCP);
+@brief      Configures what NTP server the SNTP client should use.
+@param [in] pu8NTPServerName
+            Buffer holding the NTP server name. If the first character is an asterisk (*) then it will be treated as a server pool, where the asterisk will
+            be replaced with an incrementing value from 0 to 3 each time a server fails (example: *.pool.ntp.org).
+@param [in] u8NTPServerNameLength
+            Length of the NTP server name. Should not exceed the maximum NTP server name length of @ref M2M_NTP_MAX_SERVER_NAME_LENGTH
+@param [in] useDHCP
+            Should the NTP server provided by the DHCP server be used.
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+*/
+sint8 m2m_wifi_configure_sntp(uint8 *pu8NTPServerName, uint8 u8NTPServerNameLength, tenuSNTPUseDHCP useDHCP)
+{
+    tstrM2MSNTPConfig strSNTPConfig;
+    if(u8NTPServerNameLength > M2M_NTP_MAX_SERVER_NAME_LENGTH)
+        return M2M_ERR_FAIL;
+
+    m2m_memcpy((uint8 *)strSNTPConfig.acNTPServer, pu8NTPServerName, u8NTPServerNameLength);
+    strSNTPConfig.acNTPServer[u8NTPServerNameLength] = '\0';
+    strSNTPConfig.enuUseDHCP                         = useDHCP;
+
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONFIG_SNTP,
+                    (uint8 *)&strSNTPConfig, sizeof(tstrM2MSNTPConfig), NULL, 0, 0);
+}
+
 sint8 m2m_wifi_get_firmware_version(tstrM2mRev *pstrRev)
 {
-	sint8 ret = M2M_SUCCESS;
-	ret = hif_chip_wake();
-	if(ret == M2M_SUCCESS)
-	{
-    	ret = nm_get_firmware_full_info(pstrRev);
-		hif_chip_sleep();
-	}
-	return ret;
-}
-#ifdef CONF_MGMT
-sint8 m2m_wifi_enable_monitoring_mode(tstrM2MWifiMonitorModeCtrl *pstrMtrCtrl, uint8 *pu8PayloadBuffer,
-								   uint16 u16BufferSize, uint16 u16DataOffset)
-{
-	sint8	s8Ret = -1;
-	if((pstrMtrCtrl->u8ChannelID >= M2M_WIFI_CH_1) && (pstrMtrCtrl->u8ChannelID <= M2M_WIFI_CH_14))
-	{
-		gstrMgmtCtrl.pu8Buf		= pu8PayloadBuffer;
-		gstrMgmtCtrl.u16Sz		= u16BufferSize;
-		gstrMgmtCtrl.u16Offset	= u16DataOffset;
-		s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ENABLE_MONITORING,
-			(uint8*)pstrMtrCtrl, sizeof(tstrM2MWifiMonitorModeCtrl), NULL, 0,0);
-	}
-	return s8Ret;
+    sint8 ret = M2M_SUCCESS;
+    ret = hif_chip_wake();
+    if(ret == M2M_SUCCESS)
+    {
+        ret = nm_get_firmware_full_info(pstrRev);
+        hif_chip_sleep();
+    }
+    return ret;
 }
 
-sint8 m2m_wifi_disable_monitoring_mode(void)
+sint8 m2m_wifi_start_provision_mode(tstrM2MAPConfig *pstrM2MAPConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_DISABLE_MONITORING, NULL, 0, NULL, 0,0);
+    tstrM2MAPModeConfig strM2MAPModeConfig;
+
+    m2m_memcpy((uint8 *)&strM2MAPModeConfig.strApConfig, (uint8 *)pstrM2MAPConfig, sizeof(tstrM2MAPConfig));
+    m2m_memcpy(strM2MAPModeConfig.strApConfigExt.au8DefRouterIP, pstrM2MAPConfig->au8DHCPServerIP, 4);
+    m2m_memcpy(strM2MAPModeConfig.strApConfigExt.au8DNSServerIP, pstrM2MAPConfig->au8DHCPServerIP, 4);
+
+    strM2MAPModeConfig.strApConfigExt.au8SubnetMask[0] = 0;
+
+    return m2m_wifi_start_provision_mode_ext(&strM2MAPModeConfig, pcHttpServerDomainName, bEnableHttpRedirect);
 }
 
-sint8 m2m_wifi_send_wlan_pkt(uint8 *pu8WlanPacket, uint16 u16WlanHeaderLength, uint16 u16WlanPktSize)
+sint8 m2m_wifi_start_provision_mode_ext(tstrM2MAPModeConfig *pstrAPModeConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect)
 {
-	sint8	s8Ret = -1;
-	if(pu8WlanPacket != NULL)
-	{
-		tstrM2MWifiTxPacketInfo		strTxPkt;
+    sint8   s8Ret = M2M_ERR_FAIL;
 
-		strTxPkt.u16PacketSize		= u16WlanPktSize;
-		strTxPkt.u16HeaderLength	= u16WlanHeaderLength;
-		s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SEND_WIFI_PACKET | M2M_REQ_DATA_PKT,
-		(uint8*)&strTxPkt, sizeof(tstrM2MWifiTxPacketInfo), pu8WlanPacket, u16WlanPktSize, sizeof(tstrM2MWifiTxPacketInfo));
-	}
-	return s8Ret;
-}
-#endif
+    if(pstrAPModeConfig != NULL)
+    {
+        tstrM2MProvisionModeConfig  strProvConfig;
+        if(M2M_SUCCESS == m2m_validate_ap_parameters(pstrAPModeConfig))
+        {
+            m2m_memcpy((uint8 *)&strProvConfig.strApConfig, (uint8 *)&pstrAPModeConfig->strApConfig, sizeof(tstrM2MAPConfig));
+            m2m_memcpy((uint8 *)&strProvConfig.strApConfigExt, (uint8 *)&pstrAPModeConfig->strApConfigExt, sizeof(tstrM2MAPConfigExt));
+            if((m2m_strlen((uint8 *)pcHttpServerDomainName) <= 0) || (NULL == pcHttpServerDomainName))
+            {
+                M2M_ERR("INVALID DOMAIN NAME\n");
+                goto ERR1;
+            }
+            m2m_memcpy((uint8 *)strProvConfig.acHttpServerDomainName, (uint8 *)pcHttpServerDomainName, 64);
+            strProvConfig.u8EnableRedirect = bEnableHttpRedirect;
 
-sint8 m2m_wifi_start_provision_mode(tstrM2MAPConfig *pstrAPConfig, char *pcHttpServerDomainName, uint8 bEnableHttpRedirect)
-{
-	sint8	s8Ret = M2M_ERR_FAIL;
-
-	if((pstrAPConfig != NULL))
-	{
-		tstrM2MProvisionModeConfig	strProvConfig;
-		if(M2M_SUCCESS == m2m_validate_ap_parameters(pstrAPConfig))
-		{
-			m2m_memcpy((uint8*)&strProvConfig.strApConfig, (uint8*)pstrAPConfig, sizeof(tstrM2MAPConfig));
-			if((m2m_strlen((uint8 *)pcHttpServerDomainName) <= 0) || (NULL == pcHttpServerDomainName))
-			{
-				M2M_ERR("INVALID DOMAIN NAME\n");
-				goto ERR1;
-			}
-			m2m_memcpy((uint8*)strProvConfig.acHttpServerDomainName, (uint8*)pcHttpServerDomainName, 64);
-			strProvConfig.u8EnableRedirect = bEnableHttpRedirect;
-		
-			/* Stop Scan if it is ongoing.
-			*/
-			gu8scanInProgress = 0;
-			s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_START_PROVISION_MODE | M2M_REQ_DATA_PKT, 
-						(uint8*)&strProvConfig, sizeof(tstrM2MProvisionModeConfig), NULL, 0, 0);
-		}
-		else
-		{
-			/*goto ERR1;*/
-		}
-	}
+            /* Stop Scan if it is ongoing.
+            */
+            gu8scanInProgress = 0;
+            s8Ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_START_PROVISION_MODE | M2M_REQ_DATA_PKT,
+                             (uint8 *)&strProvConfig, sizeof(tstrM2MProvisionModeConfig), NULL, 0, 0);
+        }
+        else
+        {
+            /*goto ERR1;*/
+        }
+    }
 ERR1:
-	return s8Ret;
+    return s8Ret;
 }
 
 sint8 m2m_wifi_stop_provision_mode(void)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_STOP_PROVISION_MODE, NULL, 0, NULL, 0, 0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_STOP_PROVISION_MODE, NULL, 0, NULL, 0, 0);
 }
 
 sint8 m2m_wifi_get_connection_info(void)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_CONN_INFO, NULL, 0, NULL, 0, 0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_CONN_INFO, NULL, 0, NULL, 0, 0);
 }
 
-sint8 m2m_wifi_set_sytem_time(uint32 u32UTCSeconds)
+sint8 m2m_wifi_set_system_time(uint32 u32UTCSeconds)
 {
-	/* 
-		The firmware accepts timestamps relative to 1900 like NTP Timestamp.
-	*/
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SYS_TIME, (uint8*)&u32UTCSeconds, sizeof(tstrSystemTime), NULL, 0, 0);
+    /*
+        The firmware accepts timestamps relative to 1900 like NTP Timestamp.
+    */
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_SYS_TIME, (uint8 *)&u32UTCSeconds, sizeof(tstrSystemTime), NULL, 0, 0);
 }
 /*!
- * @fn             NMI_API sint8 m2m_wifi_get_sytem_time(void);   
+ * @fn             NMI_API sint8 m2m_wifi_get_system_time(void);
  * @see            m2m_wifi_enable_sntp
- 			  		tstrSystemTime   
+                    tstrSystemTime
  * @note         get the system time from the sntp client
- *		         using the API \ref m2m_wifi_get_sytem_time.
+ *               using the API \ref m2m_wifi_get_system_time.
  * @return        The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
  */
-sint8 m2m_wifi_get_sytem_time(void)
+sint8 m2m_wifi_get_system_time(void)
 {
-	return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_SYS_TIME, NULL,0, NULL, 0, 0);
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_SYS_TIME, NULL, 0, NULL, 0, 0);
 }
 
 sint8 m2m_wifi_enable_sntp(uint8 bEnable)
 {
-	uint8	u8Req;
-
-	u8Req = bEnable ? M2M_WIFI_REQ_ENABLE_SNTP_CLIENT : M2M_WIFI_REQ_DISABLE_SNTP_CLIENT;
-	return hif_send(M2M_REQ_GROUP_WIFI, u8Req, NULL, 0, NULL, 0, 0);
+    uint8 u8Req;
+    u8Req = bEnable ? M2M_WIFI_REQ_ENABLE_SNTP_CLIENT : M2M_WIFI_REQ_DISABLE_SNTP_CLIENT;
+    return hif_send(M2M_REQ_GROUP_WIFI, u8Req, NULL, 0, NULL, 0, 0);
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode);
-@brief		Change the power profile mode 
-@param [in]	u8PwrMode
-			Change the WINC power profile to different mode 
-			PWR_LOW1/PWR_LOW2/PWR_HIGH/PWR_AUTO (tenuM2mPwrMode)
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
-@sa			tenuM2mPwrMode
-@pre		m2m_wifi_init
-@warning	must be called after the initializations and before any connection request and can't be changed in run time, 
+@fn         NMI_API sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode);
+@brief      Change the power profile mode
+@param [in] u8PwrMode
+            Change the WINC power profile to different mode
+            PWR_LOW1/PWR_LOW2/PWR_HIGH/PWR_AUTO (tenuM2mPwrMode)
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@sa         tenuM2mPwrMode
+@pre        m2m_wifi_init
+@warning    must be called after the initializations and before any connection request and can't be changed in run time,
 */
 sint8 m2m_wifi_set_power_profile(uint8 u8PwrMode)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mPwrMode strM2mPwrMode;
-	strM2mPwrMode.u8PwrMode = u8PwrMode;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_POWER_PROFILE, (uint8*)&strM2mPwrMode,sizeof(tstrM2mPwrMode), NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mPwrMode strM2mPwrMode;
+    strM2mPwrMode.u8PwrMode = u8PwrMode;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_POWER_PROFILE, (uint8 *)&strM2mPwrMode, sizeof(tstrM2mPwrMode), NULL, 0, 0);
+    return ret;
 }
+
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel);
-@brief		set the TX power tenuM2mTxPwrLevel
-@param [in]	u8TxPwrLevel
-			change the TX power tenuM2mTxPwrLevel
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
-@sa			tenuM2mTxPwrLevel
-@pre		m2m_wifi_init
-@warning	
+@fn         NMI_API sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel);
+@brief      set the TX power tenuM2mTxPwrLevel
+@param [in] u8TxPwrLevel
+            change the TX power tenuM2mTxPwrLevel
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@sa         tenuM2mTxPwrLevel
+@pre        m2m_wifi_init
+@warning
 */
 sint8 m2m_wifi_set_tx_power(uint8 u8TxPwrLevel)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mTxPwrLevel strM2mTxPwrLevel;
-	strM2mTxPwrLevel.u8TxPwrLevel = u8TxPwrLevel;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_TX_POWER, (uint8*)&strM2mTxPwrLevel,sizeof(tstrM2mTxPwrLevel), NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mTxPwrLevel strM2mTxPwrLevel;
+    strM2mTxPwrLevel.u8TxPwrLevel = u8TxPwrLevel;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_TX_POWER, (uint8 *)&strM2mTxPwrLevel, sizeof(tstrM2mTxPwrLevel), NULL, 0, 0);
+    return ret;
 }
 
 /*!
-@fn			NMI_API sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable);
-@brief		Enable or Disable logs in run time (Disable Firmware logs will 
-			enhance the firmware start-up time and performance)
-@param [in]	u8Enable
-			Set 1 to enable the logs 0 for disable
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
-@sa			__DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
-@pre		m2m_wifi_init
-@warning	
+@fn         NMI_API sint8 m2m_wifi_set_gain_table_idx(uint8 u8GainTableIdx);
+@brief      set the gain table index corresponding to a specific WiFi region
+@param [in] u8GainTableIdx
+            change the gain table index
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@pre        The gain tables must be written to the flash through gain builder tool.
+            m2m_wifi_init
+@warning
+*/
+sint8 m2m_wifi_set_gain_table_idx(uint8 u8GainTableIdx)
+{
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mWiFiGainIdx strM2mGainTableIdx;
+    strM2mGainTableIdx.u8GainTableIdx = u8GainTableIdx;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_GAIN_TABLE_IDX, (uint8 *)&strM2mGainTableIdx, sizeof(tstrM2mWiFiGainIdx), NULL, 0, 0);
+    return ret;
+}
+
+/*!
+@fn         NMI_API sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable);
+@brief      Enable or Disable logs in run time (Disable Firmware logs will
+            enhance the firmware start-up time and performance)
+@param [in] u8Enable
+            Set 1 to enable the logs 0 for disable
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@sa         __DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
+@pre        m2m_wifi_init
+@warning
 */
 sint8 m2m_wifi_enable_firmware_logs(uint8 u8Enable)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mEnableLogs strM2mEnableLogs;
-	strM2mEnableLogs.u8Enable = u8Enable;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_ENABLE_LOGS, (uint8*)&strM2mEnableLogs,sizeof(tstrM2mEnableLogs), NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mEnableLogs strM2mEnableLogs;
+    strM2mEnableLogs.u8Enable = u8Enable;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_ENABLE_LOGS, (uint8 *)&strM2mEnableLogs, sizeof(tstrM2mEnableLogs), NULL, 0, 0);
+    return ret;
 }
 
 /*!
-@fn			NMI_API sint8 m2m_wifi_set_battery_voltage(uint16 u16BattVoltx100);
-@brief		Enable or Disable logs in run time (Disable Firmware logs will 
-			enhance the firmware start-up time and performance)
-@param [in]	u16BattVoltx100
-			battery voltage multiplied by 100
-@return		The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
-@sa			__DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
-@pre		m2m_wifi_init
-@warning	
+@fn         NMI_API sint8 m2m_wifi_set_battery_voltage(uint16 u16BattVoltx100);
+@brief      Enable or Disable logs in run time (Disable Firmware logs will
+            enhance the firmware start-up time and performance)
+@param [in] u16BattVoltx100
+            battery voltage multiplied by 100
+@return     The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
+@sa         __DISABLE_FIRMWARE_LOGS__ (build option to disable logs from initializations)
+@pre        m2m_wifi_init
+@warning
 */
 sint8 m2m_wifi_set_battery_voltage(uint16 u16BattVoltx100)
 {
-	sint8 ret = M2M_SUCCESS;
-	tstrM2mBatteryVoltage strM2mBattVol = {0};
-	strM2mBattVol.u16BattVolt = u16BattVoltx100;
-	ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_BATTERY_VOLTAGE, (uint8*)&strM2mBattVol,sizeof(tstrM2mBatteryVoltage), NULL, 0, 0);
-	return ret;
+    sint8 ret = M2M_SUCCESS;
+    tstrM2mBatteryVoltage strM2mBattVol = {0};
+    strM2mBattVol.u16BattVolt = u16BattVoltx100;
+    ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_BATTERY_VOLTAGE, (uint8 *)&strM2mBattVol, sizeof(tstrM2mBatteryVoltage), NULL, 0, 0);
+    return ret;
 }
+
 /*!
-@fn        	 	 sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PrngBuff,uint16 u16PrngSize)
-@brief     	 Get random bytes using the PRNG bytes.	      
+@fn              sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PrngBuff,uint16 u16PrngSize)
+@brief       Get random bytes using the PRNG bytes.
 @param [in]    u16PrngSize
-		  	 Size of the required random bytes to be generated.   	 
+             Size of the required random bytes to be generated.
 @param [in]    pu8PrngBuff
-		        Pointer to user allocated buffer.  		            
-@return           The function SHALL return M2M_SUCCESE for success and a negative value otherwise.
+                Pointer to user allocated buffer.
+@return           The function SHALL return M2M_SUCCESS for success and a negative value otherwise.
 */
-sint8 m2m_wifi_prng_get_random_bytes(uint8 * pu8PrngBuff,uint16 u16PrngSize)
+sint8 m2m_wifi_prng_get_random_bytes(uint8 *pu8PrngBuff, uint16 u16PrngSize)
 {
-	sint8 ret = M2M_ERR_FAIL;
-	tstrPrng   strRng = {0};
-	if((u16PrngSize < (M2M_BUFFER_MAX_SIZE - sizeof(tstrPrng)))&&(pu8PrngBuff != NULL))
-	{
-		strRng.u16PrngSize = u16PrngSize;
-		strRng.pu8RngBuff  = pu8PrngBuff;
-		ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_PRNG|M2M_REQ_DATA_PKT,(uint8 *)&strRng, sizeof(tstrPrng),NULL,0, 0);
-	}
-	else
-	{
-		M2M_ERR("PRNG Buffer exceeded maximum size %d or NULL Buffer\n",u16PrngSize);
-	}
-	return ret;
+    sint8 ret = M2M_ERR_FAIL;
+    tstrPrng   strRng = {0};
+    if(
+            (u16PrngSize <= (M2M_HIF_MAX_PACKET_SIZE - (M2M_HIF_HDR_OFFSET + sizeof(tstrPrng))))
+        &&  (pu8PrngBuff != NULL)
+    )
+    {
+        strRng.u16PrngSize = u16PrngSize;
+        strRng.pu8RngBuff  = pu8PrngBuff;
+        ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_GET_PRNG|M2M_REQ_DATA_PKT, (uint8 *)&strRng, sizeof(tstrPrng), NULL, 0, 0);
+    }
+    else
+    {
+        M2M_ERR("PRNG Buffer exceeded maximum size %d or NULL Buffer\n", u16PrngSize);
+    }
+    return ret;
 }
+
+/*!
+@fn \
+     NMI_API sint8 m2m_wifi_conf_auto_rate(tstrConfAutoRate * pstrConfAutoRate)
+
+@brief
+    Allow the host MCU app to configure auto TX rate selection algorithm. The application can use this
+    API to tweak the algorithm performance. Moreover, it allows the application to force a specific WLAN
+    PHY rate for transmitted data packets to favor range vs. throughput needs.
+
+@param [in] pstrConfAutoRate
+    The Auto rate configuration parameters as listed in tstrConfAutoRate.
+@sa
+    tstrConfAutoRate
+@return
+    The function SHALL return 0 for success and a negative value otherwise.
+*/
+
+NMI_API sint8 m2m_wifi_conf_auto_rate(tstrConfAutoRate *pstrConfAutoRate)
+{
+    sint8 s8ret = M2M_ERR_FAIL;
+    s8ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_CONG_AUTO_RATE, (uint8 *)pstrConfAutoRate, sizeof(tstrConfAutoRate), NULL, 0, 0);
+
+    return s8ret;
+}
+
 #ifdef ETH_MODE
 /*!
-@fn	\
-	 NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8* pu8MulticastMacAddress, uint8 u8AddRemove)
+@fn \
+     NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8* pu8MulticastMacAddress, uint8 u8AddRemove)
 
 @brief
-	Add MAC filter to receive Multicast packets.
+    Add MAC filter to receive Multicast packets.
 
-@param [in]	pu8MulticastMacAddress
-				Pointer to the MAC address.
+@param [in] pu8MulticastMacAddress
+                Pointer to the MAC address.
 @param [in] u8AddRemove
-				Flag to Add/Remove MAC address.
+                Flag to Add/Remove MAC address.
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function SHALL return 0 for success and a negative value otherwise.
 */
 
-NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8* pu8MulticastMacAddress, uint8 u8AddRemove)
+NMI_API sint8 m2m_wifi_enable_mac_mcast(uint8 *pu8MulticastMacAddress, uint8 u8AddRemove)
 {
-	sint8 s8ret = M2M_ERR_FAIL;
-	tstrM2MMulticastMac  strMulticastMac;
+    sint8 s8ret = M2M_ERR_FAIL;
+    tstrM2MMulticastMac  strMulticastMac;
 
-	if(pu8MulticastMacAddress != NULL )
-	{
-		strMulticastMac.u8AddRemove = u8AddRemove;
-		m2m_memcpy(strMulticastMac.au8macaddress,pu8MulticastMacAddress,M2M_MAC_ADDRES_LEN);
-		M2M_DBG("mac multicast: %x:%x:%x:%x:%x:%x\r\n",strMulticastMac.au8macaddress[0],strMulticastMac.au8macaddress[1],strMulticastMac.au8macaddress[2],strMulticastMac.au8macaddress[3],strMulticastMac.au8macaddress[4],strMulticastMac.au8macaddress[5]);
-		s8ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_MAC_MCAST, (uint8 *)&strMulticastMac,sizeof(tstrM2MMulticastMac),NULL,0,0);
-	}
+    if(pu8MulticastMacAddress != NULL)
+    {
+        strMulticastMac.u8AddRemove = u8AddRemove;
+        m2m_memcpy(strMulticastMac.au8macaddress, pu8MulticastMacAddress, M2M_MAC_ADDRES_LEN);
+        M2M_DBG("mac multicast: %x:%x:%x:%x:%x:%x\r\n", strMulticastMac.au8macaddress[0], strMulticastMac.au8macaddress[1], strMulticastMac.au8macaddress[2], strMulticastMac.au8macaddress[3], strMulticastMac.au8macaddress[4], strMulticastMac.au8macaddress[5]);
+        s8ret = hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_SET_MAC_MCAST, (uint8 *)&strMulticastMac, sizeof(tstrM2MMulticastMac), NULL, 0, 0);
+    }
 
-	return s8ret;
-
+    return s8ret;
 }
 
 /*!
-@fn	\
-	NMI_API sint8  m2m_wifi_set_receive_buffer(void* pvBuffer,uint16 u16BufferLen);
+@fn \
+    NMI_API sint8  m2m_wifi_set_receive_buffer(void* pvBuffer,uint16 u16BufferLen);
 
 @brief
-	set the ethernet receive buffer, should be called in the receive call back.
+    set the ethernet receive buffer, should be called in the receive call back.
 
-@param [in]	pvBuffer
-				Pointer to the ethernet receive buffer.
+@param [in] pvBuffer
+                Pointer to the ethernet receive buffer.
 @param [in] u16BufferLen
-				Length of the buffer.
+                Length of the buffer.
 
 @return
-	The function SHALL return 0 for success and a negative value otherwise.
+    The function SHALL return 0 for success and a negative value otherwise.
 */
-NMI_API sint8  m2m_wifi_set_receive_buffer(void* pvBuffer,uint16 u16BufferLen)
+NMI_API sint8  m2m_wifi_set_receive_buffer(void *pvBuffer, uint16 u16BufferLen)
 {
-	sint8 s8ret = M2M_SUCCESS;
-	if(pvBuffer != NULL)
-	{
-		gau8ethRcvBuf = pvBuffer;
-		gu16ethRcvBufSize= u16BufferLen;
-	}
-	else
-	{
-		s8ret = M2M_ERR_FAIL;
-		M2M_ERR("Buffer NULL pointer\r\n");
-	}
-	return s8ret;
+    sint8 s8ret = M2M_SUCCESS;
+    if(pvBuffer != NULL)
+    {
+        gau8ethRcvBuf = pvBuffer;
+        gu16ethRcvBufSize= u16BufferLen;
+    }
+    else
+    {
+        s8ret = M2M_ERR_FAIL;
+        M2M_ERR("Buffer NULL pointer\r\n");
+    }
+    return s8ret;
 }
 #endif /* ETH_MODE */
+
+sint8 m2m_wifi_reinit(tstrWifiInitParam *pWifiInitParam)
+{
+    sint8 ret = m2m_wifi_reinit_hold();
+    if(M2M_SUCCESS == ret)
+        ret = m2m_wifi_reinit_start(pWifiInitParam);
+
+    return ret;
+}
+
+sint8 m2m_wifi_reinit_hold(void)
+{
+    m2m_wifi_deinit(NULL);
+    return m2m_wifi_init_hold();
+}
+
+sint8 m2m_wifi_reinit_start(tstrWifiInitParam *pWifiInitParam)
+{
+    return m2m_wifi_init_start(pWifiInitParam);
+}
+
+uint8 m2m_wifi_get_state(void)
+{
+    return gu8WifiState;
+}
+
+sint8 m2m_wifi_enable_roaming(uint8 bEnableDhcp)
+{
+    tstrM2mWiFiRoaming  strWiFiRoaming;
+    strWiFiRoaming.u8EnableRoaming = 1;
+    if(0 == bEnableDhcp || 1 == bEnableDhcp)
+    {
+        strWiFiRoaming.u8EnableDhcp = bEnableDhcp;
+        return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ROAMING,
+                        (uint8 *) &strWiFiRoaming, sizeof(tstrM2mWiFiRoaming), NULL, 0, 0);
+    }
+    else
+    {
+        return M2M_ERR_INVALID_ARG;
+    }
+}
+
+sint8 m2m_wifi_disable_roaming(void)
+{
+    tstrM2mWiFiRoaming  strWiFiRoaming;
+    strWiFiRoaming.u8EnableRoaming = 0;
+    return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_ROAMING, (uint8 *) &strWiFiRoaming, sizeof(tstrM2mWiFiRoaming), NULL, 0, 0);
+}
+
+sint8 m2m_wifi_enable_XO_during_sleep(uint8 bXOSleepEnable)
+{
+    tstrM2mWiFiXOSleepEnable  strM2mWiFiXOSleepEnable;
+
+    if(0 == bXOSleepEnable || 1 == bXOSleepEnable)
+    {
+        strM2mWiFiXOSleepEnable.u8EnableXODuringSleep = bXOSleepEnable;
+        return hif_send(M2M_REQ_GROUP_WIFI, M2M_WIFI_REQ_XO_SLEEP_ENABLE, 
+                        (uint8 *) &strM2mWiFiXOSleepEnable, sizeof(strM2mWiFiXOSleepEnable), NULL, 0, 0);	
+    }
+    else
+    {
+        return M2M_ERR_INVALID_ARG;
+    }
+}

--- a/asf/common/components/wifi/winc1500/driver/source/nmasic.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmasic.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1500 ASIC specific internal APIs.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -59,7 +52,7 @@
 
 
 
-#define TIMEOUT						(0xfffffffful)
+#define TIMEOUT						(0x2000ul)
 #define WAKUP_TRAILS_TIMEOUT		(4)
 
 sint8 chip_apply_conf(uint32 u32Conf)
@@ -83,6 +76,9 @@ sint8 chip_apply_conf(uint32 u32Conf)
 #endif
 #ifdef __DISABLE_FIRMWARE_LOGS__
 	val32 |= rHAVE_LOGS_DISABLED_BIT;
+#endif
+#if defined CONF_WINC_XO_XTALGM2_DIS
+	val32 |= rHAVE_XO_XTALGM2_DIS_BIT;
 #endif
 
 	val32 |= rHAVE_RESERVED1_BIT;
@@ -347,7 +343,7 @@ sint8 chip_wake(void)
 		trials++;
 		if(trials > WAKUP_TRAILS_TIMEOUT)
 		{
-			M2M_ERR("Failed to wakup the chip\n");
+			M2M_ERR("Failed to wake up the chip\n");
 			ret = M2M_ERR_TIME_OUT;
 			goto _WAKE_EXIT;
 		}
@@ -404,8 +400,8 @@ sint8 wait_for_bootrom(uint8 arg)
 	uint32 u32GpReg1 = 0;
 	uint32 u32DriverVerInfo = M2M_MAKE_VERSION_INFO(M2M_RELEASE_VERSION_MAJOR_NO,\
 				M2M_RELEASE_VERSION_MINOR_NO, M2M_RELEASE_VERSION_PATCH_NO,\
-				M2M_RELEASE_VERSION_MAJOR_NO, M2M_RELEASE_VERSION_MINOR_NO,\
-				M2M_RELEASE_VERSION_PATCH_NO);
+				M2M_MIN_REQ_DRV_VERSION_MAJOR_NO, M2M_MIN_REQ_DRV_VERSION_MINOR_NO,\
+				M2M_MIN_REQ_DRV_VERSION_PATCH_NO);
 
 
 	reg = 0;

--- a/asf/common/components/wifi/winc1500/driver/source/nmasic.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmasic.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1500 ASIC specific internal APIs.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -82,6 +75,8 @@
 #define rHAVE_LOGS_DISABLED_BIT		(NBIT6)
 #define rHAVE_ETHERNET_MODE_BIT		(NBIT7)
 #define rHAVE_RESERVED1_BIT     	(NBIT8)
+#define rHAVE_RESERVED2_BIT         (NBIT9)
+#define rHAVE_XO_XTALGM2_DIS_BIT    (NBIT10)
 
 typedef struct{
 	uint32 u32Mac_efuse_mib;

--- a/asf/common/components/wifi/winc1500/driver/source/nmbus.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmbus.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 bus APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -92,7 +85,7 @@ sint8 nm_bus_reset(void)
 	return nm_spi_reset();
 #elif defined (CONF_WINC_USE_I2C)
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 
 	return ret;
@@ -133,7 +126,7 @@ uint32 nm_read_reg(uint32 u32Addr)
 #elif defined (CONF_WINC_USE_I2C)
 	return nm_i2c_read_reg(u32Addr);
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 
 }
@@ -159,7 +152,7 @@ sint8 nm_read_reg_with_ret(uint32 u32Addr, uint32* pu32RetVal)
 #elif defined (CONF_WINC_USE_I2C)
 	return nm_i2c_read_reg_with_ret(u32Addr,pu32RetVal);
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 }
 
@@ -184,7 +177,7 @@ sint8 nm_write_reg(uint32 u32Addr, uint32 u32Val)
 #elif defined (CONF_WINC_USE_I2C)
 	return nm_i2c_write_reg(u32Addr,u32Val);
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 }
 
@@ -197,7 +190,7 @@ static sint8 p_nm_read_block(uint32 u32Addr, uint8 *puBuf, uint16 u16Sz)
 #elif defined (CONF_WINC_USE_I2C)
 	return nm_i2c_read_block(u32Addr,puBuf,u16Sz);
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 
 }
@@ -250,7 +243,7 @@ static sint8 p_nm_write_block(uint32 u32Addr, uint8 *puBuf, uint16 u16Sz)
 #elif defined (CONF_WINC_USE_I2C)
 	return nm_i2c_write_block(u32Addr,puBuf,u16Sz);
 #else
-#error "Plesae define bus usage"
+#error "Please define bus usage"
 #endif
 
 }

--- a/asf/common/components/wifi/winc1500/driver/source/nmbus.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmbus.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 bus APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/driver/source/nmdrv.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmdrv.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 M2M driver APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -233,7 +226,7 @@ EXIT:
 *	@date	10 Oct 2014
 *	@version	1.0
 */
-sint8 nm_drv_init_download_mode()
+sint8 nm_drv_init_download_mode(void)
 {
 	sint8 ret = M2M_SUCCESS;
 
@@ -248,7 +241,7 @@ sint8 nm_drv_init_download_mode()
 	*/
 	if(!ISNMC3000(GET_CHIPID()))
 	{
-		/*Execuate that function only for 1500A/B, no room in 3000, but it may be needed in 3400 no wait*/
+		/*Execute that function only for 1500A/B, no room in 3000, but it may be needed in 3400 no wait*/
 		chip_reset_and_cpu_halt();
 	}
 
@@ -266,30 +259,10 @@ ERR1:
 	return ret;
 }
 
-/*
-*	@fn		nm_drv_init
-*	@brief	Initialize NMC1000 driver
-*	@return	M2M_SUCCESS in case of success and Negative error code in case of failure
-*   @param [in]	arg
-*				Generic argument
-*	@author	M. Abdelmawla
-*	@date	15 July 2012
-*	@version	1.0
-*/
-sint8 nm_drv_init(void * arg)
+sint8 nm_drv_init_hold(void)
 {
 	sint8 ret = M2M_SUCCESS;
-	uint8 u8Mode;
-	
-	if(NULL != arg) {
-		u8Mode = *((uint8 *)arg);
-		if((u8Mode < M2M_WIFI_MODE_NORMAL)||(u8Mode >= M2M_WIFI_MODE_MAX)) {
-			u8Mode = M2M_WIFI_MODE_NORMAL;
-		}
-	} else {
-		u8Mode = M2M_WIFI_MODE_NORMAL;
-	}
-	
+
 	ret = nm_bus_iface_init(NULL);
 	if (M2M_SUCCESS != ret) {
 		M2M_ERR("[nmi start]: fail init bus\n");
@@ -299,10 +272,10 @@ sint8 nm_drv_init(void * arg)
 #ifdef BUS_ONLY
 	return;
 #endif
-	
-	
+
 #ifdef NO_HW_CHIP_EN
 	ret = chip_wake();
+
 	if (M2M_SUCCESS != ret) {
 		M2M_ERR("[nmi start]: fail chip_wakeup\n");
 		goto ERR2;
@@ -320,31 +293,77 @@ sint8 nm_drv_init(void * arg)
 	/* Must do this after global reset to set SPI data packet size. */
 	nm_spi_init();
 #endif
+
+	return ret;
+ERR2:
+	nm_bus_iface_deinit();
+ERR1:
+	return ret;
+}
+
+sint8 nm_drv_init_start(void * arg)
+{
+	sint8 ret = M2M_SUCCESS;
+	uint8 u8Mode = M2M_WIFI_MODE_NORMAL;
+
+	if(NULL != arg) {
+		u8Mode = *((uint8 *)arg);
+		if((u8Mode < M2M_WIFI_MODE_NORMAL)||(u8Mode >= M2M_WIFI_MODE_MAX)) {
+			u8Mode = M2M_WIFI_MODE_NORMAL;
+		}
+	}
+
 	ret = wait_for_bootrom(u8Mode);
 	if (M2M_SUCCESS != ret) {
 		goto ERR2;
 	}
-		
+
 	ret = wait_for_firmware_start(u8Mode);
 	if (M2M_SUCCESS != ret) {
 		goto ERR2;
 	}
-	
+
 	if((M2M_WIFI_MODE_ATE_HIGH == u8Mode)||(M2M_WIFI_MODE_ATE_LOW == u8Mode)) {
 		goto ERR1;
 	} else {
 		/*continue running*/
 	}
-	
+
 	ret = enable_interrupts();
 	if (M2M_SUCCESS != ret) {
 		M2M_ERR("failed to enable interrupts..\n");
 		goto ERR2;
 	}
+
 	return ret;
 ERR2:
 	nm_bus_iface_deinit();
+#ifdef CONF_WINC_USE_SPI
+	nm_spi_deinit();
+#endif
 ERR1:
+	return ret;
+}
+
+/*
+*	@fn		nm_drv_init
+*	@brief	Initialize NMC1000 driver
+*	@return	M2M_SUCCESS in case of success and Negative error code in case of failure
+*   @param [in]	arg
+*				Generic argument
+*	@author	M. Abdelmawla
+*	@date	15 July 2012
+*	@version	1.0
+*/
+sint8 nm_drv_init(void * arg)
+{
+	sint8 ret = M2M_SUCCESS;
+
+	ret = nm_drv_init_hold();
+
+	if(ret == M2M_SUCCESS)
+		ret = nm_drv_init_start(arg);
+
 	return ret;
 }
 

--- a/asf/common/components/wifi/winc1500/driver/source/nmdrv.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmdrv.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1500 M2M driver APIs declarations.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -52,10 +45,10 @@ typedef struct {
 	uint32 u32Chipid; /* HW revision which will be basically the chip ID */
 	uint8 u8FirmwareMajor; /* Version Major Number which represents the official release base */
 	uint8 u8FirmwareMinor; /* Version Minor Number which represents the engineering release base */
-	uint8 u8FirmwarePatch;	/* Version pathc Number which represents the pathces release base */
+	uint8 u8FirmwarePatch;	/* Version patch Number which represents the patches release base */
 	uint8 u8DriverMajor; /* Version Major Number which represents the official release base */
 	uint8 u8DriverMinor; /* Version Minor Number which represents the engineering release base */
-	uint8 u8DriverPatch; /* Version Patch Number which represents the pathces release base */
+	uint8 u8DriverPatch; /* Version Patch Number which represents the patches release base */
 	uint8 BuildDate[sizeof(__DATE__)];
 	uint8 BuildTime[sizeof(__TIME__)];
 	uint8 _PAD8_;
@@ -118,6 +111,28 @@ sint8 nm_drv_init_download_mode(void);
 
 */
 sint8 nm_drv_init(void * arg);
+
+/*
+*	@fn		nm_drv_init_hold
+*	@brief	First part of nm_drv_init, up to the point of initializing spi for flash access.
+*	@see	nm_drv_init
+*	@return	M2M_SUCCESS in case of success and Negative error code in case of failure
+*	@param [in]	req_serial_number
+*				Parameter inherited from nm_drv_init
+*	@return	ZERO in case of success and Negative error code in case of failure
+*/
+sint8 nm_drv_init_hold(void);
+
+/*
+*	@fn		nm_drv_init_start
+*	@brief	Second part of nm_drv_init, continuing from where nm_drv_init_hold left off.
+*	@see	nm_drv_init
+*	@return	M2M_SUCCESS in case of success and Negative error code in case of failure
+*	@param [in]	arg
+*				Parameter inherited from nm_drv_init
+*	@return	ZERO in case of success and Negative error code in case of failure
+*/
+sint8 nm_drv_init_start(void * arg);
 
 /**
 *	@fn		nm_drv_deinit

--- a/asf/common/components/wifi/winc1500/driver/source/nmi2c.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmi2c.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 I2C protocol bus APIs implementation.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/driver/source/nmi2c.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmi2c.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 I2C protocol bus APIs implementation.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/driver/source/nmspi.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmspi.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 SPI protocol bus APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -41,10 +34,6 @@
 #include "common/include/nm_common.h"
 
 #ifdef CONF_WINC_USE_SPI
-
-/* Don't force USE_OLD_SPI_SW, instead we will pass it from Zephyr side
-#define USE_OLD_SPI_SW
-*/
 
 #include "bus_wrapper/include/nm_bus_wrapper.h"
 #include "nmspi.h"
@@ -82,10 +71,10 @@
 #define CMD_SINGLE_READ			0xca
 #define CMD_RESET				0xcf
 
-#define N_OK					 1
-#define N_FAIL					 0
-#define N_RESET					-1
-#define N_RETRY					-2
+#define N_OK                     0
+#define N_FAIL                  -1
+#define N_RESET                 -2
+#define N_RETRY                 -3
 
 #define SPI_RESP_RETRY_COUNT 	(10)
 #define SPI_RETRY_COUNT			(10)
@@ -98,33 +87,19 @@
 
 static uint8 	gu8Crc_off	=   0;
 
-static sint8 nmi_spi_read(uint8* b, uint16 sz)
+static inline sint8 nmi_spi_read(uint8 *b, uint16 sz)
 {
-	tstrNmSpiRw spi;
-	spi.pu8InBuf = NULL;
-	spi.pu8OutBuf = b;
-	spi.u16Sz = sz;
-	return nm_bus_ioctl(NM_BUS_IOCTL_RW, &spi);
+    return nm_spi_rw(NULL, b, sz);
+}
+static inline sint8 nmi_spi_write(uint8 *b, uint16 sz)
+{
+    return nm_spi_rw(b, NULL, sz);
+}
+static sint8 nmi_spi_writeread(uint8 *bw, uint8 *br, uint16 sz)
+{
+    return nm_spi_rw(bw, br, sz);
 }
 
-static sint8 nmi_spi_write(uint8* b, uint16 sz)
-{
-	tstrNmSpiRw spi;
-	spi.pu8InBuf = b;
-	spi.pu8OutBuf = NULL;
-	spi.u16Sz = sz;
-	return nm_bus_ioctl(NM_BUS_IOCTL_RW, &spi);
-}
-#ifndef USE_OLD_SPI_SW
-static sint8 nmi_spi_rw(uint8 *bin,uint8* bout,uint16 sz)
-{
-	tstrNmSpiRw spi;
-	spi.pu8InBuf = bin;
-	spi.pu8OutBuf = bout;
-	spi.u16Sz = sz;
-	return nm_bus_ioctl(NM_BUS_IOCTL_RW, &spi);	
-}
-#endif
 /********************************************
 
 	Crc7
@@ -167,12 +142,12 @@ static const uint8 crc7_syndrome_table[256] = {
 };
 
 
-static uint8 crc7_byte(uint8 crc, uint8 data)
+static inline uint8 crc7_byte(uint8 crc, uint8 data)
 {
 	return crc7_syndrome_table[(crc << 1) ^ data];
 }
 
-static uint8 crc7(uint8 crc, const uint8 *buffer, uint32 len)
+static inline uint8 crc7(uint8 crc, const uint8 *buffer, uint32 len)
 {
 	while (len--)
 		crc = crc7_byte(crc, *buffer++);
@@ -184,25 +159,6 @@ static uint8 crc7(uint8 crc, const uint8 *buffer, uint32 len)
 	Spi protocol Function
 
 ********************************************/
-
-#define CMD_DMA_WRITE			0xc1
-#define CMD_DMA_READ			0xc2
-#define CMD_INTERNAL_WRITE		0xc3
-#define CMD_INTERNAL_READ		0xc4
-#define CMD_TERMINATE			0xc5
-#define CMD_REPEAT				0xc6
-#define CMD_DMA_EXT_WRITE		0xc7
-#define CMD_DMA_EXT_READ		0xc8
-#define CMD_SINGLE_WRITE		0xc9
-#define CMD_SINGLE_READ			0xca
-#define CMD_RESET				0xcf
-
-#define DATA_PKT_SZ_256 		256
-#define DATA_PKT_SZ_512			512
-#define DATA_PKT_SZ_1K			1024
-#define DATA_PKT_SZ_4K			(4 * 1024)
-#define DATA_PKT_SZ_8K			(8 * 1024)
-#define DATA_PKT_SZ				DATA_PKT_SZ_8K
 
 static sint8 spi_cmd(uint8 cmd, uint32 adr, uint32 u32data, uint32 sz,uint8 clockless)
 {
@@ -225,24 +181,29 @@ static sint8 spi_cmd(uint8 cmd, uint32 adr, uint32 u32data, uint32 sz,uint8 cloc
 		bc[3] = 0x00;
 		len = 5;
 		break;
+#if defined(CMD_TERMINATE)
 	case CMD_TERMINATE:					/* termination */
 		bc[1] = 0x00;
 		bc[2] = 0x00;
 		bc[3] = 0x00;
 		len = 5;
 		break;
+#endif
+#if defined(CMD_REPEAT)
 	case CMD_REPEAT:						/* repeat */
 		bc[1] = 0x00;
 		bc[2] = 0x00;
 		bc[3] = 0x00;
 		len = 5;
 		break;
+#endif
 	case CMD_RESET:							/* reset */
 		bc[1] = 0xff;
 		bc[2] = 0xff;
 		bc[3] = 0xff;
 		len = 5;
 		break;
+#if defined(CMD_DMA_WRITE) || defined(CMD_DMA_READ)
 	case CMD_DMA_WRITE:					/* dma write */
 	case CMD_DMA_READ:					/* dma read */
 		bc[1] = (uint8)(adr >> 16);
@@ -252,6 +213,7 @@ static sint8 spi_cmd(uint8 cmd, uint32 adr, uint32 u32data, uint32 sz,uint8 cloc
 		bc[5] = (uint8)(sz);
 		len = 7;
 		break;
+#endif
 	case CMD_DMA_EXT_WRITE:		/* dma extended write */
 	case CMD_DMA_EXT_READ:			/* dma extended read */
 		bc[1] = (uint8)(adr >> 16);
@@ -287,7 +249,7 @@ static sint8 spi_cmd(uint8 cmd, uint32 adr, uint32 u32data, uint32 sz,uint8 cloc
 		break;
 	}
 
-	if (result) {
+    if(result == N_OK) {
 		if (!gu8Crc_off)
 			bc[len-1] = (crc7(0x7f, (const uint8 *)&bc[0], len-1)) << 1;
 		else
@@ -339,14 +301,22 @@ static sint8 spi_cmd_rsp(uint8 cmd)
 	/**
 		Command/Control response
 	**/
-	if ((cmd == CMD_RESET) ||
-		 (cmd == CMD_TERMINATE) ||
-		 (cmd == CMD_REPEAT)) {
+#if defined(CMD_TERMINATE)
+    if(cmd == CMD_TERMINATE) {
+        if(M2M_SUCCESS != nmi_spi_read(&rsp, 1)) {
+            result = N_FAIL;
+            goto _fail_;
+        }
+    }
+#endif
+#if defined(CMD_REPEAT)
+    if(cmd == CMD_REPEAT) {
 		if (M2M_SUCCESS != nmi_spi_read(&rsp, 1)) {
 			result = N_FAIL;
 			goto _fail_;
 		}
 	}
+#endif
 
 	/* wait for response */
 	s8RetryCnt = SPI_RESP_RETRY_COUNT;
@@ -377,373 +347,27 @@ _fail_:
 
 	return result;
 }
-#ifndef USE_OLD_SPI_SW
-static int spi_cmd_complete(uint8_t cmd, uint32_t adr, uint8_t *b, uint32_t sz, uint8_t clockless)
+
+sint8 nm_spi_reset(void)
 {
-	uint8_t wb[32], rb[32];
-	uint8_t wix, rix;
-	uint32_t len2;
-	uint8_t rsp;
-	int len = 0;
-	int result = N_OK;
+	//M2M_INFO("Reset Spi\n");
+	spi_cmd(CMD_RESET, 0, 0, 0, 0);
 
-	wb[0] = cmd;
-	switch (cmd) {
-	case CMD_SINGLE_READ:				/* single word (4 bytes) read */
-		wb[1] = (uint8_t)(adr >> 16);
-		wb[2] = (uint8_t)(adr >> 8);
-		wb[3] = (uint8_t)adr;
-		len = 5;
-		break; 
-	case CMD_INTERNAL_READ:			/* internal register read */ 
-		wb[1] = (uint8_t)(adr >> 8);
-		if(clockless == 1)  wb[1] |= (1 << 7);
-		wb[2] = (uint8_t)adr;
-		wb[3] = 0x00;
-		len = 5;
-		break;
-	case CMD_TERMINATE:					/* termination */
-		wb[1] = 0x00;
-		wb[2] = 0x00;
-		wb[3] = 0x00;
-		len = 5;
-		break;
-	case CMD_REPEAT:						/* repeat */
-		wb[1] = 0x00;
-		wb[2] = 0x00;
-		wb[3] = 0x00;
-		len = 5;
-		break;
-	case CMD_RESET:							/* reset */
-		wb[1] = 0xff;
-		wb[2] = 0xff;
-		wb[3] = 0xff;
-		len = 5;
-		break;
-	case CMD_DMA_WRITE:					/* dma write */
-	case CMD_DMA_READ:					/* dma read */
-		wb[1] = (uint8_t)(adr >> 16);
-		wb[2] = (uint8_t)(adr >> 8);
-		wb[3] = (uint8_t)adr;
-		wb[4] = (uint8_t)(sz >> 8);
-		wb[5] = (uint8_t)(sz);
-		len = 7;
-		break;
-	case CMD_DMA_EXT_WRITE:		/* dma extended write */
-	case CMD_DMA_EXT_READ:			/* dma extended read */
-		wb[1] = (uint8_t)(adr >> 16);
-		wb[2] = (uint8_t)(adr >> 8);
-		wb[3] = (uint8_t)adr;
-		wb[4] = (uint8_t)(sz >> 16);
-		wb[5] = (uint8_t)(sz >> 8);
-		wb[6] = (uint8_t)(sz);
-		len = 8;
-		break;
-	case CMD_INTERNAL_WRITE:		/* internal register write */
-		wb[1] = (uint8_t)(adr >> 8);
-		if(clockless == 1)  wb[1] |= (1 << 7);
-		wb[2] = (uint8_t)(adr);
-		wb[3] = b[3];
-		wb[4] = b[2];
-		wb[5] = b[1];
-		wb[6] = b[0];
-		len = 8;
-		break;
-	case CMD_SINGLE_WRITE:			/* single word write */
-		wb[1] = (uint8_t)(adr >> 16);
-		wb[2] = (uint8_t)(adr >> 8);
-		wb[3] = (uint8_t)(adr);
-		wb[4] = b[3];
-		wb[5] = b[2];
-		wb[6] = b[1];
-		wb[7] = b[0];
-		len = 9;
-		break;
-	default:
-		result = N_FAIL;
-		break;
-	}
-
-	if (result != N_OK) {
-		return result;
-	}
-
-	if (!gu8Crc_off) {
-		wb[len-1] = (crc7(0x7f, (const uint8_t *)&wb[0], len-1)) << 1;
-	} else {
-		len -=1;
-	}
-
-#define NUM_SKIP_BYTES (1)
-#define NUM_RSP_BYTES (2)
-#define NUM_DATA_HDR_BYTES (1)
-#define NUM_DATA_BYTES (4)
-#define NUM_CRC_BYTES (2)
-#define NUM_DUMMY_BYTES (3)
-
-	if ((cmd == CMD_RESET) ||
-		(cmd == CMD_TERMINATE) ||
-		(cmd == CMD_REPEAT)) {
-			len2 = len + (NUM_SKIP_BYTES + NUM_RSP_BYTES + NUM_DUMMY_BYTES);
-	} else if ((cmd == CMD_INTERNAL_READ) || (cmd == CMD_SINGLE_READ)) {
-		if (!gu8Crc_off) {
-			len2 = len + (NUM_RSP_BYTES + NUM_DATA_HDR_BYTES + NUM_DATA_BYTES 
-			+ NUM_CRC_BYTES + NUM_DUMMY_BYTES);	
-		} else {
-			len2 = len + (NUM_RSP_BYTES + NUM_DATA_HDR_BYTES + NUM_DATA_BYTES 
-			+ NUM_DUMMY_BYTES);
+	if(spi_cmd_rsp(CMD_RESET) != N_OK) {
+		// Reset command failed, need to send repeated 1's until reset occurs
+		uint8 w_buf[8] = {0xFF};
+		uint8 r_buf[8];
+		M2M_ERR("[nmi spi]: Failed rst cmd response\n");
+		nmi_spi_writeread(w_buf, r_buf, 8);
+		if(r_buf[7] != 0xFF)
+		{
+			M2M_ERR("[nmi spi]: Failed repeated reset\n");
+			return N_FAIL;
 		}
-	} else {
-		len2 = len + (NUM_RSP_BYTES + NUM_DUMMY_BYTES);
 	}
-#undef NUM_DUMMY_BYTES
-
-	if(len2 > (sizeof(wb)/sizeof(wb[0]))) {
-		M2M_ERR("[nmi spi]: spi buffer size too small (%d) (%d)\n",
-			len2, (sizeof(wb)/sizeof(wb[0])));
-		result = N_FAIL;
-		return result;
-	}
-	/* zero spi write buffers. */
-	for(wix = len; wix< len2; wix++) {
-		wb[wix] = 0;
-	}
-	rix = len;
-
-	if (nmi_spi_rw(wb, rb, len2) != M2M_SUCCESS) {
-		M2M_ERR("[nmi spi]: Failed cmd write, bus error...\n");
-		result = N_FAIL;
-		return result;
-	}
-
-#if 0
-	{
-		int jj;
-		printk("--- cnd = %x, len=%d, len2=%d\n", cmd, len, len2);
-		for(jj=0; jj<sizeof(wb)/sizeof(wb[0]); jj++) {
-
-			if(jj >= len2) break;
-			if(((jj+1)%16) != 0) {
-				if((jj%16) == 0) {
-					printk("wb[%02x]: %02x ", jj, wb[jj]);
-				} else {
-					printk("%02x ", wb[jj]);
-				}
-			} else {
-				printk("%02x\n", wb[jj]);
-			}
-		}
-		printk("\n");
-
-		for(jj=0; jj<sizeof(rb)/sizeof(rb[0]); jj++) {
-
-				if(jj >= len2) break;
-				if(((jj+1)%16) != 0) {
-					if((jj%16) == 0) {
-						printk("rb[%02x]: %02x ", jj, rb[jj]);
-					} else {
-						printk("%02x ", rb[jj]);
-					}
-				} else {
-					printk("%02x\n", rb[jj]);
-				}
-			}
-		printk("\n");
-	}
-#endif
-
-	/**
-	Command/Control response
-	**/
-	if ((cmd == CMD_RESET) ||
-		(cmd == CMD_TERMINATE) ||
-		(cmd == CMD_REPEAT)) {
-			rix++; /* skip 1 byte */
-	}
-
-	rsp = rb[rix++];
-
-
-	if (rsp != cmd) {
-		M2M_ERR("[nmi spi]: Failed cmd response, cmd (%02x), resp (%02x)\n", cmd, rsp);
-		result = N_FAIL;
-		return result;
-	}
-
-	/**
-	State response
-	**/
-	rsp = rb[rix++];
-	if (rsp != 0x00) {
-		M2M_ERR("[nmi spi]: Failed cmd state response state (%02x)\n", rsp);
-		result = N_FAIL;
-		return result;
-	}
-
-	if ((cmd == CMD_INTERNAL_READ) || (cmd == CMD_SINGLE_READ)
-		|| (cmd == CMD_DMA_READ) || (cmd == CMD_DMA_EXT_READ)) {
-			int retry;
-			//uint16_t crc1, crc2;
-			uint8_t crc[2];
-			/**
-			Data Respnose header
-			**/
-			retry = SPI_RESP_RETRY_COUNT;
-			do {
-				/* ensure there is room in buffer later to read data and crc */
-				if(rix < len2) { 
-					rsp = rb[rix++];
-				} else {
-					retry = 0;
-					break;
-				}
-				if (((rsp >> 4) & 0xf) == 0xf)
-					break;
-			} while (retry--);
-
-			if (retry <= 0) {
-				M2M_ERR("[nmi spi]: Error, data read response (%02x)\n", rsp);
-				result = N_RESET;
-				return result;
-			}
-
-			if ((cmd == CMD_INTERNAL_READ) || (cmd == CMD_SINGLE_READ)) {
-				/**
-				Read bytes
-				**/
-				if((rix+3) < len2) { 
-					b[0] = rb[rix++];
-					b[1] = rb[rix++];
-					b[2] = rb[rix++];
-					b[3] = rb[rix++];
-				} else {
-					M2M_ERR("[nmi spi]: buffer overrun when reading data.\n");
-					result = N_FAIL;
-					return result;
-				}
-
-				if (!gu8Crc_off) {						
-					/**
-					Read Crc
-					**/
-					if((rix+1) < len2) { 
-						crc[0] = rb[rix++];
-						crc[1] = rb[rix++];
-					} else {
-						M2M_ERR("[nmi spi]: buffer overrun when reading crc.\n");
-						result = N_FAIL;
-						return result;
-					}
-				}
-			} else if((cmd == CMD_DMA_READ) || (cmd == CMD_DMA_EXT_READ)) {
-				int ix;
-
-				/* some data may be read in response to dummy bytes. */
-				for(ix=0; (rix < len2) && (ix < sz);) {
-					b[ix++] = rb[rix++];				
-				}
-#if 0
-				if(ix) M2M_INFO("ttt %d %d\n", sz, ix);
-#endif
-				sz -= ix;
-
-				if(sz > 0) {
-					int nbytes;
-					
-					if (sz <= (DATA_PKT_SZ-ix)) {
-						nbytes = sz;
-					} else {
-						nbytes = DATA_PKT_SZ-ix;
-					}
-
-					/**
-					Read bytes
-					**/
-					if (nmi_spi_read(&b[ix], nbytes) != M2M_SUCCESS) {
-						M2M_ERR("[nmi spi]: Failed data block read, bus error...\n");
-						result = N_FAIL;
-						goto _error_;
-					}
-
-					/**
-					Read Crc
-					**/
-					if (!gu8Crc_off) {
-						if (nmi_spi_read(crc, 2) != M2M_SUCCESS) {
-							M2M_ERR("[nmi spi]: Failed data block crc read, bus error...\n");
-							result = N_FAIL;
-							goto _error_;
-						}
-					}
-
-					
-					ix += nbytes;
-					sz -= nbytes;
-				}
-
-				/*  if any data in left unread, then read the rest using normal DMA code.*/	
-				while(sz > 0) {
-					int nbytes;
-			
-					if (sz <= DATA_PKT_SZ) {
-						nbytes = sz;
-					} else {
-						nbytes = DATA_PKT_SZ;
-					}
-
-					/** 
-					read data response only on the next DMA cycles not 
-					the first DMA since data response header is already 
-					handled above for the first DMA.
-					**/
-					/**
-					Data Respnose header
-					**/
-					retry = SPI_RESP_RETRY_COUNT;
-					do {
-						if (nmi_spi_read(&rsp, 1) != M2M_SUCCESS) {
-							M2M_ERR("[nmi spi]: Failed data response read, bus error...\n");
-							result = N_FAIL;
-							break;
-						}
-						if (((rsp >> 4) & 0xf) == 0xf)
-							break;
-					} while (retry--);
-
-					if (result == N_FAIL)
-						break;
-
-
-					/**
-					Read bytes
-					**/
-					if (nmi_spi_read(&b[ix], nbytes) != M2M_SUCCESS) {
-						M2M_ERR("[nmi spi]: Failed data block read, bus error...\n");
-						result = N_FAIL;
-						break;
-					}
-
-					/**
-					Read Crc
-					**/
-					if (!gu8Crc_off) {
-						if (nmi_spi_read(crc, 2) != M2M_SUCCESS) {
-							M2M_ERR("[nmi spi]: Failed data block crc read, bus error...\n");
-							result = N_FAIL;
-							break;
-						}
-					}
-
-					ix += nbytes;
-					sz -= nbytes;
-				}
-			}
-	}
-_error_:
-	return result;
+	return N_OK;
 }
-#endif
-#if defined USE_OLD_SPI_SW
+
 static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 {
 	sint16 retry, ix, nbytes;
@@ -762,7 +386,7 @@ static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 			nbytes = DATA_PKT_SZ;
 
 		/**
-			Data Respnose header
+			Data Response header
 		**/
 		retry = SPI_RESP_RETRY_COUNT;
 		do {
@@ -771,7 +395,7 @@ static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 				result = N_FAIL;
 				break;
 			}
-			if (((rsp >> 4) & 0xf) == 0xf)
+            if((rsp & 0xf0) == 0xf0)
 				break;
 		} while (retry--);
 
@@ -812,20 +436,18 @@ static sint8 spi_data_read(uint8 *b, uint16 sz,uint8 clockless)
 
 	return result;
 }
-#endif
 
 static sint8 spi_data_write(uint8 *b, uint16 sz)
 {
-	sint16 ix;
+    sint16 ix = 0;
 	uint16 nbytes;
-	sint8 result = 1;
+    sint8 result = N_OK;
 	uint8 cmd, order, crc[2] = {0};
 	//uint8 rsp;
 
 	/**
 		Data
 	**/
-	ix = 0;
 	do {
 		if (sz <= DATA_PKT_SZ)
 			nbytes = sz;
@@ -894,7 +516,16 @@ static sint8 spi_data_write(uint8 *b, uint16 sz)
 
 ********************************************/
 
-static sint8 spi_write_reg(uint32 addr, uint32 u32data)
+/**
+ *  @fn         nm_spi_write_reg
+ *  @brief      Write register
+ *  @param[in]  u32Addr
+ *                  Register address
+ *  @param[in]  u32Val
+ *                  Value to be written to the register
+ *  @return     @ref M2M_SUCCESS in case of success and @ref M2M_ERR_BUS_FAIL in case of failure
+ */
+sint8 nm_spi_write_reg(uint32 addr, uint32 u32data)
 {
 	uint8 retry = SPI_RETRY_COUNT;
 	sint8 result = N_OK;
@@ -910,13 +541,7 @@ _RETRY_:
 		cmd = CMD_INTERNAL_WRITE;
 		clockless = 1;
 	}
-	else
-	{
-		cmd = CMD_SINGLE_WRITE;
-		clockless = 0;
-	}
 
-#if defined USE_OLD_SPI_SW
 	result = spi_cmd(cmd, addr, u32data, 4, clockless);
 	if (result != N_OK) {
 		M2M_ERR("[nmi spi]: Failed cmd, write reg (%08x)...\n", (unsigned int)addr);
@@ -928,23 +553,13 @@ _RETRY_:
 		M2M_ERR("[nmi spi]: Failed cmd response, write reg (%08x)...\n", (unsigned int)addr);
 		goto _FAIL_;
 	}
-
-#else
-
-	result = spi_cmd_complete(cmd, addr, (uint8*)&u32data, 4, clockless);
-	if (result != N_OK) {
-		M2M_ERR( "[nmi spi]: Failed cmd, write reg (%08x)...\n", addr);
-		goto _FAIL_;
-	}
-
-#endif
 _FAIL_:
 	if(result != N_OK)
 	{
 		nm_bsp_sleep(1);
 		spi_cmd(CMD_RESET, 0, 0, 0, 0);
 		spi_cmd_rsp(CMD_RESET);
-		M2M_ERR("Reset and retry %d %lx %lx\n",retry,addr,u32data);
+		M2M_ERR("Reset and retry %d %x %x\n",retry,addr,u32data);
 		nm_bsp_sleep(1);
 		retry--;
 		if(retry) goto _RETRY_;
@@ -964,7 +579,6 @@ _RETRY_:
 	/**
 		Command
 	**/
-#if defined USE_OLD_SPI_SW
 	//Workaround hardware problem with single byte transfers over SPI bus
 	if (size == 1)
 		size = 2;
@@ -980,13 +594,6 @@ _RETRY_:
 		M2M_ERR("[nmi spi ]: Failed cmd response, write block (%08x)...\n", (unsigned int)addr);
 		goto _FAIL_;
 	}
-#else
-	result = spi_cmd_complete(cmd, addr, NULL, size, 0);
-	if (result != N_OK) {
-		M2M_ERR( "[nmi spi]: Failed cmd, write block (%08x)...\n", addr);
-		goto _FAIL_;
-	}
-#endif
 
 	/**
 		Data
@@ -1011,7 +618,7 @@ _FAIL_:
 		nm_bsp_sleep(1);
 		spi_cmd(CMD_RESET, 0, 0, 0, 0);
 		spi_cmd_rsp(CMD_RESET);
-		M2M_ERR("Reset and retry %d %lx %d\n",retry,addr,size);
+		M2M_ERR("Reset and retry %d %x %d\n",retry,addr,size);
 		nm_bsp_sleep(1);
 		retry--;
 		if(retry) goto _RETRY_;
@@ -1021,10 +628,19 @@ _FAIL_:
 	return result;
 }
 
-static sint8 spi_read_reg(uint32 addr, uint32 *u32data)
+/**
+ *  @fn         nm_spi_read_reg_with_ret
+ *  @brief      Read register with error code return
+ *  @param[in]  u32Addr
+ *                  Register address
+ *  @param[out] pu32RetVal
+ *                  Pointer to u32 variable used to return the read value
+ *  @return     @ref M2M_SUCCESS in case of success and M2M_ERR_BUS_FAIL in case of failure
+ */
+sint8 nm_spi_read_reg_with_ret(uint32 addr, uint32 *u32data)
 {
 	uint8 retry = SPI_RETRY_COUNT;
-	sint8 result = N_OK;
+	volatile sint8 result = N_OK;
 	uint8 cmd = CMD_SINGLE_READ;
 	uint8 tmp[4];
 	uint8 clockless = 0;
@@ -1039,13 +655,7 @@ _RETRY_:
 		cmd = CMD_INTERNAL_READ;
 		clockless = 1;
 	}
-	else
-	{
-		cmd = CMD_SINGLE_READ;
-		clockless = 0;
-	}
 
-#if defined USE_OLD_SPI_SW
 	result = spi_cmd(cmd, addr, 0, 4, clockless);
 	if (result != N_OK) {
 		M2M_ERR("[nmi spi]: Failed cmd, read reg (%08x)...\n", (unsigned int)addr);
@@ -1058,20 +668,12 @@ _RETRY_:
 		goto _FAIL_;
 	}
 
-	/* to avoid endianess issues */
+	/* to avoid endianness issues */
 	result = spi_data_read(&tmp[0], 4, clockless);
 	if (result != N_OK) {
 		M2M_ERR("[nmi spi]: Failed data read...\n");
 		goto _FAIL_;
 	}
-#else
-	result = spi_cmd_complete(cmd, addr, (uint8*)&tmp[0], 4, clockless);
-	if (result != N_OK) {
-		M2M_ERR( "[nmi spi]: Failed cmd, read reg (%08x)...\n", addr);
-		goto _FAIL_;
-	}
-
-#endif
 
 	*u32data = tmp[0] |
 		((uint32)tmp[1] << 8) |
@@ -1081,7 +683,6 @@ _RETRY_:
 _FAIL_:
 	if(result != N_OK)
 	{
-		
 		nm_bsp_sleep(1);
 		spi_cmd(CMD_RESET, 0, 0, 0, 0);
 		spi_cmd_rsp(CMD_RESET);
@@ -1099,17 +700,14 @@ static sint8 nm_spi_read(uint32 addr, uint8 *buf, uint16 size)
 	uint8 cmd = CMD_DMA_EXT_READ;
 	sint8 result;
 	uint8 retry = SPI_RETRY_COUNT;
-#if defined USE_OLD_SPI_SW
 	uint8 tmp[2];
 	uint8 single_byte_workaround = 0;
-#endif
 
 _RETRY_:
 
 	/**
 		Command
 	**/
-#if defined USE_OLD_SPI_SW
 	if (size == 1)
 	{
 		//Workaround hardware problem with single byte transfers over SPI bus
@@ -1143,13 +741,6 @@ _RETRY_:
 		M2M_ERR("[nmi spi]: Failed block data read...\n");
 		goto _FAIL_;
 	}
-#else
-	result = spi_cmd_complete(cmd, addr, buf, size, 0);
-	if (result != N_OK) {
-		M2M_ERR("[nmi spi]: Failed cmd, read block (%08x)...\n", addr);
-		goto _FAIL_;
-	}
-#endif
 
 _FAIL_:
 	if(result != N_OK)
@@ -1181,31 +772,32 @@ static void spi_init_pkt_sz(void)
 	val32 &= ~(0x7 << 4);
 	switch(DATA_PKT_SZ)
 	{
-	case 256:  val32 |= (0 << 4); break;
-	case 512:  val32 |= (1 << 4); break;
-	case 1024: val32 |= (2 << 4); break;
-	case 2048: val32 |= (3 << 4); break;
-	case 4096: val32 |= (4 << 4); break;
-	case 8192: val32 |= (5 << 4); break;
-
+        case 256:
+            val32 |= (0 << 4);
+            break;
+        case 512:
+            val32 |= (1 << 4);
+            break;
+        case 1024:
+            val32 |= (2 << 4);
+            break;
+        case 2048:
+            val32 |= (3 << 4);
+            break;
+        case 4096:
+            val32 |= (4 << 4);
+            break;
+        case 8192:
+            val32 |= (5 << 4);
+            break;
 	}
 	nm_spi_write_reg(SPI_BASE+0x24, val32);
 }
 
-sint8 nm_spi_reset(void)
-{
-	spi_cmd(CMD_RESET, 0, 0, 0, 0);
-	spi_cmd_rsp(CMD_RESET);
-	return M2M_SUCCESS;
-}
-
-/*
+/**
 *	@fn		nm_spi_init
 *	@brief	Initialize the SPI
-*	@return	M2M_SUCCESS in case of success and M2M_ERR_BUS_FAIL in case of failure
-*	@author	M. Abdelmawla
-*	@date	11 July 2012
-*	@version	1.0
+ *  @return     @ref M2M_SUCCESS in case of success and @ref M2M_ERR_BUS_FAIL in case of failure
 */
 sint8 nm_spi_init(void)
 {
@@ -1218,17 +810,15 @@ sint8 nm_spi_init(void)
 	**/
 	gu8Crc_off = 0;
 
-	// TODO: We can remove the CRC trials if there is a definite way to reset
-	// the SPI to it's initial value.
-	if (!spi_read_reg(NMI_SPI_PROTOCOL_CONFIG, &reg)) {
+    if(nm_spi_read_reg_with_ret(NMI_SPI_PROTOCOL_CONFIG, &reg) != M2M_SUCCESS) {
 		/* Read failed. Try with CRC off. This might happen when module
 		is removed but chip isn't reset*/
 		gu8Crc_off = 1;
-		M2M_ERR("[nmi spi]: Failed internal read protocol with CRC on, retyring with CRC off...\n");
-		if (!spi_read_reg(NMI_SPI_PROTOCOL_CONFIG, &reg)){
-			// Reaad failed with both CRC on and off, something went bad
+		M2M_ERR("[nmi spi]: Failed internal read protocol with CRC on, retrying with CRC off...\n");
+        if(nm_spi_read_reg_with_ret(NMI_SPI_PROTOCOL_CONFIG, &reg) != M2M_SUCCESS) {
+			// Read failed with both CRC on and off, something went bad
 			M2M_ERR( "[nmi spi]: Failed internal read protocol...\n");
-			return 0;
+            return M2M_ERR_BUS_FAIL;
 		}
 	}
 	if(gu8Crc_off == 0)
@@ -1236,9 +826,9 @@ sint8 nm_spi_init(void)
 		reg &= ~0xc;	/* disable crc checking */
 		reg &= ~0x70;
 		reg |= (0x5 << 4);
-		if (!spi_write_reg(NMI_SPI_PROTOCOL_CONFIG, reg)) {
+        if(nm_spi_write_reg(NMI_SPI_PROTOCOL_CONFIG, reg) != M2M_SUCCESS) {
 			M2M_ERR( "[nmi spi]: Failed internal write protocol reg...\n");
-			return 0;
+            return M2M_ERR_BUS_FAIL;
 		}
 		gu8Crc_off = 1;
 	}
@@ -1246,7 +836,7 @@ sint8 nm_spi_init(void)
 	/**
 		make sure can read back chip id correctly
 	**/
-	if (!spi_read_reg(0x1000, &chipid)) {
+    if(nm_spi_read_reg_with_ret(0x1000, &chipid) != M2M_SUCCESS) {
 		M2M_ERR("[nmi spi]: Fail cmd read chip id...\n");
 		return M2M_ERR_BUS_FAIL;
 	}
@@ -1258,13 +848,10 @@ sint8 nm_spi_init(void)
 	return M2M_SUCCESS;
 }
 
-/*
+/**
 *	@fn		nm_spi_init
 *	@brief	DeInitialize the SPI 
-*	@return	M2M_SUCCESS in case of success and M2M_ERR_BUS_FAIL in case of failure
-*	@author	Samer Sarhan
-*	@date	27 Feb 2015
-*	@version	1.0
+ *  @return     @ref M2M_SUCCESS in case of success and @ref M2M_ERR_BUS_FAIL in case of failure
 */ 
 sint8 nm_spi_deinit(void)
 {
@@ -1278,65 +865,14 @@ sint8 nm_spi_deinit(void)
 *	@param [in]	u32Addr
 *				Register address
 *	@return	Register value
-*	@author	M. Abdelmawla
-*	@date	11 July 2012
-*	@version	1.0
 */
 uint32 nm_spi_read_reg(uint32 u32Addr)
 {
 	uint32 u32Val;
 
-	spi_read_reg(u32Addr, &u32Val);
+    nm_spi_read_reg_with_ret(u32Addr, &u32Val);
 
 	return u32Val;
-}
-
-/*
-*	@fn		nm_spi_read_reg_with_ret
-*	@brief	Read register with error code return
-*	@param [in]	u32Addr
-*				Register address
-*	@param [out]	pu32RetVal
-*				Pointer to u32 variable used to return the read value
-*	@return	M2M_SUCCESS in case of success and M2M_ERR_BUS_FAIL in case of failure
-*	@author	M. Abdelmawla
-*	@date	11 July 2012
-*	@version	1.0
-*/
-sint8 nm_spi_read_reg_with_ret(uint32 u32Addr, uint32* pu32RetVal)
-{
-	sint8 s8Ret;
-
-	s8Ret = spi_read_reg(u32Addr,pu32RetVal);
-
-	if(N_OK == s8Ret) s8Ret = M2M_SUCCESS;
-	else s8Ret = M2M_ERR_BUS_FAIL;
-
-	return s8Ret;
-}
-
-/*
-*	@fn		nm_spi_write_reg
-*	@brief	write register
-*	@param [in]	u32Addr
-*				Register address
-*	@param [in]	u32Val
-*				Value to be written to the register
-*	@return	M2M_SUCCESS in case of success and M2M_ERR_BUS_FAIL in case of failure
-*	@author	M. Abdelmawla
-*	@date	11 July 2012
-*	@version	1.0
-*/
-sint8 nm_spi_write_reg(uint32 u32Addr, uint32 u32Val)
-{
-	sint8 s8Ret;
-
-	s8Ret = spi_write_reg(u32Addr, u32Val);
-
-	if(N_OK == s8Ret) s8Ret = M2M_SUCCESS;
-	else s8Ret = M2M_ERR_BUS_FAIL;
-
-	return s8Ret;
 }
 
 /*

--- a/asf/common/components/wifi/winc1500/driver/source/nmspi.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmspi.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 SPI protocol bus APIs implementation.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/driver/source/nmuart.c
+++ b/asf/common/components/wifi/winc1500/driver/source/nmuart.c
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 UART protocol bus APIs implementation.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -70,11 +63,12 @@ sint8 nm_uart_sync_cmd(void)
 	sint8 s8Ret = -1;
 	uint8 b [HDR_SZ+1];
 	uint8 rsz;
-	uint8 onchip = 0;
+	uint8 retries = 1;
 
 	/*read reg*/
+	while (retries--)
+	{
 	b[0] = 0x12;
-
 	rsz = 1;
 	strUart.pu8Buf = b;
 	strUart.u16Sz = 1;
@@ -82,32 +76,43 @@ sint8 nm_uart_sync_cmd(void)
 	if(M2M_SUCCESS == nm_bus_ioctl(NM_BUS_IOCTL_W, &strUart))
 	{
 		strUart.u16Sz = rsz;
-		if(M2M_SUCCESS != nm_bus_ioctl(NM_BUS_IOCTL_R, &strUart))
-		{
-			s8Ret = M2M_ERR_BUS_FAIL;
-		}
-	}
-	else
+			b[0] = 0;
+
+			// Pull all chars from buffer, we only care about the last
+			while (M2M_SUCCESS == nm_bus_ioctl(NM_BUS_IOCTL_R, &strUart))
 	{
-		M2M_ERR("failed to send cfg bytes\n");
-		s8Ret = M2M_ERR_BUS_FAIL;
+				strUart.u16Sz = rsz;
 	}
+
 	if (b[0] == 0x5a)
 	{
-		s8Ret = 0;
-		onchip = 1;
+				s8Ret = 1; // found on-chip (no bridge)
 		M2M_INFO("Built-in WINC1500 UART Found\n");
 	}
 	else if(b[0] == 0x5b)
 	{
-		s8Ret = 0;
-		onchip = 0;
+				s8Ret = 0; // found off-chip (std serial bridge)
 		M2M_INFO("WINC1500 Serial Bridge Found\n");
 	}
-	/*TODO: this should be the way we read the register since the cortus is little endian*/
-	/**pu32RetVal = b[0] | ((uint32)b[1] << 8) | ((uint32)b[2] << 16) | ((uint32)b[3] << 24);*/
-	if(s8Ret == M2M_SUCCESS)
-		s8Ret = (sint8)onchip;
+			else if (b[0] == 0x5c)
+			{
+				s8Ret = 0; // found of-chip (at cmd app serial bridge)
+				M2M_INFO("WINC1500 Serial Bridge Found + AT CMD app Found\n");
+			}
+			else
+			{
+				continue;
+			}
+
+			break;
+		}
+		else
+		{
+			M2M_ERR("failed to send cfg bytes\n");
+			s8Ret = M2M_ERR_BUS_FAIL;
+		}
+	}
+
 	return s8Ret;
 }
  sint8 nm_uart_read_reg_with_ret(uint32 u32Addr, uint32* pu32RetVal)
@@ -175,9 +180,6 @@ sint8 nm_uart_sync_cmd(void)
 		M2M_ERR("failed to send cfg bytes\n");
 		s8Ret = M2M_ERR_BUS_FAIL;
 	}
-	/*TODO: this should be the way we read the register since the cortus is little endian*/
-	/**pu32RetVal = b[0] | ((uint32)b[1] << 8) | ((uint32)b[2] << 16) | ((uint32)b[3] << 24);*/
-
 	*pu32RetVal = ((uint32)b[0] << 24) | ((uint32)b[1] << 16) | ((uint32)b[2] << 8) | b[3];
 
 	return s8Ret;

--- a/asf/common/components/wifi/winc1500/driver/source/nmuart.h
+++ b/asf/common/components/wifi/winc1500/driver/source/nmuart.h
@@ -4,36 +4,29 @@
  *
  * \brief This module contains NMC1000 UART protocol bus APIs implementation.
  *
- * Copyright (c) 2016 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/socket/source/socket.c
+++ b/asf/common/components/wifi/winc1500/socket/source/socket.c
@@ -4,36 +4,29 @@
  *
  * \brief BSD compatible socket interface.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -53,6 +46,25 @@ INCLUDES
 MACROS
 *=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*/
 
+/**
+ * Rename socket symbols to avoid conflict with Zephyr when POSIX socket support
+ * is enabled
+ */
+#ifdef __ZEPHYR__
+#define socket winc1500_socket
+#define bind winc1500_bind
+#define listen winc1500_listen
+#define accept winc1500_accept
+#define connect winc1500_connect
+#define secure winc1500_secure
+#define recv winc1500_recv
+#define recvfrom winc1500_recvfrom
+#define send winc1500_send
+#define sendto winc1500_sendto
+#define close winc1500_close
+#define setsocketopt winc1500_setsockopt
+#define getsocketopt winc1500_getsockopt
+#endif
 
 #define TLS_RECORD_HEADER_LENGTH			(5)
 #define ETHERNET_HEADER_OFFSET				(34)
@@ -70,13 +82,14 @@ MACROS
 	hif_send(M2M_REQ_GROUP_IP, reqID, reqArgs, reqSize, reqPayload, reqPayloadSize, reqPayloadOffset)
 
 
-#define SSL_FLAGS_ACTIVE					NBIT0
-#define SSL_FLAGS_BYPASS_X509				NBIT1
-#define SSL_FLAGS_2_RESERVD					NBIT2
-#define SSL_FLAGS_3_RESERVD					NBIT3
-#define SSL_FLAGS_CACHE_SESSION				NBIT4
-#define SSL_FLAGS_NO_TX_COPY				NBIT5
-#define SSL_FLAGS_CHECK_SNI					NBIT6
+#define SSL_FLAGS_ACTIVE                    NBIT0
+#define SSL_FLAGS_BYPASS_X509               NBIT1
+#define SSL_FLAGS_2_RESERVD                 NBIT2
+#define SSL_FLAGS_3_RESERVD                 NBIT3
+#define SSL_FLAGS_CACHE_SESSION             NBIT4
+#define SSL_FLAGS_NO_TX_COPY                NBIT5
+#define SSL_FLAGS_CHECK_SNI                 NBIT6
+#define SSL_FLAGS_DELAY                     NBIT7
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 PRIVATE DATA TYPES
@@ -96,15 +109,18 @@ typedef struct{
 /*!
 *  @brief
 */
-typedef struct{
-	uint8				*pu8UserBuffer;
-	uint16				u16UserBufferSize;
-	uint16				u16SessionID;
-	uint16				u16DataOffset;
-	uint8				bIsUsed;
-	uint8				u8SSLFlags;
-	uint8				bIsRecvPending;
-}tstrSocket;
+typedef struct {
+    uint8               *pu8UserBuffer;
+    uint16              u16UserBufferSize;
+    uint16              u16SessionID;
+    uint16              u16DataOffset;
+    uint8               bIsUsed;
+    uint8               u8SSLFlags;
+    uint8               bIsRecvPending;
+    uint8               u8AlpnStatus;
+    uint8               u8ErrSource;
+    uint8               u8ErrCode;
+} tstrSocket;
 
 /*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*=*
 GLOBALS
@@ -116,10 +132,12 @@ volatile uint8					gu8OpCode;
 volatile uint16					gu16BufferSize;
 volatile uint16					gu16SessionID = 0;	
 
-volatile tpfAppSocketCb		    gpfAppSocketCb;
-volatile tpfAppResolveCb		gpfAppResolveCb;
-volatile uint8					gbSocketInit = 0;
-volatile tpfPingCb				gfpPingCb;
+volatile tpfAppSocketCb         gpfAppSocketCb;
+volatile tpfAppResolveCb        gpfAppResolveCb;
+volatile uint8                  gbSocketInit = 0;
+
+static tpfPingCb                gfpPingCb = NULL;
+static uint32                   gu32PingId = 0;
 
 /*********************************************************************
 Function
@@ -141,58 +159,44 @@ Version
 Date
 		17 July 2012
 *********************************************************************/
-NMI_API void Socket_ReadSocketData(SOCKET sock, tstrSocketRecvMsg *pstrRecv,uint8 u8SocketMsg,
-								  uint32 u32StartAddress,uint16 u16ReadCount)
+NMI_API void Socket_ReadSocketData(SOCKET sock, tstrSocketRecvMsg *pstrRecv, uint8 u8SocketMsg,
+                                   uint32 u32StartAddress, uint16 u16ReadCount)
 {
-	if((u16ReadCount > 0) && (gastrSockets[sock].pu8UserBuffer != NULL) && (gastrSockets[sock].u16UserBufferSize > 0) && (gastrSockets[sock].bIsUsed == 1))
-	{
-		uint32	u32Address = u32StartAddress;
-		uint16	u16Read;
-		sint16	s16Diff;
-		uint8	u8SetRxDone;
+    uint32  u32Address = u32StartAddress;
+    uint16  u16Read;
+    sint16  s16Diff;
 
-		pstrRecv->u16RemainingSize = u16ReadCount;
-		do
-		{
-			u8SetRxDone = 1;
-			u16Read = u16ReadCount;
-			s16Diff	= u16Read - gastrSockets[sock].u16UserBufferSize;
-			if(s16Diff > 0)
-			{
-				u8SetRxDone = 0;
-				u16Read		= gastrSockets[sock].u16UserBufferSize;
-			}
-			
-			if(hif_receive(u32Address, gastrSockets[sock].pu8UserBuffer, u16Read, u8SetRxDone) == M2M_SUCCESS)
-			{
-				pstrRecv->pu8Buffer			= gastrSockets[sock].pu8UserBuffer;
-				pstrRecv->s16BufferSize		= u16Read;
-				pstrRecv->u16RemainingSize	-= u16Read;
+    pstrRecv->u16RemainingSize = u16ReadCount;
+    if((u16ReadCount > 0) && (gastrSockets[sock].pu8UserBuffer != NULL) && (gastrSockets[sock].u16UserBufferSize > 0) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        u16Read = u16ReadCount;
+        s16Diff = u16Read - gastrSockets[sock].u16UserBufferSize;
+        if(s16Diff > 0)
+        {
+            /* We don't expect to be here. Firmware 19.6.4 and later only sends data to the driver according to the application's buffer size.
+             * But it is worth keeping this check, eg in case the application calls recv again with a smaller buffer size, or in case of HIF hacking. */
+            u16Read = gastrSockets[sock].u16UserBufferSize;
+        }
 
-				if (gpfAppSocketCb)
-					gpfAppSocketCb(sock,u8SocketMsg, pstrRecv);
+        if(hif_receive(u32Address, gastrSockets[sock].pu8UserBuffer, u16Read, 1) == M2M_SUCCESS)
+        {
+            pstrRecv->pu8Buffer         = gastrSockets[sock].pu8UserBuffer;
+            pstrRecv->s16BufferSize     = u16Read;
+            pstrRecv->u16RemainingSize  -= u16Read;
 
-				u16ReadCount -= u16Read;
-				u32Address += u16Read;
+            gastrSockets[sock].u16UserBufferSize = 0;
+            gastrSockets[sock].pu8UserBuffer = NULL;
 
-				if((!gastrSockets[sock].bIsUsed) && (u16ReadCount))
-				{
-					M2M_DBG("Application Closed Socket While Rx Is not Complete\n");
-					if(hif_receive(0, NULL, 0, 1) == M2M_SUCCESS)
-						M2M_DBG("hif_receive Success\n");
-					else
-						M2M_DBG("hif_receive Fail\n");
-					break;
-				}
-			}
-			else
-			{
-				M2M_INFO("(ERRR)Current <%d>\n", u16ReadCount);
-				break;
-			}
-		}while(u16ReadCount != 0);
-	}
+            if(gpfAppSocketCb)
+                gpfAppSocketCb(sock, u8SocketMsg, pstrRecv);
+        }
+        else
+        {
+            M2M_ERR("Current <%d>\n", u16ReadCount);
+        }
+    }
 }
+
 /*********************************************************************
 Function
 		m2m_ip_cb
@@ -220,35 +224,35 @@ static void m2m_ip_cb(uint8 u8OpCode, uint16 u16BufferSize,uint32 u32Address)
 		tstrBindReply		strBindReply;
 		tstrSocketBindMsg	strBind;
 
-		if(hif_receive(u32Address, (uint8*)&strBindReply, sizeof(tstrBindReply), 0) == M2M_SUCCESS)
-		{
-			strBind.status = strBindReply.s8Status;
-			if(gpfAppSocketCb)
-				gpfAppSocketCb(strBindReply.sock,SOCKET_MSG_BIND,&strBind);
-		}
-	}
-	else if(u8OpCode == SOCKET_CMD_LISTEN)
-	{
-		tstrListenReply			strListenReply;
-		tstrSocketListenMsg		strListen;
-		if(hif_receive(u32Address, (uint8*)&strListenReply, sizeof(tstrListenReply), 0) == M2M_SUCCESS)
-		{
-			strListen.status = strListenReply.s8Status;
-			if(gpfAppSocketCb)
-				gpfAppSocketCb(strListenReply.sock,SOCKET_MSG_LISTEN, &strListen);
-		}
-	}
-	else if(u8OpCode == SOCKET_CMD_ACCEPT)
-	{
-		tstrAcceptReply			strAcceptReply;
-		tstrSocketAcceptMsg		strAccept;
-		if(hif_receive(u32Address, (uint8*)&strAcceptReply, sizeof(tstrAcceptReply), 0) == M2M_SUCCESS)
-		{
-			if(strAcceptReply.sConnectedSock >= 0)
-			{
-				gastrSockets[strAcceptReply.sConnectedSock].u8SSLFlags 		= gastrSockets[strAcceptReply.sListenSock].u8SSLFlags;
-				gastrSockets[strAcceptReply.sConnectedSock].bIsUsed 		= 1;
-				gastrSockets[strAcceptReply.sConnectedSock].u16DataOffset 	= strAcceptReply.u16AppDataOffset - M2M_HIF_HDR_OFFSET;
+        if(hif_receive(u32Address, (uint8 *)&strBindReply, sizeof(tstrBindReply), 0) == M2M_SUCCESS)
+        {
+            strBind.status = strBindReply.s8Status;
+            if(gpfAppSocketCb)
+                gpfAppSocketCb(strBindReply.sock, SOCKET_MSG_BIND, &strBind);
+        }
+    }
+    else if(u8OpCode == SOCKET_CMD_LISTEN)
+    {
+        tstrListenReply         strListenReply;
+        tstrSocketListenMsg     strListen;
+        if(hif_receive(u32Address, (uint8 *)&strListenReply, sizeof(tstrListenReply), 0) == M2M_SUCCESS)
+        {
+            strListen.status = strListenReply.s8Status;
+            if(gpfAppSocketCb)
+                gpfAppSocketCb(strListenReply.sock, SOCKET_MSG_LISTEN, &strListen);
+        }
+    }
+    else if(u8OpCode == SOCKET_CMD_ACCEPT)
+    {
+        tstrAcceptReply         strAcceptReply;
+        tstrSocketAcceptMsg     strAccept;
+        if(hif_receive(u32Address, (uint8 *)&strAcceptReply, sizeof(tstrAcceptReply), 0) == M2M_SUCCESS)
+        {
+            if((strAcceptReply.sConnectedSock >= 0) && (strAcceptReply.sConnectedSock < MAX_SOCKET))
+            {
+                gastrSockets[strAcceptReply.sConnectedSock].u8SSLFlags      = gastrSockets[strAcceptReply.sListenSock].u8SSLFlags;
+                gastrSockets[strAcceptReply.sConnectedSock].bIsUsed         = 1;
+                gastrSockets[strAcceptReply.sConnectedSock].u16DataOffset   = strAcceptReply.u16AppDataOffset - M2M_HIF_HDR_OFFSET;
 
 				/* The session ID is used to distinguish different socket connections
 					by comparing the assigned session ID to the one reported by the firmware*/
@@ -256,61 +260,86 @@ static void m2m_ip_cb(uint8 u8OpCode, uint16 u16BufferSize,uint32 u32Address)
 				if(gu16SessionID == 0)
 					++gu16SessionID;
 
-				gastrSockets[strAcceptReply.sConnectedSock].u16SessionID = gu16SessionID;
-				M2M_DBG("Socket %d session ID = %d\r\n",strAcceptReply.sConnectedSock , gu16SessionID );		
-			}
-			strAccept.sock = strAcceptReply.sConnectedSock;
-			strAccept.strAddr.sin_family		= AF_INET;
-			strAccept.strAddr.sin_port = strAcceptReply.strAddr.u16Port;
-			strAccept.strAddr.sin_addr.s_addr = strAcceptReply.strAddr.u32IPAddr;
-			if(gpfAppSocketCb)
-				gpfAppSocketCb(strAcceptReply.sListenSock, SOCKET_MSG_ACCEPT, &strAccept);
-		}
-	}
-	else if((u8OpCode == SOCKET_CMD_CONNECT) || (u8OpCode == SOCKET_CMD_SSL_CONNECT))
-	{
-		tstrConnectReply		strConnectReply;
-		tstrSocketConnectMsg	strConnMsg;
-		if(hif_receive(u32Address, (uint8*)&strConnectReply, sizeof(tstrConnectReply), 0) == M2M_SUCCESS)
-		{
-			strConnMsg.sock		= strConnectReply.sock;
-			strConnMsg.s8Error	= strConnectReply.s8Error;
-			if(strConnectReply.s8Error == SOCK_ERR_NO_ERROR)
-			{
-				gastrSockets[strConnectReply.sock].u16DataOffset = strConnectReply.u16AppDataOffset - M2M_HIF_HDR_OFFSET;
-			}
-			if(gpfAppSocketCb)
-				gpfAppSocketCb(strConnectReply.sock,SOCKET_MSG_CONNECT, &strConnMsg);
-		}
-	}
-	else if(u8OpCode == SOCKET_CMD_DNS_RESOLVE)
-	{
-		tstrDnsReply	strDnsReply;
-		if(hif_receive(u32Address, (uint8*)&strDnsReply, sizeof(tstrDnsReply), 0) == M2M_SUCCESS)
-		{
-			if(gpfAppResolveCb)
-				gpfAppResolveCb((uint8*)strDnsReply.acHostName, strDnsReply.u32HostIP);
-		}
-	}
-	else if((u8OpCode == SOCKET_CMD_RECV) || (u8OpCode == SOCKET_CMD_RECVFROM) || (u8OpCode == SOCKET_CMD_SSL_RECV))
-	{
-		SOCKET				sock;
-		sint16				s16RecvStatus;
-		tstrRecvReply		strRecvReply;
-		uint16				u16ReadSize;
-		tstrSocketRecvMsg	strRecvMsg;
-		uint8				u8CallbackMsgID = SOCKET_MSG_RECV;
-		uint16				u16DataOffset;
+                gastrSockets[strAcceptReply.sConnectedSock].u16SessionID = gu16SessionID;
+                M2M_DBG("Socket %d session ID = %d\r\n", strAcceptReply.sConnectedSock, gu16SessionID);
+            }
+            strAccept.sock = strAcceptReply.sConnectedSock;
+            strAccept.strAddr.sin_family        = AF_INET;
+            strAccept.strAddr.sin_port = strAcceptReply.strAddr.u16Port;
+            strAccept.strAddr.sin_addr.s_addr = strAcceptReply.strAddr.u32IPAddr;
+            if(gpfAppSocketCb)
+                gpfAppSocketCb(strAcceptReply.sListenSock, SOCKET_MSG_ACCEPT, &strAccept);
+        }
+    }
+    else if((u8OpCode == SOCKET_CMD_CONNECT) || (u8OpCode == SOCKET_CMD_SSL_CONNECT) || (u8OpCode == SOCKET_CMD_SSL_CONNECT_ALPN))
+    {
+        /* Note that for successful connections the fw always sends SOCKET_CMD_CONNECT, even for SSL connections. */
+        tstrConnectAlpnReply    strConnectAlpnReply = {{0}};
+        tstrSocketConnectMsg    strConnMsg;
+        uint16                  u16HifSz = sizeof(tstrConnectAlpnReply);
+        if(u8OpCode != SOCKET_CMD_SSL_CONNECT_ALPN)
+            u16HifSz = sizeof(tstrConnectReply);
+        if(hif_receive(u32Address, (uint8*)&strConnectAlpnReply, u16HifSz, 0) == M2M_SUCCESS)
+        {
+            if((strConnectAlpnReply.strConnReply.sock >= 0) && (strConnectAlpnReply.strConnReply.sock < MAX_SOCKET))
+            {
+                uint8 u8Msg = SOCKET_MSG_CONNECT;
+
+                strConnMsg.sock     = strConnectAlpnReply.strConnReply.sock;
+                strConnMsg.s8Error  = strConnectAlpnReply.strConnReply.s8Error;
+
+                /* If the SOCKET_CMD_SSL_CONNECT op code is received and the socket was already connected, then the
+                    callback corresponds to an attempt to make the socket secure. */
+                if(0 != gastrSockets[strConnMsg.sock].u16DataOffset)
+                {
+                    u8Msg = SOCKET_MSG_SECURE;
+                }
+                if(strConnectAlpnReply.strConnReply.s8Error == SOCK_ERR_NO_ERROR)
+                {
+                    gastrSockets[strConnMsg.sock].u16DataOffset = strConnectAlpnReply.strConnReply.u16AppDataOffset - M2M_HIF_HDR_OFFSET;
+                    gastrSockets[strConnMsg.sock].u8AlpnStatus = strConnectAlpnReply.u8AppProtocolIdx;
+                }
+                else
+                {
+                    gastrSockets[strConnMsg.sock].u8ErrSource = strConnectAlpnReply.strConnReply.u8ErrSource;
+                    gastrSockets[strConnMsg.sock].u8ErrCode = strConnectAlpnReply.strConnReply.u8ErrCode;
+                }
+                if(gpfAppSocketCb)
+                    gpfAppSocketCb(strConnMsg.sock, u8Msg, &strConnMsg);
+            }
+        }
+    }
+    else if(u8OpCode == SOCKET_CMD_DNS_RESOLVE)
+    {
+        tstrDnsReply    strDnsReply;
+        if(hif_receive(u32Address, (uint8 *)&strDnsReply, sizeof(tstrDnsReply), 0) == M2M_SUCCESS)
+        {
+            if(gpfAppResolveCb)
+                gpfAppResolveCb((uint8 *)strDnsReply.acHostName, strDnsReply.u32HostIP);
+        }
+    }
+    else if((u8OpCode == SOCKET_CMD_RECV) || (u8OpCode == SOCKET_CMD_RECVFROM) || (u8OpCode == SOCKET_CMD_SSL_RECV))
+    {
+
+        SOCKET              sock;
+        sint16              s16RecvStatus;
+        tstrRecvReply       strRecvReply;
+        uint16              u16ReadSize;
+        tstrSocketRecvMsg   strRecvMsg;
+        uint8               u8CallbackMsgID = SOCKET_MSG_RECV;
+        uint16              u16DataOffset;
 
 		if(u8OpCode == SOCKET_CMD_RECVFROM)
 			u8CallbackMsgID = SOCKET_MSG_RECVFROM;
 
-		/* Read RECV REPLY data structure.
-		*/
-		u16ReadSize = sizeof(tstrRecvReply);
-		if(hif_receive(u32Address, (uint8*)&strRecvReply, u16ReadSize, 0) == M2M_SUCCESS)
-		{
-			uint16 u16SessionID = 0;
+        /* Read RECV REPLY data structure.
+        */
+        u16ReadSize = sizeof(tstrRecvReply);
+        if(hif_receive(u32Address, (uint8 *)&strRecvReply, u16ReadSize, 0) == M2M_SUCCESS)
+        {
+            if((strRecvReply.sock >= 0) && (strRecvReply.sock < MAX_SOCKET))
+            {
+                uint16 u16SessionID = 0;
 
 			sock			= strRecvReply.sock;
 			u16SessionID = strRecvReply.u16SessionID;
@@ -325,103 +354,113 @@ static void m2m_ip_cb(uint8 u8OpCode, uint16 u16BufferSize,uint32 u32Address)
 			strRecvMsg.strRemoteAddr.sin_port 			= strRecvReply.strRemoteAddr.u16Port;
 			strRecvMsg.strRemoteAddr.sin_addr.s_addr 	= strRecvReply.strRemoteAddr.u32IPAddr;
 
+
+
 			if(u16SessionID == gastrSockets[sock].u16SessionID)
 			{
+
 				if((s16RecvStatus > 0) && (s16RecvStatus < u16BufferSize))
 				{
 					/* Skip incoming bytes until reaching the Start of Application Data. 
 					*/
 					u32Address += u16DataOffset;
 
-					/* Read the Application data and deliver it to the application callback in
-					the given application buffer. If the buffer is smaller than the received data,
-					the data is passed to the application in chunks according to its buffer size.
-					*/
-					u16ReadSize = (uint16)s16RecvStatus;
-					Socket_ReadSocketData(sock, &strRecvMsg, u8CallbackMsgID, u32Address, u16ReadSize);
-				}
-				else
-				{
-					strRecvMsg.s16BufferSize	= s16RecvStatus;
-					strRecvMsg.pu8Buffer		= NULL;
-					if(gpfAppSocketCb)
-						gpfAppSocketCb(sock,u8CallbackMsgID, &strRecvMsg);
-				}
-			}
-			else
-			{
-				M2M_DBG("Discard recv callback %d %d \r\n",u16SessionID , gastrSockets[sock].u16SessionID);
-				if(u16ReadSize < u16BufferSize)
-				{
-					if(hif_receive(0, NULL, 0, 1) == M2M_SUCCESS)
-						M2M_DBG("hif_receive Success\n");
-					else
-						M2M_DBG("hif_receive Fail\n");
-				}
-			}
-		}
-	}
-	else if((u8OpCode == SOCKET_CMD_SEND) || (u8OpCode == SOCKET_CMD_SENDTO) || (u8OpCode == SOCKET_CMD_SSL_SEND))
-	{
-		SOCKET			sock;
-		sint16			s16Rcvd;
-		tstrSendReply	strReply;
-		uint8			u8CallbackMsgID = SOCKET_MSG_SEND;
+                        /* Read the Application data and deliver it to the application callback in
+                        the given application buffer. Firmware since 19.6.4 only sends data up to
+                        the size of the application buffer. For TCP, a new call to recv is needed
+                        in order to retrieve any outstanding data from firmware.
+                        */
+                        u16ReadSize = (uint16)s16RecvStatus;
+                        Socket_ReadSocketData(sock, &strRecvMsg, u8CallbackMsgID, u32Address, u16ReadSize);
 
-		if(u8OpCode == SOCKET_CMD_SENDTO)
-			u8CallbackMsgID = SOCKET_MSG_SENDTO;
+                    }
+                    else
+                    {
 
-		if(hif_receive(u32Address, (uint8*)&strReply, sizeof(tstrSendReply), 0) == M2M_SUCCESS)
-		{
-			uint16 u16SessionID = 0;
-			
-			sock = strReply.sock;
-			u16SessionID = strReply.u16SessionID;
-			M2M_DBG("send callback session ID = %d\r\n",u16SessionID);
-			
-			s16Rcvd = NM_BSP_B_L_16(strReply.s16SentBytes);
+                        /* Don't tidy up here. Application must call close().
+                        */
+                        strRecvMsg.s16BufferSize    = s16RecvStatus;
+                        strRecvMsg.pu8Buffer        = NULL;
 
-			if(u16SessionID == gastrSockets[sock].u16SessionID)
-			{
-				if(gpfAppSocketCb)
-					gpfAppSocketCb(sock,u8CallbackMsgID, &s16Rcvd);
-			}
-			else
-			{
-				M2M_DBG("Discard send callback %d %d \r\n",u16SessionID , gastrSockets[sock].u16SessionID);
-			}
-		}
-	}
-	else if(u8OpCode == SOCKET_CMD_PING)
-	{
-		tstrPingReply	strPingReply;
-		if(hif_receive(u32Address, (uint8*)&strPingReply, sizeof(tstrPingReply), 1) == M2M_SUCCESS)
-		{
-			gfpPingCb = (void (*)(uint32 , uint32 , uint8))strPingReply.u32CmdPrivate;
-			if(gfpPingCb != NULL)
-			{
-				gfpPingCb(strPingReply.u32IPAddr, strPingReply.u32RTT, strPingReply.u8ErrorCode);
-			}
-		}
-	}
+                        if(gpfAppSocketCb)
+                            gpfAppSocketCb(sock, u8CallbackMsgID, &strRecvMsg);
+                    }
+                }
+                else
+                {
+
+                    M2M_DBG("Discard recv callback %d %d \r\n", u16SessionID, gastrSockets[sock].u16SessionID);
+                    if(u16ReadSize < u16BufferSize)
+                        if(hif_receive(0, NULL, 0, 1) != M2M_SUCCESS)
+                            M2M_ERR("hif rx done failed\n");
+                }
+            }
+        }
+    }
+    else if((u8OpCode == SOCKET_CMD_SEND) || (u8OpCode == SOCKET_CMD_SENDTO) || (u8OpCode == SOCKET_CMD_SSL_SEND))
+    {
+        SOCKET          sock;
+        sint16          s16Rcvd;
+        tstrSendReply   strReply;
+        uint8           u8CallbackMsgID = SOCKET_MSG_SEND;
+
+        if(u8OpCode == SOCKET_CMD_SENDTO)
+            u8CallbackMsgID = SOCKET_MSG_SENDTO;
+
+        if(hif_receive(u32Address, (uint8 *)&strReply, sizeof(tstrSendReply), 0) == M2M_SUCCESS)
+        {
+            if((strReply.sock >=0) && (strReply.sock < MAX_SOCKET))
+            {
+                uint16 u16SessionID = 0;
+
+                sock = strReply.sock;
+                u16SessionID = strReply.u16SessionID;
+                M2M_DBG("send callback session ID = %d\r\n", u16SessionID);
+
+                s16Rcvd = NM_BSP_B_L_16(strReply.s16SentBytes);
+
+                if(u16SessionID == gastrSockets[sock].u16SessionID)
+                {
+                    if(gpfAppSocketCb)
+                        gpfAppSocketCb(sock, u8CallbackMsgID, &s16Rcvd);
+                }
+                else
+                {
+                    M2M_DBG("Discard send callback %d %d \r\n", u16SessionID, gastrSockets[sock].u16SessionID);
+                }
+            }
+        }
+    }
+    else if(u8OpCode == SOCKET_CMD_PING)
+    {
+        tstrPingReply   strPingReply;
+        if(hif_receive(u32Address, (uint8 *)&strPingReply, sizeof(tstrPingReply), 1) == M2M_SUCCESS)
+        {
+            if((gu32PingId == strPingReply.u32CmdPrivate) && (gfpPingCb != NULL))
+            {
+                gfpPingCb(strPingReply.u32IPAddr, strPingReply.u32RTT, strPingReply.u8ErrorCode);
+            }
+        }
+    }
 }
+
 /*********************************************************************
 Function
-		socketInit
+        socketInit
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		4 June 2012
+        4 June 2012
 *********************************************************************/
 void socketInit(void)
 {
@@ -433,406 +472,236 @@ void socketInit(void)
 		gu16SessionID	= 0;
 	}
 }
+
 /*********************************************************************
 Function
-		socketDeinit
-
-Description 
-
-Return
-		None.
-
-Author
-		Samer Sarhan
-
-Version
-		1.0
-
-Date
-		27 Feb 2015
-*********************************************************************/
-void socketDeinit(void)
-{	
-	m2m_memset((uint8*)gastrSockets, 0, MAX_SOCKET * sizeof(tstrSocket));
-	hif_register_cb(M2M_REQ_GROUP_IP, NULL);
-	gpfAppSocketCb	= NULL;
-	gpfAppResolveCb	= NULL;
-	gbSocketInit	= 0;
-}
-/*********************************************************************
-Function
-		registerSocketCallback
+        socketDeinit
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Ahmed Ezzat
+        Samer Sarhan
 
-Versio
-		1.0
+Version
+        1.0
 
 Date
-		4 June 2012
+        27 Feb 2015
+*********************************************************************/
+void socketDeinit(void)
+{
+    m2m_memset((uint8 *)gastrSockets, 0, MAX_SOCKET * sizeof(tstrSocket));
+    hif_register_cb(M2M_REQ_GROUP_IP, NULL);
+    gpfAppSocketCb  = NULL;
+    gpfAppResolveCb = NULL;
+    gbSocketInit    = 0;
+}
+/*********************************************************************
+Function
+        registerSocketCallback
+
+Description
+
+Return
+        None.
+
+Author
+        Ahmed Ezzat
+
+Version
+        1.0
+
+Date
+        4 June 2012
 *********************************************************************/
 void registerSocketCallback(tpfAppSocketCb pfAppSocketCb, tpfAppResolveCb pfAppResolveCb)
 {
-	gpfAppSocketCb = pfAppSocketCb;
-	gpfAppResolveCb = pfAppResolveCb;
+    gpfAppSocketCb  = pfAppSocketCb;
+    gpfAppResolveCb = pfAppResolveCb;
 }
 
 /*********************************************************************
 Function
-		socket
+        socket
 
 Description
-		Creates a socket.
+        Creates a socket.
 
 Return
-		- Negative value for error.
-		- ZERO or positive value as a socket ID if successful.
+        - Negative value for error.
+        - ZERO or positive value as a socket ID if successful.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		4 June 2012
+        4 June 2012
 *********************************************************************/
-SOCKET winc1500_socket(uint16 u16Domain, uint8 u8Type, uint8 u8Flags)
+SOCKET socket(uint16 u16Domain, uint8 u8Type, uint8 u8Config)
 {
-	SOCKET					sock = -1;
-	uint8					u8SockID;
-	uint8					u8Count;
-	volatile tstrSocket		*pstrSock;
-	static volatile uint8	u8NextTcpSock	= 0;
-	static volatile uint8	u8NextUdpSock	= 0;
+    SOCKET                  sock = -1;
+    uint8                   u8SockID;
+    uint8                   u8Count;
+    volatile tstrSocket     *pstrSock;
+    static volatile uint8   u8NextTcpSock   = 0;
+    static volatile uint8   u8NextUdpSock   = 0;
 
-	/* The only supported family is the AF_INET for UDP and TCP transport layer protocols. */
-	if(u16Domain == AF_INET)
-	{
-		if(u8Type == SOCK_STREAM)
-		{
-			for(u8Count = 0; u8Count < TCP_SOCK_MAX; u8Count ++)
-			{
-				u8SockID	= u8NextTcpSock;
-				pstrSock	= &gastrSockets[u8NextTcpSock];
-				u8NextTcpSock = (u8NextTcpSock + 1) % TCP_SOCK_MAX;
-				if(!pstrSock->bIsUsed)
-				{
-					sock = (SOCKET)u8SockID;
-					break;
-				}
-			}
-		}
-		else if(u8Type == SOCK_DGRAM)
-		{
-			volatile tstrSocket	*pastrUDPSockets = &gastrSockets[TCP_SOCK_MAX];
-			for(u8Count = 0; u8Count < UDP_SOCK_MAX; u8Count ++)
-			{
-				u8SockID		= u8NextUdpSock;
-				pstrSock		= &pastrUDPSockets[u8NextUdpSock];
-				u8NextUdpSock	= (u8NextUdpSock + 1) % UDP_SOCK_MAX;
-				if(!pstrSock->bIsUsed)
-				{
-					sock = (SOCKET)(u8SockID + TCP_SOCK_MAX);
-					break;
-				}
-			}
-		}
+    /* The only supported family is the AF_INET for UDP and TCP transport layer protocols. */
+    if(u16Domain == AF_INET)
+    {
+        if(u8Type == SOCK_STREAM)
+        {
+            for(u8Count = 0; u8Count < TCP_SOCK_MAX; u8Count ++)
+            {
+                u8SockID    = u8NextTcpSock;
+                pstrSock    = &gastrSockets[u8NextTcpSock];
+                u8NextTcpSock = (u8NextTcpSock + 1) % TCP_SOCK_MAX;
+                if(!pstrSock->bIsUsed)
+                {
+                    sock = (SOCKET)u8SockID;
+                    break;
+                }
+            }
+        }
+        else if(u8Type == SOCK_DGRAM)
+        {
+            volatile tstrSocket *pastrUDPSockets = &gastrSockets[TCP_SOCK_MAX];
+            for(u8Count = 0; u8Count < UDP_SOCK_MAX; u8Count ++)
+            {
+                u8SockID        = u8NextUdpSock;
+                pstrSock        = &pastrUDPSockets[u8NextUdpSock];
+                u8NextUdpSock   = (u8NextUdpSock + 1) % UDP_SOCK_MAX;
+                if(!pstrSock->bIsUsed)
+                {
+                    sock = (SOCKET)(u8SockID + TCP_SOCK_MAX);
+                    break;
+                }
+            }
+        }
 
-		if(sock >= 0)
-		{
-			m2m_memset((uint8*)pstrSock, 0, sizeof(tstrSocket));
-			pstrSock->bIsUsed = 1;
+        if(sock >= 0)
+        {
+            m2m_memset((uint8 *)pstrSock, 0, sizeof(tstrSocket));
+            pstrSock->bIsUsed = 1;
 
-			/* The session ID is used to distinguish different socket connections
-				by comparing the assigned session ID to the one reported by the firmware*/
-			++gu16SessionID;
-			if(gu16SessionID == 0)
-				++gu16SessionID;
-				
-			pstrSock->u16SessionID = gu16SessionID;
-            M2M_INFO("Socket %d session ID = %d\r\n",sock, gu16SessionID );
+            /* The session ID is used to distinguish different socket connections
+                by comparing the assigned session ID to the one reported by the firmware*/
+            ++gu16SessionID;
+            if(gu16SessionID == 0)
+                ++gu16SessionID;
 
-			if(u8Flags & SOCKET_FLAGS_SSL)
-			{
-				tstrSSLSocketCreateCmd	strSSLCreate;
-				strSSLCreate.sslSock = sock;
-				pstrSock->u8SSLFlags = SSL_FLAGS_ACTIVE | SSL_FLAGS_NO_TX_COPY;
-				SOCKET_REQUEST(SOCKET_CMD_SSL_CREATE, (uint8*)&strSSLCreate, sizeof(tstrSSLSocketCreateCmd), 0, 0, 0);
-			}
-		}
-	}
-	return sock;
+            pstrSock->u16SessionID = gu16SessionID;
+            M2M_INFO("Socket %d session ID = %d\r\n", sock, gu16SessionID);
+
+            if((u8Type == SOCK_STREAM) && (u8Config != SOCKET_CONFIG_SSL_OFF))
+            {
+                tstrSSLSocketCreateCmd  strSSLCreate;
+                strSSLCreate.sslSock = sock;
+                SOCKET_REQUEST(SOCKET_CMD_SSL_CREATE, (uint8 *)&strSSLCreate, sizeof(tstrSSLSocketCreateCmd), 0, 0, 0);
+
+                pstrSock->u8SSLFlags = SSL_FLAGS_ACTIVE | SSL_FLAGS_NO_TX_COPY;
+                if(u8Config == SOCKET_CONFIG_SSL_DELAY)
+                    pstrSock->u8SSLFlags |= SSL_FLAGS_DELAY;
+            }
+        }
+    }
+    return sock;
 }
+
 /*********************************************************************
 Function
-		bind
+        bind
 
 Description
-		Request to bind a socket on a local address.
-
-Return
-
-
-Author
-		Ahmed Ezzat
-
-Version
-		1.0
-
-Date
-		5 June 2012
-*********************************************************************/
-sint8 winc1500_socket_bind(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen)
-{
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	if((pstrAddr != NULL) && (sock >= 0) && (gastrSockets[sock].bIsUsed == 1) && (u8AddrLen != 0))
-	{
-		tstrBindCmd			strBind;
-		uint8				u8CMD = SOCKET_CMD_BIND;
-		if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
-		{
-			u8CMD = SOCKET_CMD_SSL_BIND;
-		}
-
-		/* Build the bind request. */
-		strBind.sock = sock;
-		m2m_memcpy((uint8 *)&strBind.strAddr, (uint8 *)pstrAddr, sizeof(tstrSockAddr));
-		strBind.u16SessionID		= gastrSockets[sock].u16SessionID;
-		
-		/* Send the request. */
-		s8Ret = SOCKET_REQUEST(u8CMD, (uint8*)&strBind,sizeof(tstrBindCmd) , NULL , 0, 0);
-		if(s8Ret != SOCK_ERR_NO_ERROR)
-		{
-			s8Ret = SOCK_ERR_INVALID;
-		}
-	}
-	return s8Ret;
-}
-/*********************************************************************
-Function
-		listen
-
-Description
-
+        Request to bind a socket on a local address.
 
 Return
 
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		5 June 2012
+        5 June 2012
 *********************************************************************/
-sint8 winc1500_socket_listen(SOCKET sock, uint8 backlog)
+sint8 bind(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen)
 {
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	
-	if(sock >= 0 && (gastrSockets[sock].bIsUsed == 1))
-	{
-		tstrListenCmd		strListen;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+    if((pstrAddr != NULL) && (sock >= 0) && (sock < MAX_SOCKET) && (gastrSockets[sock].bIsUsed == 1) && (u8AddrLen != 0))
+    {
+        tstrBindCmd         strBind;
+        uint8               u8CMD = SOCKET_CMD_BIND;
+        if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+        {
+            u8CMD = SOCKET_CMD_SSL_BIND;
+        }
 
-		strListen.sock = sock;
-		strListen.u8BackLog = backlog;
-		strListen.u16SessionID		= gastrSockets[sock].u16SessionID;
+        /* Build the bind request. */
+        strBind.sock = sock;
+        m2m_memcpy((uint8 *)&strBind.strAddr, (uint8 *)pstrAddr, sizeof(tstrSockAddr));
+        strBind.u16SessionID        = gastrSockets[sock].u16SessionID;
 
-		s8Ret = SOCKET_REQUEST(SOCKET_CMD_LISTEN, (uint8*)&strListen, sizeof(tstrListenCmd), NULL, 0, 0);
-		if(s8Ret != SOCK_ERR_NO_ERROR)
-		{
-			s8Ret = SOCK_ERR_INVALID;
-		}
-	}
-	return s8Ret;
+        /* Send the request. */
+        s8Ret = SOCKET_REQUEST(u8CMD, (uint8 *)&strBind, sizeof(tstrBindCmd), NULL, 0, 0);
+        if(s8Ret != SOCK_ERR_NO_ERROR)
+        {
+            s8Ret = SOCK_ERR_INVALID;
+        }
+    }
+    return s8Ret;
 }
+
 /*********************************************************************
 Function
-		accept
+        listen
 
 Description
+
 
 Return
 
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		5 June 2012
+        5 June 2012
 *********************************************************************/
-sint8 winc1500_socket_accept(SOCKET sock, struct sockaddr *addr, uint8 *addrlen)
+sint8 listen(SOCKET sock, uint8 backlog)
 {
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	
-	if(sock >= 0 && (gastrSockets[sock].bIsUsed == 1) )
-	{
-		s8Ret = SOCK_ERR_NO_ERROR;
-	}
-	return s8Ret;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+
+    if((sock >= 0) && (sock < MAX_SOCKET) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        tstrListenCmd       strListen;
+
+        strListen.sock = sock;
+        strListen.u8BackLog = backlog;
+        strListen.u16SessionID      = gastrSockets[sock].u16SessionID;
+
+        s8Ret = SOCKET_REQUEST(SOCKET_CMD_LISTEN, (uint8 *)&strListen, sizeof(tstrListenCmd), NULL, 0, 0);
+        if(s8Ret != SOCK_ERR_NO_ERROR)
+        {
+            s8Ret = SOCK_ERR_INVALID;
+        }
+    }
+    return s8Ret;
 }
 /*********************************************************************
 Function
-		connect
-
-Description
-		Connect to a remote TCP Server.
-
-Return
-
-
-Author
-		Ahmed Ezzat
-
-Version
-		1.0
-
-Date
-		5 June 2012
-*********************************************************************/
-sint8 winc1500_socket_connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen)
-{
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	if((sock >= 0) && (pstrAddr != NULL) && (gastrSockets[sock].bIsUsed == 1) && (u8AddrLen != 0))
-	{
-		tstrConnectCmd	strConnect;
-		uint8			u8Cmd = SOCKET_CMD_CONNECT;
-		if((gastrSockets[sock].u8SSLFlags) & SSL_FLAGS_ACTIVE)
-		{
-			u8Cmd = SOCKET_CMD_SSL_CONNECT;
-			strConnect.u8SslFlags = gastrSockets[sock].u8SSLFlags;
-		}
-		strConnect.sock = sock;
-		m2m_memcpy((uint8 *)&strConnect.strAddr, (uint8 *)pstrAddr, sizeof(tstrSockAddr));
-
-		strConnect.u16SessionID		= gastrSockets[sock].u16SessionID;
-		s8Ret = SOCKET_REQUEST(u8Cmd, (uint8*)&strConnect,sizeof(tstrConnectCmd), NULL, 0, 0);
-		if(s8Ret != SOCK_ERR_NO_ERROR)
-		{
-			s8Ret = SOCK_ERR_INVALID;
-		}
-	}
-	return s8Ret;
-}
-/*********************************************************************
-Function
-		send
-
-Description
-
-Return
-
-Author
-		Ahmed Ezzat
-
-Version
-		1.0
-
-Date
-		5 June 2012
-*********************************************************************/
-sint16 winc1500_socket_send(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags)
-{
-	sint16	s16Ret = SOCK_ERR_INVALID_ARG;
-	
-	if((sock >= 0) && (pvSendBuffer != NULL) && (u16SendLength <= SOCKET_BUFFER_MAX_LENGTH) && (gastrSockets[sock].bIsUsed == 1))
-	{
-		uint16			u16DataOffset;
-		tstrSendCmd		strSend;
-		uint8			u8Cmd;
-
-		u8Cmd			= SOCKET_CMD_SEND;
-		u16DataOffset	= TCP_TX_PACKET_OFFSET;
-
-		strSend.sock			= sock;
-		strSend.u16DataSize		= NM_BSP_B_L_16(u16SendLength);
-		strSend.u16SessionID	= gastrSockets[sock].u16SessionID;
-
-		if(sock >= TCP_SOCK_MAX)
-		{
-			u16DataOffset = UDP_TX_PACKET_OFFSET;
-		}
-		if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
-		{
-			u8Cmd			= SOCKET_CMD_SSL_SEND;
-			u16DataOffset	= gastrSockets[sock].u16DataOffset;
-		}
-
-		s16Ret =  SOCKET_REQUEST(u8Cmd|M2M_REQ_DATA_PKT, (uint8*)&strSend, sizeof(tstrSendCmd), pvSendBuffer, u16SendLength, u16DataOffset);
-		if(s16Ret != SOCK_ERR_NO_ERROR)
-		{
-			s16Ret = SOCK_ERR_BUFFER_FULL;
-		}
-	}
-	return s16Ret;
-}
-/*********************************************************************
-Function
-		sendto
-
-Description
-
-Return
-
-Author
-		Ahmed Ezzat
-
-Version
-		1.0
-
-Date
-		4 June 2012
-*********************************************************************/
-sint16 winc1500_socket_sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags, struct sockaddr *pstrDestAddr, uint8 u8AddrLen)
-{
-	sint16	s16Ret = SOCK_ERR_INVALID_ARG;
-	
-	if((sock >= 0) && (pvSendBuffer != NULL) && (u16SendLength <= SOCKET_BUFFER_MAX_LENGTH) && (gastrSockets[sock].bIsUsed == 1))
-	{
-		if(gastrSockets[sock].bIsUsed)
-		{
-			tstrSendCmd	strSendTo;
-
-			m2m_memset((uint8*)&strSendTo, 0, sizeof(tstrSendCmd));
-
-			strSendTo.sock			= sock;
-			strSendTo.u16DataSize	= NM_BSP_B_L_16(u16SendLength);
-			strSendTo.u16SessionID	= gastrSockets[sock].u16SessionID;
-			
-			if(pstrDestAddr != NULL)
-			{
-				struct sockaddr_in	*pstrAddr;
-				pstrAddr = (void*)pstrDestAddr;
-
-				strSendTo.strAddr.u16Family	= pstrAddr->sin_family;
-				strSendTo.strAddr.u16Port	= pstrAddr->sin_port;
-				strSendTo.strAddr.u32IPAddr	= pstrAddr->sin_addr.s_addr;
-			}
-			s16Ret = SOCKET_REQUEST(SOCKET_CMD_SENDTO|M2M_REQ_DATA_PKT, (uint8*)&strSendTo,  sizeof(tstrSendCmd),
-				pvSendBuffer, u16SendLength, UDP_TX_PACKET_OFFSET);
-
-			if(s16Ret != SOCK_ERR_NO_ERROR)
-			{
-				s16Ret = SOCK_ERR_BUFFER_FULL;
-			}
-		}
-	}
-	return s16Ret;
-}
-/*********************************************************************
-Function
-		recv
+        accept
 
 Description
 
@@ -840,101 +709,327 @@ Return
 
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
-		2.0  9 April 2013 --> Add timeout for recv operation.
+        1.0
 
 Date
-		5 June 2012
+        5 June 2012
 *********************************************************************/
-sint16 winc1500_socket_recv(SOCKET sock, void *pvRecvBuf, uint16 u16BufLen, uint32 u32Timeoutmsec)
+sint8 accept(SOCKET sock, struct sockaddr *addr, uint8 *addrlen)
 {
-	sint16	s16Ret = SOCK_ERR_INVALID_ARG;
-	
-	if((sock >= 0) && (pvRecvBuf != NULL) && (u16BufLen != 0) && (gastrSockets[sock].bIsUsed == 1))
-	{
-		s16Ret = SOCK_ERR_NO_ERROR;
-		gastrSockets[sock].pu8UserBuffer 		= (uint8*)pvRecvBuf;
-		gastrSockets[sock].u16UserBufferSize 	= u16BufLen;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
 
-		if(!gastrSockets[sock].bIsRecvPending)
-		{
-			tstrRecvCmd	strRecv;
-			uint8		u8Cmd = SOCKET_CMD_RECV;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        s8Ret = SOCK_ERR_NO_ERROR;
+    }
+    return s8Ret;
+}
+/*********************************************************************
+Function
+        connect
 
-			gastrSockets[sock].bIsRecvPending = 1;
-			if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
-			{
-				u8Cmd = SOCKET_CMD_SSL_RECV;
-			}
+Description
+        Connect to a remote TCP Server.
 
-			/* Check the timeout value. */
-			if(u32Timeoutmsec == 0)
-				strRecv.u32Timeoutmsec = 0xFFFFFFFF;
-			else
-				strRecv.u32Timeoutmsec = NM_BSP_B_L_32(u32Timeoutmsec);
-			strRecv.sock = sock;
-			strRecv.u16SessionID		= gastrSockets[sock].u16SessionID;
+Return
+
+
+Author
+        Ahmed Ezzat
+
+Version
+        1.0
+
+Date
+        5 June 2012
+*********************************************************************/
+sint8 connect(SOCKET sock, struct sockaddr *pstrAddr, uint8 u8AddrLen)
+{
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (pstrAddr != NULL) && (gastrSockets[sock].bIsUsed == 1) && (u8AddrLen != 0))
+    {
+        tstrConnectCmd  strConnect;
+        uint8           u8Cmd = SOCKET_CMD_CONNECT;
+        if((gastrSockets[sock].u8SSLFlags) & SSL_FLAGS_ACTIVE)
+        {
+            u8Cmd = SOCKET_CMD_SSL_CONNECT;
+            strConnect.u8SslFlags = gastrSockets[sock].u8SSLFlags;
+        }
+        strConnect.sock = sock;
+        m2m_memcpy((uint8 *)&strConnect.strAddr, (uint8 *)pstrAddr, sizeof(tstrSockAddr));
+
+        strConnect.u16SessionID     = gastrSockets[sock].u16SessionID;
+        s8Ret = SOCKET_REQUEST(u8Cmd, (uint8 *)&strConnect, sizeof(tstrConnectCmd), NULL, 0, 0);
+        if(s8Ret != SOCK_ERR_NO_ERROR)
+        {
+            s8Ret = SOCK_ERR_INVALID;
+        }
+    }
+    return s8Ret;
+}
+/*********************************************************************
+Function
+        secure
+
+Description
+        Make secure (TLS) an open TCP client connection.
+
+Return
+
+
+Author
+        Matthew Gunton
+
+Version
+        1.0
+
+Date
+        7 November 2019
+*********************************************************************/
+sint8 secure(SOCKET sock)
+{
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        if(
+                (gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+            &&  (gastrSockets[sock].u8SSLFlags & SSL_FLAGS_DELAY)
+            &&  (gastrSockets[sock].u16DataOffset != 0)
+        )
+        {
+            tstrConnectCmd  strConnect = {0};
+
+            gastrSockets[sock].u8SSLFlags &= ~SSL_FLAGS_DELAY;
+            strConnect.u8SslFlags = gastrSockets[sock].u8SSLFlags;
+            strConnect.sock = sock;
+            strConnect.u16SessionID = gastrSockets[sock].u16SessionID;
+
+            s8Ret = SOCKET_REQUEST(SOCKET_CMD_SECURE, (uint8*)&strConnect, sizeof(tstrConnectCmd), NULL, 0, 0);
+            if(s8Ret != SOCK_ERR_NO_ERROR)
+            {
+                s8Ret = SOCK_ERR_INVALID;
+            }
+        }
+    }
+    return s8Ret;
+}
+/*********************************************************************
+Function
+        send
+
+Description
+
+Return
+
+Author
+        Ahmed Ezzat
+
+Version
+        1.0
+
+Date
+        5 June 2012
+*********************************************************************/
+sint16 send(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags)
+{
+    sint16  s16Ret = SOCK_ERR_INVALID_ARG;
+
+    if((sock >= 0) && (sock < MAX_SOCKET) && (pvSendBuffer != NULL) && (u16SendLength <= SOCKET_BUFFER_MAX_LENGTH) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        uint16          u16DataOffset;
+        tstrSendCmd     strSend;
+        uint8           u8Cmd;
+
+        u8Cmd           = SOCKET_CMD_SEND;
+        u16DataOffset   = TCP_TX_PACKET_OFFSET;
+
+        strSend.sock            = sock;
+        strSend.u16DataSize     = NM_BSP_B_L_16(u16SendLength);
+        strSend.u16SessionID    = gastrSockets[sock].u16SessionID;
+
+        if(sock >= TCP_SOCK_MAX)
+        {
+            u16DataOffset = UDP_TX_PACKET_OFFSET;
+        }
+        if(
+                (gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+            &&  (!(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_DELAY))
+        )
+        {
+            u8Cmd           = SOCKET_CMD_SSL_SEND;
+            u16DataOffset   = gastrSockets[sock].u16DataOffset;
+        }
+
+        s16Ret =  SOCKET_REQUEST(u8Cmd|M2M_REQ_DATA_PKT, (uint8 *)&strSend, sizeof(tstrSendCmd), pvSendBuffer, u16SendLength, u16DataOffset);
+        if(s16Ret != SOCK_ERR_NO_ERROR)
+        {
+            s16Ret = SOCK_ERR_BUFFER_FULL;
+        }
+    }
+    return s16Ret;
+}
+/*********************************************************************
+Function
+        sendto
+
+Description
+
+Return
+
+Author
+        Ahmed Ezzat
+
+Version
+        1.0
+
+Date
+        4 June 2012
+*********************************************************************/
+sint16 sendto(SOCKET sock, void *pvSendBuffer, uint16 u16SendLength, uint16 flags, struct sockaddr *pstrDestAddr, uint8 u8AddrLen)
+{
+    sint16  s16Ret = SOCK_ERR_INVALID_ARG;
+
+    if((sock >= 0) && (sock < MAX_SOCKET) && (pvSendBuffer != NULL) && (u16SendLength <= SOCKET_BUFFER_MAX_LENGTH) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        if(gastrSockets[sock].bIsUsed)
+        {
+            tstrSendCmd strSendTo;
+
+            m2m_memset((uint8 *)&strSendTo, 0, sizeof(tstrSendCmd));
+
+            strSendTo.sock          = sock;
+            strSendTo.u16DataSize   = NM_BSP_B_L_16(u16SendLength);
+            strSendTo.u16SessionID  = gastrSockets[sock].u16SessionID;
+
+            if(pstrDestAddr != NULL)
+            {
+                struct sockaddr_in  *pstrAddr;
+                pstrAddr = (void *)pstrDestAddr;
+
+                strSendTo.strAddr.u16Family = pstrAddr->sin_family;
+                strSendTo.strAddr.u16Port   = pstrAddr->sin_port;
+                strSendTo.strAddr.u32IPAddr = pstrAddr->sin_addr.s_addr;
+            }
+            s16Ret = SOCKET_REQUEST(SOCKET_CMD_SENDTO|M2M_REQ_DATA_PKT, (uint8 *)&strSendTo,  sizeof(tstrSendCmd),
+                                    pvSendBuffer, u16SendLength, UDP_TX_PACKET_OFFSET);
+
+            if(s16Ret != SOCK_ERR_NO_ERROR)
+            {
+                s16Ret = SOCK_ERR_BUFFER_FULL;
+            }
+        }
+    }
+    return s16Ret;
+}
+/*********************************************************************
+Function
+        recv
+
+Description
+
+Return
+
+
+Author
+        Ahmed Ezzat
+
+Version
+        1.0
+        2.0  9 April 2013 --> Add timeout for recv operation.
+
+Date
+        5 June 2012
+*********************************************************************/
+sint16 recv(SOCKET sock, void *pvRecvBuf, uint16 u16BufLen, uint32 u32Timeoutmsec)
+{
+    sint16  s16Ret = SOCK_ERR_INVALID_ARG;
+
+    if((sock >= 0) && (sock < MAX_SOCKET) && (pvRecvBuf != NULL) && (u16BufLen != 0) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        s16Ret = SOCK_ERR_NO_ERROR;
+        gastrSockets[sock].pu8UserBuffer        = (uint8 *)pvRecvBuf;
+        gastrSockets[sock].u16UserBufferSize    = u16BufLen;
+
+        if(!gastrSockets[sock].bIsRecvPending)
+        {
+            tstrRecvCmd strRecv;
+            uint8       u8Cmd = SOCKET_CMD_RECV;
+
+            gastrSockets[sock].bIsRecvPending = 1;
+            if(
+                    (gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+                &&  (!(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_DELAY))
+            )
+            {
+                u8Cmd = SOCKET_CMD_SSL_RECV;
+            }
+
+            /* Check the timeout value. */
+            if(u32Timeoutmsec == 0)
+                strRecv.u32Timeoutmsec = 0xFFFFFFFF;
+            else
+                strRecv.u32Timeoutmsec = NM_BSP_B_L_32(u32Timeoutmsec);
+            strRecv.sock = sock;
+            strRecv.u16SessionID        = gastrSockets[sock].u16SessionID;
+            strRecv.u16BufLen           = u16BufLen;
 		
 			s16Ret = SOCKET_REQUEST(u8Cmd, (uint8*)&strRecv, sizeof(tstrRecvCmd), NULL , 0, 0);
-			if(s16Ret != SOCK_ERR_NO_ERROR)
-			{
-				s16Ret = SOCK_ERR_BUFFER_FULL;
-			}
-		}
-	}
-	return s16Ret;
+            if(s16Ret != SOCK_ERR_NO_ERROR)
+            {
+                s16Ret = SOCK_ERR_BUFFER_FULL;
+            }
+        }
+    }
+    return s16Ret;
 }
 /*********************************************************************
 Function
-		close
+        close
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		4 June 2012
+        4 June 2012
 *********************************************************************/
-sint8 winc1500_close(SOCKET sock)
+sint8 close(SOCKET sock)
 {
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
     M2M_INFO("Sock to delete <%d>\n", sock);
-	if(sock >= 0 && (gastrSockets[sock].bIsUsed == 1))
-	{
-		uint8	u8Cmd = SOCKET_CMD_CLOSE;
-		tstrCloseCmd strclose;
-		strclose.sock = sock; 
-		strclose.u16SessionID		= gastrSockets[sock].u16SessionID;
-		
-		gastrSockets[sock].bIsUsed = 0;
-		gastrSockets[sock].u16SessionID =0;
-		
-		if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
-		{
-			u8Cmd = SOCKET_CMD_SSL_CLOSE;
-		}
-		s8Ret = SOCKET_REQUEST(u8Cmd, (uint8*)&strclose, sizeof(tstrCloseCmd), NULL,0, 0);
-		if(s8Ret != SOCK_ERR_NO_ERROR)
-		{
-			s8Ret = SOCK_ERR_INVALID;
-		}
-		m2m_memset((uint8*)&gastrSockets[sock], 0, sizeof(tstrSocket));
-	}
-	return s8Ret;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        uint8   u8Cmd = SOCKET_CMD_CLOSE;
+        tstrCloseCmd strclose;
+        strclose.sock = sock;
+        strclose.u16SessionID       = gastrSockets[sock].u16SessionID;
+
+        if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+        {
+            u8Cmd = SOCKET_CMD_SSL_CLOSE;
+        }
+        s8Ret = SOCKET_REQUEST(u8Cmd, (uint8 *)&strclose, sizeof(tstrCloseCmd), NULL, 0, 0);
+        if(s8Ret != SOCK_ERR_NO_ERROR)
+        {
+            s8Ret = SOCK_ERR_INVALID;
+        }
+        m2m_memset((uint8 *)&gastrSockets[sock], 0, sizeof(tstrSocket));
+    }
+    return s8Ret;
 }
 /*********************************************************************
 Function
-		recvfrom
+        recvfrom
 
 Description
 
@@ -942,368 +1037,487 @@ Return
 
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
-		2.0  9 April 2013 --> Add timeout for recv operation.
+        1.0
+        2.0  9 April 2013 --> Add timeout for recv operation.
 
 Date
-		5 June 2012
+        5 June 2012
 *********************************************************************/
-sint16 winc1500_socket_recvfrom(SOCKET sock, void *pvRecvBuf, uint16 u16BufLen, uint32 u32Timeoutmsec)
+sint16 recvfrom(SOCKET sock, void *pvRecvBuf, uint16 u16BufLen, uint32 u32Timeoutmsec)
 {
-	sint16	s16Ret = SOCK_ERR_NO_ERROR;
-	if((sock >= 0) && (pvRecvBuf != NULL) && (u16BufLen != 0) && (gastrSockets[sock].bIsUsed == 1))
-	{
-		if(gastrSockets[sock].bIsUsed)
-		{
-			s16Ret = SOCK_ERR_NO_ERROR;
-			gastrSockets[sock].pu8UserBuffer = (uint8*)pvRecvBuf;
-			gastrSockets[sock].u16UserBufferSize = u16BufLen;
+    sint16  s16Ret = SOCK_ERR_NO_ERROR;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (pvRecvBuf != NULL) && (u16BufLen != 0) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        if(gastrSockets[sock].bIsUsed)
+        {
+            s16Ret = SOCK_ERR_NO_ERROR;
+            gastrSockets[sock].pu8UserBuffer = (uint8 *)pvRecvBuf;
+            gastrSockets[sock].u16UserBufferSize = u16BufLen;
 
-			if(!gastrSockets[sock].bIsRecvPending)
-			{
-				tstrRecvCmd	strRecv;
+            if(!gastrSockets[sock].bIsRecvPending)
+            {
+                tstrRecvCmd strRecv;
+                gastrSockets[sock].bIsRecvPending = 1;
 
-				gastrSockets[sock].bIsRecvPending = 1;
-
-				/* Check the timeout value. */
-				if(u32Timeoutmsec == 0)
-					strRecv.u32Timeoutmsec = 0xFFFFFFFF;
-				else
-					strRecv.u32Timeoutmsec = NM_BSP_B_L_32(u32Timeoutmsec);
-				strRecv.sock = sock;
-				strRecv.u16SessionID		= gastrSockets[sock].u16SessionID;
+                /* Check the timeout value. */
+                if(u32Timeoutmsec == 0)
+                    strRecv.u32Timeoutmsec = 0xFFFFFFFF;
+                else
+                    strRecv.u32Timeoutmsec = NM_BSP_B_L_32(u32Timeoutmsec);
+                strRecv.sock = sock;
+                strRecv.u16SessionID        = gastrSockets[sock].u16SessionID;
+                strRecv.u16BufLen           = u16BufLen;
 				
 				s16Ret = SOCKET_REQUEST(SOCKET_CMD_RECVFROM, (uint8*)&strRecv, sizeof(tstrRecvCmd), NULL , 0, 0);
 				if(s16Ret != SOCK_ERR_NO_ERROR)
-				{
-					s16Ret = SOCK_ERR_BUFFER_FULL;
-				}
-			}
-		}
-	}
-	else
-	{
-		s16Ret = SOCK_ERR_INVALID_ARG;
-	}
-	return s16Ret;
+                {
+                    s16Ret = SOCK_ERR_BUFFER_FULL;
+                }
+            }
+        }
+    }
+    else
+    {
+        s16Ret = SOCK_ERR_INVALID_ARG;
+    }
+    return s16Ret;
 }
 /*********************************************************************
 Function
-		nmi_inet_addr
+        nmi_inet_addr
 
 Description
 
 Return
-		Unsigned 32-bit integer representing the IP address in Network
-		byte order.
+        Unsigned 32-bit integer representing the IP address in Network
+        byte order.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		4 June 2012
+        4 June 2012
 *********************************************************************/
 uint32 nmi_inet_addr(char *pcIpAddr)
 {
-	uint8	tmp;
-	uint32	u32IP = 0;
-	uint8	au8IP[4];
-	uint8 	c;
-	uint8	i, j;
+    uint8   tmp   = 0;
+    uint32  u32IP = 0;
+    uint8   au8IP[4];
+    uint8   c;
+    uint8   i, j;
 
-	tmp = 0;
-
-	for(i = 0; i < 4; ++i)
-	{
-		j = 0;
-		do
-		{
-			c = *pcIpAddr;
-			++j;
-			if(j > 4)
-			{
-				return 0;
-			}
-			if(c == '.' || c == 0)
-			{
-				au8IP[i] = tmp;
-				tmp = 0;
-			}
-			else if(c >= '0' && c <= '9')
-			{
-				tmp = (tmp * 10) + (c - '0');
-			}
-			else
-			{
-				return 0;
-			}
-			++pcIpAddr;
-		} while(c != '.' && c != 0);
-	}
-	m2m_memcpy((uint8*)&u32IP, au8IP, 4);
-	return u32IP;
+    for(i = 0; i < 4; ++i)
+    {
+        j = 0;
+        do
+        {
+            c = *pcIpAddr;
+            ++j;
+            if(j > 4)
+            {
+                return 0;
+            }
+            if(c == '.' || c == 0)
+            {
+                au8IP[i] = tmp;
+                tmp = 0;
+            }
+            else if(c >= '0' && c <= '9')
+            {
+                tmp = (tmp * 10) + (c - '0');
+            }
+            else
+            {
+                return 0;
+            }
+            ++pcIpAddr;
+        } while(c != '.' && c != 0);
+    }
+    m2m_memcpy((uint8 *)&u32IP, au8IP, 4);
+    return u32IP;
 }
+
 /*********************************************************************
 Function
-		gethostbyname
+        gethostbyname
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		4 June 2012
+        4 June 2012
 *********************************************************************/
-sint8 winc1500_socket_gethostbyname(uint8 * pcHostName)
+sint8 gethostbyname(uint8 *pcHostName)
 {
-	sint8	s8Err = SOCK_ERR_INVALID_ARG;
-	uint8	u8HostNameSize = (uint8)m2m_strlen(pcHostName);
-	if(u8HostNameSize <= HOSTNAME_MAX_SIZE)
-	{
-		s8Err = SOCKET_REQUEST(SOCKET_CMD_DNS_RESOLVE, (uint8*)pcHostName, u8HostNameSize + 1, NULL,0, 0);
-	}
-	return s8Err;
+    sint8   s8Err = SOCK_ERR_INVALID_ARG;
+    uint8   u8HostNameSize = (uint8)m2m_strlen(pcHostName);
+    if(u8HostNameSize <= HOSTNAME_MAX_SIZE)
+    {
+        s8Err = SOCKET_REQUEST(SOCKET_CMD_DNS_RESOLVE, (uint8 *)pcHostName, u8HostNameSize + 1, NULL, 0, 0);
+    }
+    return s8Err;
 }
+
 /*********************************************************************
 Function
-		setsockopt
+        setsockopt
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Abdelrahman Diab
+        Abdelrahman Diab
 
 Version
-		1.0
+        1.0
 
 Date
-		9 September 2014
+        9 September 2014
 *********************************************************************/
 static sint8 sslSetSockOpt(SOCKET sock, uint8  u8Opt, const void *pvOptVal, uint16 u16OptLen)
 {
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	if(sock < TCP_SOCK_MAX)
-	{
-		if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
-		{
-			if(u8Opt == SO_SSL_BYPASS_X509_VERIF)
-			{
-				int	optVal = *((int*)pvOptVal);
-				if(optVal)
-				{
-					gastrSockets[sock].u8SSLFlags |= SSL_FLAGS_BYPASS_X509;
-				}
-				else
-				{
-					gastrSockets[sock].u8SSLFlags &= ~SSL_FLAGS_BYPASS_X509;
-				}
-				s8Ret = SOCK_ERR_NO_ERROR;
-			}
-			else if(u8Opt == SO_SSL_ENABLE_SESSION_CACHING)
-			{
-				int	optVal = *((int*)pvOptVal);
-				if(optVal)
-				{
-					gastrSockets[sock].u8SSLFlags |= SSL_FLAGS_CACHE_SESSION;
-				}
-				else
-				{
-					gastrSockets[sock].u8SSLFlags &= ~SSL_FLAGS_CACHE_SESSION;
-				}
-				s8Ret = SOCK_ERR_NO_ERROR;
-			}
-			else if(u8Opt == SO_SSL_ENABLE_SNI_VALIDATION)
-			{
-				int	optVal = *((int*)pvOptVal);
-				if(optVal)
-				{
-					gastrSockets[sock].u8SSLFlags |= SSL_FLAGS_CHECK_SNI;
-				}
-				else
-				{
-					gastrSockets[sock].u8SSLFlags &= ~SSL_FLAGS_CHECK_SNI;
-				}
-				s8Ret = SOCK_ERR_NO_ERROR;
-			}
-			else if(u8Opt == SO_SSL_SNI)
-			{
-				if(u16OptLen < HOSTNAME_MAX_SIZE)
-				{
-					uint8					*pu8SNI = (uint8*)pvOptVal;
-					tstrSSLSetSockOptCmd	strCmd;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+    if(sock < TCP_SOCK_MAX)
+    {
+        if(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE)
+        {
+            uint8   sslFlag = 0;
 
-					strCmd.sock			= sock;
-					strCmd.u16SessionID	= gastrSockets[sock].u16SessionID;
-					strCmd.u8Option		= u8Opt;
-					strCmd.u32OptLen	= u16OptLen;
-					m2m_memcpy(strCmd.au8OptVal, pu8SNI, HOSTNAME_MAX_SIZE);
-					
-					if(SOCKET_REQUEST(SOCKET_CMD_SSL_SET_SOCK_OPT, (uint8*)&strCmd, sizeof(tstrSSLSetSockOptCmd),
-						0, 0, 0) == M2M_ERR_MEM_ALLOC)
-					{
-						s8Ret = SOCKET_REQUEST(SOCKET_CMD_SSL_SET_SOCK_OPT | M2M_REQ_DATA_PKT, 
-							(uint8*)&strCmd, sizeof(tstrSSLSetSockOptCmd), 0, 0, 0);
-					}
-					s8Ret = SOCK_ERR_NO_ERROR;
-				}
-				else
-				{
-					M2M_ERR("SNI Exceeds Max Length\n");
-				}
-			}
-			else
-			{
-				M2M_ERR("Unknown SSL Socket Option %d\n",u8Opt);
-			}
-		}
-		else
-		{
-			M2M_ERR("Not SSL Socket\n");
-		}
-	}
-	return s8Ret;
+            s8Ret = SOCK_ERR_NO_ERROR;
+            if(u16OptLen == sizeof(int))
+            {
+                if(u8Opt == SO_SSL_BYPASS_X509_VERIF)
+                {
+                    sslFlag = SSL_FLAGS_BYPASS_X509;
+                }
+                else if(u8Opt == SO_SSL_ENABLE_SESSION_CACHING)
+                {
+                    sslFlag = SSL_FLAGS_CACHE_SESSION;
+                }
+                else if(u8Opt == SO_SSL_ENABLE_SNI_VALIDATION)
+                {
+                    sslFlag = SSL_FLAGS_CHECK_SNI;
+                }
+            }
+            if(sslFlag)
+            {
+                int optVal = *((int*)pvOptVal);
+                if(optVal)
+                {
+                    gastrSockets[sock].u8SSLFlags |= sslFlag;
+                }
+                else
+                {
+                    gastrSockets[sock].u8SSLFlags &= ~sslFlag;
+                }
+            }
+            else if(
+                ((u8Opt == SO_SSL_SNI) && (u16OptLen < HOSTNAME_MAX_SIZE))
+                || ((u8Opt == SO_SSL_ALPN) && (u16OptLen <= ALPN_LIST_MAX_SIZE))
+            )
+            {
+                tstrSSLSetSockOptCmd    strCmd = {0};
+
+                strCmd.sock         = sock;
+                strCmd.u16SessionID = gastrSockets[sock].u16SessionID;
+                strCmd.u8Option     = u8Opt;
+                strCmd.u32OptLen    = u16OptLen;
+                m2m_memcpy(strCmd.au8OptVal, (uint8*)pvOptVal, u16OptLen);
+
+                s8Ret = SOCKET_REQUEST(SOCKET_CMD_SSL_SET_SOCK_OPT, (uint8*)&strCmd, sizeof(tstrSSLSetSockOptCmd), 0, 0, 0);
+                if(s8Ret == M2M_ERR_MEM_ALLOC)
+                {
+                    s8Ret = SOCKET_REQUEST(SOCKET_CMD_SSL_SET_SOCK_OPT | M2M_REQ_DATA_PKT,
+                                           (uint8*)&strCmd, sizeof(tstrSSLSetSockOptCmd), 0, 0, 0);
+                }
+            }
+            else
+            {
+                M2M_ERR("Unknown SSL Socket Option %d\n", u8Opt);
+                s8Ret = SOCK_ERR_INVALID_ARG;
+            }
+        }
+        else
+        {
+            M2M_ERR("Not SSL Socket\n");
+        }
+    }
+    return s8Ret;
 }
+
 /*********************************************************************
 Function
-		setsockopt
+        setsockopt
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Abdelrahman Diab
+        Abdelrahman Diab
 
 Version
-		1.0
+        1.0
 
 Date
-		9 September 2014
+        9 September 2014
 *********************************************************************/
-sint8 winc1500_socket_setsockopt(SOCKET sock, uint8  u8Level, uint8  option_name,
-       const void *option_value, uint16 u16OptionLen)
+sint8 setsockopt(SOCKET sock, uint8  u8Level, uint8  option_name,
+    const void *option_value, uint16 u16OptionLen)
 {
-	sint8	s8Ret = SOCK_ERR_INVALID_ARG;
-	if((sock >= 0)  && (option_value != NULL)  && (gastrSockets[sock].bIsUsed == 1))
-	{
-		if(u8Level == SOL_SSL_SOCKET)
-		{
-			s8Ret = sslSetSockOpt(sock, option_name, option_value, u16OptionLen);
-		}
-		else
-		{
-			uint8	u8Cmd = SOCKET_CMD_SET_SOCKET_OPTION;
-			tstrSetSocketOptCmd strSetSockOpt;
-			strSetSockOpt.u8Option=option_name;
-			strSetSockOpt.sock = sock; 
-			strSetSockOpt.u32OptionValue = *(uint32*)option_value;
-			strSetSockOpt.u16SessionID		= gastrSockets[sock].u16SessionID;
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+    if((sock >= 0) && (sock < MAX_SOCKET) && (option_value != NULL) && (gastrSockets[sock].bIsUsed == 1))
+    {
+        if(u8Level == SOL_SSL_SOCKET)
+        {
+            s8Ret = sslSetSockOpt(sock, option_name, option_value, u16OptionLen);
+        }
+        else if(u8Level == SOL_SOCKET)
+        {
+            if(u16OptionLen == sizeof(uint32))
+            {
+                uint8   u8Cmd = SOCKET_CMD_SET_SOCKET_OPTION;
+                tstrSetSocketOptCmd strSetSockOpt;
+                strSetSockOpt.u8Option=option_name;
+                strSetSockOpt.sock = sock;
+                strSetSockOpt.u32OptionValue = *(uint32*)option_value;
+                strSetSockOpt.u16SessionID      = gastrSockets[sock].u16SessionID;
 
-			s8Ret = SOCKET_REQUEST(u8Cmd, (uint8*)&strSetSockOpt, sizeof(tstrSetSocketOptCmd), NULL,0, 0);
-			if(s8Ret != SOCK_ERR_NO_ERROR)
-			{
-				s8Ret = SOCK_ERR_INVALID;
-			}
-		}
-	}
-	return s8Ret;	
+                s8Ret = SOCKET_REQUEST(u8Cmd, (uint8*)&strSetSockOpt, sizeof(tstrSetSocketOptCmd), NULL, 0, 0);
+                if(s8Ret != SOCK_ERR_NO_ERROR)
+                {
+                    s8Ret = SOCK_ERR_INVALID;
+                }
+            }
+        }
+    }
+    return s8Ret;
 }
+
 /*********************************************************************
 Function
-		getsockopt
+        getsockopt
 
 Description
 
 Return
-		None.
+        None.
 
 Author
-		Ahmed Ezzat
+        Ahmed Ezzat
 
 Version
-		1.0
+        1.0
 
 Date
-		24 August 2014
+        24 August 2014
 *********************************************************************/
-sint8 winc1500_socket_getsockopt(SOCKET sock, uint8 u8Level, uint8 u8OptName, const void *pvOptValue, uint8* pu8OptLen)
+sint8 getsockopt(SOCKET sock, uint8 u8Level, uint8 u8OptName, const void *pvOptValue, uint8 *pu8OptLen)
 {
-	/* TBD */
-	return M2M_SUCCESS;
+    // This is not implemented so return a value that will cause failure should this be used.
+    return SOCK_ERR_INVALID_ARG;
 }
+
 /*********************************************************************
 Function
-	m2m_ping_req
+    m2m_ping_req
 
 Description
-	Send Ping request.
+    Send Ping request.
 
 Return
-	
+
 Author
-	Ahmed Ezzat
+    Ahmed Ezzat
 
 Version
-	1.0
+    1.0
 
 Date
-	4 June 2015
+    4 June 2015
 *********************************************************************/
 sint8 m2m_ping_req(uint32 u32DstIP, uint8 u8TTL, tpfPingCb fpPingCb)
 {
-	sint8	s8Ret = M2M_ERR_INVALID_ARG;
+    sint8   s8Ret = M2M_ERR_INVALID_ARG;
 
-	if((u32DstIP != 0) && (fpPingCb != NULL))
-	{
-		tstrPingCmd	strPingCmd;
+    if((u32DstIP != 0) && (fpPingCb != NULL))
+    {
+        tstrPingCmd strPingCmd;
+        strPingCmd.u16PingCount     = 1;
+        strPingCmd.u32DestIPAddr    = u32DstIP;
+        strPingCmd.u32CmdPrivate    = ++gu32PingId;
+        strPingCmd.u8TTL            = u8TTL;
 
-		strPingCmd.u16PingCount		= 1;
-		strPingCmd.u32DestIPAddr	= u32DstIP;
-		strPingCmd.u32CmdPrivate	= (uint32)fpPingCb;
-		strPingCmd.u8TTL			= u8TTL;
+        gfpPingCb = fpPingCb;
+        s8Ret = SOCKET_REQUEST(SOCKET_CMD_PING, (uint8 *)&strPingCmd, sizeof(tstrPingCmd), NULL, 0, 0);
+    }
+    return s8Ret;
+}
 
-		s8Ret = SOCKET_REQUEST(SOCKET_CMD_PING, (uint8*)&strPingCmd, sizeof(tstrPingCmd), NULL, 0, 0);
-	}
-	return s8Ret;
+/*********************************************************************
+Function
+    set_alpn_protocol_list
+
+Description
+    This function sets the protocol list used for application-layer protocol negotiation (ALPN).
+    If used, it must be called after creating a SSL socket (using @ref socket) and before
+    connecting/binding (using @ref connect or @ref bind).
+
+Return
+    The function returns @ref M2M_SUCCESS for successful operations and a negative value otherwise.
+*********************************************************************/
+sint8 set_alpn_list(SOCKET sock, const char *pcProtocolList)
+{
+    sint8   s8Ret = SOCK_ERR_INVALID_ARG;
+
+    if((sock >= 0) && (sock < TCP_SOCK_MAX) && (pcProtocolList != NULL))
+    {
+        uint8   u8Length = m2m_strlen((uint8 *)pcProtocolList);
+        if((u8Length > 0) && (u8Length < ALPN_LIST_MAX_APP_LENGTH))
+        {
+            /*
+                ALPN socket option requires Alpn list in this format:
+                 0       1       2       3 ... (bytes)
+                +-------+-------+-------+  ...        +-------+  ...        +-------+  ...
+                | Length L (BE) | len1  | name1...    | len2  | name2...    | len3  | name3...
+                +-------+-------+-------+  ...        +-------+  ...        +-------+  ...
+                Length fields do not include themselves.
+            */
+            uint8   au8AlpnList[ALPN_LIST_MAX_SIZE] = {0};
+            uint8   *pu8Ptr = &au8AlpnList[3] + u8Length;
+            uint8   u8Len = 0;
+
+            m2m_memcpy(&au8AlpnList[3], (uint8 *)pcProtocolList, u8Length);
+            u8Length++;
+            au8AlpnList[1] = u8Length;
+            au8AlpnList[2] = ' ';
+
+            /* Convert space characters into length fields. */
+            while(u8Length--)
+            {
+                if(*--pu8Ptr == ' ')
+                {
+                    if(u8Len == 0) goto ERR;
+                    *pu8Ptr = u8Len;
+                    u8Len = 0;
+                }
+                else u8Len++;
+            }
+            s8Ret = setsockopt(sock, SOL_SSL_SOCKET, SO_SSL_ALPN, au8AlpnList, sizeof(au8AlpnList));
+        }
+    }
+ERR:
+    return s8Ret;
 }
 /*********************************************************************
 Function
-	sslEnableCertExpirationCheck
+    get_alpn_protocol_index
 
 Description
-	Enable/Disable TLS Certificate Expiration Check.
+    This function gets the protocol list used for application-layer protocol negotiation (ALPN).
+    If used, it must be called after creating a SSL socket (using @ref socket) and before
+    connecting/binding (using @ref connect or @ref bind).
 
 Return
-	
+    The function returns the index of the selected application-layer protocol.
+    Special values:
+    0: no negotiation has occurred.
+    <0: error.
+*********************************************************************/
+sint8 get_alpn_index(SOCKET sock)
+{
+    if(sock >= TCP_SOCK_MAX || sock < 0)
+        return SOCK_ERR_INVALID_ARG;
+    if(!(gastrSockets[sock].u8SSLFlags & SSL_FLAGS_ACTIVE) || !gastrSockets[sock].bIsUsed)
+        return SOCK_ERR_INVALID_ARG;
+    return gastrSockets[sock].u8AlpnStatus;
+}
+
+/*********************************************************************
+Function
+    sslEnableCertExpirationCheck
+
+Description
+    Enable/Disable TLS Certificate Expiration Check.
+
+Return
+
 Author
-	Ahmed Ezzat
+    Ahmed Ezzat
 
 Version
-	1.0
+    1.0
 
 Date
-	
+
 *********************************************************************/
 sint8 sslEnableCertExpirationCheck(tenuSslCertExpSettings enuValidationSetting)
 {
-	tstrSslCertExpSettings	strSettings;
-	strSettings.u32CertExpValidationOpt = (uint32)enuValidationSetting;
-	return SOCKET_REQUEST(SOCKET_CMD_SSL_EXP_CHECK, (uint8*)&strSettings, sizeof(tstrSslCertExpSettings), NULL, 0, 0);
+    tstrSslCertExpSettings  strSettings;
+    strSettings.u32CertExpValidationOpt = (uint32)enuValidationSetting;
+    return SOCKET_REQUEST(SOCKET_CMD_SSL_EXP_CHECK, (uint8 *)&strSettings, sizeof(tstrSslCertExpSettings), NULL, 0, 0);
+}
+
+/*********************************************************************
+Function
+        IsSocketReady
+
+Description
+
+Return
+        None.
+
+Author
+
+
+Version
+        1.0
+
+Date
+        24 Apr 2018
+*********************************************************************/
+uint8 IsSocketReady(void)
+{
+    return gbSocketInit;
+}
+/*********************************************************************
+Function
+    get_error_detail
+
+Description
+    This function gets detail about a socket failure.
+    The application can call this when notified of a socket failure via
+    @ref SOCKET_MSG_CONNECT or @ref SOCKET_MSG_RECV.
+    If used, it must be called before @ref close.
+
+Return
+    The function returns @ref SOCK_ERR_NO_ERROR if the request is successful
+    and a negative value otherwise.
+*********************************************************************/
+sint8 get_error_detail(SOCKET sock, tstrSockErr *pstrErr)
+{
+    if((sock >= TCP_SOCK_MAX) || (sock < 0) || (pstrErr == NULL))
+        return SOCK_ERR_INVALID_ARG;
+    if(!gastrSockets[sock].bIsUsed)
+        return SOCK_ERR_INVALID_ARG;
+    pstrErr->enuErrSource = gastrSockets[sock].u8ErrSource;
+    pstrErr->u8ErrCode = gastrSockets[sock].u8ErrCode;
+    return SOCK_ERR_NO_ERROR;
 }

--- a/asf/common/components/wifi/winc1500/socket/source/socket_internal.h
+++ b/asf/common/components/wifi/winc1500/socket/source/socket_internal.h
@@ -4,36 +4,29 @@
  *
  * \brief BSD compatible socket interface internal types.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *

--- a/asf/common/components/wifi/winc1500/spi_flash/include/spi_flash.h
+++ b/asf/common/components/wifi/winc1500/spi_flash/include/spi_flash.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC1500 SPI Flash.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -112,6 +105,10 @@
 #include "bus_wrapper/include/nm_bus_wrapper.h"
 #include "driver/source/nmbus.h"
 #include "driver/source/nmasic.h"
+
+#define FLASH_SECTOR_SZ						(4 * 1024UL)
+/*!<Sector Size in Flash Memory
+ */
 
 /**
  *	@fn		spi_flash_enable
@@ -219,4 +216,5 @@ sint8 spi_flash_write(uint8* pu8Buf, uint32 u32Offset, uint32 u32Sz);
  */
 sint8 spi_flash_erase(uint32 u32Offset, uint32 u32Sz);
  /**@}*/
+
 #endif	//__SPI_FLASH_H__

--- a/asf/common/components/wifi/winc1500/spi_flash/include/spi_flash_map.h
+++ b/asf/common/components/wifi/winc1500/spi_flash/include/spi_flash_map.h
@@ -4,36 +4,29 @@
  *
  * \brief WINC1500 SPI Flash.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -53,8 +46,9 @@
 #define FLASH_MAP_VER_1		(1)
 #define FLASH_MAP_VER_2		(2)
 #define FLASH_MAP_VER_3		(3)
+#define FLASH_MAP_VER_4     (4)
 
-#define FLASH_MAP_VERSION	FLASH_MAP_VER_3
+#define FLASH_MAP_VERSION   FLASH_MAP_VER_4
 
 //#define DOWNLOAD_ROLLBACK
 //#define OTA_GEN
@@ -104,8 +98,10 @@
  * |	 36	K			|	  4	K	|	Connection Parameters	|	Parameters for success connection to AP		|
  * |	 40	K			|	236 K 	|	Main Firmware/program	|	Main Firmware to run WiFi Chip				|
  * |	276	K			|	236 K	|	OTA Firmware		    |	OTA firmware								|
- * |    512 K                                                       Total flash size							|
- * |____________________|___________|___________________________|_______________________________________________|
+ * |    512 K           |   512 K   |   Host File Storage       |    WINC1510 (8Mb of Flash) only               |
+ * |------------------------------------------------------------------------------------------------------------|
+ * |                     Total flash size is 512 K for WINC1500 and 1024 K for WINC1510                         |
+ * |____________________________________________________________________________________________________________|
  *
  *
  * *Keys for Comments with each MACRO:
@@ -228,18 +224,30 @@
  * App(Cortus App 4M): App. which runs over firmware
  *
  */
+#ifdef CORTUS_APP
 #define M2M_APP_4M_MEM_FLASH_SZ					(FLASH_SECTOR_SZ * 16)
 #define M2M_APP_4M_MEM_FLASH_OFFSET				(FLASH_4M_TOTAL_SZ - M2M_APP_4M_MEM_FLASH_SZ)
 #define M2M_APP_8M_MEM_FLASH_OFFSET				(M2M_OTA_IMAGE2_OFFSET + OTA_IMAGE_SIZE)
 #define M2M_APP_8M_MEM_FLASH_SZ					(FLASH_SECTOR_SZ * 32)
 #define M2M_APP_OTA_MEM_FLASH_OFFSET			(M2M_APP_8M_MEM_FLASH_OFFSET + M2M_APP_8M_MEM_FLASH_SZ)
-
+#define M2M_HFD_8M_MEM_FLASH_OFFSET             (M2M_APP_8M_MEM_FLASH_OFFSET + M2M_APP_8M_MEM_FLASH_SZ)
+#else
+#define M2M_HFD_8M_MEM_FLASH_OFFSET             (M2M_OTA_IMAGE2_OFFSET + OTA_IMAGE_SIZE)
+#endif
 /* Check if total size of content
  *  don't exceed total size of memory allowed
  **/
 #if (M2M_COMMON_DATA_SEC  +  (OTA_IMAGE_SIZE *2)> FLASH_4M_TOTAL_SZ)
-#error "Excced 4M Flash Size"
+#error "Exceeds 4M Flash Size"
 #endif /* (FLASH_CONTENT_SZ > FLASH_TOTAL_SZ) */
+
+/**
+ * Magic value to differentiate between old HTTP flash section format and newer formats.
+ * The lowest byte is ignored when checking the value as it contains the
+ * version number (it should always be 00 here, image_builder will set this value in flash).
+ **/
+#define HTTP_FLASH_SECTION_MAGIC	0xB00B1500
+#define HTTP_FLASH_SECTION_VERSION	2
 
 
 #endif /* __SPI_FLASH_MAP_H__ */

--- a/asf/common/components/wifi/winc1500/spi_flash/source/spi_flash.c
+++ b/asf/common/components/wifi/winc1500/spi_flash/source/spi_flash.c
@@ -4,36 +4,29 @@
  *
  * \brief WINC1500 SPI Flash.
  *
- * Copyright (c) 2016-2017 Atmel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Microchip Technology Inc. and its subsidiaries.
  *
  * \asf_license_start
  *
  * \page License
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
+ * Subject to your compliance with these terms, you may use Microchip
+ * software and any derivatives exclusively with Microchip products.
+ * It is your responsibility to comply with third party license terms applicable
+ * to your use of third party software (including open source software) that
+ * may accompany Microchip software.
  *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * 3. The name of Atmel may not be used to endorse or promote products derived
- *    from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
- * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
- * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
- * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES,
+ * WHETHER EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE,
+ * INCLUDING ANY IMPLIED WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY,
+ * AND FITNESS FOR A PARTICULAR PURPOSE. IN NO EVENT WILL MICROCHIP BE
+ * LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE, INCIDENTAL OR CONSEQUENTIAL
+ * LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER RELATED TO THE
+ * SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS BEEN ADVISED OF THE
+ * POSSIBILITY OR THE DAMAGES ARE FORESEEABLE.  TO THE FULLEST EXTENT
+ * ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN ANY WAY
+ * RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
+ * THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
  *
  * \asf_license_stop
  *
@@ -52,12 +45,8 @@
 #define FLASH_BLOCK_SIZE					(32UL * 1024)
 /*!<Block Size in Flash Memory
  */
-#define FLASH_SECTOR_SZ						(4 * 1024UL)
-/*!<Sector Size in Flash Memory
- */
 #define FLASH_PAGE_SZ						(256)
 /*!<Page Size in Flash Memory */
-
 
 #define HOST_SHARE_MEM_BASE		(0xd0000UL)
 #define CORTUS_SHARE_MEM_BASE	(0x60000000UL)
@@ -238,7 +227,7 @@ static sint8 spi_flash_load_to_cortus_mem(uint32 u32MemAdr, uint32 u32FlashAdr, 
 	cmd[4] = 0xA5;
 
 	ret += nm_write_reg(SPI_FLASH_DATA_CNT, u32Sz);
-	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(cmd[1]<<8)|(cmd[2]<<16)|(cmd[3]<<24));
+	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(((uint32)cmd[1])<<8)|(((uint32)cmd[2])<<16)|(((uint32)cmd[3])<<24));
 	ret += nm_write_reg(SPI_FLASH_BUF2, cmd[4]);
 	ret += nm_write_reg(SPI_FLASH_BUF_DIR, 0x1f);
 	ret += nm_write_reg(SPI_FLASH_DMA_ADDR, u32MemAdr);
@@ -275,7 +264,7 @@ static sint8 spi_flash_sector_erase(uint32 u32FlashAdr)
 	cmd[3] = (uint8)(u32FlashAdr);
 
 	ret += nm_write_reg(SPI_FLASH_DATA_CNT, 0);
-	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(cmd[1]<<8)|(cmd[2]<<16)|(cmd[3]<<24));
+	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(((uint32)cmd[1])<<8)|(((uint32)cmd[2])<<16)|(((uint32)cmd[3])<<24));
 	ret += nm_write_reg(SPI_FLASH_BUF_DIR, 0x0f);
 	ret += nm_write_reg(SPI_FLASH_DMA_ADDR, 0);
 	ret += nm_write_reg(SPI_FLASH_CMD_CNT, 4 | (1<<7));
@@ -374,7 +363,7 @@ static sint8 spi_flash_page_program(uint32 u32MemAdr, uint32 u32FlashAdr, uint32
 	cmd[3] = (uint8)(u32FlashAdr);
 
 	ret += nm_write_reg(SPI_FLASH_DATA_CNT, 0);
-	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(cmd[1]<<8)|(cmd[2]<<16)|(cmd[3]<<24));
+	ret += nm_write_reg(SPI_FLASH_BUF1, cmd[0]|(((uint32)cmd[1])<<8)|(((uint32)cmd[2])<<16)|(((uint32)cmd[3])<<24));
 	ret += nm_write_reg(SPI_FLASH_BUF_DIR, 0x0f);
 	ret += nm_write_reg(SPI_FLASH_DMA_ADDR, u32MemAdr);
 	ret += nm_write_reg(SPI_FLASH_CMD_CNT, 4 | (1<<7) | ((u32Sz & 0xfffff) << 8));
@@ -550,17 +539,16 @@ sint8 spi_flash_enable(uint8 enable)
 		}
 		/* GPIO15/16/17/18 */
 		u32Val &= ~((0x7777ul) << 12);
-		u32Val |= ((0x1111ul) << 12);
-		nm_write_reg(0x1410, u32Val);
 		if(enable) {
+			u32Val |= ((0x1111ul) << 12);
+			nm_write_reg(0x1410, u32Val);
 			spi_flash_leave_low_power_mode();
 		} else {
 			spi_flash_enter_low_power_mode();
+			/* Disable pinmux to SPI flash to minimize leakage. */
+			u32Val |= ((0x0010ul) << 12);
+			nm_write_reg(0x1410, u32Val);
 		}
-		/* Disable pinmux to SPI flash to minimize leakage. */
-		u32Val &= ~((0x7777ul) << 12);
-		u32Val |= ((0x0010ul) << 12);
-		nm_write_reg(0x1410, u32Val);
 	}
 ERR1:
 	return s8Ret;
@@ -602,7 +590,7 @@ ERR:
 
 /**
 *	@fn			spi_flash_write
-*	@brief		Proram SPI flash
+*	@brief		Program SPI flash
 *	@param[IN]	pu8Buf
 *					Pointer to data buffer
 *	@param[IN]	u32Offset
@@ -731,24 +719,24 @@ ERR:
 uint32 spi_flash_get_size(void)
 {
 	uint32 u32FlashId = 0, u32FlashPwr = 0;
-	static uint32 gu32InernalFlashSize= 0;
+	static uint32 gu32InternalFlashSize= 0;
 	
-	if(!gu32InernalFlashSize)
+	if(!gu32InternalFlashSize)
 	{
-		u32FlashId = spi_flash_rdid();//spi_flash_probe();
-		if(u32FlashId != 0xffffffff)
+		u32FlashId = spi_flash_rdid();
+		if((u32FlashId != 0xffffffff) && (u32FlashId !=0))
 		{
 			/*flash size is the third byte from the FLASH RDID*/
 			u32FlashPwr = ((u32FlashId>>16)&0xff) - 0x11; /*2MBIT is the min*/
 			/*That number power 2 to get the flash size*/
-			gu32InernalFlashSize = 1<<u32FlashPwr;
-			M2M_INFO("Flash Size %lu Mb\n",gu32InernalFlashSize);
+			gu32InternalFlashSize = 1<<u32FlashPwr;
+			M2M_INFO("Flash Size %lu Mb\n",gu32InternalFlashSize);
 		}
 		else
 		{
-			M2M_ERR("Cann't Detect Flash size\n");
+			M2M_ERR("Can't detect Flash size\n");
 		}
 	}
 
-	return gu32InernalFlashSize;
+	return gu32InternalFlashSize;
 }


### PR DESCRIPTION
Rename the configuration symbol in `nm_bsp_internal.h` from `CONFIG_WIFI_WINC1500` to `CONFIG_ATMEL_WINC1500` to decouple the BSP header inclusion from the default Zephyr driver.

This change allows alternative driver implementations to use the BSP headers without being forced to enable `CONFIG_WIFI_WINC1500`, which otherwise enables the built-in Zephyr driver and can cause conflicts when providing a custom driver.