### PR TITLE
sam3x: spi: missing dac macro

### DIFF
--- a/asf/sam/include/sam3x/README
+++ b/asf/sam/include/sam3x/README
@@ -45,3 +45,4 @@ Patch Lst:
    * Fix SSC registers macros
    * Fix missing SPI_CSR_BITS macro
    * Fix missing ADC_MR_STARTUP and ADC_MR_SETTLING macros
+   * Fix missing DACC_MR_USER_SEL macro

--- a/asf/sam/include/sam3x/component/dacc.h
+++ b/asf/sam/include/sam3x/component/dacc.h
@@ -85,6 +85,7 @@ typedef struct {
 #define DACC_MR_REFRESH(value) ((DACC_MR_REFRESH_Msk & ((value) << DACC_MR_REFRESH_Pos)))
 #define DACC_MR_USER_SEL_Pos 16
 #define DACC_MR_USER_SEL_Msk (0x3u << DACC_MR_USER_SEL_Pos) /**< \brief (DACC_MR) User Channel Selection */
+#define DACC_MR_USER_SEL(value) ((DACC_MR_USER_SEL_Msk & ((value) << DACC_MR_USER_SEL_Pos)))
 #define   DACC_MR_USER_SEL_CHANNEL0 (0x0u << 16) /**< \brief (DACC_MR) Channel 0 */
 #define   DACC_MR_USER_SEL_CHANNEL1 (0x1u << 16) /**< \brief (DACC_MR) Channel 1 */
 #define DACC_MR_TAG (0x1u << 20) /**< \brief (DACC_MR) Tag Selection Mode */


### PR DESCRIPTION
Add missing DACC_MR_USER_SEL macro for sam3x variants