### PR TITLE
pinctrl: samx7x: Fix incorrect pinctrl config

### DIFF
--- a/include/dt-bindings/pinctrl/same70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/same70q-pinctrl.h
@@ -1986,8 +1986,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */

--- a/include/dt-bindings/pinctrl/sams70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/sams70q-pinctrl.h
@@ -1874,8 +1874,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */

--- a/include/dt-bindings/pinctrl/samv70q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv70q-pinctrl.h
@@ -1910,8 +1910,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */

--- a/include/dt-bindings/pinctrl/samv71q-pinctrl.h
+++ b/include/dt-bindings/pinctrl/samv71q-pinctrl.h
@@ -1998,8 +1998,8 @@
 #define PE4B_TC3_TIOB10 \
 	SAM_PINMUX(e, 4, b, periph)
 
-/* pe4x_afe1_ad4 */
-#define PE4X_AFE1_AD4 \
+/* pe4x_afe0_ad4 */
+#define PE4X_AFE0_AD4 \
 	SAM_PINMUX(e, 4, x, extra)
 
 /* pe5_gpio */


### PR DESCRIPTION
The pinctrl configuration for SAMx7x SOC PE4 should be afe0_ad4 instead of afe1_ad4.